### PR TITLE
agent reports up-to-date endpoint info

### DIFF
--- a/charts/ambassador/templates/ambassador-agent.yaml
+++ b/charts/ambassador/templates/ambassador-agent.yaml
@@ -195,6 +195,29 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
+  name: {{ include "ambassador.fullname" . }}-agent-endpoints
+  labels:
+    rbac.getambassador.io/role-group: {{ include "ambassador.rbacName" . }}-agent
+    {{- if ne .Values.deploymentTool "getambassador.io" }}
+    app.kubernetes.io/name: {{ include "ambassador.name" . }}-agent
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+    helm.sh/chart: {{ include "ambassador.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- if .Values.deploymentTool }}
+    app.kubernetes.io/managed-by: {{ .Values.deploymentTool }}
+    {{- else }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- end }}
+    {{- end }}
+    product: aes
+rules:
+- apiGroups: [""]
+  resources: [ "endpoints" ]
+  verbs: [ "get", "list", "watch" ]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
   name: {{ include "ambassador.fullname" . }}-agent-configmaps
   labels:
     rbac.getambassador.io/role-group: {{ include "ambassador.rbacName" . }}-agent

--- a/pkg/agent/agent_internal_test.go
+++ b/pkg/agent/agent_internal_test.go
@@ -825,6 +825,59 @@ func TestWatchWithSnapshot(t *testing.T) {
 	watchDone := make(chan error)
 	podAcc := &mockAccumulator{
 		changedChan: make(chan struct{}),
+		targetInterface: CoreSnapshot{
+			Pods: []*kates.Pod{
+				{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Pod",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "some-pod",
+						Namespace: "default",
+					},
+					Status: v1.PodStatus{
+						Phase: v1.PodRunning,
+					},
+				},
+			},
+			Endpoints: []*kates.Endpoints{
+				{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Endpoints",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "some-endpoint",
+						Namespace: "default",
+					},
+				},
+			},
+			Deployments: []*kates.Deployment{
+				{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Deployment",
+						APIVersion: "apps/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "some-deployment",
+						Namespace: "default",
+					},
+				},
+			},
+			ConfigMaps: []*kates.ConfigMap{
+				{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ConfigMap",
+						APIVersion: "",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "some-config-map",
+						Namespace: "default",
+					},
+				},
+			},
+		},
 	}
 	configAcc := &mockAccumulator{
 		changedChan: make(chan struct{}),
@@ -844,6 +897,7 @@ func TestWatchWithSnapshot(t *testing.T) {
 	// returning static content
 	reportsSent := 0
 	for reportsSent < 2 {
+		podAcc.changedChan <- struct{}{}
 		select {
 		case err := <-a.reportComplete:
 			assert.Nil(t, err)
@@ -877,7 +931,7 @@ func TestWatchWithSnapshot(t *testing.T) {
 	assert.Equal(t, md[0], apiKey)
 
 	/////// Make sure the raw snapshot that got sent looks like we expect
-	sentSnapshot := sentSnaps[0]
+	sentSnapshot := sentSnaps[1]
 	var actualSnapshot snapshotTypes.Snapshot
 	err = json.Unmarshal(sentSnapshot.RawSnapshot, &actualSnapshot)
 	assert.Nil(t, err)
@@ -905,6 +959,12 @@ func TestWatchWithSnapshot(t *testing.T) {
 	secretData := actualSnapshot.Kubernetes.Secrets[0].Data
 	assert.NotEqual(t, []byte("d293YXNlY3JldA=="), secretData["data1"])
 	assert.NotEqual(t, []byte("d293YW5vdGhlcm9uZQ=="), secretData["data2"])
+
+	// check that the other resources we watch make it into the snapshot
+	assert.Equal(t, len(actualSnapshot.Kubernetes.Endpoints), 1)
+	assert.Equal(t, len(actualSnapshot.Kubernetes.Pods), 1)
+	assert.Equal(t, len(actualSnapshot.Kubernetes.ConfigMaps), 1)
+	assert.Equal(t, len(actualSnapshot.Kubernetes.Deployments), 1)
 
 	/////// Make sure that the timestamp we sent makes sense
 	assert.NotNil(t, sentSnapshot.SnapshotTs)


### PR DESCRIPTION
## Description
The snapshot coming from ambassador doesn't always have up to date info on the endpoints because if _only_ endpoints change, it doesn't update the cached snapshot.
Instead of making a scary and potentially harmful change to the watcher, we can just watch the endpoints in the agent.

Also, in order to not needlessly spam the API server when we don't even have an api key to use to send the snapshot, I added an initial wait until we actually have a key before starting the expensive watches.

## Related Issues
List related issues.

## Testing
A few sentences describing what testing you've done, e.g., manual tests, automated tests, deployed in production, etc.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `CHANGELOG.md`.
   
   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations
 
 - [ ] This is unlikely to impact how Ambassador performs at scale.
 
   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability
 
 - [ ] My change is adequately tested.
 
   Remember when considering testing:
    + LEGACY MODE TESTS DO NOT RUN FOR EVERY PR. If your change is affected by legacy mode, you need
      to run legacy-mode tests manually (set `AMBASSADOR_LEGACY_MODE=true` and run the tests).
      (This will be fixed soon.)
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points
 
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
