### PR TITLE
[v1.13.9] Changelog date update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,12 +63,12 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 ## RELEASE NOTES
 
-## [1.13.9] (TBD)
+## [1.13.9] June 30, 2021
 [1.13.9]: https://github.com/emissary-ingress/emissary/compare/v1.13.8...v1.13.9
 
 ### Emissary Ingress and Ambassador Edge Stack
 
-- Bugfix: Multiple TCPMappings with the same ports but different hosts no longer create invalid envoy configs.
+- Bugfix: Configuring multiple TCPMappings with the same ports (but different hosts) no longer generates invalid Envoy configuration.
 
 ## [1.13.8] June 08, 2021
 [1.13.8]: https://github.com/emissary-ingress/emissary/compare/v1.13.7...v1.13.8


### PR DESCRIPTION
Changelog date updates for 1.13.9

Reviewers: The only changes in this PR should be updating the changelog entry for 1.13.9 to the date it was released.

If there are any other changes, the PR creator should note the reason.