### PR TITLE
Clean up some sad-path handling

### DIFF
--- a/charts/emissary-ingress/crds/x.getambassador.io_ambassadorlisteners.yaml
+++ b/charts/emissary-ingress/crds/x.getambassador.io_ambassadorlisteners.yaml
@@ -144,6 +144,10 @@ spec:
               - SECURE
               - INSECURE
               type: string
+          required:
+          - hostBinding
+          - port
+          - securityModel
           type: object
       type: object
   version: v3alpha1

--- a/manifests/emissary/ambassador-crds.yaml
+++ b/manifests/emissary/ambassador-crds.yaml
@@ -1906,6 +1906,10 @@ spec:
               - SECURE
               - INSECURE
               type: string
+          required:
+          - hostBinding
+          - port
+          - securityModel
           type: object
       type: object
   version: v3alpha1

--- a/manifests/emissary/emissary-crds.yaml
+++ b/manifests/emissary/emissary-crds.yaml
@@ -1906,6 +1906,10 @@ spec:
               - SECURE
               - INSECURE
               type: string
+          required:
+          - hostBinding
+          - port
+          - securityModel
           type: object
       type: object
   version: v3alpha1

--- a/pkg/api/getambassador.io/v3alpha1/listener_types.go
+++ b/pkg/api/getambassador.io/v3alpha1/listener_types.go
@@ -142,6 +142,7 @@ type AmbassadorListenerSpec struct {
 	// Port is the network port. Only one AmbassadorListener can use a given port.
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=65535
+	// +kubebuilder:validation:Required
 	Port int32 `json:"port"`
 
 	// Protocol is a shorthand for certain predefined stacks. Exactly one of Protocol
@@ -154,13 +155,15 @@ type AmbassadorListenerSpec struct {
 
 	// SecurityModel specifies how to determine whether connections to this port are secure
 	// or insecure.
+	// +kubebuilder:validation:Required
 	SecurityModel SecurityModelType `json:"securityModel"`
 
 	// L7Depth specifies how many layer 7 load balancers are between us and the edge of
 	// the network.
-	L7Depth int32 `json:"l7Depth"`
+	L7Depth int32 `json:"l7Depth,omitempty"`
 
 	// HostBinding allows restricting which Hosts will be used for this AmbassadorListener.
+	// +kubebuilder:validation:Required
 	HostBinding HostBindingType `json:"hostBinding"`
 }
 

--- a/python/ambassador/envoy/common.py
+++ b/python/ambassador/envoy/common.py
@@ -70,6 +70,10 @@ class EnvoyConfig:
         return obj
 
     @abstractmethod
+    def has_listeners(self) -> bool:
+        pass
+
+    @abstractmethod
     def split_config(self) -> Tuple[Dict[str, Any], Dict[str, Any], Dict[str, 'ClustermapEntry']]:
         pass
 

--- a/python/ambassador/envoy/v2/v2config.py
+++ b/python/ambassador/envoy/v2/v2config.py
@@ -68,6 +68,9 @@ class V2Config (EnvoyConfig):
         V2StaticResources.generate(self)
         V2Bootstrap.generate(self)
 
+    def has_listeners(self) -> bool:
+        return len(self.listeners) > 0
+
     def as_dict(self) -> Dict[str, Any]:
         bootstrap_config, ads_config, clustermap = self.split_config()
 

--- a/python/ambassador/envoy/v2/v2listener.py
+++ b/python/ambassador/envoy/v2/v2listener.py
@@ -970,9 +970,8 @@ class V2Listener(dict):
             v2listener = V2Listener(config, irlistener)
             v2listener.finalize()
 
-            config.listeners.append(v2listener)
             config.ir.logger.info(f"V2Listener: ==== GENERATED {v2listener}")
-            
+
             if v2listener._log_debug:
                 for k in sorted(v2listener._chains.keys()):
                     chain = v2listener._chains[k]
@@ -980,3 +979,9 @@ class V2Listener(dict):
 
                     for r in chain.routes:
                         config.ir.logger.debug("      %s", v2prettyroute(r))
+
+            # Does this listener have any filter chains?
+            if v2listener._filter_chains:
+                config.listeners.append(v2listener)
+            else:
+                irlistener.post_error("No matching AmbassadorHosts found, disabling!")

--- a/python/ambassador/envoy/v3/v3config.py
+++ b/python/ambassador/envoy/v3/v3config.py
@@ -68,6 +68,9 @@ class V3Config (EnvoyConfig):
         V3StaticResources.generate(self)
         V3Bootstrap.generate(self)
 
+    def has_listeners(self) -> bool:
+        return len(self.listeners) > 0
+
     def as_dict(self) -> Dict[str, Any]:
         bootstrap_config, ads_config, clustermap = self.split_config()
 

--- a/python/ambassador/envoy/v3/v3listener.py
+++ b/python/ambassador/envoy/v3/v3listener.py
@@ -995,9 +995,8 @@ class V3Listener(dict):
             v3listener = V3Listener(config, irlistener)
             v3listener.finalize()
 
-            config.listeners.append(v3listener)
             config.ir.logger.info(f"V3Listener: ==== GENERATED {v3listener}")
-            
+
             if v3listener._log_debug:
                 for k in sorted(v3listener._chains.keys()):
                     chain = v3listener._chains[k]
@@ -1005,3 +1004,9 @@ class V3Listener(dict):
 
                     for r in chain.routes:
                         config.ir.logger.debug("      %s", v3prettyroute(r))
+
+            # Does this listener have any filter chains?
+            if v3listener._filter_chains:
+                config.listeners.append(v3listener)
+            else:
+                irlistener.post_error("No matching AmbassadorHosts found, disabling!")

--- a/python/ambassador_diag/diagd.py
+++ b/python/ambassador_diag/diagd.py
@@ -1590,18 +1590,37 @@ class AmbassadorEventWatcher(threading.Thread):
         # DON'T generate the Diagnostics here, because that turns out to be expensive.
         # Instead, we'll just reset app.diag to None, then generate it on-demand when
         # we need it.
-
+        #
+        # DO go ahead and split the Envoy config into its components for later, though.
         bootstrap_config, ads_config, clustermap = econf.split_config()
 
-        if not self.validate_envoy_config(ir, config=ads_config, retries=self.app.validation_retries):
-            self.logger.info("no updates were performed due to invalid envoy configuration, continuing with current configuration...")
+        # OK. Assume that the Envoy config is valid...
+        econf_is_valid = True
+        econf_bad_reason = ""
+
+        # ...then look for reasons it's not valid.
+        if not econf.has_listeners():
+            # No listeners == something in the Ambassador config is totally horked.
+            # Probably this is the user not defining any AmbassadorHosts that match
+            # the AmbassadorListeners in the system.
+            econf_is_valid = False
+            econf_bad_reason = "Envoy configuration has no listeners at all; check your AmbassadorListener and AmbassadorHost configuration"
+        elif not self.validate_envoy_config(ir, config=ads_config, retries=self.app.validation_retries):
+            # Invalid Envoy config probably indicates a bug in Emissary itself. Sigh.
+            econf_is_valid = False
+            econf_bad_reason = "invalid envoy configuration generated"
+
+        # OK. Is the config invalid?
+        if not econf_is_valid:
+            # BZzzt. Don't post this update.
+            self.logger.info("no update performed (%s), continuing with current configuration..." % econf_bad_reason)
 
             # Don't use app.check_scout; it will deadlock.
             self.check_scout("attempted bad update")
 
             # DO stop the reconfiguration timer before leaving.
             self.app.config_timer.stop()
-            self._respond(rqueue, 500, 'ignoring: invalid Envoy configuration in snapshot %s' % snapshot)
+            self._respond(rqueue, 500, 'ignoring (%s) in snapshot %s' % (econf_bad_reason, snapshot))
             return
 
         snapcount = int(os.environ.get('AMBASSADOR_SNAPSHOT_COUNT', "4"))


### PR DESCRIPTION
Probably simplest to review commit-by-commit.

- Make sure that required elements in the `AmbassadorListener` are marked "required" for validation.
- If an Envoy `Listener` has no filter chains, don't include it in the Envoy config.
   - This can happen if no `AmbassadorHost`s match an `AmbassadorListener`.
- If an Envoy config has no Envoy `Listener`s at all, don't try to hand it to Envoy.
   - This can happen if no `AmbassadorHost`s match _any_ `AmbassadorListener`s.

 - [x] I don't need to update `CHANGELOG.md`.
 - [x] This is unlikely to impact how Ambassador performs at scale.
 - [ ] My change is manually tested, but I want to sort out a `Fake` test too. Hopefully this evening -- in the meantime I want CI to run here.
 - [x] I don't need to update `DEVELOPING.md`.