### PR TITLE
python: support auth_context_extensions on Mapping/v2

### DIFF
--- a/cmd/kat-server/services/grpc-auth.go
+++ b/cmd/kat-server/services/grpc-auth.go
@@ -94,6 +94,16 @@ func (g *GRPCAUTH) Check(ctx context.Context, r *pb.CheckRequest) (*pb.CheckResp
 		rheader["body"] = rbody
 	}
 
+	rextensions := r.GetAttributes().GetContextExtensions()
+	if rextensions != nil {
+		val, err := json.Marshal(rextensions)
+		if err != nil {
+			val = []byte(fmt.Sprintf("Error: %v", err))
+		}
+
+		rs.AddHeader(false, "x-request-context-extensions", string(val))
+	}
+
 	// Sets requested HTTP status.
 	rs.SetStatus(rheader["requested-status"])
 

--- a/python/ambassador/envoy/v2/v2route.py
+++ b/python/ambassador/envoy/v2/v2route.py
@@ -126,6 +126,11 @@ class V2Route(Cacheable):
 
         if mapping.get('bypass_auth', False):
             per_filter_config['envoy.ext_authz'] = {'disabled': True}
+        else:
+            # Additional ext_auth configuration only makes sense when not bypassing auth.
+            auth_context_extensions = mapping.get('auth_context_extensions', False)
+            if auth_context_extensions:
+                per_filter_config['envoy.ext_authz'] = {'check_settings': {'context_extensions': auth_context_extensions}}
 
         if per_filter_config:
             self['per_filter_config'] = per_filter_config

--- a/python/ambassador/ir/irhttpmapping.py
+++ b/python/ambassador/ir/irhttpmapping.py
@@ -73,6 +73,7 @@ class IRHTTPMapping (IRBaseMapping):
     AllowedKeys: ClassVar[Dict[str, bool]] = {
         "add_linkerd_headers": False,
         # Do not include add_request_headers and add_response_headers
+        "auth_context_extensions": False,
         "auto_host_rewrite": False,
         "bypass_auth": False,
         "case_sensitive": False,

--- a/python/schemas/v2/Mapping.schema
+++ b/python/schemas/v2/Mapping.schema
@@ -132,6 +132,7 @@
         },
         "weight": { "type": "integer" },
         "bypass_auth": { "type": "boolean" },
+        "auth_context_extensions": { "$ref": "#/definitions/mapStrStrStrict" },
 
         "modules": {
             "type": "array",
@@ -179,6 +180,10 @@
         "mapStrStr": {
             "type": "object",
             "additionalProperties": { "type": [ "string", "boolean" ] }
+        },
+        "mapStrStrStrict": {
+            "type": "object",
+            "additionalProperties": { "type": [ "string" ] }
         },
         "mapStrObj": {
             "type": "object",


### PR DESCRIPTION
## Description

WIP: final docs still needed

Envoy supports passing arbitrary per-route context to ext_authz. This
allows an auth service to know details about the route that was matched
for various purposes.

- Adds 'auth_context_extensions' to Mapping/v2 and irhttpmapping
- Sets 'context_extensions' on 'envoy.ext_authz.check_settings'


## Testing
Added new test cases to pytest for gRPC ext_authz

## Tasks That Must Be Done
- [ ] Did you update CHANGELOG.md?
- [ ] Did you add or update tests?
- [ ] Did you update documentation?
- [ ] Were there any special dev tricks you had to use to work on this code efficiently?
  + [ ] Did you add them to DEVELOPING.md?
- [ ] Is this a build change?
  + [ ] If so, did you test on both Mac and Linux?

## Other
* If this is a documentation change for a particular release, please open the pull request against the release branch.
