### PR TITLE
Fetch the sidecar process-info and relay it in snapshots published by ambassador-agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,12 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 ## RELEASE NOTES
 
+## Next Release
+
+### Emissary Ingress
+
+- Feature: Ambassador Agent reports sidecar process information and Mapping OpenAPI documentation to Ambassador Cloud to provide more visibility into services and clusters.
+
 ## [2.0.0-ea] June 24, 2021
 [2.0.0-ea]: https://github.com/emissary-ingress/emissary/compare/v1.13.8...v2.0.0-ea
 

--- a/cmd/entrypoint/snapshot_server.go
+++ b/cmd/entrypoint/snapshot_server.go
@@ -20,45 +20,12 @@ const ExternalSnapshotPort = 8005
 func externalSnapshotServer(ctx context.Context, snapshot *atomic.Value) error {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/snapshot-external", func(w http.ResponseWriter, r *http.Request) {
-		rawSnapshot := snapshot.Load().([]byte)
-		snapDecoded := snapshotTypes.Snapshot{}
-		err := json.Unmarshal(rawSnapshot, &snapDecoded)
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-		err = snapDecoded.Sanitize()
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-		if snapDecoded.AmbassadorMeta != nil && IsEdgeStack() {
-			sidecarProcessInfoUrl := fmt.Sprintf("%s/process-info/", GetSidecarHost())
-			dlog.Debugf(ctx, "loading sidecar process-info using [%s]...", sidecarProcessInfoUrl)
-			resp, err := http.DefaultClient.Get(sidecarProcessInfoUrl)
-			if err != nil {
-				dlog.Error(ctx, err.Error())
-			} else {
-				defer resp.Body.Close()
-				if resp.StatusCode == 200 {
-					bodyBytes, err := ioutil.ReadAll(resp.Body)
-					if err != nil {
-						dlog.Warnf(ctx, "error reading response body: %v", err)
-					} else {
-						snapDecoded.AmbassadorMeta.Sidecar = bodyBytes
-					}
-				} else {
-					dlog.Warnf(ctx, "unexpected status code %v", resp.StatusCode)
-				}
-			}
-		}
-		sanitizedSnap, err := json.Marshal(snapDecoded)
+		sanitizedSnap, err := sanitizeExternalSnapshot(ctx, snapshot.Load().([]byte), http.DefaultClient)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 		w.Header().Set("content-type", "application/json")
-
 		w.Write(sanitizedSnap)
 	})
 
@@ -80,4 +47,38 @@ func snapshotServer(ctx context.Context, snapshot *atomic.Value) error {
 	}
 
 	return s.ListenAndServe(ctx, "localhost:9696")
+}
+
+func sanitizeExternalSnapshot(ctx context.Context, rawSnapshot []byte, client *http.Client) ([]byte, error) {
+	snapDecoded := snapshotTypes.Snapshot{}
+	err := json.Unmarshal(rawSnapshot, &snapDecoded)
+	if err != nil {
+		return nil, err
+	}
+	err = snapDecoded.Sanitize()
+	if err != nil {
+		return nil, err
+	}
+	if snapDecoded.AmbassadorMeta != nil && IsEdgeStack() {
+		sidecarProcessInfoUrl := fmt.Sprintf("%s/process-info/", GetSidecarHost())
+		dlog.Debugf(ctx, "loading sidecar process-info using [%s]...", sidecarProcessInfoUrl)
+		resp, err := client.Get(sidecarProcessInfoUrl)
+		if err != nil {
+			dlog.Error(ctx, err.Error())
+		} else {
+			defer resp.Body.Close()
+			if resp.StatusCode == 200 {
+				bodyBytes, err := ioutil.ReadAll(resp.Body)
+				if err != nil {
+					dlog.Warnf(ctx, "error reading response body: %v", err)
+				} else {
+					snapDecoded.AmbassadorMeta.Sidecar = bodyBytes
+				}
+			} else {
+				dlog.Warnf(ctx, "unexpected status code %v", resp.StatusCode)
+			}
+		}
+	}
+
+	return json.Marshal(snapDecoded)
 }

--- a/cmd/entrypoint/snapshot_server.go
+++ b/cmd/entrypoint/snapshot_server.go
@@ -34,7 +34,7 @@ func externalSnapshotServer(ctx context.Context, snapshot *atomic.Value) error {
 		}
 		if snapDecoded.AmbassadorMeta != nil && IsEdgeStack() {
 			sidecarProcessInfoUrl := fmt.Sprintf("%s/process-info/", GetSidecarHost())
-			dlog.Debugf(ctx, "loading sidecard process-info using [%s]...", sidecarProcessInfoUrl)
+			dlog.Debugf(ctx, "loading sidecar process-info using [%s]...", sidecarProcessInfoUrl)
 			resp, err := http.DefaultClient.Get(sidecarProcessInfoUrl)
 			if err != nil {
 				dlog.Error(ctx, err.Error())

--- a/cmd/entrypoint/snapshot_server_test.go
+++ b/cmd/entrypoint/snapshot_server_test.go
@@ -1,0 +1,87 @@
+package entrypoint
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var sanitizeExternalSnapshotTests = []struct {
+	testName                 string
+	rawJSON                  string
+	hasEdgeStackSidecar      bool
+	edgeStackSidecarResponse int
+	expectedSanitizedJSON    string
+}{
+	{
+		testName:                 "no AmbassadorMeta",
+		rawJSON:                  `{"AmbassadorMeta":null,"Kubernetes":null,"Consul":null,"Deltas":null,"Invalid":null}`,
+		hasEdgeStackSidecar:      true,
+		edgeStackSidecarResponse: 200,
+		expectedSanitizedJSON:    `{"AmbassadorMeta":null,"Kubernetes":null,"Consul":null,"Deltas":null,"Invalid":null}`,
+	},
+	{
+		testName:                 "AmbassadorMeta with sidecar",
+		rawJSON:                  `{"AmbassadorMeta":{"cluster_id":"","ambassador_id":"","ambassador_version":"","kube_version":""}}`,
+		hasEdgeStackSidecar:      true,
+		edgeStackSidecarResponse: 200,
+		expectedSanitizedJSON:    `{"AmbassadorMeta":{"cluster_id":"","ambassador_id":"","ambassador_version":"","kube_version":"","sidecar":{"contains":"raw sidecar process-info content"}},"Kubernetes":null,"Consul":null,"Deltas":null,"Invalid":null}`,
+	},
+	{
+		testName:                 "AmbassadorMeta with bad sidecar response",
+		rawJSON:                  `{"AmbassadorMeta":{"cluster_id":"","ambassador_id":"","ambassador_version":"","kube_version":""}}`,
+		hasEdgeStackSidecar:      true,
+		edgeStackSidecarResponse: 500,
+		expectedSanitizedJSON:    `{"AmbassadorMeta":{"cluster_id":"","ambassador_id":"","ambassador_version":"","kube_version":"","sidecar":null},"Kubernetes":null,"Consul":null,"Deltas":null,"Invalid":null}`,
+	},
+	{
+		testName:              "AmbassadorMeta without any sidecar",
+		rawJSON:               `{"AmbassadorMeta":{"cluster_id":"","ambassador_id":"","ambassador_version":"","kube_version":""}}`,
+		hasEdgeStackSidecar:   false,
+		expectedSanitizedJSON: `{"AmbassadorMeta":{"cluster_id":"","ambassador_id":"","ambassador_version":"","kube_version":"","sidecar":null},"Kubernetes":null,"Consul":null,"Deltas":null,"Invalid":null}`,
+	},
+}
+
+func TestSanitizeExternalSnapshot(t *testing.T) {
+	const isEdgeStackEnvironmentVariable = "EDGE_STACK"
+	const rawSidecarProcessInfoResponse = `{"contains":"raw sidecar process-info content"}`
+
+	for _, sanitizeExternalSnapshotTest := range sanitizeExternalSnapshotTests {
+		t.Run(sanitizeExternalSnapshotTest.testName, func(innerT *testing.T) {
+			defer os.Unsetenv(isEdgeStackEnvironmentVariable)
+			if sanitizeExternalSnapshotTest.hasEdgeStackSidecar {
+				os.Setenv(isEdgeStackEnvironmentVariable, "true")
+			}
+
+			client := newHTTPTestClient(func(req *http.Request) *http.Response {
+				assert.Equal(t, "http://localhost:8500/process-info/", req.URL.String())
+				return &http.Response{
+					StatusCode: sanitizeExternalSnapshotTest.edgeStackSidecarResponse,
+					Body:       ioutil.NopCloser(bytes.NewBufferString(rawSidecarProcessInfoResponse)),
+				}
+			})
+
+			snapshot, err := sanitizeExternalSnapshot(context.Background(), []byte(sanitizeExternalSnapshotTest.rawJSON), client)
+
+			assert.Nil(innerT, err)
+			assert.Equal(innerT, sanitizeExternalSnapshotTest.expectedSanitizedJSON, string(snapshot))
+		})
+	}
+}
+
+type roundTripFunc func(req *http.Request) *http.Response
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req), nil
+}
+
+func newHTTPTestClient(mockHandler roundTripFunc) *http.Client {
+	return &http.Client{
+		Transport: mockHandler,
+	}
+}

--- a/pkg/snapshot/v1/types.go
+++ b/pkg/snapshot/v1/types.go
@@ -44,10 +44,11 @@ type Snapshot struct {
 }
 
 type AmbassadorMetaInfo struct {
-	ClusterID         string `json:"cluster_id"`
-	AmbassadorID      string `json:"ambassador_id"`
-	AmbassadorVersion string `json:"ambassador_version"`
-	KubeVersion       string `json:"kube_version"`
+	ClusterID         string          `json:"cluster_id"`
+	AmbassadorID      string          `json:"ambassador_id"`
+	AmbassadorVersion string          `json:"ambassador_version"`
+	KubeVersion       string          `json:"kube_version"`
+	Sidecar           json.RawMessage `json:"sidecar"`
 }
 
 type KubernetesSnapshot struct {


### PR DESCRIPTION
## Description
Relay additional information from the agent to Ambassador Cloud by fetching the sidecar process-info and publishing its response in the snapshot AmbassadorMetaInfo.

## Related Issues
None

## Testing
Manual tests

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `CHANGELOG.md`.
   
   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations
 
 - [x] This is unlikely to impact how Ambassador performs at scale.
 
   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability
 
 - [x] My change is adequately tested.
 
   Remember when considering testing:
    + LEGACY MODE TESTS DO NOT RUN FOR EVERY PR. If your change is affected by legacy mode, you need
      to run legacy-mode tests manually (set `AMBASSADOR_LEGACY_MODE=true` and run the tests).
      (This will be fixed soon.)
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points
 
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
