### PR TITLE
reorder config application

### DIFF
--- a/python/ambassador/ir/ir.py
+++ b/python/ambassador/ir/ir.py
@@ -267,15 +267,15 @@ class IR:
         self.ratelimit = typecast(IRRateLimit, self.save_resource(IRRateLimit(self, aconf)))
         IRLogServiceFactory.load_all(self, aconf)
 
-        # After the Ambassador and TLS modules are done, we need to set up the
-        # filter chains. Note that order of the filters matters. Start with auth,
-        # since it needs to be able to override everything...
-        self.save_filter(IRAuth(self, aconf))
-
         # ...then deal with the non-configurable cors filter...
         self.save_filter(IRFilter(ir=self, aconf=aconf,
                                   rkey="ir.cors", kind="ir.cors", name="cors",
                                   config={}))
+
+        # After the Ambassador and TLS modules are done, we need to set up the
+        # filter chains. Note that order of the filters matters. Start with auth,
+        # since it needs to be able to override everything...
+        self.save_filter(IRAuth(self, aconf))
 
         # ...then the ratelimit filter...
         if self.ratelimit:


### PR DESCRIPTION
## Description
Because of current order of filters:
```
http_filters : [ext_auth, envoy.filters.http.cors, envoy.filters.http.router]
```
when ext_auth returns 4xx (or it fails because of whatever other reasons) the cors handler is not called and no cors headers are injected (for example access-control-allow-origin) - because of that browser is not able to handle such response gently.  
I first tested if reordering of these filters will help, using plain envoy, and following configuration gave me expected result - cors where injected even if ext-auth returned 4xx (it makes sense because cors is handled first)

```yaml
http_filters:
  - name: envoy.filters.http.cors
  - name: envoy.filters.http.ext_authz
    typed_config:
      "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
      http_service:
          server_uri:
            uri: 172.17.0.2:8080
            cluster: ext-authz
            timeout: 2.25s
  - name: envoy.filters.http.router
```
then I tried do the same with Ambassador Intermediate Representation - and It also works.

## Testing
Tested on stage env (kubernetes).

## Checklist
I am not filling this section yet.
