### PR TITLE
[v1.13.9] Release Branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,13 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 ## RELEASE NOTES
 
+## [1.13.9] (TBD)
+[1.13.9]: https://github.com/emissary-ingress/emissary/compare/v1.13.8...v1.13.9
+
+### Emissary Ingress and Ambassador Edge Stack
+
+(no changes yet)
+
 ## [1.13.8] June 08, 2021
 [1.13.8]: https://github.com/emissary-ingress/emissary/compare/v1.13.7...v1.13.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 ### Emissary Ingress and Ambassador Edge Stack
 
-(no changes yet)
+- Bugfix: Multiple TCPMappings with the same ports but different hosts no longer create invalid envoy configs.
 
 ## [1.13.8] June 08, 2021
 [1.13.8]: https://github.com/emissary-ingress/emissary/compare/v1.13.7...v1.13.8

--- a/docs/yaml/versions.yml
+++ b/docs/yaml/versions.yml
@@ -1,2 +1,2 @@
-version: 1.13.8
+version: 1.13.9
 quoteVersion: 0.4.1

--- a/python/ambassador/envoy/v2/v2listener.py
+++ b/python/ambassador/envoy/v2/v2listener.py
@@ -664,14 +664,14 @@ class V2TCPListener(dict):
             # Apply the context to the chain...
             chain_entry['tls_context'] = self.tls_context
 
-            # Do we have a host match?
-            host_wanted = group.get('host') or '*'
+        # Do we have a host match?
+        host_wanted = group.get('host') or '*'
 
-            if host_wanted != '*':
-                # Yup. Hook it in.
-                chain_entry['filter_chain_match'] = {
-                    'server_names': [ host_wanted ]
-                }
+        if host_wanted != '*':
+            # Yup. Hook it in.
+            chain_entry['filter_chain_match'] = {
+                'server_names': [ host_wanted ]
+            }
 
         # OK, once that's done, stick this into our filter chains.
         self['filter_chains'].append(chain_entry)

--- a/python/ambassador/envoy/v3/v3listener.py
+++ b/python/ambassador/envoy/v3/v3listener.py
@@ -677,14 +677,14 @@ class V3TCPListener(dict):
                     }
             }
 
-            # Do we have a host match?
-            host_wanted = group.get('host') or '*'
+        # Do we have a host match?
+        host_wanted = group.get('host') or '*'
 
-            if host_wanted != '*':
-                # Yup. Hook it in.
-                chain_entry['filter_chain_match'] = {
-                    'server_names': [ host_wanted ]
-                }
+        if host_wanted != '*':
+            # Yup. Hook it in.
+            chain_entry['filter_chain_match'] = {
+                'server_names': [ host_wanted ]
+            }
 
         # OK, once that's done, stick this into our filter chains.
         self['filter_chains'].append(chain_entry)


### PR DESCRIPTION

All commits that are going out in 1.13.9 release **must** be on rel/v1.13.9.
This will allow the appropriate CI to run.

To get the hotfix changes onto this branch you can do one of the following:
    * use rel/v1.13.9 as the development branch for the fix
    * land (or have already landed) hotfix changes on release/v1.13 branch, and merge release/v1.13 into rel/v1.13.9
    * cherry-pick hotfix commits from ambassador.git to rel/v1.13.9

It is okay if you've already landed the hotfix changes on release/v1.13 branch,
reviewers just need to validate that the hotfix commits are in the tree for rel/v1.13.9,
and all the appropriate changelog updates exist.

## REVIEWERS MUST CHECK THAT:
* hotfix commits are on rel/v1.13.9
* CHANGELOG updates are on rel/v1.13.9
