### PR TITLE
[v1.13.7] Changelog date update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 ## RELEASE NOTES
 
-## [1.13.7] (TBD)
+## [1.13.7] June 03, 2021
 [1.13.7]: https://github.com/datawire/ambassador/compare/v1.13.6...v1.13.7
 
 ### Emissary Ingress and Ambassador Edge Stack


### PR DESCRIPTION
Changelog date updates for 1.13.7

Reviewers: The only changes in this PR should be updating the changelog entry for 1.13.7 to the date it was released.

If there are any other changes, the PR creator should note the reason.