### PR TITLE
resourcefetcher: Untangle and comment

### DIFF
--- a/python/ambassador/config/resourcefetcher.py
+++ b/python/ambassador/config/resourcefetcher.py
@@ -132,19 +132,19 @@ class ResourceFetcher:
                         continue
 
                     # self.logger.debug("%s: SAVE configuration file" % filepath)
-                    inputs.append((filepath, filename))
+                    inputs.append(filepath)
 
         else:
             # this allows a file to be passed into the ambassador cli
             # rather than just a directory
             inputs.append((config_dir_path, os.path.basename(config_dir_path)))
 
-        for filepath, filename in inputs:
-            self.logger.info("reading %s (%s)" % (filename, filepath))
+        for filepath in inputs:
+            self.logger.info(f"reading {filepath}")
 
             try:
                 serialization = open(filepath, "r").read()
-                self.parse_yaml(serialization, k8s=k8s, filename=filename, finalize=False)
+                self.parse_yaml(serialization, k8s=k8s, filename=filepath, finalize=False)
             except IOError as e:
                 self.aconf.post_error("could not read YAML from %s: %s" % (filepath, e))
 

--- a/python/ambassador/config/resourcefetcher.py
+++ b/python/ambassador/config/resourcefetcher.py
@@ -71,7 +71,7 @@ class ResourceFetcher:
     #          |   |            |         |                               _secret       |
     #          |   |   ,--------'         |                               _service      |
     #          V   V   V                  |                               _ingressclass |
-    #        parse_object                 |                                             |
+    #       process_objects               |                                             |
     #              |                      +---------------------------------------------+
     #              V
     #       process_object
@@ -201,7 +201,7 @@ class ResourceFetcher:
                     self.handle_k8s(obj)
                 self.pop_location()
             else:
-                self.parse_object(objects=objects, filename=filename)
+                self.process_objects(objects=objects, filename=filename)
         except yaml.error.YAMLError as e:
             self.aconf.post_error("%s: could not parse YAML: %s" % (self.location, e))
 
@@ -332,7 +332,7 @@ class ResourceFetcher:
         if result:
             rkey, parsed_objects = result
 
-            self.parse_object(parsed_objects, filename=self.filename, rkey=rkey)
+            self.process_objects(parsed_objects, filename=self.filename, rkey=rkey)
 
     def handle_k8s_crd(self, obj: dict) -> None:
         # CRDs are _not_ allowed to have embedded objects in annotations, because ew.
@@ -414,17 +414,17 @@ class ResourceFetcher:
         amb_object['metadata_labels']['ambassador_crd'] = resource_identifier
 
         # Done. Parse it.
-        self.parse_object([ amb_object ], filename=self.filename, rkey=resource_identifier)
+        self.process_objects([ amb_object ], filename=self.filename, rkey=resource_identifier)
 
-    def parse_object(self, objects, rkey: Optional[str]=None,
-                     filename: Optional[str]=None, namespace: Optional[str]=None):
+    def process_objects(self, objects, rkey: Optional[str]=None,
+                        filename: Optional[str]=None, namespace: Optional[str]=None):
         """Process a list parsed-YAML-objects as old-style/annotation-style resources."""
         self.push_location(filename, 1)
 
-        # self.logger.debug("PARSE_OBJECT: incoming %d" % len(objects))
+        # self.logger.debug("PROCESS_OBJECTS: incoming %d" % len(objects))
 
         for obj in objects:
-            # self.logger.debug("PARSE_OBJECT: checking %s" % obj)
+            # self.logger.debug("PROCESS_OBJECTS: checking %s" % obj)
 
             # if not obj:
             #     self.logger.debug("%s: empty object from %s" % (self.location, serialization))

--- a/python/ambassador/config/resourcefetcher.py
+++ b/python/ambassador/config/resourcefetcher.py
@@ -58,7 +58,7 @@ class ResourceFetcher:
     #     | load_from_filesystem*    parse_watt*    sorted |
     #     +---------- | ---------------- /|\ --------------+
     #                 V                 / | \
-    #             parse_yaml*          /  /  \
+    #             parse_yaml           /  /  \
     #                / \              /  /    \
     #               /   `----,   ,---'  /      \
     #              /         V   V     /        V
@@ -179,16 +179,14 @@ class ResourceFetcher:
 
             try:
                 serialization = open(filepath, "r").read()
-                self.parse_yaml(serialization, k8s=k8s, filename=filepath, finalize=False)
+                self.parse_yaml(serialization, filename=filepath, k8s=k8s)
             except IOError as e:
                 self.aconf.post_error("could not read YAML from %s: %s" % (filepath, e))
 
         if finalize:
             self.finalize()
 
-    def parse_yaml(self, serialization: str, k8s=False, rkey: Optional[str]=None,
-                   filename: Optional[str]=None, finalize: bool=True, namespace: Optional[str]=None,
-                   metadata_labels: Optional[Dict[str, str]]=None) -> None:
+    def parse_yaml(self, serialization: str, filename: str, k8s: bool=False) -> None:
         # self.logger.info(f"RF YAML: {serialization}")
 
         # Expand environment variables allowing interpolation in manifests.
@@ -203,13 +201,9 @@ class ResourceFetcher:
                     self.handle_k8s(obj)
                 self.pop_location()
             else:
-                self.parse_object(objects=objects, rkey=rkey, filename=filename,
-                                  namespace=namespace)
+                self.parse_object(objects=objects, filename=filename)
         except yaml.error.YAMLError as e:
             self.aconf.post_error("%s: could not parse YAML: %s" % (self.location, e))
-
-        if finalize:
-            self.finalize()
 
     def parse_watt(self, serialization: str, finalize: bool=True) -> None:
         basedir = os.environ.get('AMBASSADOR_CONFIG_BASE_DIR', '/ambassador')

--- a/python/ambassador/config/resourcefetcher.py
+++ b/python/ambassador/config/resourcefetcher.py
@@ -619,7 +619,7 @@ class ResourceFetcher:
                 self.filename += ":annotation"
 
             try:
-                parsed_ambassador_annotations = parse_yaml(ambassador_annotations, namespace=ingress_namespace)
+                parsed_ambassador_annotations = parse_yaml(ambassador_annotations)
             except yaml.error.YAMLError as e:
                 self.logger.debug("could not parse YAML: %s" % e)
 

--- a/python/ambassador/config/resourcefetcher.py
+++ b/python/ambassador/config/resourcefetcher.py
@@ -220,13 +220,7 @@ class ResourceFetcher:
             consul_endpoints = watt_consul.get('Endpoints', {})
 
             for consul_rkey, consul_object in consul_endpoints.items():
-                result = self.handle_consul_service(consul_rkey, consul_object)
-
-                if result:
-                    rkey, parsed_objects = result
-
-                    self.parse_object(parsed_objects, k8s=False,
-                                      filename=self.filename, rkey=rkey)
+                self.handle_consul_service(consul_rkey, consul_object)
         except json.decoder.JSONDecodeError as e:
             self.aconf.post_error("%s: could not parse WATT: %s" % (self.location, e))
 
@@ -1065,7 +1059,7 @@ class ResourceFetcher:
 
     # Handler for Consul services
     def handle_consul_service(self,
-                              consul_rkey: str, consul_object: AnyDict) -> HandlerResult:
+                              consul_rkey: str, consul_object: AnyDict) -> None:
         # resource_identifier = f'consul-{consul_rkey}'
 
         endpoints = consul_object.get('Endpoints', [])
@@ -1074,7 +1068,7 @@ class ResourceFetcher:
         if len(endpoints) < 1:
             # Bzzt.
             self.logger.debug(f"ignoring Consul service {name} with no Endpoints")
-            return None
+            return
 
         # We can turn this directly into an Ambassador Service resource, since Consul keeps
         # services and endpoints together (as it should!!).
@@ -1110,8 +1104,6 @@ class ResourceFetcher:
 
         # Once again: don't return this. Instead, save it in self.services.
         self.services[f"consul-{name}-{svc['datacenter']}"] = svc
-
-        return None
 
     def finalize(self) -> None:
         # The point here is to sort out self.k8s_services and self.k8s_endpoints and

--- a/python/ambassador/config/resourcefetcher.py
+++ b/python/ambassador/config/resourcefetcher.py
@@ -170,24 +170,6 @@ class ResourceFetcher:
         if finalize:
             self.finalize()
 
-    def parse_json(self, serialization: str, k8s=False, rkey: Optional[str]=None,
-                   filename: Optional[str]=None, finalize: bool=True) -> None:
-        # self.logger.debug("%s: parsing %d byte%s of YAML:\n%s" %
-        #                   (self.location, len(serialization), "" if (len(serialization) == 1) else "s",
-        #                    serialization))
-
-        # Expand environment variables allowing interpolation in manifests.
-        serialization = os.path.expandvars(serialization)
-
-        try:
-            objects = json.loads(serialization)
-            self.parse_object(objects=objects, k8s=k8s, rkey=rkey, filename=filename)
-        except json.decoder.JSONDecodeError as e:
-            self.aconf.post_error("%s: could not parse YAML: %s" % (self.location, e))
-
-        if finalize:
-            self.finalize()
-
     def parse_watt(self, serialization: str, finalize: bool=True) -> None:
         basedir = os.environ.get('AMBASSADOR_CONFIG_BASE_DIR', '/ambassador')
 

--- a/python/ambassador/config/resourcefetcher.py
+++ b/python/ambassador/config/resourcefetcher.py
@@ -162,8 +162,14 @@ class ResourceFetcher:
         try:
             # UGH. This parse_yaml is the one we imported from utils. XXX This needs to be fixed.
             objects = parse_yaml(serialization)
-            self.parse_object(objects=objects, k8s=k8s, rkey=rkey, filename=filename,
-                              namespace=namespace)
+            if k8s:
+                self.push_location(filename, 1)
+                for obj in objects:
+                    self.handle_k8s(obj)
+                self.pop_location()
+            else:
+                self.parse_object(objects=objects, rkey=rkey, filename=filename,
+                                  namespace=namespace)
         except yaml.error.YAMLError as e:
             self.aconf.post_error("%s: could not parse YAML: %s" % (self.location, e))
 
@@ -297,7 +303,7 @@ class ResourceFetcher:
         if result:
             rkey, parsed_objects = result
 
-            self.parse_object(parsed_objects, k8s=False, filename=self.filename, rkey=rkey)
+            self.parse_object(parsed_objects, filename=self.filename, rkey=rkey)
 
     def handle_k8s_crd(self, obj: dict) -> None:
         # CRDs are _not_ allowed to have embedded objects in annotations, because ew.
@@ -379,9 +385,9 @@ class ResourceFetcher:
         amb_object['metadata_labels']['ambassador_crd'] = resource_identifier
 
         # Done. Parse it.
-        self.parse_object([ amb_object ], k8s=False, filename=self.filename, rkey=resource_identifier)
+        self.parse_object([ amb_object ], filename=self.filename, rkey=resource_identifier)
 
-    def parse_object(self, objects, k8s=False, rkey: Optional[str]=None,
+    def parse_object(self, objects, rkey: Optional[str]=None,
                      filename: Optional[str]=None, namespace: Optional[str]=None):
         self.push_location(filename, 1)
 
@@ -390,14 +396,11 @@ class ResourceFetcher:
         for obj in objects:
             # self.logger.debug("PARSE_OBJECT: checking %s" % obj)
 
-            if k8s:
-                self.handle_k8s(obj)
-            else:
-                # if not obj:
-                #     self.logger.debug("%s: empty object from %s" % (self.location, serialization))
+            # if not obj:
+            #     self.logger.debug("%s: empty object from %s" % (self.location, serialization))
 
-                self.process_object(obj, rkey=rkey, namespace=namespace)
-                self.ocount += 1
+            self.process_object(obj, rkey=rkey, namespace=namespace)
+            self.ocount += 1
 
         self.pop_location()
 

--- a/python/ambassador/utils.py
+++ b/python/ambassador/utils.py
@@ -59,7 +59,7 @@ yaml_logged_loader = False
 yaml_logged_dumper = False
 
 
-def parse_yaml(serialization: str, **kwargs) -> Any:
+def parse_yaml(serialization: str) -> Any:
     global yaml_logged_loader
 
     if not yaml_logged_loader:

--- a/python/tests/test_envvar_expansion.py
+++ b/python/tests/test_envvar_expansion.py
@@ -33,7 +33,8 @@ def test_envvar_expansion():
     aconf = Config()
 
     fetcher = ResourceFetcher(logger, aconf)
-    fetcher.parse_yaml(yaml)
+    fetcher.parse_yaml(yaml, filename='phony://test_envvar_expansion.yaml')
+    fetcher.finalize()
 
     aconf.load_all(fetcher.sorted())
 

--- a/python/tests/test_lookup.py
+++ b/python/tests/test_lookup.py
@@ -53,7 +53,8 @@ def test_lookup():
     aconf = Config()
 
     fetcher = ResourceFetcher(logger, aconf)
-    fetcher.parse_yaml(yaml)
+    fetcher.parse_yaml(yaml, filename='phony://test_lookup.yaml')
+    fetcher.finalize()
 
     aconf.load_all(fetcher.sorted())
 


### PR DESCRIPTION
## Description

This is my attempt at simplifying and commenting resourcefetcher to the point that I think I could productively work on it.  This is intended to be a no-op change; there should be absolutely zero change in behavior.

## Testing

```shell
make pytest KAT_RUN_MODE=envoy && make pytest-gold
```

Of course, all of the timestamps in the `snapshots.yaml`s changed, so
```shell
git checkout HEAD python/tests/**/snapshot.yaml
```
Once I did that, the only remaining diff was:
```patch
--- a/python/tests/gold/empty/snapshots/aconf.json
+++ b/python/tests/gold/empty/snapshots/aconf.json
@@ -5,25 +5,25 @@
                 "error": "Ambassador could not find core CRD definitions. Please visit https://www.getambassador.io/reference/core/crds/ for more information. You can continue using Ambassador via Kubernetes annotations, any configuration via CRDs w
ill be ignored...",                                                                                                                                                                                                                                      
                 "hostname": "empty",
                 "ok": false,
-                "version": "1.2.0-4-g8f507fdcf-dirty"
+                "version": "1.2.2-69-g18f28a3de"
             },
             {
                 "error": "Ambassador could not find Resolver type CRD definitions. Please visit https://www.getambassador.io/reference/core/crds/ for more information. You can continue using Ambassador via Kubernetes annotations, any configuration v
ia CRDs will be ignored...",                                                                                                                                                                                                                             
                 "hostname": "empty",
                 "ok": false,
-                "version": "1.2.0-4-g8f507fdcf-dirty"
+                "version": "1.2.2-69-g18f28a3de"
             },
             {
                 "error": "Ambassador could not find the Host CRD definition. Please visit https://www.getambassador.io/reference/core/crds/ for more information. You can continue using Ambassador via Kubernetes annotations, any configuration via CRD
s will be ignored...",                                                                                                                                                                                                                                   
                 "hostname": "empty",
                 "ok": false,
-                "version": "1.2.0-4-g8f507fdcf-dirty"
+                "version": "1.2.2-69-g18f28a3de"
             },
             {
                 "error": "Ambassador could not find the LogService CRD definition. Please visit https://www.getambassador.io/reference/core/crds/ for more information. You can continue using Ambassador via Kubernetes annotations, any configuration v
ia CRDs will be ignored...",                                                                                                                                                                                                                             
                 "hostname": "empty",
                 "ok": false,
-                "version": "1.2.0-4-g8f507fdcf-dirty"
+                "version": "1.2.2-69-g18f28a3de"
             }
         ]
     },
diff --git a/python/tests/gold/plain/snapshots/aconf.json b/python/tests/gold/plain/snapshots/aconf.json
index 3115b3f78..179584cd6 100644
--- a/python/tests/gold/plain/snapshots/aconf.json
+++ b/python/tests/gold/plain/snapshots/aconf.json
@@ -5,25 +5,25 @@
                 "error": "Ambassador could not find core CRD definitions. Please visit https://www.getambassador.io/reference/core/crds/ for more information. You can continue using Ambassador via Kubernetes annotations, any configuration via CRDs w
ill be ignored...",                                                                                                                                                                                                                                      
                 "hostname": "plain",
                 "ok": false,
-                "version": "1.2.0-4-g8f507fdcf-dirty"
+                "version": "1.2.2-69-g18f28a3de"
             },
             {
                 "error": "Ambassador could not find Resolver type CRD definitions. Please visit https://www.getambassador.io/reference/core/crds/ for more information. You can continue using Ambassador via Kubernetes annotations, any configuration v
ia CRDs will be ignored...",                                                                                                                                                                                                                             
                 "hostname": "plain",
                 "ok": false,
-                "version": "1.2.0-4-g8f507fdcf-dirty"
+                "version": "1.2.2-69-g18f28a3de"
             },
             {
                 "error": "Ambassador could not find the Host CRD definition. Please visit https://www.getambassador.io/reference/core/crds/ for more information. You can continue using Ambassador via Kubernetes annotations, any configuration via CRD
s will be ignored...",                                                                                                                                                                                                                                   
                 "hostname": "plain",
                 "ok": false,
-                "version": "1.2.0-4-g8f507fdcf-dirty"
+                "version": "1.2.2-69-g18f28a3de"
             },
             {
                 "error": "Ambassador could not find the LogService CRD definition. Please visit https://www.getambassador.io/reference/core/crds/ for more information. You can continue using Ambassador via Kubernetes annotations, any configuration v
ia CRDs will be ignored...",                                                                                                                                                                                                                             
                 "hostname": "plain",
                 "ok": false,
-                "version": "1.2.0-4-g8f507fdcf-dirty"
+                "version": "1.2.2-69-g18f28a3de"
             }
         ]
     },
```

This verifies that the IR is not affected by this change; none of the `ir.json`s changed.

## Tasks That Must Be Done
- [x] Did you update CHANGELOG.md? - no applicable changes
- [x] Did you add or update tests? - no applicable changes
- [x] Did you update documentation? - no applicable changes
- [x] Were there any special dev tricks you had to use to work on this code efficiently? - reading very carefully