### PR TITLE
dtest_k3s: Work with newer cgroups

### DIFF
--- a/cmd/k3sctl/main.go
+++ b/cmd/k3sctl/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -45,8 +46,9 @@ func main() {
 	k3s.AddCommand(up)
 
 	up.RunE = func(cmd *cobra.Command, args []string) error {
-		regid := dtest.RegistryUp()
-		k3sid := dtest.K3sUp()
+		ctx := cmd.Context()
+		regid := dtest.RegistryUp(ctx)
+		k3sid := dtest.K3sUp(ctx)
 		fmt.Printf("DOCKER_CONTAINER=%q\n", regid)
 		fmt.Printf("K3S_CONTAINER=%q\n", k3sid)
 		return nil
@@ -60,8 +62,9 @@ func main() {
 	k3s.AddCommand(down)
 
 	down.RunE = func(cmd *cobra.Command, args []string) error {
-		k3sid := dtest.K3sDown()
-		regid := dtest.RegistryDown()
+		ctx := cmd.Context()
+		k3sid := dtest.K3sDown(ctx)
+		regid := dtest.RegistryDown(ctx)
 		fmt.Printf("Shutdown k3s container: %s\n", k3sid)
 		fmt.Printf("Shutdown registry container: %s\n", regid)
 		return nil
@@ -75,7 +78,8 @@ func main() {
 	k3s.AddCommand(registry)
 
 	registry.RunE = func(cmd *cobra.Command, args []string) error {
-		fmt.Println(dtest.DockerRegistry())
+		ctx := cmd.Context()
+		fmt.Println(dtest.DockerRegistry(ctx))
 		return nil
 	}
 
@@ -89,7 +93,8 @@ func main() {
 	k3s.AddCommand(config)
 
 	config.RunE = func(cmd *cobra.Command, args []string) error {
-		kubeconfig := dtest.GetKubeconfig()
+		ctx := cmd.Context()
+		kubeconfig := dtest.GetKubeconfig(ctx)
 		if kubeconfig == "" {
 			return errors.New("no k3s cluster is running")
 		}
@@ -124,7 +129,7 @@ func main() {
 		return nil
 	}
 
-	err := k3s.Execute()
+	err := k3s.ExecuteContext(context.Background())
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		logFile.Close()

--- a/internal/pkg/nat/nat_test.go
+++ b/internal/pkg/nat/nat_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestMain(m *testing.M) {
 	dtest.Sudo()
-	dtest.WithMachineLock(func() {
+	dtest.WithMachineLock(context.TODO(), func(ctx context.Context) {
 		os.Exit(m.Run())
 	})
 }

--- a/pkg/dtest/k8sapply.go
+++ b/pkg/dtest/k8sapply.go
@@ -1,6 +1,7 @@
 package dtest
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"time"
@@ -14,11 +15,11 @@ const prefix = "DTEST"
 
 // K8sApply applies the supplied manifests to the cluster indicated by
 // the supplied kubeconfig.
-func K8sApply(files ...string) {
+func K8sApply(ctx context.Context, files ...string) {
 	if os.Getenv("DOCKER_REGISTRY") == "" {
-		os.Setenv("DOCKER_REGISTRY", DockerRegistry())
+		os.Setenv("DOCKER_REGISTRY", DockerRegistry(ctx))
 	}
-	kubeconfig := Kubeconfig()
+	kubeconfig := Kubeconfig(ctx)
 	err := kubeapply.Kubeapply(k8s.NewKubeInfo(kubeconfig, "", ""), 300*time.Second, false, false, files...)
 	if err != nil {
 		fmt.Println()

--- a/pkg/dtest/testprocess/tp.go
+++ b/pkg/dtest/testprocess/tp.go
@@ -1,13 +1,15 @@
 package testprocess
 
 import (
+	"context"
 	"flag"
-	"log"
 	"os"
 	"os/exec"
 	"reflect"
 	"runtime"
 	"runtime/debug"
+
+	"github.com/datawire/dlib/dlog"
 )
 
 // flags.  Initialize these in the init() step, in case anything else
@@ -83,6 +85,7 @@ func _make(sudo bool, f func()) *exec.Cmd {
 // calling testprocess.Dispatch.  If flag.Parse has not been called,
 // then testprocess.Dispatch will call it.
 func Dispatch() {
+	ctx := context.TODO()
 	dispatched = true
 
 	if !flag.Parsed() {
@@ -92,19 +95,19 @@ func Dispatch() {
 		return
 	}
 
-	log.Printf("TESTPROCESS %s PID: %d", *name, os.Getpid())
+	dlog.Printf(ctx, "TESTPROCESS %s PID: %d", *name, os.Getpid())
 
 	defer func() {
 		if r := recover(); r != nil {
 			stack := string(debug.Stack())
-			log.Printf("TESTPROCESS %s PANICKED: %v\n%s", *name, r, stack)
+			dlog.Printf(ctx, "TESTPROCESS %s PANICKED: %v\n%s", *name, r, stack)
 			os.Exit(1)
 		}
 	}()
 
 	functions[*name]()
 
-	log.Printf("TESTPROCESS %s NORMAL EXIT", *name)
+	dlog.Printf(ctx, "TESTPROCESS %s NORMAL EXIT", *name)
 	os.Exit(0)
 }
 

--- a/pkg/dtest_k3s/k3s_test.go
+++ b/pkg/dtest_k3s/k3s_test.go
@@ -1,28 +1,32 @@
 package dtest_k3s
 
 import (
+	"context"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/datawire/dlib/dlog"
 )
 
 func TestMain(m *testing.M) {
 	// we get the lock to make sure we are the only thing running
 	// because the nat tests interfere with docker functionality
-	WithMachineLock(func() {
+	WithMachineLock(context.TODO(), func(ctx context.Context) {
 		os.Exit(m.Run())
 	})
 }
 
 func TestContainer(t *testing.T) {
-	id := dockerUp("dtest-test-tag", "nginx")
+	ctx := dlog.NewTestContext(t, false)
+	id := dockerUp(ctx, "dtest-test-tag", "nginx")
 
-	running := dockerPs()
+	running := dockerPs(ctx)
 	assert.Contains(t, running, id)
 
-	dockerKill(id)
+	dockerKill(ctx, id)
 
-	running = dockerPs()
+	running = dockerPs(ctx)
 	assert.NotContains(t, running, id)
 }

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -1,18 +1,20 @@
 package k8s_test
 
 import (
+	"context"
 	"os"
 	"testing"
 
 	"github.com/datawire/ambassador/pkg/dtest"
 	"github.com/datawire/ambassador/pkg/k8s"
+	"github.com/datawire/dlib/dlog"
 )
 
 func TestMain(m *testing.M) {
 	// we get the lock to make sure we are the only thing running
 	// because the nat tests interfere with docker functionality
-	dtest.WithMachineLock(func() {
-		dtest.K8sApply("00-custom-crd.yaml", "custom.yaml")
+	dtest.WithMachineLock(context.TODO(), func(ctx context.Context) {
+		dtest.K8sApply(ctx, "00-custom-crd.yaml", "custom.yaml")
 
 		os.Exit(m.Run())
 	})
@@ -20,7 +22,8 @@ func TestMain(m *testing.M) {
 
 func TestList(t *testing.T) {
 	t.Parallel()
-	c, err := k8s.NewClient(info())
+	ctx := dlog.NewTestContext(t, false)
+	c, err := k8s.NewClient(info(ctx))
 	if err != nil {
 		t.Error(err)
 		return

--- a/pkg/k8s/watcher_test.go
+++ b/pkg/k8s/watcher_test.go
@@ -1,6 +1,7 @@
 package k8s_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -8,6 +9,7 @@ import (
 
 	"github.com/datawire/ambassador/pkg/dtest"
 	"github.com/datawire/ambassador/pkg/k8s"
+	"github.com/datawire/dlib/dlog"
 )
 
 const (
@@ -37,13 +39,14 @@ func fetch(w *k8s.Watcher, resource, qname string) (result k8s.Resource) {
 	return result
 }
 
-func info() *k8s.KubeInfo {
-	return k8s.NewKubeInfo(dtest.Kubeconfig(), "", "")
+func info(ctx context.Context) *k8s.KubeInfo {
+	return k8s.NewKubeInfo(dtest.Kubeconfig(ctx), "", "")
 }
 
 func TestUpdateStatus(t *testing.T) {
 	t.Parallel()
-	w := k8s.MustNewWatcher(info())
+	ctx := dlog.NewTestContext(t, false)
+	w := k8s.MustNewWatcher(info(ctx))
 
 	svc := fetch(w, "services", "kubernetes.default")
 	svc.Status()["loadBalancer"].(map[string]interface{})["ingress"] = []map[string]interface{}{{"hostname": "foo", "ip": "1.2.3.4"}}
@@ -55,7 +58,7 @@ func TestUpdateStatus(t *testing.T) {
 		t.Logf("updated %s status, result: %v\n", svc.QName(), result.ResourceVersion())
 	}
 
-	svc = fetch(k8s.MustNewWatcher(info()), "services", "kubernetes.default")
+	svc = fetch(k8s.MustNewWatcher(info(ctx)), "services", "kubernetes.default")
 	ingresses := svc.Status()["loadBalancer"].(map[string]interface{})["ingress"].([]interface{})
 	ingress := ingresses[0].(map[string]interface{})
 	if ingress["hostname"] != "foo" {
@@ -69,7 +72,8 @@ func TestUpdateStatus(t *testing.T) {
 
 func TestWatchCustom(t *testing.T) {
 	t.Parallel()
-	w := k8s.MustNewWatcher(info())
+	ctx := dlog.NewTestContext(t, false)
+	w := k8s.MustNewWatcher(info(ctx))
 
 	// XXX: we can only watch custom resources... k8s doesn't
 	// support status for CRDs until 1.12
@@ -86,7 +90,8 @@ func TestWatchCustom(t *testing.T) {
 
 func TestWatchCustomCollision(t *testing.T) {
 	t.Parallel()
-	w := k8s.MustNewWatcher(info())
+	ctx := dlog.NewTestContext(t, false)
+	w := k8s.MustNewWatcher(info(ctx))
 
 	easter := fetch(w, "csrv", "easter.default")
 	if easter == nil {
@@ -102,7 +107,8 @@ func TestWatchCustomCollision(t *testing.T) {
 
 func TestWatchQuery(t *testing.T) {
 	t.Parallel()
-	w := k8s.MustNewWatcher(info())
+	ctx := dlog.NewTestContext(t, false)
+	w := k8s.MustNewWatcher(info(ctx))
 
 	services := []string{}
 	err := w.WatchQuery(k8s.Query{

--- a/pkg/kates/client_test.go
+++ b/pkg/kates/client_test.go
@@ -14,10 +14,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/datawire/ambassador/pkg/dtest_k3s"
+	"github.com/datawire/dlib/dlog"
 )
 
 func testClient(t *testing.T) *Client {
-	cli, err := NewClient(ClientConfig{Kubeconfig: dtest_k3s.Kubeconfig()})
+	ctx := dlog.NewTestContext(t, false)
+	cli, err := NewClient(ClientConfig{Kubeconfig: dtest_k3s.Kubeconfig(ctx)})
 	require.NoError(t, err)
 	return cli
 }

--- a/pkg/kubeapply/resource_kubeapply_test.go
+++ b/pkg/kubeapply/resource_kubeapply_test.go
@@ -7,15 +7,18 @@ import (
 
 	"github.com/datawire/ambassador/pkg/dtest"
 	"github.com/datawire/ambassador/pkg/kubeapply"
+	"github.com/datawire/dlib/dlog"
 )
 
 func TestDocker(t *testing.T) {
+	ctx := dlog.NewTestContext(t, false)
+
 	if _, err := exec.LookPath("docker"); err != nil {
 		t.Skip(err)
 	}
 
 	if os.Getenv("DOCKER_REGISTRY") == "" {
-		os.Setenv("DOCKER_REGISTRY", dtest.DockerRegistry())
+		os.Setenv("DOCKER_REGISTRY", dtest.DockerRegistry(ctx))
 	}
 
 	_, err := kubeapply.ExpandResource("docker.yaml")


### PR DESCRIPTION
## Description

If something's going wrong, don't silently try to retry repeatedly until `go test` finally times out and panics. Detect errors! Log things!

And that error detecting and logging gets us to the real fix: Work with Linux kernels with newer cgroups.

v2:
- Rebased to be closer to master

## Testing

When I stick a `replace` line in the Telepresence `go.mod` to point to this, the tests once again work on my laptop.
## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `CHANGELOG.md`. - no applicable changes
   
   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations
 
 - [x] This is unlikely to impact how Ambassador performs at scale. - should only affect the tests
 
   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability
 
 - [x] My change is adequately tested. - no, but that's an existing problem with `dtest` being under-tested
 
   Remember when considering testing:
    + LEGACY MODE TESTS DO NOT RUN FOR EVERY PR. If your change is affected by legacy mode, you need
      to run legacy-mode tests manually (set `AMBASSADOR_LEGACY_MODE=true` and run the tests).
      (This will be fixed soon.)
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points
 
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently. - no tricks
