### PR TITLE
Watch Listener in LEGACY mode.

### DIFF
--- a/python/entrypoint.sh
+++ b/python/entrypoint.sh
@@ -451,7 +451,7 @@ if [[ -z "${AMBASSADOR_NO_KUBEWATCH}" ]]; then
     fi
 
     if [ ! -f "${AMBASSADOR_CONFIG_BASE_DIR}/.ambassador_ignore_crds" ]; then
-        watt_query_flags+=(-s AuthService -s Mapping -s Module -s RateLimitService -s TCPMapping -s TLSContext -s TracingService)
+        watt_query_flags+=(-s AuthService -s Listener -s Mapping -s Module -s RateLimitService -s TCPMapping -s TLSContext -s TracingService)
     fi
 
     if [ ! -f "${AMBASSADOR_CONFIG_BASE_DIR}/.ambassador_ignore_crds_2" ]; then


### PR DESCRIPTION
LEGACY mode is `watt` rather than `entrypoint.go`, so `watt` needed to be watching for `Listener`.

Signed-off-by: Flynn <flynn@datawire.io>
