### PR TITLE
[2.0.0-ea] fix for acme controller

### DIFF
--- a/pkg/snapshot/v1/types.go
+++ b/pkg/snapshot/v1/types.go
@@ -115,6 +115,28 @@ type KubernetesSnapshot struct {
 	ArgoApplications []*kates.Unstructured `json:"ArgoApplications,omitempty"`
 }
 
+func (a *KubernetesSnapshot) UnmarshalJSON(data []byte) error {
+	legacyK8sTranslator := struct {
+		LegacyModeListeners   []*ambv3alpha1.AmbassadorListener   `json:"AmbassadorListener"`
+		LegacyModeHosts       []*ambv3alpha1.AmbassadorHost       `json:"AmbassadorHost"`
+		LegacyModeMappings    []*ambv3alpha1.AmbassadorMapping    `json:"AmbassadorMapping"`
+		LegacyModeTCPMappings []*ambv3alpha1.AmbassadorTCPMapping `json:"AmbassadorTCPMapping"`
+	}{}
+
+	if err := json.Unmarshal(data, &legacyK8sTranslator); err != nil {
+		return err
+	}
+	type k8ssnap2 KubernetesSnapshot
+	if err := json.Unmarshal(data, (*k8ssnap2)(a)); err != nil {
+		return err
+	}
+	a.Listeners = append(a.Listeners, legacyK8sTranslator.LegacyModeListeners...)
+	a.Hosts = append(a.Hosts, legacyK8sTranslator.LegacyModeHosts...)
+	a.Mappings = append(a.Mappings, legacyK8sTranslator.LegacyModeMappings...)
+	a.TCPMappings = append(a.TCPMappings, legacyK8sTranslator.LegacyModeTCPMappings...)
+	return nil
+}
+
 func (a *KubernetesSnapshot) Render() string {
 	result := &strings.Builder{}
 	v := reflect.ValueOf(a)

--- a/pkg/snapshot/v1/types.go
+++ b/pkg/snapshot/v1/types.go
@@ -115,6 +115,10 @@ type KubernetesSnapshot struct {
 	ArgoApplications []*kates.Unstructured `json:"ArgoApplications,omitempty"`
 }
 
+// Custom Unmarshaller for the kubernetes snapshot
+// TODO: This should be REMOVED once LEGACY_MODE is removed.
+// This unmarshall will take a snapshot that comes from watt, and translate the mis-named fields
+// into the correct fields in KubernetesSnapshot
 func (a *KubernetesSnapshot) UnmarshalJSON(data []byte) error {
 	legacyK8sTranslator := struct {
 		LegacyModeListeners   []*ambv3alpha1.AmbassadorListener   `json:"AmbassadorListener"`


### PR DESCRIPTION
## Description
In legacy mode, the new Ambassador[Host|Listener|Mapping] fields get keyed on, e.g. `AmbassadorHost`, however in regular mode they just get keyed on, e.g. `Host`. This screws up anything that unmarshals the watt snapshot with the snapshot struct in pkg/snapshots/v1.

## Related Issues
List related issues.

## Testing
A few sentences describing what testing you've done, e.g., manual tests, automated tests, deployed in production, etc.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `CHANGELOG.md`.
   
   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations
 
 - [ ] This is unlikely to impact how Ambassador performs at scale.
 
   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability
 
 - [ ] My change is adequately tested.
 
   Remember when considering testing:
    + LEGACY MODE TESTS DO NOT RUN FOR EVERY PR. If your change is affected by legacy mode, you need
      to run legacy-mode tests manually (set `AMBASSADOR_LEGACY_MODE=true` and run the tests).
      (This will be fixed soon.)
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points
 
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
