### PR TITLE
Mapping.spec.hostname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 - Bugfix: `requestPolicy.insecure.action` works independently across `Host`s ([#2888])
 - Bugfix: Fixed a regression in detecting the Ambassador Kubernetes service that could cause the wrong IP or hostname to be used in Ingress statuses.
 - Change: `Host`s and `Mapping`s will not be associated unless a `Host` selector or a `Mapping`'s `host` element explicitly agree.
+- Change: `Mapping`'s `host` field is either an exact match or (with `host_regex` set) a regex. `Mapping` now has a new `hostname` element that is functionally the same as `host`, but is always a DNS glob.
 - Change: The `tls` field on the Ambassador module is now deprecated. Please use TLSContexts instead https://www.getambassador.io/docs/edge-stack/latest/topics/running/tls/#tlscontext.
 - Change: Envoy V3 is now the default.
 - Change: The `Host` CRD is now required when terminating TLS.

--- a/charts/emissary-ingress/crds/getambassador.io_mappings.yaml
+++ b/charts/emissary-ingress/crds/getambassador.io_mappings.yaml
@@ -208,12 +208,16 @@ spec:
                 - type: boolean
               type: object
             host:
+              description: "Exact match for the hostname of a request if HostRegex is false; regex match for the hostname if HostRegex is true. \n Host specifies both a match for the ':authority' header of a request, as well as a match criterion for Host CRDs: a Mapping that specifies Host will not associate with a Host that doesn't have a matching Hostname. \n If both Host and Hostname are set, an error is logged, Host is ignored, and Hostname is used."
               type: string
             host_redirect:
               type: boolean
             host_regex:
               type: boolean
             host_rewrite:
+              type: string
+            hostname:
+              description: "Glob match for the hostname of a request. Ignores HostRegex. \n Hostname specifies both a match for the ':authority' header of a request, as well as a match criterion for Host CRDs: a Mapping that specifies Hostname will not associate with a Host that doesn't have a matching Hostname. \n If both Host and Hostname are set, an error is logged, Host is ignored, and Hostname is used."
               type: string
             idle_timeout_ms:
               type: integer

--- a/cmd/entrypoint/testdata/hostsem-cleartextonly.yaml
+++ b/cmd/entrypoint/testdata/hostsem-cleartextonly.yaml
@@ -44,7 +44,7 @@ kind: Mapping
 metadata:
   name: qotm-mapping
 spec:
-  host: "*"
+  hostname: "*"
   prefix: /quote/
   service: quote.ambassador
 ---

--- a/manifests/emissary/ambassador-crds.yaml
+++ b/manifests/emissary/ambassador-crds.yaml
@@ -1045,12 +1045,16 @@ spec:
                 - type: boolean
               type: object
             host:
+              description: "Exact match for the hostname of a request if HostRegex is false; regex match for the hostname if HostRegex is true. \n Host specifies both a match for the ':authority' header of a request, as well as a match criterion for Host CRDs: a Mapping that specifies Host will not associate with a Host that doesn't have a matching Hostname. \n If both Host and Hostname are set, an error is logged, Host is ignored, and Hostname is used."
               type: string
             host_redirect:
               type: boolean
             host_regex:
               type: boolean
             host_rewrite:
+              type: string
+            hostname:
+              description: "Glob match for the hostname of a request. Ignores HostRegex. \n Hostname specifies both a match for the ':authority' header of a request, as well as a match criterion for Host CRDs: a Mapping that specifies Hostname will not associate with a Host that doesn't have a matching Hostname. \n If both Host and Hostname are set, an error is logged, Host is ignored, and Hostname is used."
               type: string
             idle_timeout_ms:
               type: integer

--- a/manifests/emissary/emissary-crds.yaml
+++ b/manifests/emissary/emissary-crds.yaml
@@ -1045,12 +1045,16 @@ spec:
                 - type: boolean
               type: object
             host:
+              description: "Exact match for the hostname of a request if HostRegex is false; regex match for the hostname if HostRegex is true. \n Host specifies both a match for the ':authority' header of a request, as well as a match criterion for Host CRDs: a Mapping that specifies Host will not associate with a Host that doesn't have a matching Hostname. \n If both Host and Hostname are set, an error is logged, Host is ignored, and Hostname is used."
               type: string
             host_redirect:
               type: boolean
             host_regex:
               type: boolean
             host_rewrite:
+              type: string
+            hostname:
+              description: "Glob match for the hostname of a request. Ignores HostRegex. \n Hostname specifies both a match for the ':authority' header of a request, as well as a match criterion for Host CRDs: a Mapping that specifies Hostname will not associate with a Host that doesn't have a matching Hostname. \n If both Host and Hostname are set, an error is logged, Host is ignored, and Hostname is used."
               type: string
             idle_timeout_ms:
               type: integer

--- a/pkg/api/getambassador.io/v2/mapping_types.go
+++ b/pkg/api/getambassador.io/v2/mapping_types.go
@@ -117,15 +117,33 @@ type MappingSpec struct {
 	// +kubebuilder:validation:MinItems=1
 	ErrorResponseOverrides []ErrorResponseOverride `json:"error_response_overrides,omitempty"`
 	Modules                []UntypedDict           `json:"modules,omitempty"`
-	Host                   string                  `json:"host,omitempty"`
-	HostRegex              *bool                   `json:"host_regex,omitempty"`
-	Headers                map[string]BoolOrString `json:"headers,omitempty"`
-	RegexHeaders           map[string]BoolOrString `json:"regex_headers,omitempty"`
-	Labels                 DomainMap               `json:"labels,omitempty"`
-	EnvoyOverride          *UntypedDict            `json:"envoy_override,omitempty"`
-	LoadBalancer           *LoadBalancer           `json:"load_balancer,omitempty"`
-	QueryParameters        map[string]BoolOrString `json:"query_parameters,omitempty"`
-	RegexQueryParameters   map[string]BoolOrString `json:"regex_query_parameters,omitempty"`
+	// Exact match for the hostname of a request if HostRegex is false; regex match for the
+	// hostname if HostRegex is true.
+	//
+	// Host specifies both a match for the ':authority' header of a request, as well as a match
+	// criterion for Host CRDs: a Mapping that specifies Host will not associate with a Host that
+	// doesn't have a matching Hostname.
+	//
+	// If both Host and Hostname are set, an error is logged, Host is ignored, and Hostname is
+	// used.
+	Host      string `json:"host,omitempty"`
+	HostRegex *bool  `json:"host_regex,omitempty"`
+	// Glob match for the hostname of a request. Ignores HostRegex.
+	//
+	// Hostname specifies both a match for the ':authority' header of a request, as well as a
+	// match criterion for Host CRDs: a Mapping that specifies Hostname will not associate with
+	// a Host that doesn't have a matching Hostname.
+	//
+	// If both Host and Hostname are set, an error is logged, Host is ignored, and Hostname is
+	// used.
+	Hostname             string                  `json:"hostname,omitempty"`
+	Headers              map[string]BoolOrString `json:"headers,omitempty"`
+	RegexHeaders         map[string]BoolOrString `json:"regex_headers,omitempty"`
+	Labels               DomainMap               `json:"labels,omitempty"`
+	EnvoyOverride        *UntypedDict            `json:"envoy_override,omitempty"`
+	LoadBalancer         *LoadBalancer           `json:"load_balancer,omitempty"`
+	QueryParameters      map[string]BoolOrString `json:"query_parameters,omitempty"`
+	RegexQueryParameters map[string]BoolOrString `json:"regex_query_parameters,omitempty"`
 }
 
 // DocsInfo provides some extra information about the docs for the Mapping

--- a/python/ambassador/fetch/ingress.py
+++ b/python/ambassador/fetch/ingress.py
@@ -1,4 +1,4 @@
-from typing import ClassVar, FrozenSet
+from typing import ClassVar, FrozenSet, Optional
 
 from ..config import Config
 
@@ -118,8 +118,16 @@ class IngressProcessor (ManagedKubernetesProcessor):
         self.logger.debug(f"Handling Ingress {obj.name}...")
         self.aconf.incr_count('k8s_ingress')
 
+        # We'll generate an ingress_id to match up this Ingress with its Mappings, but
+        # only if this Ingress defines a Host. If no Host is defined, ingress_id will stay
+        # None.
+        ingress_id: Optional[str] = None
+
         ingress_tls = obj.spec.get('tls', [])
         for tls_count, tls in enumerate(ingress_tls):
+            # Use the name and namespace to make a unique ID for this Ingress. We'll use
+            # this for matching up this Ingress with its Mappings.
+            ingress_id = f"a10r-ingress-{obj.name}-{obj.namespace}"
 
             tls_secret = tls.get('secretName', None)
             if tls_secret is not None:
@@ -135,6 +143,11 @@ class IngressProcessor (ManagedKubernetesProcessor):
                         },
                         'tlsSecret': {
                             'name': tls_secret
+                        },
+                        'selector': {
+                            'matchLabels': {
+                                'a10r-k8s-ingress': ingress_id
+                            }
                         },
                         'requestPolicy': {
                             'insecure': {
@@ -162,11 +175,16 @@ class IngressProcessor (ManagedKubernetesProcessor):
         if db_service_name is not None and db_service_port is not None:
             db_mapping_identifier = f"{obj.name}-default-backend"
 
+            mapping_labels = dict(obj.labels)
+
+            if ingress_id:
+                mapping_labels["a10r-k8s-ingress"] = ingress_id
+
             default_backend_mapping = NormalizedResource.from_data(
                 'Mapping',
                 db_mapping_identifier,
                 namespace=obj.namespace,
-                labels=obj.labels,
+                labels=mapping_labels,
                 spec={
                     'ambassador_id': obj.ambassador_id,
                     'prefix': '/',
@@ -221,13 +239,24 @@ class IngressProcessor (ManagedKubernetesProcessor):
                             .replace('*', '^[a-z0-9]([-a-z0-9]*[a-z0-9])?', 1) + '$'
                         spec['host_regex'] = True
                     else:
-                        spec['host'] = rule_host
+                        # Use hostname since this can be a hostname of "*" too.
+                        spec['hostname'] = rule_host
+                else:
+                    # If there's no rule_host, and we don't have an ingress_id, force a hostname
+                    # of "*" so that the Mapping we generate doesn't get dropped.
+                    if not ingress_id:
+                        spec['hostname'] = "*"
+                
+                mapping_labels = dict(obj.labels)
+
+                if ingress_id:
+                    mapping_labels["a10r-k8s-ingress"] = ingress_id
 
                 path_mapping = NormalizedResource.from_data(
                     'Mapping',
                     mapping_identifier,
                     namespace=obj.namespace,
-                    labels=obj.labels,
+                    labels=mapping_labels,
                     spec=spec,
                 )
 

--- a/python/ambassador/ir/irambassador.py
+++ b/python/ambassador/ir/irambassador.py
@@ -410,7 +410,7 @@ class IRAmbassador (IRResource):
                 name = "internal_%s_probe_mapping" % name
 
                 mapping = IRHTTPMapping(ir, aconf, rkey=self.rkey, name=name, location=self.location,
-                                        timeout_ms=10000, host="*", **cur)
+                                        timeout_ms=10000, hostname="*", **cur)
                 mapping.referenced_by(self)
                 ir.add_mapping(aconf, mapping)
 
@@ -426,7 +426,7 @@ class IRAmbassador (IRResource):
                                         service="127.0.0.1:8500",
                                         precedence=1000000,
                                         timeout_ms=60000,
-                                        host="*",
+                                        hostname="*",
                                         add_response_headers=edge_stack_response_header)
                 mapping.referenced_by(self)
                 ir.add_mapping(aconf, mapping)
@@ -439,7 +439,7 @@ class IRAmbassador (IRResource):
                                         service="127.0.0.1:8500",
                                         precedence=-1000000,
                                         timeout_ms=60000,
-                                        host="*",
+                                        hostname="*",
                                         add_response_headers=edge_stack_response_header)
                 mapping.referenced_by(self)
                 ir.add_mapping(aconf, mapping)

--- a/python/ambassador/ir/irbasemapping.py
+++ b/python/ambassador/ir/irbasemapping.py
@@ -77,7 +77,7 @@ def normalize_service_name(ir: 'IR', in_service: str, mapping_namespace: Optiona
 
 class IRBaseMapping (IRResource):
     group_id: str
-    host: str
+    host: Optional[str]
     route_weight: List[Union[str, int]]
     cached_status: Optional[Dict[str, str]]
     status_update: Optional[Dict[str, str]]

--- a/python/ambassador/ir/irhost.py
+++ b/python/ambassador/ir/irhost.py
@@ -356,11 +356,18 @@ class IRHost(IRResource):
         host_match = False
         sel_match = False
 
-        group_glob = group.get('host') or None
+        group_regex = group.get('host_regex') or False
 
-        if group_glob:
-            host_match = hostglob_matches(self.hostname, group_glob)
-            self.logger.info("-- hostname %s group glob %s => %s", self.hostname, group_glob, host_match)
+        if group_regex:
+            # It matches.
+            host_match = True
+            self.logger.info("-- hostname %s group regex => %s", self.hostname, host_match)
+        else:
+            group_glob = group.get('host') or None
+
+            if group_glob:
+                host_match = hostglob_matches(self.hostname, group_glob)
+                self.logger.info("-- hostname %s group glob %s => %s", self.hostname, group_glob, host_match)
 
         selector = self.get('selector')
 

--- a/python/schemas/v0/Mapping.schema
+++ b/python/schemas/v0/Mapping.schema
@@ -85,6 +85,7 @@
         },
         "host": { "type": "string" },
         "host_regex": { "type": "boolean" },
+        "hostname": { "type": "string" },
         "headers": { "$ref": "#/definitions/mapStrStr" },
         "regex_headers": { "$ref": "#/definitions/mapStrStr" },
         "rate_limits": {

--- a/python/schemas/v1/Mapping.schema
+++ b/python/schemas/v1/Mapping.schema
@@ -146,6 +146,7 @@
         },
         "host": { "type": "string" },
         "host_regex": { "type": "boolean" },
+        "hostname": { "type": "string" },
         "headers": { "$ref": "#/definitions/mapStrStr" },
         "regex_headers": { "$ref": "#/definitions/mapStrStr" },
         "labels": {

--- a/python/schemas/v2/Mapping.schema
+++ b/python/schemas/v2/Mapping.schema
@@ -202,6 +202,7 @@
         },
         "host": { "type": "string" },
         "host_regex": { "type": "boolean" },
+        "hostname": { "type": "string" },
         "headers": { "$ref": "#/definitions/mapStrStr" },
         "regex_headers": { "$ref": "#/definitions/mapStrStr" },
         "labels": {

--- a/python/tests/gold/plain/snapshots/econf.json
+++ b/python/tests/gold/plain/snapshots/econf.json
@@ -4264,6 +4264,94 @@
                           },
                           {
                             "match": {
+                              "case_sensitive": true,
+                              "headers": [
+                                {
+                                  "exact_match": "https",
+                                  "name": "x-forwarded-proto"
+                                }
+                              ],
+                              "prefix": "/SimpleIngressWithAnnotations-HTTP/",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                },
+                                "runtime_key": "routing.traffic_shift.cluster_plain_simpleingresswithannotatio-1"
+                              }
+                            },
+                            "route": {
+                              "cluster": "cluster_plain_simpleingresswithannotatio-1",
+                              "prefix_rewrite": "/",
+                              "priority": null,
+                              "timeout": "3.000s"
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "prefix": "/SimpleIngressWithAnnotations-HTTP/",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                },
+                                "runtime_key": "routing.traffic_shift.cluster_plain_simpleingresswithannotatio-1"
+                              }
+                            },
+                            "route": {
+                              "cluster": "cluster_plain_simpleingresswithannotatio-1",
+                              "prefix_rewrite": "/",
+                              "priority": null,
+                              "timeout": "3.000s"
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "headers": [
+                                {
+                                  "exact_match": "https",
+                                  "name": "x-forwarded-proto"
+                                }
+                              ],
+                              "prefix": "/SimpleIngressWithAnnotations-GRPC/",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                },
+                                "runtime_key": "routing.traffic_shift.cluster_plain_simpleingresswithannotatio-0"
+                              }
+                            },
+                            "route": {
+                              "cluster": "cluster_plain_simpleingresswithannotatio-0",
+                              "prefix_rewrite": "/",
+                              "priority": null,
+                              "timeout": "3.000s"
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "prefix": "/SimpleIngressWithAnnotations-GRPC/",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                },
+                                "runtime_key": "routing.traffic_shift.cluster_plain_simpleingresswithannotatio-0"
+                              }
+                            },
+                            "route": {
+                              "cluster": "cluster_plain_simpleingresswithannotatio-0",
+                              "prefix_rewrite": "/",
+                              "priority": null,
+                              "timeout": "3.000s"
+                            }
+                          },
+                          {
+                            "match": {
                               "case_sensitive": false,
                               "headers": [
                                 {
@@ -5321,6 +5409,94 @@
                             ],
                             "route": {
                               "cluster": "cluster_httpbin_default_plain_namespace",
+                              "prefix_rewrite": "/",
+                              "priority": null,
+                              "timeout": "3.000s"
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "headers": [
+                                {
+                                  "exact_match": "https",
+                                  "name": "x-forwarded-proto"
+                                }
+                              ],
+                              "prefix": "/SimpleMappingIngress-HTTP/",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                },
+                                "runtime_key": "routing.traffic_shift.cluster_plain_simplemappingingress_http_-0"
+                              }
+                            },
+                            "route": {
+                              "cluster": "cluster_plain_simplemappingingress_http_-0",
+                              "prefix_rewrite": "/",
+                              "priority": null,
+                              "timeout": "3.000s"
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "prefix": "/SimpleMappingIngress-HTTP/",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                },
+                                "runtime_key": "routing.traffic_shift.cluster_plain_simplemappingingress_http_-0"
+                              }
+                            },
+                            "route": {
+                              "cluster": "cluster_plain_simplemappingingress_http_-0",
+                              "prefix_rewrite": "/",
+                              "priority": null,
+                              "timeout": "3.000s"
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "headers": [
+                                {
+                                  "exact_match": "https",
+                                  "name": "x-forwarded-proto"
+                                }
+                              ],
+                              "prefix": "/SimpleMappingIngress-GRPC/",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                },
+                                "runtime_key": "routing.traffic_shift.cluster_plain_simplemappingingress_grpc_-0"
+                              }
+                            },
+                            "route": {
+                              "cluster": "cluster_plain_simplemappingingress_grpc_-0",
+                              "prefix_rewrite": "/",
+                              "priority": null,
+                              "timeout": "3.000s"
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "prefix": "/SimpleMappingIngress-GRPC/",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                },
+                                "runtime_key": "routing.traffic_shift.cluster_plain_simplemappingingress_grpc_-0"
+                              }
+                            },
+                            "route": {
+                              "cluster": "cluster_plain_simplemappingingress_grpc_-0",
                               "prefix_rewrite": "/",
                               "priority": null,
                               "timeout": "3.000s"

--- a/python/tests/integration/test_header_case_overrides.py
+++ b/python/tests/integration/test_header_case_overrides.py
@@ -71,7 +71,7 @@ metadata:
   name:  headerecho-mapping
   namespace: {namespace}
 spec:
-  host: "*"
+  hostname: "*"
   prefix: /headerecho/
   rewrite: /
   service: headerecho
@@ -120,7 +120,7 @@ apiVersion: getambassador.io/v2
 kind: Mapping
 name: httpbin-mapping
 service: httpbin
-host: "*"
+hostname: "*"
 prefix: /httpbin/
 '''
 

--- a/python/tests/integration/test_watt_scaling.py
+++ b/python/tests/integration/test_watt_scaling.py
@@ -37,7 +37,7 @@ metadata:
   name:  qotm-mapping
   namespace: {namespace}
 spec:
-  host: "*"
+  hostname: "*"
   prefix: /qotm/
   service: qotm.{namespace}
   resolver: qotm-resolver
@@ -56,7 +56,7 @@ metadata:
   name:  qotm-mapping
   namespace: {namespace}
 spec:
-  host: "*"
+  hostname: "*"
   prefix: /qotm/
   service: qotm.{namespace}
   resolver: qotm-resolver

--- a/python/tests/kat/t_basics.py
+++ b/python/tests/kat/t_basics.py
@@ -72,7 +72,7 @@ config:
 apiVersion: ambassador/v0
 kind:  Mapping
 name:  {self.path.k8s}-{prefix}
-host: "*"
+hostname: "*"
 prefix: /{prefix}/
 service: {self.target.path.fqdn}
 ambassador_id: {amb_id}
@@ -108,7 +108,7 @@ metadata:
   name:  {self.path.k8s}-m-good-<<WHICH>>
 spec:
   ambassador_id: ["{self.ambassador_id}"]
-  host: "*"
+  hostname: "*"
   prefix: /good-<<WHICH>>/
   service: {self.target.path.fqdn}
 """, """
@@ -118,7 +118,7 @@ metadata:
   name:  {self.path.k8s}-m-bad-<<WHICH>>
 spec:
   ambassador_id: ["{self.ambassador_id}"]
-  host: "*"
+  hostname: "*"
   prefix_bad: /bad-<<WHICH>>/
   service: {self.target.path.fqdn}
 """, """
@@ -269,7 +269,7 @@ config:
 apiVersion: ambassador/v0
 kind:  Mapping
 name:  {self.path.k8s}/server-name
-host: "*"
+hostname: "*"
 prefix: /server-name
 service: {self.target.path.fqdn}
 """)

--- a/python/tests/kat/t_circuitbreaker.py
+++ b/python/tests/kat/t_circuitbreaker.py
@@ -95,7 +95,7 @@ spec:
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.target.path.k8s}-pr
-host: "*"
+hostname: "*"
 prefix: /{self.name}-pr/
 service: {self.target.path.fqdn}
 circuit_breakers:
@@ -107,7 +107,7 @@ apiVersion: ambassador/v1
 kind: Mapping
 name: {self.name}-reset
 case_sensitive: false
-host: "*"
+hostname: "*"
 prefix: /reset/
 rewrite: /RESET/
 service: cbstatsd-sink
@@ -116,7 +116,7 @@ apiVersion: ambassador/v1
 kind: Mapping
 name: {self.name}-dump
 case_sensitive: false
-host: "*"
+hostname: "*"
 prefix: /dump/
 rewrite: /DUMP/
 service: cbstatsd-sink
@@ -219,7 +219,7 @@ requestPolicy:
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.target.path.k8s}-pr
-host: "*"
+hostname: "*"
 prefix: /{self.name}-pr/
 service: {self.target.path.fqdn}
 circuit_breakers:
@@ -230,7 +230,7 @@ circuit_breakers:
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.target.path.k8s}-normal
-host: "*"
+hostname: "*"
 prefix: /{self.name}-normal/
 service: {self.target.path.fqdn}
 ---

--- a/python/tests/kat/t_cluster_tag.py
+++ b/python/tests/kat/t_cluster_tag.py
@@ -18,7 +18,7 @@ metadata:
   name: cluster-tag-1
 spec:
   ambassador_id: {self.ambassador_id}
-  host: "*"
+  hostname: "*"
   prefix: /mapping-1/
   service: {self.target_1.path.fqdn}
 ---
@@ -28,7 +28,7 @@ metadata:
   name: cluster-tag-2
 spec:
   ambassador_id: {self.ambassador_id}
-  host: "*"
+  hostname: "*"
   prefix: /mapping-2/
   service: {self.target_1.path.fqdn}
   cluster_tag: tag-1
@@ -39,7 +39,7 @@ metadata:
   name: cluster-tag-3
 spec:
   ambassador_id: {self.ambassador_id}
-  host: "*"
+  hostname: "*"
   prefix: /mapping-3/
   service: {self.target_1.path.fqdn}
   cluster_tag: tag-2
@@ -50,7 +50,7 @@ metadata:
   name: cluster-tag-4
 spec:
   ambassador_id: {self.ambassador_id}
-  host: "*"
+  hostname: "*"
   prefix: /mapping-4/
   service: {self.target_2.path.fqdn}
   cluster_tag: tag-2
@@ -61,7 +61,7 @@ metadata:
   name: cluster-tag-5
 spec:
   ambassador_id: {self.ambassador_id}
-  host: "*"
+  hostname: "*"
   prefix: /mapping-5/
   service: {self.target_1.path.fqdn}
   cluster_tag: some-really-long-tag-that-is-really-long
@@ -72,7 +72,7 @@ metadata:
   name: cluster-tag-6
 spec:
   ambassador_id: {self.ambassador_id}
-  host: "*"
+  hostname: "*"
   prefix: /mapping-6/
   service: {self.target_2.path.fqdn}
   cluster_tag: some-really-long-tag-that-is-really-long

--- a/python/tests/kat/t_consul.py
+++ b/python/tests/kat/t_consul.py
@@ -102,7 +102,7 @@ metadata:
   namespace: consul-test-namespace
 spec:
   ambassador_id: [consultest]
-  host: "*"
+  hostname: "*"
   prefix: /{self.path.k8s}_consul_ns/
   service: {self.path.k8s}-consul-ns-service
   resolver: {self.path.k8s}-resolver
@@ -116,14 +116,14 @@ spec:
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.path.k8s}_k8s_mapping
-host: "*"
+hostname: "*"
 prefix: /{self.path.k8s}_k8s/
 service: {self.k8s_target.path.k8s}
 ---
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.path.k8s}_consul_mapping
-host: "*"
+hostname: "*"
 prefix: /{self.path.k8s}_consul/
 service: {self.path.k8s}-consul-service
 # tls: {self.path.k8s}-client-context # this doesn't seem to work... ambassador complains with "no private key in secret ..."
@@ -134,7 +134,7 @@ load_balancer:
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.path.k8s}_consul_node_mapping
-host: "*"
+hostname: "*"
 prefix: /{self.path.k8s}_consul_node/ # this is testing that Ambassador correctly falls back to the `Address` if `Service.Address` does not exist
 service: {self.path.k8s}-consul-node
 # tls: {self.path.k8s}-client-context # this doesn't seem to work... ambassador complains with "no private key in secret ..."

--- a/python/tests/kat/t_cors.py
+++ b/python/tests/kat/t_cors.py
@@ -25,14 +25,14 @@ config:
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.target.path.k8s}-foo
-host: "*"
+hostname: "*"
 prefix: /foo/
 service: {self.target.path.fqdn}
 ---
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.target.path.k8s}-bar
-host: "*"
+hostname: "*"
 prefix: /bar/
 service: {self.target.path.fqdn}
 cors:

--- a/python/tests/kat/t_error_response.py
+++ b/python/tests/kat/t_error_response.py
@@ -49,7 +49,7 @@ apiVersion: ambassador/v2
 kind:  Mapping
 name:  {self.target.path.k8s}
 ambassador_id: ["{self.ambassador_id}"]
-host: "*"
+hostname: "*"
 prefix: /target/
 service: {self.target.path.fqdn}
 ---
@@ -57,7 +57,7 @@ apiVersion: ambassador/v2
 kind:  Mapping
 name:  {self.target.path.k8s}-invalidservice
 ambassador_id: ["{self.ambassador_id}"]
-host: "*"
+hostname: "*"
 prefix: /target/invalidservice
 service: {self.target.path.fqdn}-invalidservice
 ---
@@ -65,7 +65,7 @@ apiVersion: ambassador/v2
 kind:  Mapping
 name:  {self.target.path.k8s}-invalidservice-empty
 ambassador_id: ["{self.ambassador_id}"]
-host: "*"
+hostname: "*"
 prefix: /target/invalidservice/empty
 service: {self.target.path.fqdn}-invalidservice-empty
 error_response_overrides:
@@ -167,7 +167,7 @@ metadata:
   name:  {self.target.path.k8s}-crd
 spec:
   ambassador_id: ["{self.ambassador_id}"]
-  host: "*"
+  hostname: "*"
   prefix: /target/
   service: {self.target.path.fqdn}
   error_response_overrides:
@@ -203,7 +203,7 @@ metadata:
   name: {self.target.path.k8s}-invalidservice-crd
 spec:
   ambassador_id: ["{self.ambassador_id}"]
-  host: "*"
+  hostname: "*"
   prefix: /target/invalidservice
   service: {self.target.path.fqdn}-invalidservice
 ---
@@ -213,7 +213,7 @@ metadata:
   name: {self.target.path.k8s}-invalidservice-override-crd
 spec:
   ambassador_id: ["{self.ambassador_id}"]
-  host: "*"
+  hostname: "*"
   prefix: /target/invalidservice/override
   service: {self.target.path.fqdn}-invalidservice
   error_response_overrides:
@@ -339,7 +339,7 @@ apiVersion: ambassador/v2
 kind:  Mapping
 name:  {self.target.path.k8s}
 ambassador_id: ["{self.ambassador_id}"]
-host: "*"
+hostname: "*"
 prefix: /target/
 service: {self.target.path.fqdn}
 '''
@@ -410,7 +410,7 @@ apiVersion: ambassador/v2
 kind:  Mapping
 name:  {self.target.path.k8s}
 ambassador_id: ["{self.ambassador_id}"]
-host: "*"
+hostname: "*"
 prefix: /target/
 service: {self.target.path.fqdn}
 '''
@@ -477,7 +477,7 @@ apiVersion: ambassador/v2
 kind:  Mapping
 name:  {self.target.path.k8s}
 ambassador_id: ["{self.ambassador_id}"]
-host: "*"
+hostname: "*"
 prefix: /target/
 service: {self.target.path.fqdn}
 '''
@@ -544,7 +544,7 @@ kind:  Mapping
 name:  {self.target.path.k8s}
 ambassador_id: ["{self.ambassador_id}"]
 ambassador_id: {self.ambassador_id}
-host: "*"
+hostname: "*"
 prefix: /target/
 service: {self.target.path.fqdn}
 ---
@@ -552,7 +552,7 @@ apiVersion: ambassador/v2
 kind:  Mapping
 name:  {self.target.path.k8s}-invalidservice
 ambassador_id: ["{self.ambassador_id}"]
-host: "*"
+hostname: "*"
 prefix: /target/invalidservice
 service: {self.target.path.fqdn}-invalidservice
 ---
@@ -560,7 +560,7 @@ apiVersion: ambassador/v2
 kind:  Mapping
 name:  {self.target.path.k8s}-bypass
 ambassador_id: ["{self.ambassador_id}"]
-host: "*"
+hostname: "*"
 prefix: /bypass/
 service: {self.target.path.fqdn}
 bypass_error_response_overrides: true
@@ -569,7 +569,7 @@ apiVersion: ambassador/v2
 kind:  Mapping
 name:  {self.target.path.k8s}-target-bypass
 ambassador_id: ["{self.ambassador_id}"]
-host: "*"
+hostname: "*"
 prefix: /target/bypass/
 service: {self.target.path.fqdn}
 bypass_error_response_overrides: true
@@ -578,7 +578,7 @@ apiVersion: ambassador/v2
 kind:  Mapping
 name:  {self.target.path.k8s}-bypass-invalidservice
 ambassador_id: ["{self.ambassador_id}"]
-host: "*"
+hostname: "*"
 prefix: /bypass/invalidservice
 service: {self.target.path.fqdn}-invalidservice
 bypass_error_response_overrides: true
@@ -679,7 +679,7 @@ apiVersion: ambassador/v2
 kind:  Mapping
 name:  {self.target.path.k8s}
 ambassador_id: ["{self.ambassador_id}"]
-host: "*"
+hostname: "*"
 prefix: /target/
 service: {self.target.path.fqdn}
 ---
@@ -687,7 +687,7 @@ apiVersion: ambassador/v2
 kind:  Mapping
 name:  {self.target.path.k8s}-invalidservice
 ambassador_id: ["{self.ambassador_id}"]
-host: "*"
+hostname: "*"
 prefix: /target/invalidservice
 service: {self.target.path.fqdn}-invalidservice
 ---
@@ -695,7 +695,7 @@ apiVersion: ambassador/v2
 kind:  Mapping
 name:  {self.target.path.k8s}-bypass
 ambassador_id: ["{self.ambassador_id}"]
-host: "*"
+hostname: "*"
 prefix: /bypass/
 service: {self.target.path.fqdn}
 bypass_error_response_overrides: true
@@ -751,7 +751,7 @@ apiVersion: ambassador/v2
 kind:  Mapping
 name:  {self.target.path.k8s}
 ambassador_id: ["{self.ambassador_id}"]
-host: "*"
+hostname: "*"
 prefix: /target/
 service: {self.target.path.fqdn}
 ---
@@ -759,7 +759,7 @@ apiVersion: ambassador/v2
 kind:  Mapping
 name:  {self.target.path.k8s}-bypass
 ambassador_id: ["{self.ambassador_id}"]
-host: "*"
+hostname: "*"
 prefix: /bypass/
 service: {self.target.path.fqdn}
 bypass_error_response_overrides: true
@@ -768,7 +768,7 @@ apiVersion: ambassador/v2
 kind:  Mapping
 name:  {self.target.path.k8s}-overrides
 ambassador_id: ["{self.ambassador_id}"]
-host: "*"
+hostname: "*"
 prefix: /overrides/
 service: {self.target.path.fqdn}
 error_response_overrides:
@@ -837,7 +837,7 @@ apiVersion: ambassador/v2
 kind:  Mapping
 name:  {self.target.path.k8s}
 ambassador_id: ["{self.ambassador_id}"]
-host: "*"
+hostname: "*"
 prefix: /target/
 service: {self.target.path.fqdn}
 ---
@@ -845,7 +845,7 @@ apiVersion: ambassador/v2
 kind:  Mapping
 name:  {self.target.path.k8s}-override-401
 ambassador_id: ["{self.ambassador_id}"]
-host: "*"
+hostname: "*"
 prefix: /override/401/
 service: {self.target.path.fqdn}
 error_response_overrides:
@@ -859,7 +859,7 @@ apiVersion: ambassador/v2
 kind:  Mapping
 name:  {self.target.path.k8s}-override-503
 ambassador_id: ["{self.ambassador_id}"]
-host: "*"
+hostname: "*"
 prefix: /override/503/
 service: {self.target.path.fqdn}
 error_response_overrides:
@@ -962,7 +962,7 @@ metadata:
   name:  {self.target.path.k8s}-one
 spec:
   ambassador_id: ["{self.ambassador_id}"]
-  host: "*"
+  hostname: "*"
   prefix: /target-one/
   service: {self.target.path.fqdn}
   error_response_overrides:
@@ -979,7 +979,7 @@ metadata:
   name: {self.target.path.k8s}-two
 spec:
   ambassador_id: ["{self.ambassador_id}"]
-  host: "*"
+  hostname: "*"
   prefix: /target-two/
   service: {self.target.path.fqdn}
   error_response_overrides:
@@ -996,7 +996,7 @@ metadata:
   name: {self.target.path.k8s}-three
 spec:
   ambassador_id: ["{self.ambassador_id}"]
-  host: "*"
+  hostname: "*"
   prefix: /target-three/
   service: {self.target.path.fqdn}
 ---
@@ -1006,7 +1006,7 @@ metadata:
   name: {self.target.path.k8s}-four
 spec:
   ambassador_id: ["{self.ambassador_id}"]
-  host: "*"
+  hostname: "*"
   prefix: /target-four/
   service: {self.target.path.fqdn}
   error_response_overrides:

--- a/python/tests/kat/t_extauth.py
+++ b/python/tests/kat/t_extauth.py
@@ -29,7 +29,7 @@ metadata:
 spec:
   ambassador_id: {self.ambassador_id}
   service: {self.target.path.fqdn}
-  host: "*"
+  hostname: "*"
   prefix: /context-extensions-crd/
   auth_context_extensions:
     context: "auth-context-name"
@@ -51,14 +51,14 @@ proto: grpc
 apiVersion: ambassador/v0
 kind:  Mapping
 name:  {self.target.path.k8s}
-host: "*"
+hostname: "*"
 prefix: /target/
 service: {self.target.path.fqdn}
 ---
 apiVersion: ambassador/v2
 kind:  Mapping
 name:  {self.target.path.k8s}-context-extensions
-host: "*"
+hostname: "*"
 prefix: /context-extensions/
 service: {self.target.path.fqdn}
 auth_context_extensions:
@@ -212,7 +212,7 @@ include_body:
 apiVersion: ambassador/v0
 kind:  Mapping
 name:  {self.target.path.k8s}
-host: "*"
+hostname: "*"
 prefix: /target/
 service: {self.target.path.fqdn}
 """)
@@ -316,7 +316,7 @@ include_body:
 apiVersion: ambassador/v0
 kind:  Mapping
 name:  {self.target.path.k8s}
-host: "*"
+hostname: "*"
 prefix: /target/
 service: {self.target.path.fqdn}
 """)
@@ -442,7 +442,7 @@ failure_mode_allow: true
 apiVersion: ambassador/v0
 kind:  Mapping
 name:  {self.target.path.k8s}
-host: "*"
+hostname: "*"
 prefix: /target/
 service: {self.target.path.fqdn}
 """)
@@ -532,14 +532,14 @@ status_on_error:
 apiVersion: ambassador/v0
 kind:  Mapping
 name:  {self.target.path.k8s}
-host: "*"
+hostname: "*"
 prefix: /target/
 service: {self.target.path.fqdn}
 ---
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.target.path.fqdn}-unauthed
-host: "*"
+hostname: "*"
 prefix: /target/unauthed/
 service: {self.target.path.fqdn}
 bypass_auth: true
@@ -719,7 +719,7 @@ allowed_headers:
 apiVersion: ambassador/v0
 kind:  Mapping
 name:  {self.target.path.k8s}
-host: "*"
+hostname: "*"
 prefix: /target/
 service: {self.target.path.fqdn}
 """)
@@ -843,7 +843,7 @@ allow_request_body: true
 apiVersion: ambassador/v0
 kind:  Mapping
 name: {self.name}
-host: "*"
+hostname: "*"
 prefix: /{self.name}/
 service: websocket-echo-server.default
 use_websocket: true
@@ -886,7 +886,7 @@ proto: grpc
 apiVersion: ambassador/v0
 kind:  Mapping
 name:  {self.target.path.k8s}
-host: "*"
+hostname: "*"
 prefix: /target/
 service: {self.target.path.fqdn}
 """)
@@ -981,7 +981,7 @@ proto: grpc
 apiVersion: ambassador/v0
 kind:  Mapping
 name:  {self.target.path.k8s}
-host: "*"
+hostname: "*"
 prefix: /target/
 service: {self.target.path.fqdn}
 """)

--- a/python/tests/kat/t_grpc.py
+++ b/python/tests/kat/t_grpc.py
@@ -21,7 +21,7 @@ class AcceptanceGrpcTest(AmbassadorTest):
 apiVersion: ambassador/v0
 kind:  Mapping
 grpc: True
-host: "*"
+hostname: "*"
 prefix: /echo.EchoService/
 rewrite: /echo.EchoService/
 name:  {self.target.path.k8s}
@@ -80,7 +80,7 @@ spec:
 apiVersion: ambassador/v1
 kind:  Mapping
 grpc: True
-host: "*"
+hostname: "*"
 prefix: /echo.EchoService/
 rewrite: /echo.EchoService/
 name:  {self.target.path.k8s}

--- a/python/tests/kat/t_grpc_bridge.py
+++ b/python/tests/kat/t_grpc_bridge.py
@@ -24,7 +24,7 @@ config:
 apiVersion: ambassador/v0
 kind:  Mapping
 grpc: True
-host: "*"
+hostname: "*"
 prefix: /echo.EchoService/
 rewrite: /echo.EchoService/
 name:  {self.target.path.k8s}

--- a/python/tests/kat/t_grpc_stats.py
+++ b/python/tests/kat/t_grpc_stats.py
@@ -23,7 +23,7 @@ config:
 apiVersion: getambassador.io/v2
 kind:  Mapping
 grpc: True
-host: "*"
+hostname: "*"
 prefix: /echo.EchoService/
 rewrite: /echo.EchoService/
 name:  {self.target.path.k8s}
@@ -34,7 +34,7 @@ service: {self.target.path.k8s}
 apiVersion: getambassador.io/v2
 kind:  Mapping
 name:  metrics
-host: "*"
+hostname: "*"
 prefix: /metrics
 rewrite: /metrics
 service: http://127.0.0.1:8877
@@ -121,7 +121,7 @@ config:
 apiVersion: getambassador.io/v2
 kind:  Mapping
 grpc: True
-host: "*"
+hostname: "*"
 prefix: /echo.EchoService/
 rewrite: /echo.EchoService/
 name:  {self.target.path.k8s}
@@ -132,7 +132,7 @@ service: {self.target.path.k8s}
 apiVersion: getambassador.io/v2
 kind:  Mapping
 name:  metrics
-host: "*"
+hostname: "*"
 prefix: /metrics
 rewrite: /metrics
 service: http://127.0.0.1:8877
@@ -212,7 +212,7 @@ config:
 apiVersion: getambassador.io/v2
 kind:  Mapping
 grpc: True
-host: "*"
+hostname: "*"
 prefix: /echo.EchoService/
 rewrite: /echo.EchoService/
 name:  {self.target.path.k8s}
@@ -223,7 +223,7 @@ service: {self.target.path.k8s}
 apiVersion: getambassador.io/v2
 kind:  Mapping
 name:  metrics
-host: "*"
+hostname: "*"
 prefix: /metrics
 rewrite: /metrics
 service: http://127.0.0.1:8877

--- a/python/tests/kat/t_grpc_web.py
+++ b/python/tests/kat/t_grpc_web.py
@@ -26,7 +26,7 @@ config:
 apiVersion: ambassador/v0
 kind:  Mapping
 grpc: True
-host: "*"
+hostname: "*"
 prefix: /echo.EchoService/
 rewrite: /echo.EchoService/
 name:  {self.target.path.k8s}

--- a/python/tests/kat/t_gzip.py
+++ b/python/tests/kat/t_gzip.py
@@ -26,7 +26,7 @@ config:
 apiVersion: ambassador/v0
 kind:  Mapping
 name:  {self.target.path.k8s}
-host: "*"
+hostname: "*"
 prefix: /target/
 service: {self.target.path.fqdn}
 """)
@@ -62,7 +62,7 @@ config:
 apiVersion: ambassador/v0
 kind:  Mapping
 name:  {self.target.path.k8s}
-host: "*"
+hostname: "*"
 prefix: /target/
 service: {self.target.path.fqdn}
 """)
@@ -97,7 +97,7 @@ config:
 apiVersion: ambassador/v0
 kind:  Mapping
 name:  {self.target.path.k8s}
-host: "*"
+hostname: "*"
 prefix: /target/
 service: {self.target.path.fqdn}
 """)

--- a/python/tests/kat/t_headerrouting.py
+++ b/python/tests/kat/t_headerrouting.py
@@ -27,7 +27,7 @@ class HeaderRoutingTest(MappingTest):
 apiVersion: ambassador/v0
 kind:  Mapping
 name:  {self.name}-target1
-host: "*"
+hostname: "*"
 prefix: /{self.name}/
 service: http://{self.target.path.fqdn}
 """)
@@ -36,7 +36,7 @@ service: http://{self.target.path.fqdn}
 apiVersion: ambassador/v0
 kind:  Mapping
 name:  {self.name}-target2
-host: "*"
+hostname: "*"
 prefix: /{self.name}/
 service: http://{self.target2.path.fqdn}
 headers:
@@ -132,7 +132,7 @@ allowed_authorization_headers:
 apiVersion: ambassador/v0
 kind:  Mapping
 name:  {self.name}-target1
-host: "*"
+hostname: "*"
 prefix: /target/
 service: http://{self.target1.path.fqdn}
 """)
@@ -141,7 +141,7 @@ service: http://{self.target1.path.fqdn}
 apiVersion: ambassador/v0
 kind:  Mapping
 name:  {self.name}-target2
-host: "*"
+hostname: "*"
 prefix: /target/
 service: http://{self.target2.path.fqdn}
 headers:

--- a/python/tests/kat/t_headerswithunderscoresaction.py
+++ b/python/tests/kat/t_headerswithunderscoresaction.py
@@ -15,7 +15,7 @@ apiVersion: ambassador/v2
 kind:  Mapping
 name:  config__dump
 ambassador_id: {self.ambassador_id}
-host: "*"
+hostname: "*"
 prefix: /target/
 service: http://{self.target.path.fqdn}
 """)
@@ -48,7 +48,7 @@ apiVersion: ambassador/v2
 kind:  Mapping
 name:  config__dump
 ambassador_id: {self.ambassador_id}
-host: "*"
+hostname: "*"
 prefix: /target/
 service: http://{self.target.path.fqdn}
 """)

--- a/python/tests/kat/t_hosts.py
+++ b/python/tests/kat/t_hosts.py
@@ -636,7 +636,7 @@ metadata:
     kat-ambassador-id: {self.ambassador_id}
 spec:
   ambassador_id: [ {self.ambassador_id} ]
-  host: "*"
+  hostname: "*"
   prefix: /target-shared/
   service: {self.targetshared.path.fqdn}
 ''') + super().manifests()
@@ -824,7 +824,7 @@ metadata:
     kat-ambassador-id: {self.ambassador_id}
 spec:
   ambassador_id: [ {self.ambassador_id} ]
-  host: "*"
+  hostname: "*"
   prefix: /foo/
   service: {self.target.path.fqdn}
 ''') + super().manifests()
@@ -928,7 +928,7 @@ metadata:
     kat-ambassador-id: {self.ambassador_id}
 spec:
   ambassador_id: [ {self.ambassador_id} ]
-  host: "*"
+  hostname: "*"
   prefix: /
   service: {self.target.path.fqdn}
 ''') +  super().manifests()
@@ -1053,7 +1053,7 @@ metadata:
     kat-ambassador-id: {self.ambassador_id}
 spec:
   ambassador_id: [ {self.ambassador_id} ]
-  host: "*"
+  hostname: "*"
   prefix: /
   service: {self.target.path.fqdn}
 ''') +  super().manifests()
@@ -1474,7 +1474,7 @@ metadata:
   name: {self.name.k8s}-target-mapping
 spec:
   ambassador_id: [ {self.ambassador_id} ]
-  host: "*"
+  hostname: "*"
   prefix: /foo/
   service: {self.target.path.fqdn}
 ''') + super().manifests()

--- a/python/tests/kat/t_ingress.py
+++ b/python/tests/kat/t_ingress.py
@@ -22,10 +22,6 @@ class IngressStatusTest1(AmbassadorTest):
     }
 
     def init(self):
-        self.xfail = "IHA FIXME (Ingress)"
-        self.skip_node = True
-        return
-
         self.target = HTTP()
 
     def manifests(self) -> str:
@@ -49,7 +45,7 @@ spec:
 """ + super().manifests()
 
     def queries(self):
-        if sys.platform != 'darwin':
+        if True or sys.platform != 'darwin':
             text = json.dumps(self.status_update)
 
             update_cmd = [KUBESTATUS_PATH, 'Service', '-n', 'default', '-f', f'metadata.name={self.name.k8s}', '-u', '/dev/fd/0']
@@ -66,7 +62,7 @@ spec:
         if not parse_bool(os.environ.get("AMBASSADOR_PYTEST_INGRESS_TEST", "false")):
             pytest.xfail('AMBASSADOR_PYTEST_INGRESS_TEST not set, xfailing...')
 
-        if sys.platform == 'darwin':
+        if False and sys.platform == 'darwin':
             pytest.xfail('not supported on Darwin')
 
         for r in self.results:
@@ -92,10 +88,6 @@ class IngressStatusTest2(AmbassadorTest):
     }
 
     def init(self):
-        self.xfail = "IHA FIXME (Ingress)"
-        self.skip_node = True
-        return
-
         self.target = HTTP()
 
     def manifests(self) -> str:
@@ -119,7 +111,7 @@ spec:
 """ + super().manifests()
 
     def queries(self):
-        if sys.platform != 'darwin':
+        if True or sys.platform != 'darwin':
             text = json.dumps(self.status_update)
 
             update_cmd = [KUBESTATUS_PATH, 'Service', '-n', 'default', '-f', f'metadata.name={self.name.k8s}', '-u', '/dev/fd/0']
@@ -136,7 +128,7 @@ spec:
         if not parse_bool(os.environ.get("AMBASSADOR_PYTEST_INGRESS_TEST", "false")):
             pytest.xfail('AMBASSADOR_PYTEST_INGRESS_TEST not set, xfailing...')
 
-        if sys.platform == 'darwin':
+        if False and sys.platform == 'darwin':
             pytest.xfail('not supported on Darwin')
 
         for r in self.results:
@@ -162,10 +154,6 @@ class IngressStatusTestAcrossNamespaces(AmbassadorTest):
     }
 
     def init(self):
-        self.xfail = "IHA FIXME (Ingress)"
-        self.skip_node = True
-        return
-
         self.target = HTTP(namespace="alt-namespace")
 
     def manifests(self) -> str:
@@ -190,7 +178,7 @@ spec:
 """ + super().manifests()
 
     def queries(self):
-        if sys.platform != 'darwin':
+        if True or sys.platform != 'darwin':
             text = json.dumps(self.status_update)
 
             update_cmd = [KUBESTATUS_PATH, 'Service', '-n', 'default', '-f', f'metadata.name={self.name.k8s}', '-u', '/dev/fd/0']
@@ -207,7 +195,7 @@ spec:
         if not parse_bool(os.environ.get("AMBASSADOR_PYTEST_INGRESS_TEST", "false")):
             pytest.xfail('AMBASSADOR_PYTEST_INGRESS_TEST not set, xfailing...')
 
-        if sys.platform == 'darwin':
+        if False and sys.platform == 'darwin':
             pytest.xfail('not supported on Darwin')
 
         for r in self.results:
@@ -233,10 +221,6 @@ class IngressStatusTestWithAnnotations(AmbassadorTest):
     }
 
     def init(self):
-        self.xfail = "IHA FIXME (Ingress)"
-        self.skip_node = True
-        return
-
         self.target = HTTP()
 
     def manifests(self) -> str:
@@ -251,7 +235,7 @@ metadata:
       apiVersion: ambassador/v1
       kind:  Mapping
       name:  {self.name}-nested
-      host: "*"
+      hostname: "*"
       prefix: /{self.name}-nested/
       service: http://{self.target.path.fqdn}
       ambassador_id: {self.ambassador_id}
@@ -304,10 +288,6 @@ class SameIngressMultipleNamespaces(AmbassadorTest):
     }
 
     def init(self):
-        self.xfail = "IHA FIXME (Ingress)"
-        self.skip_node = True
-        return
-
         self.target = HTTP()
         self.target1 = HTTP(name="target1", namespace="same-ingress-1")
         self.target2 = HTTP(name="target2", namespace="same-ingress-2")
@@ -352,7 +332,7 @@ spec:
 """ + super().manifests()
 
     def queries(self):
-        if sys.platform != 'darwin':
+        if True or sys.platform != 'darwin':
             text = json.dumps(self.status_update)
 
             update_cmd = [KUBESTATUS_PATH, 'Service', '-n', 'default', '-f', f'metadata.name={self.name.k8s}', '-u', '/dev/fd/0']
@@ -369,7 +349,7 @@ spec:
         if not parse_bool(os.environ.get("AMBASSADOR_PYTEST_INGRESS_TEST", "false")):
             pytest.xfail('AMBASSADOR_PYTEST_INGRESS_TEST not set, xfailing...')
 
-        if sys.platform == 'darwin':
+        if False and sys.platform == 'darwin':
             pytest.xfail('not supported on Darwin')
 
         for namespace in ['same-ingress-1', 'same-ingress-2']:
@@ -391,10 +371,6 @@ class IngressStatusTestWithIngressClass(AmbassadorTest):
     }
 
     def init(self):
-        self.xfail = "IHA FIXME (Ingress)"
-        self.skip_node = True
-        return
-
         self.target = HTTP()
 
         if not is_ingress_class_compatible():
@@ -452,7 +428,7 @@ spec:
 """ + super().manifests()
 
     def queries(self):
-        if sys.platform != 'darwin':
+        if True or sys.platform != 'darwin':
             text = json.dumps(self.status_update)
 
             update_cmd = [KUBESTATUS_PATH, 'Service', '-n', 'default', '-f', f'metadata.name={self.name.k8s}', '-u', '/dev/fd/0']
@@ -469,7 +445,7 @@ spec:
         if not parse_bool(os.environ.get("AMBASSADOR_PYTEST_INGRESS_TEST", "false")):
             pytest.xfail('AMBASSADOR_PYTEST_INGRESS_TEST not set, xfailing...')
 
-        if sys.platform == 'darwin':
+        if False and sys.platform == 'darwin':
             pytest.xfail('not supported on Darwin')
 
         for r in self.results:

--- a/python/tests/kat/t_ip_allow_deny.py
+++ b/python/tests/kat/t_ip_allow_deny.py
@@ -50,7 +50,7 @@ metadata:
   name: {self.path.k8s}-target-mapping
 spec:
   ambassador_id: {self.ambassador_id}
-  host: "*"
+  hostname: "*"
   prefix: /target/
   service: {self.target.path.fqdn}
 ---
@@ -60,7 +60,7 @@ metadata:
   name: {self.path.k8s}-localhost-mapping
 spec:
   ambassador_id: {self.ambassador_id}
-  host: "*"
+  hostname: "*"
   prefix: /localhost/
   rewrite: /target/             # See NOTE above
   service: 127.0.0.1:8080       # See NOTE above
@@ -119,7 +119,7 @@ metadata:
   name: {self.path.k8s}-target-mapping
 spec:
   ambassador_id: {self.ambassador_id}
-  host: "*"
+  hostname: "*"
   prefix: /target/
   service: {self.target.path.fqdn}
 ---
@@ -129,7 +129,7 @@ metadata:
   name: {self.path.k8s}-localhost-mapping
 spec:
   ambassador_id: {self.ambassador_id}
-  host: "*"
+  hostname: "*"
   prefix: /localhost/
   rewrite: /target/             # See NOTE above
   service: 127.0.0.1:8080       # See NOTE above

--- a/python/tests/kat/t_listeneridletimeout.py
+++ b/python/tests/kat/t_listeneridletimeout.py
@@ -23,7 +23,7 @@ config:
 apiVersion: ambassador/v0
 kind:  Mapping
 name:  config__dump
-host: "*"
+hostname: "*"
 prefix: /config_dump
 rewrite: /config_dump
 service: http://127.0.0.1:8001

--- a/python/tests/kat/t_loadbalancer.py
+++ b/python/tests/kat/t_loadbalancer.py
@@ -40,14 +40,14 @@ class LoadBalancerTest(AmbassadorTest):
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.name}-0
-host: "*"
+hostname: "*"
 prefix: /{self.name}-0/
 service: {self.target.path.fqdn}
 ---
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.name}-1
-host: "*"
+hostname: "*"
 prefix: /{self.name}-1/
 service: {self.target.path.fqdn}
 resolver:  endpoint
@@ -57,7 +57,7 @@ load_balancer:
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.name}-2
-host: "*"
+hostname: "*"
 prefix: /{self.name}-2/
 service: {self.target.path.fqdn}
 resolver: endpoint
@@ -68,7 +68,7 @@ load_balancer:
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.name}-3
-host: "*"
+hostname: "*"
 prefix: /{self.name}-3/
 service: {self.target.path.fqdn}
 resolver: endpoint
@@ -79,7 +79,7 @@ load_balancer:
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.name}-4
-host: "*"
+hostname: "*"
 prefix: /{self.name}-4/
 service: {self.target.path.fqdn}
 resolver: endpoint
@@ -91,7 +91,7 @@ load_balancer:
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.name}-5
-host: "*"
+hostname: "*"
 prefix: /{self.name}-5/
 service: {self.target.path.fqdn}
 resolver: endpoint
@@ -105,7 +105,7 @@ load_balancer:
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.name}-6
-host: "*"
+hostname: "*"
 prefix: /{self.name}-6/
 service: {self.target.path.fqdn}
 resolver: endpoint
@@ -117,7 +117,7 @@ load_balancer:
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.name}-7
-host: "*"
+hostname: "*"
 prefix: /{self.name}-7/
 service: {self.target.path.fqdn}
 resolver: endpoint
@@ -127,7 +127,7 @@ load_balancer:
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.name}-8
-host: "*"
+hostname: "*"
 prefix: /{self.name}-8/
 service: {self.target.path.fqdn}
 resolver: endpoint
@@ -137,7 +137,7 @@ load_balancer:
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.name}-9
-host: "*"
+hostname: "*"
 prefix: /{self.name}-9/
 service: {self.target.path.fqdn}
 resolver: endpoint
@@ -203,7 +203,7 @@ config:
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.name}-header
-host: "*"
+hostname: "*"
 prefix: /{self.name}-header/
 service: globalloadbalancing-service
 load_balancer:
@@ -214,7 +214,7 @@ load_balancer:
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.name}-generic
-host: "*"
+hostname: "*"
 prefix: /{self.name}-generic/
 service: globalloadbalancing-service
 """)
@@ -346,7 +346,7 @@ spec:
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.name}-header-{self.policy}
-host: "*"
+hostname: "*"
 prefix: /{self.name}-header-{self.policy}/
 service: permappingloadbalancing-service
 resolver: endpoint
@@ -357,7 +357,7 @@ load_balancer:
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.name}-sourceip-{self.policy}
-host: "*"
+hostname: "*"
 prefix: /{self.name}-sourceip-{self.policy}/
 service: permappingloadbalancing-service
 resolver: endpoint
@@ -368,7 +368,7 @@ load_balancer:
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.name}-cookie-{self.policy}
-host: "*"
+hostname: "*"
 prefix: /{self.name}-cookie-{self.policy}/
 service: permappingloadbalancing-service
 resolver: endpoint
@@ -382,7 +382,7 @@ load_balancer:
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.name}-cookie-no-ttl-{self.policy}
-host: "*"
+hostname: "*"
 prefix: /{self.name}-cookie-no-ttl-{self.policy}/
 service: permappingloadbalancing-service
 resolver: endpoint

--- a/python/tests/kat/t_logservice.py
+++ b/python/tests/kat/t_logservice.py
@@ -85,7 +85,7 @@ flush_interval_byte_size: 1
 apiVersion: ambassador/v0
 kind:  Mapping
 name:  config__dump
-host: "*"
+hostname: "*"
 prefix: /config_dump
 rewrite: /config_dump
 service: http://127.0.0.1:8001
@@ -224,7 +224,7 @@ flush_interval_byte_size: 1
 apiVersion: ambassador/v0
 kind:  Mapping
 name:  config__dump-longservicename
-host: "*"
+hostname: "*"
 prefix: /config_dump
 rewrite: /config_dump
 service: http://127.0.0.1:8001

--- a/python/tests/kat/t_lua_scripts.py
+++ b/python/tests/kat/t_lua_scripts.py
@@ -34,7 +34,7 @@ metadata:
   name: lua-target-mapping
 spec:
   ambassador_id: {self.ambassador_id}
-  host: "*"
+  hostname: "*"
   prefix: /target/
   service: {self.target.path.fqdn}
 ''') + super().manifests()

--- a/python/tests/kat/t_mappingtests.py
+++ b/python/tests/kat/t_mappingtests.py
@@ -41,7 +41,7 @@ class SimpleMapping(MappingTest):
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.name}
-host: "*"
+hostname: "*"
 prefix: /{self.name}/
 service: http://{self.target.path.fqdn}
 """)
@@ -156,7 +156,7 @@ metadata:
       apiVersion: ambassador/v1
       kind:  Mapping
       name:  {self.name}-nested
-      host: "*"
+      hostname: "*"
       prefix: /{self.name}-nested/
       service: http://{self.target.path.fqdn}
       ambassador_id: plain
@@ -234,7 +234,6 @@ class HostHeaderMapping(MappingTest):
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.name}
-host: "*"
 prefix: /{self.name}/
 service: http://{self.target.path.fqdn}
 host: inspector.external
@@ -270,7 +269,6 @@ config:
 apiVersion: ambassador/v2
 kind:  Mapping
 name:  {self.name}
-host: "*"
 prefix: /{self.name}/
 service: http://{self.target.path.fqdn}
 host: myhostname.com
@@ -304,7 +302,7 @@ class MergeSlashesDisabled(AmbassadorTest):
 apiVersion: ambassador/v2
 kind:  Mapping
 name:  {self.name}
-host: "*"
+hostname: "*"
 prefix: /{self.name}/status/
 rewrite: /status/
 service: httpbin.default
@@ -340,7 +338,7 @@ config:
 apiVersion: ambassador/v2
 kind:  Mapping
 name:  {self.name}
-host: "*"
+hostname: "*"
 prefix: /{self.name}/status/
 rewrite: /status/
 service: httpbin.default
@@ -369,7 +367,7 @@ class RejectRequestsWithEscapedSlashesDisabled(AmbassadorTest):
 apiVersion: ambassador/v2
 kind:  Mapping
 name:  {self.name}
-host: "*"
+hostname: "*"
 prefix: /{self.name}/status/
 rewrite: /status/
 service: httpbin
@@ -408,7 +406,7 @@ config:
 apiVersion: ambassador/v2
 kind:  Mapping
 name:  {self.name}
-host: "*"
+hostname: "*"
 prefix: /{self.name}/status/
 rewrite: /status/
 service: httpbin
@@ -441,7 +439,7 @@ class InvalidPortMapping(MappingTest):
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.name}
-host: "*"
+hostname: "*"
 prefix: /{self.name}/
 service: http://{self.target.path.fqdn}:80.invalid
 """)
@@ -474,7 +472,7 @@ class WebSocketMapping(MappingTest):
 apiVersion: ambassador/v0
 kind:  Mapping
 name:  {self.name}
-host: "*"
+hostname: "*"
 prefix: /{self.name}/
 service: websocket-echo-server.default
 use_websocket: true
@@ -499,7 +497,7 @@ class TLSOrigination(MappingTest):
 apiVersion: ambassador/v0
 kind:  Mapping
 name:  {self.name}
-host: "*"
+hostname: "*"
 prefix: /{self.name}/
 service: https://{self.target.path.fqdn}
 """
@@ -509,7 +507,7 @@ service: https://{self.target.path.fqdn}
 apiVersion: ambassador/v0
 kind:  Mapping
 name:  {self.name}
-host: "*"
+hostname: "*"
 prefix: /{self.name}/
 service: {self.target.path.fqdn}
 tls: true
@@ -552,7 +550,7 @@ class HostRedirectMapping(MappingTest):
 apiVersion: ambassador/v2
 kind:  Mapping
 name:  {self.name}
-host: "*"
+hostname: "*"
 prefix: /{self.name}/
 service: foobar.com
 host_redirect: true
@@ -560,7 +558,7 @@ host_redirect: true
 apiVersion: ambassador/v2
 kind:  Mapping
 name:  {self.name}-2
-host: "*"
+hostname: "*"
 prefix: /{self.name}-2/
 case_sensitive: false
 service: foobar.com
@@ -569,7 +567,7 @@ host_redirect: true
 apiVersion: ambassador/v2
 kind:  Mapping
 name:  {self.name}-3
-host: "*"
+hostname: "*"
 prefix: /{self.name}-3/foo/
 service: foobar.com
 host_redirect: true
@@ -579,7 +577,7 @@ redirect_response_code: 302
 apiVersion: ambassador/v2
 kind:  Mapping
 name:  {self.name}-4
-host: "*"
+hostname: "*"
 prefix: /{self.name}-4/foo/bar/baz
 service: foobar.com
 host_redirect: true
@@ -589,7 +587,7 @@ redirect_response_code: 307
 apiVersion: ambassador/v2
 kind:  Mapping
 name:  {self.name}-5
-host: "*"
+hostname: "*"
 prefix: /{self.name}-5/assets/([a-f0-9]{{12}})/images
 prefix_regex: true
 service: foobar.com
@@ -682,7 +680,7 @@ class CanaryMapping(MappingTest):
 apiVersion: ambassador/v0
 kind:  Mapping
 name:  {self.name}
-host: "*"
+hostname: "*"
 prefix: /{self.name}/
 service: http://{self.target.path.fqdn}
 """)
@@ -691,7 +689,7 @@ service: http://{self.target.path.fqdn}
 apiVersion: ambassador/v0
 kind:  Mapping
 name:  {self.name}-canary
-host: "*"
+hostname: "*"
 prefix: /{self.name}/
 service: http://{self.canary.path.fqdn}
 weight: {self.weight}
@@ -745,7 +743,7 @@ class CanaryDiffMapping(MappingTest):
 apiVersion: ambassador/v0
 kind:  Mapping
 name:  {self.name}
-host: "*"
+hostname: "*"
 prefix: /{self.name}/
 service: http://{self.target.path.fqdn}
 host_rewrite: canary.1.example.com
@@ -755,7 +753,7 @@ host_rewrite: canary.1.example.com
 apiVersion: ambassador/v0
 kind:  Mapping
 name:  {self.name}-canary
-host: "*"
+hostname: "*"
 prefix: /{self.name}/
 service: http://{self.canary.path.fqdn}
 host_rewrite: canary.2.example.com
@@ -804,7 +802,7 @@ class AddRespHeadersMapping(MappingTest):
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.name}
-host: "*"
+hostname: "*"
 prefix: /{self.name}/
 service: httpbin.default
 add_response_headers:
@@ -849,7 +847,7 @@ class EdgeStackMapping(MappingTest):
 apiVersion: ambassador/v0
 kind:  Mapping
 name:  {self.name}
-host: "*"
+hostname: "*"
 prefix: /{self.name}/
 service: http://{self.target.path.fqdn}
 """)
@@ -877,7 +875,7 @@ class RemoveReqHeadersMapping(MappingTest):
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.name}
-host: "*"
+hostname: "*"
 prefix: /{self.name}/
 service: httpbin.default
 remove_request_headers:
@@ -915,7 +913,7 @@ class AddReqHeadersMapping(MappingTest):
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.name}
-host: "*"
+hostname: "*"
 prefix: /{self.name}/
 service: http://{self.target.path.fqdn}
 add_request_headers:
@@ -975,7 +973,7 @@ config:
 apiVersion: ambassador/v1
 kind: Mapping
 name: {self.target_add_linkerd_header_only.path.k8s}
-host: "*"
+hostname: "*"
 prefix: /target_add_linkerd_header_only/
 service: {self.target_add_linkerd_header_only.path.fqdn}
 add_request_headers: {{}}
@@ -984,7 +982,7 @@ remove_request_headers: []
 apiVersion: ambassador/v1
 kind: Mapping
 name: {self.target_no_header.path.k8s}
-host: "*"
+hostname: "*"
 prefix: /target_no_header/
 service: {self.target_no_header.path.fqdn}
 add_linkerd_headers: false
@@ -992,7 +990,7 @@ add_linkerd_headers: false
 apiVersion: ambassador/v1
 kind: Mapping
 name: {self.target.path.k8s}
-host: "*"
+hostname: "*"
 prefix: /target/
 service: {self.target.path.fqdn}
 add_request_headers:
@@ -1058,7 +1056,7 @@ metadata:
   namespace: same-mapping-1
 spec:
   ambassador_id: {self.ambassador_id}
-  host: "*"
+  hostname: "*"
   prefix: /{self.name}-1/
   service: {self.target.path.fqdn}.default
 ---
@@ -1069,7 +1067,7 @@ metadata:
   namespace: same-mapping-2
 spec:
   ambassador_id: {self.ambassador_id}
-  host: "*"
+  hostname: "*"
   prefix: /{self.name}-2/
   service: {self.target.path.fqdn}.default
 ''') + super().manifests()
@@ -1102,7 +1100,7 @@ metadata:
   name: {self.target.path.k8s}
 spec:
   ambassador_id: {self.ambassador_id}
-  host: "*"
+  hostname: "*"
   prefix: /{self.name}-1/
   service: thisisaverylongservicenameoverwithsixythreecharacters123456789
 ''') + super().manifests()

--- a/python/tests/kat/t_max_req_header_kb.py
+++ b/python/tests/kat/t_max_req_header_kb.py
@@ -23,7 +23,7 @@ config:
 apiVersion: ambassador/v2
 kind:  Mapping
 name:  {self.name}
-host: "*"
+hostname: "*"
 prefix: /target/
 service: http://{self.target.path.fqdn}
 """)
@@ -61,7 +61,7 @@ config:
 apiVersion: ambassador/v2
 kind:  Mapping
 name:  {self.name}
-host: "*"
+hostname: "*"
 prefix: /target/
 service: http://{self.target.path.fqdn}
 """)

--- a/python/tests/kat/t_plain.py
+++ b/python/tests/kat/t_plain.py
@@ -31,7 +31,7 @@ metadata:
       apiVersion: ambassador/v1
       kind: Mapping
       name: SimpleMapping-HTTP-all
-      host: "*"
+      hostname: "*"
       prefix: /SimpleMapping-HTTP-all/
       service: http://plain-simplemapping-http-all-http.plain
       ambassador_id: plain      

--- a/python/tests/kat/t_queryparameter_routing.py
+++ b/python/tests/kat/t_queryparameter_routing.py
@@ -15,7 +15,7 @@ class QueryParameterRoutingTest(AmbassadorTest):
 apiVersion: ambassador/v2
 kind:  Mapping
 name:  {self.name}-target1
-host: "*"
+hostname: "*"
 prefix: /target/
 service: http://{self.target1.path.fqdn}
 """)
@@ -24,7 +24,7 @@ service: http://{self.target1.path.fqdn}
 apiVersion: ambassador/v2
 kind:  Mapping
 name:  {self.name}-target2
-host: "*"
+hostname: "*"
 prefix: /target/
 service: http://{self.target2.path.fqdn}
 query_parameters:
@@ -51,7 +51,7 @@ class QueryParameterRoutingWithRegexTest(AmbassadorTest):
 apiVersion: ambassador/v2
 kind:  Mapping
 name:  {self.name}-target
-host: "*"
+hostname: "*"
 prefix: /target/
 service: http://{self.target.path.fqdn}
 regex_query_parameters:
@@ -80,7 +80,7 @@ class QueryParameterPresentRoutingTest(AmbassadorTest):
 apiVersion: ambassador/v2
 kind:  Mapping
 name:  {self.name}-target
-host: "*"
+hostname: "*"
 prefix: /target/
 service: http://{self.target.path.fqdn}
 query_parameters:

--- a/python/tests/kat/t_ratelimit.py
+++ b/python/tests/kat/t_ratelimit.py
@@ -25,7 +25,7 @@ class RateLimitV0Test(AmbassadorTest):
 apiVersion: ambassador/v0
 kind:  Mapping
 name:  ratelimit_target_mapping
-host: "*"
+hostname: "*"
 prefix: /target/
 service: {self.target.path.fqdn}
 rate_limits:
@@ -37,7 +37,7 @@ rate_limits:
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  ratelimit_label_mapping
-host: "*"
+hostname: "*"
 prefix: /labels/
 service: {self.target.path.fqdn}
 labels:
@@ -116,7 +116,7 @@ class RateLimitV1Test(AmbassadorTest):
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  ratelimit_target_mapping
-host: "*"
+hostname: "*"
 prefix: /target/
 service: {self.target.path.fqdn}
 labels:
@@ -203,7 +203,7 @@ alpn_protocols: h2
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  ratelimit_target_mapping
-host: "*"
+hostname: "*"
 prefix: /target/
 service: {self.target.path.fqdn}
 labels:
@@ -271,7 +271,7 @@ class RateLimitV2Test(AmbassadorTest):
 apiVersion: ambassador/v2
 kind:  Mapping
 name:  ratelimit_target_mapping
-host: "*"
+hostname: "*"
 prefix: /target/
 service: {self.target.path.fqdn}
 labels:
@@ -343,7 +343,7 @@ class RateLimitV3Test(AmbassadorTest):
 apiVersion: ambassador/v2
 kind:  Mapping
 name:  ratelimit_target_mapping
-host: "*"
+hostname: "*"
 prefix: /target/
 service: {self.target.path.fqdn}
 labels:

--- a/python/tests/kat/t_redirect.py
+++ b/python/tests/kat/t_redirect.py
@@ -75,7 +75,7 @@ config:
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  tls_target_mapping
-host: "*"
+hostname: "*"
 prefix: /tls-target/
 service: {self.target.path.fqdn}
 """)
@@ -128,7 +128,7 @@ config:
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  tls_target_mapping
-host: "*"
+hostname: "*"
 prefix: /tls-target/
 service: {self.target.path.fqdn}
 """)
@@ -193,7 +193,7 @@ config:
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  tls_target_mapping
-host: "*"
+hostname: "*"
 prefix: /tls-target/
 service: {self.target.path.fqdn}
 """)
@@ -266,7 +266,7 @@ config:
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.name}
-host: "*"
+hostname: "*"
 prefix: /{self.name}/
 service: {self.target.path.fqdn}
 """)

--- a/python/tests/kat/t_regexrewrite_forwarding.py
+++ b/python/tests/kat/t_regexrewrite_forwarding.py
@@ -15,7 +15,7 @@ class RegexRewriteForwardingTest(AmbassadorTest):
 apiVersion: ambassador/v2
 kind:  Mapping
 name:  regex_rewrite_mapping
-host: "*"
+hostname: "*"
 prefix: /foo/
 service: http://{self.target.path.fqdn}
 regex_rewrite:
@@ -46,7 +46,7 @@ class RegexRewriteForwardingWithExtractAndSubstituteTest(AmbassadorTest):
 apiVersion: ambassador/v2
 kind:  Mapping
 name:  regex_rewrite_mapping
-host: "*"
+hostname: "*"
 prefix: /foo/
 service: http://{self.target.path.fqdn}
 regex_rewrite:

--- a/python/tests/kat/t_request_header.py
+++ b/python/tests/kat/t_request_header.py
@@ -19,7 +19,7 @@ config:
 apiVersion: ambassador/v2
 kind:  Mapping
 name:  {self.name}-target
-host: "*"
+hostname: "*"
 prefix: /target/
 service: http://{self.target.path.fqdn}
 """)
@@ -48,7 +48,7 @@ name:  ambassador
 apiVersion: ambassador/v2
 kind:  Mapping
 name:  {self.name}-target
-host: "*"
+hostname: "*"
 prefix: /target/
 service: http://{self.target.path.fqdn}
 """)
@@ -73,7 +73,7 @@ class EnvoyHeadersTest(AmbassadorTest):
 apiVersion: ambassador/v2
 kind:  Mapping
 name:  {self.name}-target
-host: "*"
+hostname: "*"
 prefix: /target/
 rewrite: /rewrite/
 timeout_ms: 5001
@@ -111,7 +111,7 @@ config:
 apiVersion: ambassador/v2
 kind:  Mapping
 name:  {self.name}-target
-host: "*"
+hostname: "*"
 prefix: /target/
 rewrite: /rewrite/
 timeout_ms: 5001

--- a/python/tests/kat/t_retrypolicy.py
+++ b/python/tests/kat/t_retrypolicy.py
@@ -20,7 +20,7 @@ class RetryPolicyTest(AmbassadorTest):
 apiVersion: ambassador/v0
 kind:  Mapping
 name:  {self.name}-normal
-host: "*"
+hostname: "*"
 prefix: /{self.name}-normal/
 service: {self.target.path.fqdn}
 timeout_ms: 3000
@@ -31,7 +31,7 @@ timeout_ms: 3000
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.name}-target
-host: "*"
+hostname: "*"
 prefix: /{self.name}-retry/
 service: {self.target.path.fqdn}
 timeout_ms: 3000

--- a/python/tests/kat/t_shadow.py
+++ b/python/tests/kat/t_shadow.py
@@ -64,7 +64,7 @@ spec:
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.name}-target
-host: "*"
+hostname: "*"
 prefix: /{self.name}/mark/
 rewrite: /mark/
 service: https://{self.target.path.fqdn}
@@ -72,7 +72,7 @@ service: https://{self.target.path.fqdn}
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.name}-weighted-target
-host: "*"
+hostname: "*"
 prefix: /{self.name}/weighted-mark/
 rewrite: /mark/
 service: https://{self.target.path.fqdn}
@@ -80,7 +80,7 @@ service: https://{self.target.path.fqdn}
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.name}-shadow
-host: "*"
+hostname: "*"
 prefix: /{self.name}/mark/
 rewrite: /mark/
 service: shadow.plain-namespace
@@ -89,7 +89,7 @@ shadow: true
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.name}-weighted-shadow
-host: "*"
+hostname: "*"
 prefix: /{self.name}/weighted-mark/
 rewrite: /mark/
 service: shadow.plain-namespace
@@ -99,7 +99,7 @@ shadow: true
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.name}-checkshadow
-host: "*"
+hostname: "*"
 prefix: /{self.name}/check/
 rewrite: /check/
 service: shadow.plain-namespace

--- a/python/tests/kat/t_stats.py
+++ b/python/tests/kat/t_stats.py
@@ -118,14 +118,14 @@ class StatsdTest(AmbassadorTest):
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.name}
-host: "*"
+hostname: "*"
 prefix: /{self.name}/
 service: http://{self.target.path.fqdn}
 ---
 apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.name}-reset
-host: "*"
+hostname: "*"
 case_sensitive: false
 prefix: /reset/
 rewrite: /RESET/
@@ -134,7 +134,7 @@ service: statsd-sink
 apiVersion: ambassador/v0
 kind:  Mapping
 name:  metrics
-host: "*"
+hostname: "*"
 prefix: /metrics
 rewrite: /metrics
 service: http://127.0.0.1:8877
@@ -198,7 +198,7 @@ class DogstatsdTest(AmbassadorTest):
 apiVersion: ambassador/v0
 kind:  Mapping
 name:  {self.name}
-host: "*"
+hostname: "*"
 prefix: /{self.name}/
 service: http://{self.target.path.fqdn}
 ---
@@ -206,7 +206,7 @@ apiVersion: ambassador/v1
 kind:  Mapping
 name:  {self.name}-reset
 case_sensitive: false
-host: "*"
+hostname: "*"
 prefix: /reset/
 rewrite: /RESET/
 service: dogstatsd-sink

--- a/python/tests/kat/t_tls.py
+++ b/python/tests/kat/t_tls.py
@@ -875,6 +875,7 @@ config:
 ---
 apiVersion: ambassador/v1
 kind:  Mapping
+hostname: "*"
 name:  {self.name}-other-mapping
 prefix: /{self.name}/
 service: https://{self.target.path.fqdn}

--- a/python/tests/kat/t_tracing.py
+++ b/python/tests/kat/t_tracing.py
@@ -72,7 +72,7 @@ spec:
 apiVersion: ambassador/v0
 kind:  Mapping
 name:  tracing_target_mapping
-host: "*"
+hostname: "*"
 prefix: /target/
 service: {self.target.path.fqdn}
 """)
@@ -191,7 +191,7 @@ spec:
 apiVersion: ambassador/v0
 kind:  Mapping
 name:  tracing_target_mapping_longclustername
-host: "*"
+hostname: "*"
 prefix: /target/
 service: {self.target.path.fqdn}
 """)
@@ -304,7 +304,7 @@ spec:
 apiVersion: ambassador/v0
 kind:  Mapping
 name:  tracing_target_mapping_64
-host: "*"
+hostname: "*"
 prefix: /target-64/
 service: {self.target.path.fqdn}
 """)
@@ -396,7 +396,7 @@ spec:
 apiVersion: ambassador/v0
 kind:  Mapping
 name:  tracing_target_mapping
-host: "*"
+hostname: "*"
 prefix: /target/
 service: {self.target.path.fqdn}
 """)
@@ -499,7 +499,7 @@ spec:
 apiVersion: ambassador/v0
 kind:  Mapping
 name:  tracing_target_mapping_65
-host: "*"
+hostname: "*"
 prefix: /target-65/
 service: {self.target.path.fqdn}
 """)
@@ -601,7 +601,7 @@ spec:
 apiVersion: ambassador/v0
 kind:  Mapping
 name:  tracing_target_mapping
-host: "*"
+hostname: "*"
 prefix: /target/
 service: {self.target.path.fqdn}
 """)
@@ -723,7 +723,7 @@ spec:
 apiVersion: ambassador/v0
 kind:  Mapping
 name:  tracing_target_mapping
-host: "*"
+hostname: "*"
 prefix: /target/
 service: {self.target.path.fqdn}
 """)

--- a/python/tests/test_envvar_expansion.py
+++ b/python/tests/test_envvar_expansion.py
@@ -25,7 +25,7 @@ yaml = '''
 apiVersion: getambassador.io/v1
 kind: Mapping
 name: test_mapping
-host: "*"
+hostname: "*"
 prefix: /test/
 service: ${TEST_SERVICE}:9999
 '''

--- a/python/tests/test_fetch.py
+++ b/python/tests/test_fetch.py
@@ -96,7 +96,7 @@ metadata:
   name: test
   namespace: default
 spec:
-  host: "*"
+  hostname: "*"
   prefix: /test/
   service: test.default
 ''')
@@ -109,7 +109,7 @@ metadata:
   name: test
   namespace: default
 spec:
-  host: "*"
+  hostname: "*"
   prefix: /test/
   service: test.default
 ''')
@@ -362,7 +362,7 @@ class TestServiceAnnotations:
                     'getambassador.io/config': """apiVersion: getambassador.io/v1
 kind: Mapping
 name: test_mapping
-host: "*"
+hostname: "*"
 prefix: /test/
 service: test:9999""",
                 },
@@ -375,7 +375,7 @@ service: test:9999""",
             'apiVersion': 'getambassador.io/v1',
             'kind': 'Mapping',
             'name': 'test_mapping',
-            'host': "*",
+            'hostname': "*",
             'prefix': '/test/',
             'service': 'test:9999',
             'namespace': 'default',

--- a/python/tests/test_host_redirect_errors.py
+++ b/python/tests/test_host_redirect_errors.py
@@ -48,7 +48,7 @@ metadata:
     name: mapping-1
     namespace: default
 spec:
-    host: "*"
+    hostname: "*"
     prefix: /
     service: svc1
 ---
@@ -58,7 +58,7 @@ metadata:
     name: mapping-2
     namespace: default
 spec:
-    host: "*"
+    hostname: "*"
     prefix: /
     service: svc2
 """
@@ -82,7 +82,7 @@ metadata:
     name: mapping-1
     namespace: default
 spec:
-    host: "*"
+    hostname: "*"
     prefix: /
     service: svc1
     host_redirect: true
@@ -93,7 +93,7 @@ metadata:
     name: mapping-2
     namespace: default
 spec:
-    host: "*"
+    hostname: "*"
     prefix: /
     service: svc2
     host_redirect: true
@@ -122,7 +122,7 @@ metadata:
     name: mapping-1
     namespace: default
 spec:
-    host: "*"
+    hostname: "*"
     prefix: /
     service: svc1
     host_redirect: true
@@ -133,7 +133,7 @@ metadata:
     name: mapping-2
     namespace: default
 spec:
-    host: "*"
+    hostname: "*"
     prefix: /
     service: svc2
 """
@@ -161,7 +161,7 @@ metadata:
     name: mapping-1
     namespace: default
 spec:
-    host: "*"
+    hostname: "*"
     prefix: /
     service: svc1
 ---
@@ -171,7 +171,7 @@ metadata:
     name: mapping-2
     namespace: default
 spec:
-    host: "*"
+    hostname: "*"
     prefix: /
     service: svc2
     host_redirect: true
@@ -200,7 +200,7 @@ metadata:
     name: mapping-1
     namespace: default
 spec:
-    host: "*"
+    hostname: "*"
     prefix: /svc1
     service: svc1
     host_redirect: true
@@ -213,7 +213,7 @@ metadata:
     name: mapping-2
     namespace: default
 spec:
-    host: "*"
+    hostname: "*"
     prefix: /svc2
     service: svc2
     host_redirect: true
@@ -228,7 +228,7 @@ metadata:
     name: mapping-3
     namespace: default
 spec:
-    host: "*"
+    hostname: "*"
     prefix: /svc3
     service: svc3
     host_redirect: true

--- a/python/tests/test_lookup.py
+++ b/python/tests/test_lookup.py
@@ -36,7 +36,7 @@ config:
 apiVersion: getambassador.io/v1
 kind: Mapping
 name: test_mapping
-host: "*"
+hostname: "*"
 prefix: /test/
 service: test:9999
 '''

--- a/python/tests/test_mapping.py
+++ b/python/tests/test_mapping.py
@@ -1,0 +1,309 @@
+import json
+import pytest
+
+from utils import compile_with_cachecheck
+
+@pytest.mark.compilertest
+def test_mapping_host_star_error():
+    test_yaml = """
+---
+apiVersion: getambassador.io/v2
+kind: Mapping
+metadata:
+  name: bad-mapping
+  namespace: default
+spec:
+  host: "*"
+  prefix: /star/
+  service: star
+"""
+
+    r = compile_with_cachecheck(test_yaml, envoy_version="v3", errors_ok=True)
+
+    ir = r["ir"]
+
+    # print(json.dumps(ir.aconf.errors, sort_keys=True, indent=4))
+
+    errors = ir.aconf.errors["bad-mapping.default.1"]
+    assert len(errors) == 1, f"Expected 1 error but got {len(errors)}"
+
+    assert errors[0]["ok"] == False
+    assert errors[0]["error"] == "host exact-match * contains *, which cannot match anything."
+
+    for g in ir.groups.values():
+        assert g.prefix != "/star/"
+
+    # print(json.dumps(ir.as_dict(), sort_keys=True, indent=4))
+
+@pytest.mark.compilertest
+def test_mapping_host_authority_star_error():
+    test_yaml = """
+---
+apiVersion: getambassador.io/v2
+kind: Mapping
+metadata:
+  name: bad-mapping
+  namespace: default
+spec:
+  headers:
+    ":authority": "*"
+  prefix: /star/
+  service: star
+"""
+
+    r = compile_with_cachecheck(test_yaml, envoy_version="v3", errors_ok=True)
+
+    ir = r["ir"]
+
+    # print(json.dumps(ir.aconf.errors, sort_keys=True, indent=4))
+
+    errors = ir.aconf.errors["bad-mapping.default.1"]
+    assert len(errors) == 1, f"Expected 1 error but got {len(errors)}"
+
+    assert errors[0]["ok"] == False
+    assert errors[0]["error"] == ":authority exact-match '*' contains *, which cannot match anything."
+
+    for g in ir.groups.values():
+        assert g.prefix != "/star/"
+
+    # print(json.dumps(ir.as_dict(), sort_keys=True, indent=4))
+
+@pytest.mark.compilertest
+def test_mapping_host_ok():
+    test_yaml = """
+---
+apiVersion: getambassador.io/v2
+kind: Mapping
+metadata:
+  name: good-host-mapping
+  namespace: default
+spec:
+  host: foo.example.com
+  prefix: /wanted_group/
+  service: star
+"""
+
+    r = compile_with_cachecheck(test_yaml, envoy_version="v3", errors_ok=True)
+
+    ir = r["ir"]
+
+    errors = ir.aconf.errors
+    assert len(errors) == 0, "Expected no errors but got %s" % (json.dumps(errors, sort_keys=True, indent=4))
+
+    found = 0
+
+    for g in ir.groups.values():
+        if g.prefix == "/wanted_group/":
+            assert g.host == "foo.example.com"
+            found += 1
+
+    assert found == 1, "Expected 1 /wanted_group/ prefix, got %d" % found
+
+    # print(json.dumps(ir.as_dict(), sort_keys=True, indent=4))
+
+@pytest.mark.compilertest
+def test_mapping_host_authority_ok():
+    test_yaml = """
+---
+apiVersion: getambassador.io/v2
+kind: Mapping
+metadata:
+  name: good-host-mapping
+  namespace: default
+spec:
+  headers:
+    ":authority": foo.example.com
+  prefix: /wanted_group/
+  service: star
+"""
+
+    r = compile_with_cachecheck(test_yaml, envoy_version="v3", errors_ok=True)
+
+    ir = r["ir"]
+
+    errors = ir.aconf.errors
+    assert len(errors) == 0, "Expected no errors but got %s" % (json.dumps(errors, sort_keys=True, indent=4))
+
+    found = 0
+
+    for g in ir.groups.values():
+        if g.prefix == "/wanted_group/":
+            assert g.host == "foo.example.com"
+            found += 1
+
+    assert found == 1, "Expected 1 /wanted_group/ prefix, got %d" % found
+
+    # print(json.dumps(ir.as_dict(), sort_keys=True, indent=4))
+
+@pytest.mark.compilertest
+def test_mapping_host_authority_and_host():
+    test_yaml = """
+---
+apiVersion: getambassador.io/v2
+kind: Mapping
+metadata:
+  name: good-host-mapping
+  namespace: default
+spec:
+  headers:
+    ":authority": bar.example.com
+  host: foo.example.com
+  prefix: /wanted_group/
+  service: star
+"""
+
+    r = compile_with_cachecheck(test_yaml, envoy_version="v3", errors_ok=True)
+
+    ir = r["ir"]
+
+    errors = ir.aconf.errors
+    assert len(errors) == 0, "Expected no errors but got %s" % (json.dumps(errors, sort_keys=True, indent=4))
+
+    found = 0
+
+    for g in ir.groups.values():
+        if g.prefix == "/wanted_group/":
+            assert g.host == "foo.example.com"
+            found += 1
+
+    assert found == 1, "Expected 1 /wanted_group/ prefix, got %d" % found
+
+    # print(json.dumps(ir.as_dict(), sort_keys=True, indent=4))
+
+@pytest.mark.compilertest
+def test_mapping_hostname_ok():
+    test_yaml = """
+---
+apiVersion: getambassador.io/v2
+kind: Mapping
+metadata:
+  name: good-hostname-mapping
+  namespace: default
+spec:
+  hostname: "*.example.com"
+  prefix: /wanted_group/
+  service: star
+"""
+
+    r = compile_with_cachecheck(test_yaml, envoy_version="v3", errors_ok=True)
+
+    ir = r["ir"]
+
+    errors = ir.aconf.errors
+    assert len(errors) == 0, "Expected no errors but got %s" % (json.dumps(errors, sort_keys=True, indent=4))
+
+    found = 0
+
+    for g in ir.groups.values():
+        if g.prefix == "/wanted_group/":
+            assert g.host == "*.example.com"
+            found += 1
+
+    assert found == 1, "Expected 1 /wanted_group/ prefix, got %d" % found
+
+    # print(json.dumps(ir.as_dict(), sort_keys=True, indent=4))
+
+@pytest.mark.compilertest
+def test_mapping_hostname_and_host():
+    test_yaml = """
+---
+apiVersion: getambassador.io/v2
+kind: Mapping
+metadata:
+  name: hostname-and-host-mapping
+  namespace: default
+spec:
+  host: foo.example.com
+  hostname: "*.example.com"
+  prefix: /wanted_group/
+  service: star
+"""
+
+    r = compile_with_cachecheck(test_yaml, envoy_version="v3", errors_ok=True)
+
+    ir = r["ir"]
+
+    errors = ir.aconf.errors
+    assert len(errors) == 0, "Expected no errors but got %s" % (json.dumps(errors, sort_keys=True, indent=4))
+
+    found = 0
+
+    for g in ir.groups.values():
+        if g.prefix == "/wanted_group/":
+            assert g.host == "*.example.com"
+            found += 1
+
+    assert found == 1, "Expected 1 /wanted_group/ prefix, got %d" % found
+
+    # print(json.dumps(ir.as_dict(), sort_keys=True, indent=4))
+
+@pytest.mark.compilertest
+def test_mapping_hostname_and_authority():
+    test_yaml = """
+---
+apiVersion: getambassador.io/v2
+kind: Mapping
+metadata:
+  name: hostname-and-host-mapping
+  namespace: default
+spec:
+  headers:
+    ":authority": foo.example.com
+  hostname: "*.example.com"
+  prefix: /wanted_group/
+  service: star
+"""
+
+    r = compile_with_cachecheck(test_yaml, envoy_version="v3", errors_ok=True)
+
+    ir = r["ir"]
+
+    errors = ir.aconf.errors
+    assert len(errors) == 0, "Expected no errors but got %s" % (json.dumps(errors, sort_keys=True, indent=4))
+
+    found = 0
+
+    for g in ir.groups.values():
+        if g.prefix == "/wanted_group/":
+            assert g.host == "*.example.com"
+            found += 1
+
+    assert found == 1, "Expected 1 /wanted_group/ prefix, got %d" % found
+
+    # print(json.dumps(ir.as_dict(), sort_keys=True, indent=4))
+
+@pytest.mark.compilertest
+def test_mapping_hostname_and_host_and_authority():
+    test_yaml = """
+---
+apiVersion: getambassador.io/v2
+kind: Mapping
+metadata:
+  name: hostname-and-host-mapping
+  namespace: default
+spec:
+  headers:
+    ":authority": bar.example.com
+  host: foo.example.com
+  hostname: "*.example.com"
+  prefix: /wanted_group/
+  service: star
+"""
+
+    r = compile_with_cachecheck(test_yaml, envoy_version="v3", errors_ok=True)
+
+    ir = r["ir"]
+
+    errors = ir.aconf.errors
+    assert len(errors) == 0, "Expected no errors but got %s" % (json.dumps(errors, sort_keys=True, indent=4))
+
+    found = 0
+
+    for g in ir.groups.values():
+        if g.prefix == "/wanted_group/":
+            assert g.host == "*.example.com"
+            found += 1
+
+    assert found == 1, "Expected 1 /wanted_group/ prefix, got %d" % found
+
+    # print(json.dumps(ir.as_dict(), sort_keys=True, indent=4))

--- a/python/tests/test_max_request_header.py
+++ b/python/tests/test_max_request_header.py
@@ -44,7 +44,7 @@ config:
 apiVersion: getambassador.io/v2
 kind: Mapping
 name: ambassador
-host: "*"
+hostname: "*"
 prefix: /test/
 service: test:9999
 """
@@ -81,7 +81,7 @@ config:
 apiVersion: getambassador.io/v2
 kind: Mapping
 name: ambassador
-host: "*"
+hostname: "*"
 prefix: /test/
 service: test:9999
 """

--- a/python/tests/test_shadow.py
+++ b/python/tests/test_shadow.py
@@ -144,14 +144,14 @@ apiVersion: getambassador.io/v2
 kind: Mapping
 name: httpbin-mapping
 service: httpbin
-host: "*"
+hostname: "*"
 prefix: /httpbin/
 ---
 apiVersion: getambassador.io/v2
 kind: Mapping
 name: httpbin-mapping-shadow
 service: httpbin-shadow
-host: "*"
+hostname: "*"
 prefix: /httpbin/
 shadow: true
 weight: 10
@@ -193,14 +193,14 @@ apiVersion: getambassador.io/v2
 kind: Mapping
 name: httpbin-mapping
 service: httpbin
-host: "*"
+hostname: "*"
 prefix: /httpbin/
 ---
 apiVersion: getambassador.io/v2
 kind: Mapping
 name: httpbin-mapping-shadow
 service: httpbin-shadow
-host: "*"
+hostname: "*"
 prefix: /httpbin/
 shadow: true
 weight: 10

--- a/python/tests/test_statsd.py
+++ b/python/tests/test_statsd.py
@@ -59,7 +59,7 @@ apiVersion: ambassador/v1
 kind:  Mapping
 name:  thing-rest
 case_sensitive: false
-host: "*"
+hostname: "*"
 prefix: /reset/
 rewrite: /RESET/
 service: beepboop
@@ -106,7 +106,7 @@ apiVersion: ambassador/v1
 kind:  Mapping
 name:  thing-rest
 case_sensitive: false
-host: "*"
+hostname: "*"
 prefix: /reset/
 rewrite: /RESET/
 service: beepboop
@@ -154,7 +154,7 @@ apiVersion: ambassador/v1
 kind:  Mapping
 name:  thing-rest
 case_sensitive: false
-host: "*"
+hostname: "*"
 prefix: /reset/
 rewrite: /RESET/
 service: beepboop

--- a/python/tests/utils.py
+++ b/python/tests/utils.py
@@ -245,23 +245,29 @@ def _secret_handler():
     cache_dir = tempfile.TemporaryDirectory(prefix="null-secret-", suffix="-cache")
     return NullSecretHandler(logger, source_root.name, cache_dir.name, "fake")
 
-def econf_compile(yaml, envoy_version="V2"):
+def compile_with_cachecheck(yaml, envoy_version="V2", errors_ok=False):
     # Compile with and without a cache. Neither should produce errors.
     cache = Cache(logger)
     secret_handler = _secret_handler()
     r1 = Compile(logger, yaml, k8s=True, secret_handler=secret_handler, envoy_version=envoy_version)
     r2 = Compile(logger, yaml, k8s=True, secret_handler=secret_handler, cache=cache,
             envoy_version=envoy_version)
-    _require_no_errors(r1["ir"])
-    _require_no_errors(r2["ir"])
+
+    if not errors_ok:
+        _require_no_errors(r1["ir"])
+        _require_no_errors(r2["ir"])
 
     # Both should produce equal Envoy config as sorted json.
     r1j = json.dumps(r1[envoy_version.lower()].as_dict(), sort_keys=True, indent=2)
     r2j = json.dumps(r2[envoy_version.lower()].as_dict(), sort_keys=True, indent=2)
     assert r1j == r2j
 
-    # Now we can return the Envoy config as a dictionary
-    return r1[envoy_version.lower()].as_dict()
+    # All good.
+    return r1
+
+def econf_compile(yaml, envoy_version="V2"):
+    compiled = compile_with_cachecheck(yaml, envoy_version=envoy_version)
+    return compiled[envoy_version.lower()].as_dict()
 
 def econf_foreach_hcm(econf, fn, envoy_version='V2', chain_count=2):
     found_hcm = False

--- a/python/tests/utils.py
+++ b/python/tests/utils.py
@@ -147,7 +147,7 @@ metadata:
   name:  qotm-mapping
   namespace: {namespace}
 spec:
-  host: "*"
+  hostname: "*"
   prefix: /qotm/
   service: qotm
 """
@@ -163,7 +163,7 @@ metadata:
   name:  httpbin-mapping
   namespace: {namespace}
 spec:
-  host: "*"
+  hostname: "*"
   prefix: /httpbin/
   rewrite: /
   service: httpbin
@@ -228,7 +228,7 @@ metadata:
   name: ambassador
   namespace: default
 spec:
-  host: "*"
+  hostname: "*"
   prefix: /httpbin/
   service: httpbin"""
     if mapping_confs:


### PR DESCRIPTION
Support `Mapping.spec.hostname` in addition to `Mapping.spec.host`:

- `Mapping.spec.host` can be either an exact match or a regex, according to `Mapping.spec.host_regex`.
- `Mapping.spec.hostname` is always a DNS glob.
- Specifying both is an error, and `hostname` will win.

This PR also tackles some `Ingress` issues into the mix, since the `Ingress` had to use the new `hostname` and (it turned out) it wasn't doing the right thing with an `Ingress` with no `host` defined.

 - [x] I made sure to update `CHANGELOG.md`.
 - [x] This is unlikely to impact how Ambassador performs at scale.
 - [x] My change is adequately tested.
  - [x] I did not need to update `DEVELOPING.md`.
