### PR TITLE
Mount snapshot directory in memory backed `EmptyDir`

### DIFF
--- a/charts/ambassador/CHANGELOG.md
+++ b/charts/ambassador/CHANGELOG.md
@@ -6,6 +6,7 @@ numbering uses [semantic versioning](http://semver.org).
 ## Next Release
 
 - Change: unless image.repository or image.fullImageOverride is explicitly set, the ambassador image used will be templated on .Values.enableAES. If AES is enabled, the chart will use docker.io/datawire/aes, otherwise will use docker.io/datawire/ambassador.
+- Ambassador's snapshot directory `/ambassador/snapshot` is now mounted in a memory backed `emptyDir`.
 
 ## v6.7.5
 

--- a/charts/ambassador/templates/deployment.yaml
+++ b/charts/ambassador/templates/deployment.yaml
@@ -131,6 +131,11 @@ spec:
             secretName: {{ include "ambassador.fullname" . }}-edge-stack
             {{- end }}
         {{- end }}
+        {{- if .Values.security.snapshot.mountInMemory }}
+        - name: ambassador-snapshot
+          emptyDir:
+            medium: Memory
+        {{- end }}
       {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -251,6 +256,10 @@ spec:
             - name: {{ include "ambassador.fullname" . }}-edge-stack-secrets
               mountPath: /.config/ambassador
               readOnly: true
+          {{- end }}
+          {{- if .Values.security.snapshot.mountInMemory }}
+            - name: ambassador-snapshot
+              mountPath: /ambassador/snapshot
           {{- end }}
           {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}

--- a/charts/ambassador/values.yaml
+++ b/charts/ambassador/values.yaml
@@ -117,7 +117,7 @@ security:
     #   runAsUser:
     #     rule: MustRunAsNonRoot
   snapshot:
-    mountInMemory: true
+    mountInMemory: false
 
 image:
   tag: 1.13.3

--- a/charts/ambassador/values.yaml
+++ b/charts/ambassador/values.yaml
@@ -116,6 +116,8 @@ security:
     #   allowPrivilegeEscalation: false
     #   runAsUser:
     #     rule: MustRunAsNonRoot
+  snapshot:
+    mountInMemory: true
 
 image:
   tag: 1.13.3


### PR DESCRIPTION
## Description

Mount `/ambassadaor/snapshot` directory into a memory backed `EmptyDir`.

The snapshot directory contains sensitive information like TLS secrets. They should not be written to the filesystem. 

This **might** impact memory usage of pods depending on how big the snapshots are. We can turn it off by default if the impact is a concern.

## Testing

Installed chart with the changes and tested everything works fine.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `CHANGELOG.md`.
   
   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations
 
 - [ ] This is unlikely to impact how Ambassador performs at scale.
 
   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability
 
 - [x] My change is adequately tested.
 
   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points
 
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
