### PR TITLE
Scraping Mappings for API documentation to relay through ambassador-agent

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,6 +65,7 @@ require (
 	github.com/ecodia/golang-awaitility v0.0.0-20180710094957-fb55e59708c7
 	github.com/envoyproxy/protoc-gen-validate v0.3.0-java.0.20200609174644-bd816e4522c1
 	github.com/fsnotify/fsnotify v1.4.9
+	github.com/getkin/kin-openapi v0.66.0
 	github.com/golang/protobuf v1.4.3
 	github.com/google/go-cmp v0.5.5
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510

--- a/go.sum
+++ b/go.sum
@@ -271,6 +271,8 @@ github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4
 github.com/fvbommel/sortorder v1.0.1/go.mod h1:uk88iVf1ovNn1iLfgUVU2F9o5eO30ui720w+kxuqRs0=
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7 h1:LofdAjjjqCSXMwLGgOgnE+rdPuvX9DxCqaHwKy7i/ko=
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
+github.com/getkin/kin-openapi v0.66.0 h1:GNEnjUYK5j5TR8CrXBQ5Nao9kVd7kPpoTr0Y0q4eaSA=
+github.com/getkin/kin-openapi v0.66.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -305,6 +307,8 @@ github.com/go-openapi/jsonpointer v0.18.0/go.mod h1:cOnomiV+CVVwFLk0A/MExoFMjwds
 github.com/go-openapi/jsonpointer v0.19.2/go.mod h1:3akKfEdA7DF1sugOqz1dVQHBcuDBPKZGEoHC/NkiQRg=
 github.com/go-openapi/jsonpointer v0.19.3 h1:gihV7YNZK1iK6Tgwwsxo2rJbD1GTbdm72325Bq8FI3w=
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
+github.com/go-openapi/jsonpointer v0.19.5 h1:gZr+CIYByUqjcgeLXnQu2gHYQC9o73G2XUeOFYEICuY=
+github.com/go-openapi/jsonpointer v0.19.5/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/jsonreference v0.0.0-20160704190145-13c6e3589ad9/go.mod h1:W3Z9FmVs9qj+KR4zFKmDPGiLdk1D9Rlm7cyMvf57TTg=
 github.com/go-openapi/jsonreference v0.17.0/go.mod h1:g4xxGn04lDIRh0GJb5QlpE3HfopLOL6uZrK/VgnsK9I=
 github.com/go-openapi/jsonreference v0.18.0/go.mod h1:g4xxGn04lDIRh0GJb5QlpE3HfopLOL6uZrK/VgnsK9I=
@@ -443,6 +447,7 @@ github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2z
 github.com/gorilla/mux v1.7.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=

--- a/go.sum
+++ b/go.sum
@@ -447,6 +447,7 @@ github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2z
 github.com/gorilla/mux v1.7.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -81,6 +81,9 @@ type Agent struct {
 	// current cluster state of core resources
 	coreStore *coreStore
 
+	// apiDocsStore holds OpenAPI documents from cluster Mappings
+	apiDocsStore *APIDocsStore
+
 	// rolloutStore holds Argo Rollouts state from cluster
 	rolloutStore *RolloutStore
 	// applicationStore holds Argo Applications state from cluster
@@ -366,6 +369,7 @@ func (a *Agent) watch(ctx context.Context, snapshotURL string, configAccumulator
 		return err
 	}
 
+	a.apiDocsStore = NewAPIDocsStore()
 	applicationStore := NewApplicationStore()
 	rolloutStore := NewRolloutStore()
 	coreSnapshot := CoreSnapshot{}
@@ -565,6 +569,11 @@ func (a *Agent) ProcessSnapshot(ctx context.Context, snapshot *snapshotTypes.Sna
 		if a.applicationStore != nil {
 			snapshot.Kubernetes.ArgoApplications = a.applicationStore.StateOfWorld()
 			dlog.Debugf(ctx, "Found %d argo applications", len(snapshot.Kubernetes.ArgoApplications))
+		}
+		if a.apiDocsStore != nil {
+			a.apiDocsStore.ProcessSnapshot(ctx, snapshot)
+			snapshot.APIDocs = a.apiDocsStore.StateOfWorld()
+			dlog.Debugf(ctx, "Found %d api docs", len(snapshot.APIDocs))
 		}
 	}
 

--- a/pkg/agent/api_docs.go
+++ b/pkg/agent/api_docs.go
@@ -1,0 +1,419 @@
+package agent
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
+	"path"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/pkg/errors"
+
+	amb "github.com/datawire/ambassador/v2/pkg/api/getambassador.io/v2"
+	"github.com/datawire/ambassador/v2/pkg/kates"
+	snapshotTypes "github.com/datawire/ambassador/v2/pkg/snapshot/v1"
+	"github.com/datawire/dlib/dlog"
+)
+
+// APIDocsStore is responsible for collecting the API docs from Mapping resources in a k8s cluster.
+type APIDocsStore struct {
+	// snapshot holding the Mapping resources from which API docs will be scraped
+	snapshot *CoreSnapshot
+	// store hold the state of the world, with all Mappings and their API docs
+	store *inMemoryStore
+	// client is used to scrape all Mappings for API documentation
+	client *apiDocsHTTPClient
+	// docsDiff helps calculate whether an API doc should be kept or discarded after processing a snapshot
+	docsDiff *docsDiffCalculator
+}
+
+// NewAPIDocsStore is the main APIDocsStore constructor.
+func NewAPIDocsStore() *APIDocsStore {
+	return &APIDocsStore{
+		client:   newAPIDocsHTTPClient(),
+		store:    newInMemoryStore(),
+		docsDiff: newMappingDocsCalculator([]mappingDoc{}),
+	}
+}
+
+// ProcessSnapshot will query the required services to retrieve the API documentation for each
+// of the Mappings in the snapshot
+func (a *APIDocsStore) ProcessSnapshot(ctx context.Context, snapshot *snapshotTypes.Snapshot) {
+	dlog.Debug(ctx, "Processing snapshot...")
+	a.retrieve(ctx, snapshot)
+}
+
+// StateOfWorld returns the current state of all discovered API docs.
+func (a *APIDocsStore) StateOfWorld() []*snapshotTypes.APIDoc {
+	return toAPIDocs(a.store.getAllMappingDocs())
+}
+
+func (a *APIDocsStore) retrieve(ctx context.Context, snapshot *snapshotTypes.Snapshot) {
+	defer func() {
+		// Once we are finished retrieving mapping docs, delete anything we
+		// don't need anymore
+		a.docsDiff.deleteOld(ctx, a.store)
+
+		dlog.Debug(ctx, "Iteration done")
+	}()
+
+	dlog.Debugf(ctx, "Found %d Mappings", len(snapshot.Kubernetes.Mappings))
+	for _, mapping := range snapshot.Kubernetes.Mappings {
+		if mapping == nil {
+			continue
+		}
+		mappingDocs := mapping.Spec.Docs
+		if mappingDocs == nil || (mappingDocs.Ignored != nil && *mappingDocs.Ignored == true) {
+			continue
+		}
+		displayName := mappingDocs.DisplayName
+		if displayName == "" {
+			displayName = fmt.Sprintf("%s.%s", mapping.GetName(), mapping.GetNamespace())
+		}
+		mappingHeaders := a.buildMappingRequestHeaders(mapping.Spec.Headers)
+		mappingPrefix := mapping.Spec.Prefix
+		mappingRewrite := "/"
+		if mapping.Spec.Rewrite != nil {
+			mappingRewrite = *mapping.Spec.Rewrite
+		}
+		mappingHost := mapping.Spec.Host
+
+		var doc *openAPIDoc
+		if mappingDocs.URL != "" {
+			parsedURL, err := url.Parse(mappingDocs.URL)
+			if err != nil {
+				dlog.Errorf(ctx, "could not parse URL or path in 'docs' %q", mappingDocs.URL)
+				continue
+			}
+
+			dlog.Debugf(ctx, "'url' specified: querying %s", parsedURL)
+			doc = a.getDoc(ctx, parsedURL, "", mappingHeaders, mappingHost, "", false)
+		} else {
+			mappingDocsPath := mappingDocs.Path
+			if mappingDocsPath != "" {
+				// note: filepath.Join() does not work, because it removes any trailing `/`
+				mappingDocsPath = strings.ReplaceAll(mappingRewrite+mappingDocsPath, "//", "/")
+				dlog.Debugf(ctx, "'path' specified: resulting in %s", mappingDocsPath)
+			}
+
+			// TODO(alexgervais): Improve the way mappingsDocsURL is built, according to namespaces, ports and whatnot
+			mappingsDocsURL, err := url.Parse(mapping.Spec.Service + mappingDocsPath)
+			if err != nil {
+				dlog.Errorf(ctx, "could not parse URL or path in 'docs' %q", mappingsDocsURL)
+				continue
+			}
+			mappingsDocsURL.Scheme = "http"
+
+			dlog.Debugf(ctx, "'url' specified: querying %s", mappingsDocsURL)
+			doc = a.getDoc(ctx, mappingsDocsURL, mappingHost, mappingHeaders, mappingHost, mappingPrefix, true)
+		}
+
+		if doc != nil {
+			dlog.Debugf(ctx, "Adding mapping docs")
+			md := mappingDoc{
+				Ref: &kates.ObjectReference{
+					Kind:            mapping.Kind,
+					Namespace:       mapping.Namespace,
+					Name:            mapping.Name,
+					UID:             mapping.UID,
+					APIVersion:      mapping.APIVersion,
+					ResourceVersion: mapping.ResourceVersion,
+				},
+				Name: displayName,
+			}
+			err := a.store.add(md, doc)
+			if err == nil {
+				a.docsDiff.add(md)
+			}
+		}
+	}
+}
+
+func (a *APIDocsStore) getDoc(ctx context.Context, queryURL *url.URL, queryHost string, queryHeaders []header, publicHost string, prefix string, keep bool) *openAPIDoc {
+	b, err := a.client.get(ctx, queryURL, queryHost, queryHeaders)
+	if err != nil {
+		dlog.Errorf(ctx, "get failed %s: %v", queryURL, err)
+		return nil
+	}
+
+	if b != nil {
+		return newOpenAPI(ctx, b, publicHost, prefix, keep)
+	}
+	return nil
+}
+
+// openAPIDoc represent a typed OpenAPI/Swagger document
+type openAPIDoc struct {
+	// The actual OpenAPI/Swagger document in JSON
+	JSON []byte
+	// The document type (OpenAPI)
+	Type string
+	// The document version (v3)
+	Version string
+}
+
+// openAPIDoc constructor from raw bytes.
+// The baseURL and prefix are used to edit the original document with server information to query the API publicly
+func newOpenAPI(ctx context.Context, docBytes []byte, baseURL string, prefix string, keep bool) *openAPIDoc {
+	dlog.Debugf(ctx, "Trying to create new OpenAPI doc: base_url=%q prefix=%q", baseURL, prefix)
+
+	loader := openapi3.NewLoader()
+	doc, err := loader.LoadFromData(docBytes)
+	if err != nil {
+		dlog.Errorln(ctx, "failed to load OpenAPI spec:", err)
+		return nil
+	}
+	err = doc.Validate(loader.Context)
+	if err != nil {
+		dlog.Errorln(ctx, "failed to validate OpenAPI spec:", err)
+		return nil
+	}
+
+	// Get prefix out of first server URL. E.g. if it's
+	// http://example.com/v1, we want to to add /v1 after the Ambassador
+	// prefix.
+	existingPrefix := ""
+	if doc.Servers != nil && doc.Servers[0] != nil {
+		currentServerURL := doc.Servers[0].URL
+		dlog.Debugf(ctx, "Checking first server's URL: url=%#v", currentServerURL)
+		existingUrl, err := url.Parse(currentServerURL)
+		if err == nil {
+			existingPrefix = existingUrl.Path
+		} else {
+			dlog.Errorf(ctx, "failed to parse 'servers' URL: url=%q: %v", currentServerURL, err)
+		}
+	}
+	base, err := url.Parse(baseURL)
+	if err != nil {
+		dlog.Debugf(ctx, "could not parse URL %q", baseURL)
+	} else {
+		if prefix != "" {
+			if existingPrefix != "" && keep {
+				base.Path = path.Join(base.Path, prefix, existingPrefix)
+			} else {
+				base.Path = path.Join(base.Path, prefix)
+			}
+		} else {
+			base.Path = existingPrefix
+		}
+
+		doc.Servers = []*openapi3.Server{{
+			URL: base.String(),
+		}}
+	}
+
+	json, err := doc.MarshalJSON()
+	if err != nil {
+		dlog.Errorln(ctx, "failed to marshal OpenAPI spec:", err)
+		return nil
+	}
+
+	return &openAPIDoc{
+		JSON:    json,
+		Type:    "OpenAPI",
+		Version: "v3",
+	}
+}
+
+func (a *APIDocsStore) buildMappingRequestHeaders(mappingHeaders map[string]amb.BoolOrString) []header {
+	headers := []header{}
+
+	for key, headerValue := range mappingHeaders {
+		if key == ":authority" {
+			continue
+		}
+		value := ""
+		if headerValue.String != nil {
+			value = *headerValue.String
+		}
+		if headerValue.Bool != nil {
+			value = strconv.FormatBool(*headerValue.Bool)
+		}
+		headers = append(headers, header{name: key, value: value})
+	}
+
+	return headers
+}
+
+type header struct {
+	name  string
+	value string
+}
+
+type apiDocsHTTPClient struct {
+	*http.Client
+}
+
+func newAPIDocsHTTPClient() *apiDocsHTTPClient {
+	dialer := &net.Dialer{
+		Timeout: time.Second * 2,
+	}
+	c := &http.Client{
+		Timeout: time.Second * 2,
+		Transport: &http.Transport{
+			/* #nosec */
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			Dial:            dialer.Dial,
+		},
+	}
+	return &apiDocsHTTPClient{c}
+}
+
+func (c *apiDocsHTTPClient) get(ctx context.Context, requestURL *url.URL, requestHost string, requestHeaders []header) ([]byte, error) {
+	ctx = dlog.WithField(ctx, "url", requestURL)
+	ctx = dlog.WithField(ctx, "host", requestHost)
+
+	req, err := http.NewRequest("GET", requestURL.String(), nil)
+	if err != nil {
+		dlog.Error(ctx, err)
+		return nil, err
+	}
+	req.Close = true
+
+	if requestHost != "" {
+		dlog.Debugf(ctx, "Using host=%s", requestHost)
+		req.Host = requestHost
+	}
+
+	if requestHeaders != nil {
+		for _, queryHeader := range requestHeaders {
+			dlog.Debugf(ctx, "Adding header %s=%s", queryHeader.name, queryHeader.value)
+			req.Header.Set(queryHeader.name, queryHeader.value)
+		}
+	}
+
+	res, err := c.Do(req)
+	if err != nil {
+		dlog.Error(ctx, err)
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != 200 {
+		dlog.Errorf(ctx, "Bad HTTP request: status_code=%v", res.StatusCode)
+		return nil, fmt.Errorf("HTTP error %d from %s", res.StatusCode, requestURL)
+	}
+
+	buf, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read HTTP response body")
+	}
+
+	return buf, nil
+}
+
+// mappingDoc holds a reference to a Mapping with a 'docs' attribute, for a given display name.
+type mappingDoc struct {
+	Ref  *kates.ObjectReference
+	Name string
+}
+
+type mappingDocMap map[mappingDoc]bool
+
+// Figure out which Mapping and API doc no longer exist and need to be deleted.
+type docsDiffCalculator struct {
+	previous mappingDocMap
+	current  mappingDocMap
+}
+
+// newMappingDocsCalculator creates a new diff calculator for mapping docs
+func newMappingDocsCalculator(known []mappingDoc) *docsDiffCalculator {
+	knownMap := make(mappingDocMap)
+	for _, m := range known {
+		knownMap[m] = true
+	}
+	return &docsDiffCalculator{current: make(mappingDocMap), previous: knownMap}
+}
+
+// After retrieving all known mappings, newRound will return list of mapping docs to delete
+func (d *docsDiffCalculator) newRound() []mappingDoc {
+	toDelete := make([]mappingDoc, 0)
+	for md := range d.previous {
+		if !d.current[md] {
+			toDelete = append(toDelete, md)
+		}
+	}
+	d.previous = d.current
+	d.current = make(mappingDocMap)
+	return toDelete
+}
+
+// add a MappingDoc that was successfully retrieved this round
+func (d *docsDiffCalculator) add(md mappingDoc) {
+	d.current[md] = true
+}
+
+// deleteOld deletes old MappingDocs that are no longer present
+func (d *docsDiffCalculator) deleteOld(ctx context.Context, store *inMemoryStore) {
+	for _, md := range d.newRound() {
+		dlog.Debugf(ctx, "Deleting old Mapping Docs %s", md)
+		store.delete(md)
+	}
+}
+
+type mappingDocsMap map[mappingDoc]*openAPIDoc
+
+type inMemoryStore struct {
+	entriesMutex sync.RWMutex
+	entries      mappingDocsMap
+}
+
+func newInMemoryStore() *inMemoryStore {
+	res := &inMemoryStore{
+		entries: make(mappingDocsMap),
+	}
+
+	return res
+}
+
+func (s *inMemoryStore) add(md mappingDoc, openAPIDoc *openAPIDoc) error {
+	s.entriesMutex.Lock()
+	defer s.entriesMutex.Unlock()
+
+	s.entries[md] = openAPIDoc
+	return nil
+}
+
+func (s *inMemoryStore) delete(md mappingDoc) error {
+	s.entriesMutex.Lock()
+	defer s.entriesMutex.Unlock()
+
+	delete(s.entries, md)
+	return nil
+}
+
+func (s *inMemoryStore) getAllMappingDocs() mappingDocsMap {
+	s.entriesMutex.RLock()
+	defer s.entriesMutex.RUnlock()
+
+	return s.entries
+}
+
+func toAPIDocs(mappingDocsMap mappingDocsMap) []*snapshotTypes.APIDoc {
+	results := make([]*snapshotTypes.APIDoc, 0)
+	for md, openAPIDocs := range mappingDocsMap {
+		if openAPIDocs != nil {
+			apiDoc := &snapshotTypes.APIDoc{
+				Data: openAPIDocs.JSON,
+				TypeMeta: &kates.TypeMeta{
+					Kind:       openAPIDocs.Type,
+					APIVersion: openAPIDocs.Version,
+				},
+				Metadata: &kates.ObjectMeta{
+					Name: md.Name,
+				},
+				TargetRef: md.Ref,
+			}
+			results = append(results, apiDoc)
+		}
+	}
+	return results
+}

--- a/pkg/agent/api_docs_test.go
+++ b/pkg/agent/api_docs_test.go
@@ -75,7 +75,7 @@ func TestAPIDocsStore(t *testing.T) {
 					Spec: v3alpha1.AmbassadorMappingSpec{
 						Prefix:  "",
 						Rewrite: &mappingRewrite,
-						Service: "some-svc",
+						Service: "https://some-svc.fqdn:443",
 						Docs: &v3alpha1.DocsInfo{
 							DisplayName: "docs-display-name",
 							Path:        "/docs-location",
@@ -95,7 +95,7 @@ func TestAPIDocsStore(t *testing.T) {
 
 			rawJSONDocsContent: "this is not JSON",
 
-			expectedRequestURL:     "http://some-svc/internal-path/docs-location",
+			expectedRequestURL:     "https://some-svc.fqdn:443/internal-path/docs-location",
 			expectedRequestHost:    "",
 			expectedRequestHeaders: []agent.Header{{Name: "header-key", Value: "header-value"}},
 			expectedSOTW:           []*snapshotTypes.APIDoc{},
@@ -109,7 +109,7 @@ func TestAPIDocsStore(t *testing.T) {
 					},
 					Spec: v3alpha1.AmbassadorMappingSpec{
 						Prefix:  "/prefix",
-						Service: "some-svc",
+						Service: "some-svc:8080",
 						Docs: &v3alpha1.DocsInfo{
 							DisplayName: "docs-display-name",
 							Path:        "/docs-location",
@@ -125,7 +125,7 @@ func TestAPIDocsStore(t *testing.T) {
 
 			rawJSONDocsContent: `{"openapi":"3.0.0", "info":{"title": "Sample API", "version":"0.0"}, "paths":{}}`,
 
-			expectedRequestURL:     "http://some-svc/docs-location",
+			expectedRequestURL:     "http://some-svc.default:8080/docs-location",
 			expectedRequestHost:    "mapping-hostname",
 			expectedRequestHeaders: []agent.Header{},
 			expectedSOTW: []*snapshotTypes.APIDoc{{

--- a/pkg/agent/api_docs_test.go
+++ b/pkg/agent/api_docs_test.go
@@ -203,15 +203,14 @@ func TestAPIDocsStore(t *testing.T) {
 
 			store := agent.NewAPIDocsStore()
 			store.Client = NewMockAPIDocsHTTPClient(t, c.expectedRequestURL, c.expectedRequestHost, c.expectedRequestHeaders, c.rawJSONDocsContent, c.JSONDocsErr)
-			store.ProcessSnapshot(ctx, snapshot)
-			result := store.StateOfWorld()
 
 			// Processing the test case snapshot should yield the expected state of the world
-			assert.Equal(t, c.expectedSOTW, result)
+			store.ProcessSnapshot(ctx, snapshot)
+			assert.Equal(t, c.expectedSOTW, store.StateOfWorld())
 
-			// Processing an empty snapshot should clear the state of the world
+			// Processing an empty snapshot should be ignored and not change the state of the world
 			store.ProcessSnapshot(ctx, &snapshotTypes.Snapshot{})
-			assert.Equal(t, []*snapshotTypes.APIDoc{}, store.StateOfWorld())
+			assert.Equal(t, c.expectedSOTW, store.StateOfWorld())
 		})
 	}
 }

--- a/pkg/agent/api_docs_test.go
+++ b/pkg/agent/api_docs_test.go
@@ -1,0 +1,251 @@
+package agent_test
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/datawire/ambassador/v2/pkg/agent"
+	amb "github.com/datawire/ambassador/v2/pkg/api/getambassador.io/v2"
+	"github.com/datawire/ambassador/v2/pkg/api/getambassador.io/v3alpha1"
+	"github.com/datawire/ambassador/v2/pkg/kates"
+	snapshotTypes "github.com/datawire/ambassador/v2/pkg/snapshot/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAPIDocsStore(t *testing.T) {
+	shouldIgnore := true
+	mappingRewrite := "/internal-path"
+	headerValue := "header-value"
+
+	type testCases struct {
+		name     string
+		mappings []*v3alpha1.AmbassadorMapping
+
+		rawJSONDocsContent string
+		JSONDocsErr        error
+
+		expectedRequestURL     string
+		expectedRequestHost    string
+		expectedRequestHeaders []agent.Header
+		expectedSOTW           []*snapshotTypes.APIDoc
+	}
+	cases := []*testCases{
+		{
+			name: "will ignore mappings without a 'docs' property",
+			mappings: []*v3alpha1.AmbassadorMapping{
+				{
+					Spec: v3alpha1.AmbassadorMappingSpec{
+						Prefix:  "",
+						Service: "some-svc",
+						Docs:    nil,
+					},
+					ObjectMeta: kates.ObjectMeta{
+						Name:      "some-endpoint",
+						Namespace: "default",
+					},
+				},
+				nil,
+			},
+			expectedSOTW: []*snapshotTypes.APIDoc{},
+		},
+		{
+			name: "will ignore mappings with docs.ignored setting",
+			mappings: []*v3alpha1.AmbassadorMapping{
+				{
+					Spec: v3alpha1.AmbassadorMappingSpec{
+						Prefix:  "",
+						Service: "some-svc",
+						Docs: &v3alpha1.DocsInfo{
+							Ignored: &shouldIgnore,
+						},
+					},
+					ObjectMeta: kates.ObjectMeta{
+						Name:      "some-endpoint",
+						Namespace: "default",
+					},
+				},
+			},
+			expectedSOTW: []*snapshotTypes.APIDoc{},
+		},
+		{
+			name: "will scrape OpenAPI docs from docs path and ignore malformed OpenAPI docs",
+			mappings: []*v3alpha1.AmbassadorMapping{
+				{
+					Spec: v3alpha1.AmbassadorMappingSpec{
+						Prefix:  "",
+						Rewrite: &mappingRewrite,
+						Service: "some-svc",
+						Docs: &v3alpha1.DocsInfo{
+							DisplayName: "docs-display-name",
+							Path:        "/docs-location",
+						},
+						Headers: map[string]amb.BoolOrString{
+							"header-key": {
+								String: &headerValue,
+							},
+						},
+					},
+					ObjectMeta: kates.ObjectMeta{
+						Name:      "some-endpoint",
+						Namespace: "default",
+					},
+				},
+			},
+
+			rawJSONDocsContent: "this is not JSON",
+
+			expectedRequestURL:     "http://some-svc/internal-path/docs-location",
+			expectedRequestHost:    "",
+			expectedRequestHeaders: []agent.Header{{Name: "header-key", Value: "header-value"}},
+			expectedSOTW:           []*snapshotTypes.APIDoc{},
+		},
+		{
+			name: "will scrape OpenAPI docs from docs path",
+			mappings: []*v3alpha1.AmbassadorMapping{
+				{
+					TypeMeta: kates.TypeMeta{
+						Kind: "Mapping",
+					},
+					Spec: v3alpha1.AmbassadorMappingSpec{
+						Prefix:  "/prefix",
+						Service: "some-svc",
+						Docs: &v3alpha1.DocsInfo{
+							DisplayName: "docs-display-name",
+							Path:        "/docs-location",
+						},
+						Host: "mapping-hostname",
+					},
+					ObjectMeta: kates.ObjectMeta{
+						Name:      "some-endpoint",
+						Namespace: "default",
+					},
+				},
+			},
+
+			rawJSONDocsContent: `{"openapi":"3.0.0", "info":{"title": "Sample API", "version":"0.0"}, "paths":{}}`,
+
+			expectedRequestURL:     "http://some-svc/docs-location",
+			expectedRequestHost:    "mapping-hostname",
+			expectedRequestHeaders: []agent.Header{},
+			expectedSOTW: []*snapshotTypes.APIDoc{{
+				TypeMeta: &kates.TypeMeta{
+					Kind:       "OpenAPI",
+					APIVersion: "v3",
+				},
+				Metadata: &kates.ObjectMeta{
+					Name: "docs-display-name",
+				},
+				TargetRef: &kates.ObjectReference{
+					Kind:      "Mapping",
+					Name:      "some-endpoint",
+					Namespace: "default",
+				},
+				Data: []byte(`{"components":{},"info":{"title":"Sample API","version":"0.0"},"openapi":"3.0.0","paths":{},"servers":[{"url":"mapping-hostname/prefix"}]}`),
+			}},
+		},
+		{
+			name: "will scrape OpenAPI docs from docs url",
+			mappings: []*v3alpha1.AmbassadorMapping{
+				{
+					TypeMeta: kates.TypeMeta{
+						Kind: "Mapping",
+					},
+					Spec: v3alpha1.AmbassadorMappingSpec{
+						Prefix:  "/api-prefix",
+						Service: "some-svc",
+						Docs: &v3alpha1.DocsInfo{
+							URL: "https://external-url",
+						},
+					},
+					ObjectMeta: kates.ObjectMeta{
+						Name:      "some-endpoint",
+						Namespace: "default",
+					},
+				},
+			},
+
+			rawJSONDocsContent: `{"openapi":"3.0.0", "info":{"title": "Sample API", "version":"0.0"}, "paths":{}}`,
+
+			expectedRequestURL:     "https://external-url",
+			expectedRequestHost:    "",
+			expectedRequestHeaders: []agent.Header{},
+			expectedSOTW: []*snapshotTypes.APIDoc{{
+				TypeMeta: &kates.TypeMeta{
+					Kind:       "OpenAPI",
+					APIVersion: "v3",
+				},
+				Metadata: &kates.ObjectMeta{
+					Name: "some-endpoint.default",
+				},
+				TargetRef: &kates.ObjectReference{
+					Kind:      "Mapping",
+					Name:      "some-endpoint",
+					Namespace: "default",
+				},
+				Data: []byte(`{"components":{},"info":{"title":"Sample API","version":"0.0"},"openapi":"3.0.0","paths":{},"servers":[{"url":""}]}`),
+			}},
+		},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			snapshot := &snapshotTypes.Snapshot{
+				Kubernetes: &snapshotTypes.KubernetesSnapshot{
+					Mappings: c.mappings,
+				},
+			}
+
+			store := agent.NewAPIDocsStore()
+			store.Client = NewMockAPIDocsHTTPClient(t, c.expectedRequestURL, c.expectedRequestHost, c.expectedRequestHeaders, c.rawJSONDocsContent, c.JSONDocsErr)
+			store.ProcessSnapshot(ctx, snapshot)
+			result := store.StateOfWorld()
+
+			// Processing the test case snapshot should yield the expected state of the world
+			assert.Equal(t, c.expectedSOTW, result)
+
+			// Processing an empty snapshot should clear the state of the world
+			store.ProcessSnapshot(ctx, &snapshotTypes.Snapshot{})
+			assert.Equal(t, []*snapshotTypes.APIDoc{}, store.StateOfWorld())
+		})
+	}
+}
+
+func NewMockAPIDocsHTTPClient(t *testing.T, expectedRequestURL string, expectedRequestHost string, expectedRequestHeaders []agent.Header, content string, err error) agent.APIDocsHTTPClient {
+	return &mockAPIDocsHTTPClient{
+		t:                      t,
+		expectedRequestURL:     expectedRequestURL,
+		expectedRequestHost:    expectedRequestHost,
+		expectedRequestHeaders: expectedRequestHeaders,
+		resultContent:          content,
+		resultErr:              err,
+	}
+}
+
+type mockAPIDocsHTTPClient struct {
+	t *testing.T
+
+	expectedRequestURL     string
+	expectedRequestHost    string
+	expectedRequestHeaders []agent.Header
+
+	resultContent string
+	resultErr     error
+}
+
+func (c *mockAPIDocsHTTPClient) Get(ctx context.Context, requestURL *url.URL, requestHost string, requestHeaders []agent.Header) ([]byte, error) {
+	if c.expectedRequestURL == "" {
+		c.t.Errorf("unexpected call to APIDocsHTTPClient.Get")
+		c.t.Fail()
+	}
+	assert.Equal(c.t, c.expectedRequestURL, requestURL.String())
+	assert.Equal(c.t, c.expectedRequestHost, requestHost)
+	assert.Equal(c.t, c.expectedRequestHeaders, requestHeaders)
+
+	return []byte(c.resultContent), c.resultErr
+}

--- a/pkg/kates/aliases.go
+++ b/pkg/kates/aliases.go
@@ -49,6 +49,7 @@ type APIResource = metav1.APIResource
 
 type Namespace = corev1.Namespace
 
+type ObjectReference = corev1.ObjectReference
 type LocalObjectReference = corev1.LocalObjectReference
 
 type Event = corev1.Event

--- a/pkg/snapshot/v1/types.go
+++ b/pkg/snapshot/v1/types.go
@@ -37,6 +37,9 @@ type Snapshot struct {
 	// portion of the snapshot. Changes in the Consul endpoint data are not
 	// reflected in this field.
 	Deltas []*kates.Delta
+	// The APIDocs field contains a list of OpenAPI documents scrapped from
+	// Ambassador Mappings part of the KubernetesSnapshot
+	APIDocs []*APIDoc `json:"APIDocs,omitempty"`
 	// The Invalid field contains any kubernetes resources that have failed
 	// validation.
 	Invalid []*kates.Unstructured
@@ -113,6 +116,15 @@ type KubernetesSnapshot struct {
 	// ArgoApplications represents the argo-rollout CRD state of the world that may or may not be present
 	// in the client's cluster. For reasons why this is defined as unstructured see ArgoRollouts attribute.
 	ArgoApplications []*kates.Unstructured `json:"ArgoApplications,omitempty"`
+}
+
+// The APIDoc type is custom object built in the style of a Kubernetes resource (name, type, version)
+// which holds a reference to a Kubernetes object from which an OpenAPI document was scrapped (Data field)
+type APIDoc struct {
+	*kates.TypeMeta
+	Metadata  *kates.ObjectMeta      `json:"metadata,omitempty"`
+	TargetRef *kates.ObjectReference `json:"targetRef,omitempty"`
+	Data      []byte                 `json:"data,omitempty"`
 }
 
 // Custom Unmarshaller for the kubernetes snapshot

--- a/vendor/github.com/getkin/kin-openapi/LICENSE
+++ b/vendor/github.com/getkin/kin-openapi/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017-2018 the project authors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/getkin/kin-openapi/jsoninfo/doc.go
+++ b/vendor/github.com/getkin/kin-openapi/jsoninfo/doc.go
@@ -1,0 +1,2 @@
+// Package jsoninfo provides information and functions for marshalling/unmarshalling JSON.
+package jsoninfo

--- a/vendor/github.com/getkin/kin-openapi/jsoninfo/field_info.go
+++ b/vendor/github.com/getkin/kin-openapi/jsoninfo/field_info.go
@@ -1,0 +1,118 @@
+package jsoninfo
+
+import (
+	"reflect"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// FieldInfo contains information about JSON serialization of a field.
+type FieldInfo struct {
+	MultipleFields     bool // Whether multiple Go fields share this JSON name
+	HasJSONTag         bool
+	TypeIsMarshaller   bool
+	TypeIsUnmarshaller bool
+	JSONOmitEmpty      bool
+	JSONString         bool
+	Index              []int
+	Type               reflect.Type
+	JSONName           string
+}
+
+func AppendFields(fields []FieldInfo, parentIndex []int, t reflect.Type) []FieldInfo {
+	// For each field
+	numField := t.NumField()
+iteration:
+	for i := 0; i < numField; i++ {
+		f := t.Field(i)
+		index := make([]int, 0, len(parentIndex)+1)
+		index = append(index, parentIndex...)
+		index = append(index, i)
+
+		// See whether this is an embedded field
+		if f.Anonymous {
+			if f.Tag.Get("json") == "-" {
+				continue
+			}
+			fields = AppendFields(fields, index, f.Type)
+			continue iteration
+		}
+
+		// Ignore certain types
+		switch f.Type.Kind() {
+		case reflect.Func, reflect.Chan:
+			continue iteration
+		}
+
+		// Is it a private (lowercase) field?
+		firstRune, _ := utf8.DecodeRuneInString(f.Name)
+		if unicode.IsLower(firstRune) {
+			continue iteration
+		}
+
+		// Declare a field
+		field := FieldInfo{
+			Index:    index,
+			Type:     f.Type,
+			JSONName: f.Name,
+		}
+
+		// Read "json" tag
+		jsonTag := f.Tag.Get("json")
+
+		// Read our custom "multijson" tag that
+		// allows multiple fields with the same name.
+		if v := f.Tag.Get("multijson"); v != "" {
+			field.MultipleFields = true
+			jsonTag = v
+		}
+
+		// Handle "-"
+		if jsonTag == "-" {
+			continue
+		}
+
+		// Parse the tag
+		if jsonTag != "" {
+			field.HasJSONTag = true
+			for i, part := range strings.Split(jsonTag, ",") {
+				if i == 0 {
+					if part != "" {
+						field.JSONName = part
+					}
+				} else {
+					switch part {
+					case "omitempty":
+						field.JSONOmitEmpty = true
+					case "string":
+						field.JSONString = true
+					}
+				}
+			}
+		}
+
+		_, field.TypeIsMarshaller = field.Type.MethodByName("MarshalJSON")
+		_, field.TypeIsUnmarshaller = field.Type.MethodByName("UnmarshalJSON")
+
+		// Field is done
+		fields = append(fields, field)
+	}
+
+	return fields
+}
+
+type sortableFieldInfos []FieldInfo
+
+func (list sortableFieldInfos) Len() int {
+	return len(list)
+}
+
+func (list sortableFieldInfos) Less(i, j int) bool {
+	return list[i].JSONName < list[j].JSONName
+}
+
+func (list sortableFieldInfos) Swap(i, j int) {
+	a, b := list[i], list[j]
+	list[i], list[j] = b, a
+}

--- a/vendor/github.com/getkin/kin-openapi/jsoninfo/marshal.go
+++ b/vendor/github.com/getkin/kin-openapi/jsoninfo/marshal.go
@@ -1,0 +1,162 @@
+package jsoninfo
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+)
+
+// MarshalStrictStruct function:
+//   * Marshals struct fields, ignoring MarshalJSON() and fields without 'json' tag.
+//   * Correctly handles StrictStruct semantics.
+func MarshalStrictStruct(value StrictStruct) ([]byte, error) {
+	encoder := NewObjectEncoder()
+	if err := value.EncodeWith(encoder, value); err != nil {
+		return nil, err
+	}
+	return encoder.Bytes()
+}
+
+type ObjectEncoder struct {
+	result map[string]json.RawMessage
+}
+
+func NewObjectEncoder() *ObjectEncoder {
+	return &ObjectEncoder{
+		result: make(map[string]json.RawMessage, 8),
+	}
+}
+
+// Bytes returns the result of encoding.
+func (encoder *ObjectEncoder) Bytes() ([]byte, error) {
+	return json.Marshal(encoder.result)
+}
+
+// EncodeExtension adds a key/value to the current JSON object.
+func (encoder *ObjectEncoder) EncodeExtension(key string, value interface{}) error {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	encoder.result[key] = data
+	return nil
+}
+
+// EncodeExtensionMap adds all properties to the result.
+func (encoder *ObjectEncoder) EncodeExtensionMap(value map[string]json.RawMessage) error {
+	if value != nil {
+		result := encoder.result
+		for k, v := range value {
+			result[k] = v
+		}
+	}
+	return nil
+}
+
+func (encoder *ObjectEncoder) EncodeStructFieldsAndExtensions(value interface{}) error {
+	reflection := reflect.ValueOf(value)
+
+	// Follow "encoding/json" semantics
+	if reflection.Kind() != reflect.Ptr {
+		// Panic because this is a clear programming error
+		panic(fmt.Errorf("value %s is not a pointer", reflection.Type().String()))
+	}
+	if reflection.IsNil() {
+		// Panic because this is a clear programming error
+		panic(fmt.Errorf("value %s is nil", reflection.Type().String()))
+	}
+
+	// Take the element
+	reflection = reflection.Elem()
+
+	// Obtain typeInfo
+	typeInfo := GetTypeInfo(reflection.Type())
+
+	// Declare result
+	result := encoder.result
+
+	// Supported fields
+iteration:
+	for _, field := range typeInfo.Fields {
+		// Fields without JSON tag are ignored
+		if !field.HasJSONTag {
+			continue
+		}
+
+		// Marshal
+		fieldValue := reflection.FieldByIndex(field.Index)
+		if v, ok := fieldValue.Interface().(json.Marshaler); ok {
+			if fieldValue.Kind() == reflect.Ptr && fieldValue.IsNil() {
+				if field.JSONOmitEmpty {
+					continue iteration
+				}
+				result[field.JSONName] = []byte("null")
+				continue
+			}
+			fieldData, err := v.MarshalJSON()
+			if err != nil {
+				return err
+			}
+			result[field.JSONName] = fieldData
+			continue
+		}
+		switch fieldValue.Kind() {
+		case reflect.Ptr, reflect.Interface:
+			if fieldValue.IsNil() {
+				if field.JSONOmitEmpty {
+					continue iteration
+				}
+				result[field.JSONName] = []byte("null")
+				continue
+			}
+		case reflect.Struct:
+		case reflect.Map:
+			if field.JSONOmitEmpty && (fieldValue.IsNil() || fieldValue.Len() == 0) {
+				continue iteration
+			}
+		case reflect.Slice:
+			if field.JSONOmitEmpty && fieldValue.Len() == 0 {
+				continue iteration
+			}
+		case reflect.Bool:
+			x := fieldValue.Bool()
+			if field.JSONOmitEmpty && !x {
+				continue iteration
+			}
+			s := "false"
+			if x {
+				s = "true"
+			}
+			result[field.JSONName] = []byte(s)
+			continue iteration
+		case reflect.Int64, reflect.Int, reflect.Int32:
+			if field.JSONOmitEmpty && fieldValue.Int() == 0 {
+				continue iteration
+			}
+		case reflect.Uint64, reflect.Uint, reflect.Uint32:
+			if field.JSONOmitEmpty && fieldValue.Uint() == 0 {
+				continue iteration
+			}
+		case reflect.Float64:
+			if field.JSONOmitEmpty && fieldValue.Float() == 0.0 {
+				continue iteration
+			}
+		case reflect.String:
+			if field.JSONOmitEmpty && len(fieldValue.String()) == 0 {
+				continue iteration
+			}
+		default:
+			panic(fmt.Errorf("field %q has unsupported type %s", field.JSONName, field.Type.String()))
+		}
+
+		// No special treament is needed
+		// Use plain old "encoding/json".Marshal
+		fieldData, err := json.Marshal(fieldValue.Addr().Interface())
+		if err != nil {
+			return err
+		}
+		result[field.JSONName] = fieldData
+	}
+
+	return nil
+}

--- a/vendor/github.com/getkin/kin-openapi/jsoninfo/marshal_ref.go
+++ b/vendor/github.com/getkin/kin-openapi/jsoninfo/marshal_ref.go
@@ -1,0 +1,30 @@
+package jsoninfo
+
+import (
+	"encoding/json"
+)
+
+func MarshalRef(value string, otherwise interface{}) ([]byte, error) {
+	if len(value) > 0 {
+		return json.Marshal(&refProps{
+			Ref: value,
+		})
+	}
+	return json.Marshal(otherwise)
+}
+
+func UnmarshalRef(data []byte, destRef *string, destOtherwise interface{}) error {
+	refProps := &refProps{}
+	if err := json.Unmarshal(data, refProps); err == nil {
+		ref := refProps.Ref
+		if len(ref) > 0 {
+			*destRef = ref
+			return nil
+		}
+	}
+	return json.Unmarshal(data, destOtherwise)
+}
+
+type refProps struct {
+	Ref string `json:"$ref,omitempty"`
+}

--- a/vendor/github.com/getkin/kin-openapi/jsoninfo/strict_struct.go
+++ b/vendor/github.com/getkin/kin-openapi/jsoninfo/strict_struct.go
@@ -1,0 +1,6 @@
+package jsoninfo
+
+type StrictStruct interface {
+	EncodeWith(encoder *ObjectEncoder, value interface{}) error
+	DecodeWith(decoder *ObjectDecoder, value interface{}) error
+}

--- a/vendor/github.com/getkin/kin-openapi/jsoninfo/type_info.go
+++ b/vendor/github.com/getkin/kin-openapi/jsoninfo/type_info.go
@@ -1,0 +1,68 @@
+package jsoninfo
+
+import (
+	"reflect"
+	"sort"
+	"sync"
+)
+
+var (
+	typeInfos      = map[reflect.Type]*TypeInfo{}
+	typeInfosMutex sync.RWMutex
+)
+
+// TypeInfo contains information about JSON serialization of a type
+type TypeInfo struct {
+	Type   reflect.Type
+	Fields []FieldInfo
+}
+
+func GetTypeInfoForValue(value interface{}) *TypeInfo {
+	return GetTypeInfo(reflect.TypeOf(value))
+}
+
+// GetTypeInfo returns TypeInfo for the given type.
+func GetTypeInfo(t reflect.Type) *TypeInfo {
+	for t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	typeInfosMutex.RLock()
+	typeInfo, exists := typeInfos[t]
+	typeInfosMutex.RUnlock()
+	if exists {
+		return typeInfo
+	}
+	if t.Kind() != reflect.Struct {
+		typeInfo = &TypeInfo{
+			Type: t,
+		}
+	} else {
+		// Allocate
+		typeInfo = &TypeInfo{
+			Type:   t,
+			Fields: make([]FieldInfo, 0, 16),
+		}
+
+		// Add fields
+		typeInfo.Fields = AppendFields(nil, nil, t)
+
+		// Sort fields
+		sort.Sort(sortableFieldInfos(typeInfo.Fields))
+	}
+
+	// Publish
+	typeInfosMutex.Lock()
+	typeInfos[t] = typeInfo
+	typeInfosMutex.Unlock()
+	return typeInfo
+}
+
+// FieldNames returns all field names
+func (typeInfo *TypeInfo) FieldNames() []string {
+	fields := typeInfo.Fields
+	names := make([]string, 0, len(fields))
+	for _, field := range fields {
+		names = append(names, field.JSONName)
+	}
+	return names
+}

--- a/vendor/github.com/getkin/kin-openapi/jsoninfo/unmarshal.go
+++ b/vendor/github.com/getkin/kin-openapi/jsoninfo/unmarshal.go
@@ -1,0 +1,121 @@
+package jsoninfo
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+)
+
+// UnmarshalStrictStruct function:
+//   * Unmarshals struct fields, ignoring UnmarshalJSON(...) and fields without 'json' tag.
+//   * Correctly handles StrictStruct
+func UnmarshalStrictStruct(data []byte, value StrictStruct) error {
+	decoder, err := NewObjectDecoder(data)
+	if err != nil {
+		return err
+	}
+	return value.DecodeWith(decoder, value)
+}
+
+type ObjectDecoder struct {
+	Data            []byte
+	remainingFields map[string]json.RawMessage
+}
+
+func NewObjectDecoder(data []byte) (*ObjectDecoder, error) {
+	var remainingFields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &remainingFields); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal extension properties: %v (%s)", err, data)
+	}
+	return &ObjectDecoder{
+		Data:            data,
+		remainingFields: remainingFields,
+	}, nil
+}
+
+// DecodeExtensionMap returns all properties that were not decoded previously.
+func (decoder *ObjectDecoder) DecodeExtensionMap() map[string]json.RawMessage {
+	return decoder.remainingFields
+}
+
+func (decoder *ObjectDecoder) DecodeStructFieldsAndExtensions(value interface{}) error {
+	reflection := reflect.ValueOf(value)
+	if reflection.Kind() != reflect.Ptr {
+		panic(fmt.Errorf("value %T is not a pointer", value))
+	}
+	if reflection.IsNil() {
+		panic(fmt.Errorf("value %T is nil", value))
+	}
+	reflection = reflection.Elem()
+	for (reflection.Kind() == reflect.Interface || reflection.Kind() == reflect.Ptr) && !reflection.IsNil() {
+		reflection = reflection.Elem()
+	}
+	reflectionType := reflection.Type()
+	if reflectionType.Kind() != reflect.Struct {
+		panic(fmt.Errorf("value %T is not a struct", value))
+	}
+	typeInfo := GetTypeInfo(reflectionType)
+
+	// Supported fields
+	fields := typeInfo.Fields
+	remainingFields := decoder.remainingFields
+	for fieldIndex, field := range fields {
+		// Fields without JSON tag are ignored
+		if !field.HasJSONTag {
+			continue
+		}
+
+		// Get data
+		fieldData, exists := remainingFields[field.JSONName]
+		if !exists {
+			continue
+		}
+
+		// Unmarshal
+		if field.TypeIsUnmarshaller {
+			fieldType := field.Type
+			isPtr := false
+			if fieldType.Kind() == reflect.Ptr {
+				fieldType = fieldType.Elem()
+				isPtr = true
+			}
+			fieldValue := reflect.New(fieldType)
+			if err := fieldValue.Interface().(json.Unmarshaler).UnmarshalJSON(fieldData); err != nil {
+				if field.MultipleFields {
+					i := fieldIndex + 1
+					if i < len(fields) && fields[i].JSONName == field.JSONName {
+						continue
+					}
+				}
+				return fmt.Errorf("failed to unmarshal property %q (%s): %v",
+					field.JSONName, fieldValue.Type().String(), err)
+			}
+			if !isPtr {
+				fieldValue = fieldValue.Elem()
+			}
+			reflection.FieldByIndex(field.Index).Set(fieldValue)
+
+			// Remove the field from remaining fields
+			delete(remainingFields, field.JSONName)
+		} else {
+			fieldPtr := reflection.FieldByIndex(field.Index)
+			if fieldPtr.Kind() != reflect.Ptr || fieldPtr.IsNil() {
+				fieldPtr = fieldPtr.Addr()
+			}
+			if err := json.Unmarshal(fieldData, fieldPtr.Interface()); err != nil {
+				if field.MultipleFields {
+					i := fieldIndex + 1
+					if i < len(fields) && fields[i].JSONName == field.JSONName {
+						continue
+					}
+				}
+				return fmt.Errorf("failed to unmarshal property %q (%s): %v",
+					field.JSONName, fieldPtr.Type().String(), err)
+			}
+
+			// Remove the field from remaining fields
+			delete(remainingFields, field.JSONName)
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/getkin/kin-openapi/jsoninfo/unsupported_properties_error.go
+++ b/vendor/github.com/getkin/kin-openapi/jsoninfo/unsupported_properties_error.go
@@ -1,0 +1,42 @@
+package jsoninfo
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+)
+
+// UnsupportedPropertiesError is a helper for extensions that want to refuse
+// unsupported JSON object properties.
+//
+// It produces a helpful error message.
+type UnsupportedPropertiesError struct {
+	Value                 interface{}
+	UnsupportedProperties map[string]json.RawMessage
+}
+
+func NewUnsupportedPropertiesError(v interface{}, m map[string]json.RawMessage) error {
+	return &UnsupportedPropertiesError{
+		Value:                 v,
+		UnsupportedProperties: m,
+	}
+}
+
+func (err *UnsupportedPropertiesError) Error() string {
+	m := err.UnsupportedProperties
+	typeInfo := GetTypeInfoForValue(err.Value)
+	if m == nil || typeInfo == nil {
+		return fmt.Sprintf("invalid %T", *err)
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	supported := typeInfo.FieldNames()
+	if len(supported) == 0 {
+		return fmt.Sprintf("type \"%T\" doesn't take any properties. Unsupported properties: %+v",
+			err.Value, keys)
+	}
+	return fmt.Sprintf("unsupported properties: %+v (supported properties are: %+v)", keys, supported)
+}

--- a/vendor/github.com/getkin/kin-openapi/openapi3/callback.go
+++ b/vendor/github.com/getkin/kin-openapi/openapi3/callback.go
@@ -1,0 +1,36 @@
+package openapi3
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-openapi/jsonpointer"
+)
+
+type Callbacks map[string]*CallbackRef
+
+var _ jsonpointer.JSONPointable = (*Callbacks)(nil)
+
+func (c Callbacks) JSONLookup(token string) (interface{}, error) {
+	ref, ok := c[token]
+	if ref == nil || !ok {
+		return nil, fmt.Errorf("object has no field %q", token)
+	}
+
+	if ref.Ref != "" {
+		return &Ref{Ref: ref.Ref}, nil
+	}
+	return ref.Value, nil
+}
+
+// Callback is specified by OpenAPI/Swagger standard version 3.0.
+type Callback map[string]*PathItem
+
+func (value Callback) Validate(ctx context.Context) error {
+	for _, v := range value {
+		if err := v.Validate(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/getkin/kin-openapi/openapi3/components.go
+++ b/vendor/github.com/getkin/kin-openapi/openapi3/components.go
@@ -1,0 +1,107 @@
+package openapi3
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	"github.com/getkin/kin-openapi/jsoninfo"
+)
+
+// Components is specified by OpenAPI/Swagger standard version 3.0.
+type Components struct {
+	ExtensionProps
+	Schemas         Schemas         `json:"schemas,omitempty" yaml:"schemas,omitempty"`
+	Parameters      ParametersMap   `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	Headers         Headers         `json:"headers,omitempty" yaml:"headers,omitempty"`
+	RequestBodies   RequestBodies   `json:"requestBodies,omitempty" yaml:"requestBodies,omitempty"`
+	Responses       Responses       `json:"responses,omitempty" yaml:"responses,omitempty"`
+	SecuritySchemes SecuritySchemes `json:"securitySchemes,omitempty" yaml:"securitySchemes,omitempty"`
+	Examples        Examples        `json:"examples,omitempty" yaml:"examples,omitempty"`
+	Links           Links           `json:"links,omitempty" yaml:"links,omitempty"`
+	Callbacks       Callbacks       `json:"callbacks,omitempty" yaml:"callbacks,omitempty"`
+}
+
+func NewComponents() Components {
+	return Components{}
+}
+
+func (components *Components) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalStrictStruct(components)
+}
+
+func (components *Components) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalStrictStruct(data, components)
+}
+
+func (components *Components) Validate(ctx context.Context) (err error) {
+	for k, v := range components.Schemas {
+		if err = ValidateIdentifier(k); err != nil {
+			return
+		}
+		if err = v.Validate(ctx); err != nil {
+			return
+		}
+	}
+
+	for k, v := range components.Parameters {
+		if err = ValidateIdentifier(k); err != nil {
+			return
+		}
+		if err = v.Validate(ctx); err != nil {
+			return
+		}
+	}
+
+	for k, v := range components.RequestBodies {
+		if err = ValidateIdentifier(k); err != nil {
+			return
+		}
+		if err = v.Validate(ctx); err != nil {
+			return
+		}
+	}
+
+	for k, v := range components.Responses {
+		if err = ValidateIdentifier(k); err != nil {
+			return
+		}
+		if err = v.Validate(ctx); err != nil {
+			return
+		}
+	}
+
+	for k, v := range components.Headers {
+		if err = ValidateIdentifier(k); err != nil {
+			return
+		}
+		if err = v.Validate(ctx); err != nil {
+			return
+		}
+	}
+
+	for k, v := range components.SecuritySchemes {
+		if err = ValidateIdentifier(k); err != nil {
+			return
+		}
+		if err = v.Validate(ctx); err != nil {
+			return
+		}
+	}
+
+	return
+}
+
+const identifierPattern = `^[a-zA-Z0-9._-]+$`
+
+// IdentifierRegExp verifies whether Component object key matches 'identifierPattern' pattern, according to OapiAPI v3.x.0.
+// Hovever, to be able supporting legacy OpenAPI v2.x, there is a need to customize above pattern in orde not to fail
+// converted v2-v3 validation
+var IdentifierRegExp = regexp.MustCompile(identifierPattern)
+
+func ValidateIdentifier(value string) error {
+	if IdentifierRegExp.MatchString(value) {
+		return nil
+	}
+	return fmt.Errorf("identifier %q is not supported by OpenAPIv3 standard (regexp: %q)", value, identifierPattern)
+}

--- a/vendor/github.com/getkin/kin-openapi/openapi3/content.go
+++ b/vendor/github.com/getkin/kin-openapi/openapi3/content.go
@@ -1,0 +1,115 @@
+package openapi3
+
+import (
+	"context"
+	"strings"
+)
+
+// Content is specified by OpenAPI/Swagger 3.0 standard.
+type Content map[string]*MediaType
+
+func NewContent() Content {
+	return make(map[string]*MediaType, 4)
+}
+
+func NewContentWithSchema(schema *Schema, consumes []string) Content {
+	if len(consumes) == 0 {
+		return Content{
+			"*/*": NewMediaType().WithSchema(schema),
+		}
+	}
+	content := make(map[string]*MediaType, len(consumes))
+	for _, mediaType := range consumes {
+		content[mediaType] = NewMediaType().WithSchema(schema)
+	}
+	return content
+}
+
+func NewContentWithSchemaRef(schema *SchemaRef, consumes []string) Content {
+	if len(consumes) == 0 {
+		return Content{
+			"*/*": NewMediaType().WithSchemaRef(schema),
+		}
+	}
+	content := make(map[string]*MediaType, len(consumes))
+	for _, mediaType := range consumes {
+		content[mediaType] = NewMediaType().WithSchemaRef(schema)
+	}
+	return content
+}
+
+func NewContentWithJSONSchema(schema *Schema) Content {
+	return Content{
+		"application/json": NewMediaType().WithSchema(schema),
+	}
+}
+func NewContentWithJSONSchemaRef(schema *SchemaRef) Content {
+	return Content{
+		"application/json": NewMediaType().WithSchemaRef(schema),
+	}
+}
+
+func NewContentWithFormDataSchema(schema *Schema) Content {
+	return Content{
+		"multipart/form-data": NewMediaType().WithSchema(schema),
+	}
+}
+
+func NewContentWithFormDataSchemaRef(schema *SchemaRef) Content {
+	return Content{
+		"multipart/form-data": NewMediaType().WithSchemaRef(schema),
+	}
+}
+
+func (content Content) Get(mime string) *MediaType {
+	// If the mime is empty then short-circuit to the wildcard.
+	// We do this here so that we catch only the specific case of
+	// and empty mime rather than a present, but invalid, mime type.
+	if mime == "" {
+		return content["*/*"]
+	}
+	// Start by making the most specific match possible
+	// by using the mime type in full.
+	if v := content[mime]; v != nil {
+		return v
+	}
+	// If an exact match is not found then we strip all
+	// metadata from the mime type and only use the x/y
+	// portion.
+	i := strings.IndexByte(mime, ';')
+	if i < 0 {
+		// If there is no metadata then preserve the full mime type
+		// string for later wildcard searches.
+		i = len(mime)
+	}
+	mime = mime[:i]
+	if v := content[mime]; v != nil {
+		return v
+	}
+	// If the x/y pattern has no specific match then we
+	// try the x/* pattern.
+	i = strings.IndexByte(mime, '/')
+	if i < 0 {
+		// In the case that the given mime type is not valid because it is
+		// missing the subtype we return nil so that this does not accidentally
+		// resolve with the wildcard.
+		return nil
+	}
+	mime = mime[:i] + "/*"
+	if v := content[mime]; v != nil {
+		return v
+	}
+	// Finally, the most generic match of */* is returned
+	// as a catch-all.
+	return content["*/*"]
+}
+
+func (value Content) Validate(ctx context.Context) error {
+	for _, v := range value {
+		// Validate MediaType
+		if err := v.Validate(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/getkin/kin-openapi/openapi3/discriminator.go
+++ b/vendor/github.com/getkin/kin-openapi/openapi3/discriminator.go
@@ -1,0 +1,26 @@
+package openapi3
+
+import (
+	"context"
+
+	"github.com/getkin/kin-openapi/jsoninfo"
+)
+
+// Discriminator is specified by OpenAPI/Swagger standard version 3.0.
+type Discriminator struct {
+	ExtensionProps
+	PropertyName string            `json:"propertyName" yaml:"propertyName"`
+	Mapping      map[string]string `json:"mapping,omitempty" yaml:"mapping,omitempty"`
+}
+
+func (value *Discriminator) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalStrictStruct(value)
+}
+
+func (value *Discriminator) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalStrictStruct(data, value)
+}
+
+func (value *Discriminator) Validate(ctx context.Context) error {
+	return nil
+}

--- a/vendor/github.com/getkin/kin-openapi/openapi3/doc.go
+++ b/vendor/github.com/getkin/kin-openapi/openapi3/doc.go
@@ -1,0 +1,4 @@
+// Package openapi3 parses and writes OpenAPI 3 specification documents.
+//
+// See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md
+package openapi3

--- a/vendor/github.com/getkin/kin-openapi/openapi3/encoding.go
+++ b/vendor/github.com/getkin/kin-openapi/openapi3/encoding.go
@@ -1,0 +1,93 @@
+package openapi3
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/getkin/kin-openapi/jsoninfo"
+)
+
+// Encoding is specified by OpenAPI/Swagger 3.0 standard.
+type Encoding struct {
+	ExtensionProps
+
+	ContentType   string  `json:"contentType,omitempty" yaml:"contentType,omitempty"`
+	Headers       Headers `json:"headers,omitempty" yaml:"headers,omitempty"`
+	Style         string  `json:"style,omitempty" yaml:"style,omitempty"`
+	Explode       *bool   `json:"explode,omitempty" yaml:"explode,omitempty"`
+	AllowReserved bool    `json:"allowReserved,omitempty" yaml:"allowReserved,omitempty"`
+}
+
+func NewEncoding() *Encoding {
+	return &Encoding{}
+}
+
+func (encoding *Encoding) WithHeader(name string, header *Header) *Encoding {
+	return encoding.WithHeaderRef(name, &HeaderRef{
+		Value: header,
+	})
+}
+
+func (encoding *Encoding) WithHeaderRef(name string, ref *HeaderRef) *Encoding {
+	headers := encoding.Headers
+	if headers == nil {
+		headers = make(map[string]*HeaderRef)
+		encoding.Headers = headers
+	}
+	headers[name] = ref
+	return encoding
+}
+
+func (encoding *Encoding) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalStrictStruct(encoding)
+}
+
+func (encoding *Encoding) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalStrictStruct(data, encoding)
+}
+
+// SerializationMethod returns a serialization method of request body.
+// When serialization method is not defined the method returns the default serialization method.
+func (encoding *Encoding) SerializationMethod() *SerializationMethod {
+	sm := &SerializationMethod{Style: SerializationForm, Explode: true}
+	if encoding != nil {
+		if encoding.Style != "" {
+			sm.Style = encoding.Style
+		}
+		if encoding.Explode != nil {
+			sm.Explode = *encoding.Explode
+		}
+	}
+	return sm
+}
+
+func (value *Encoding) Validate(ctx context.Context) error {
+	if value == nil {
+		return nil
+	}
+	for k, v := range value.Headers {
+		if err := ValidateIdentifier(k); err != nil {
+			return nil
+		}
+		if err := v.Validate(ctx); err != nil {
+			return nil
+		}
+	}
+
+	// Validate a media types's serialization method.
+	sm := value.SerializationMethod()
+	switch {
+	case sm.Style == SerializationForm && sm.Explode,
+		sm.Style == SerializationForm && !sm.Explode,
+		sm.Style == SerializationSpaceDelimited && sm.Explode,
+		sm.Style == SerializationSpaceDelimited && !sm.Explode,
+		sm.Style == SerializationPipeDelimited && sm.Explode,
+		sm.Style == SerializationPipeDelimited && !sm.Explode,
+		sm.Style == SerializationDeepObject && sm.Explode:
+		// it is a valid
+	default:
+		return fmt.Errorf("serialization method with style=%q and explode=%v is not supported by media type", sm.Style, sm.Explode)
+	}
+
+	return nil
+}

--- a/vendor/github.com/getkin/kin-openapi/openapi3/errors.go
+++ b/vendor/github.com/getkin/kin-openapi/openapi3/errors.go
@@ -1,0 +1,43 @@
+package openapi3
+
+import (
+	"bytes"
+	"errors"
+)
+
+// MultiError is a collection of errors, intended for when
+// multiple issues need to be reported upstream
+type MultiError []error
+
+func (me MultiError) Error() string {
+	buff := &bytes.Buffer{}
+	for _, e := range me {
+		buff.WriteString(e.Error())
+		buff.WriteString(" | ")
+	}
+	return buff.String()
+}
+
+//Is allows you to determine if a generic error is in fact a MultiError using `errors.Is()`
+//It will also return true if any of the contained errors match target
+func (me MultiError) Is(target error) bool {
+	if _, ok := target.(MultiError); ok {
+		return true
+	}
+	for _, e := range me {
+		if errors.Is(e, target) {
+			return true
+		}
+	}
+	return false
+}
+
+//As allows you to use `errors.As()` to set target to the first error within the multi error that matches the target type
+func (me MultiError) As(target interface{}) bool {
+	for _, e := range me {
+		if errors.As(e, target) {
+			return true
+		}
+	}
+	return false
+}

--- a/vendor/github.com/getkin/kin-openapi/openapi3/examples.go
+++ b/vendor/github.com/getkin/kin-openapi/openapi3/examples.go
@@ -1,0 +1,53 @@
+package openapi3
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/getkin/kin-openapi/jsoninfo"
+	"github.com/go-openapi/jsonpointer"
+)
+
+type Examples map[string]*ExampleRef
+
+var _ jsonpointer.JSONPointable = (*Examples)(nil)
+
+func (e Examples) JSONLookup(token string) (interface{}, error) {
+	ref, ok := e[token]
+	if ref == nil || !ok {
+		return nil, fmt.Errorf("object has no field %q", token)
+	}
+
+	if ref.Ref != "" {
+		return &Ref{Ref: ref.Ref}, nil
+	}
+	return ref.Value, nil
+}
+
+// Example is specified by OpenAPI/Swagger 3.0 standard.
+type Example struct {
+	ExtensionProps
+
+	Summary       string      `json:"summary,omitempty" yaml:"summary,omitempty"`
+	Description   string      `json:"description,omitempty" yaml:"description,omitempty"`
+	Value         interface{} `json:"value,omitempty" yaml:"value,omitempty"`
+	ExternalValue string      `json:"externalValue,omitempty" yaml:"externalValue,omitempty"`
+}
+
+func NewExample(value interface{}) *Example {
+	return &Example{
+		Value: value,
+	}
+}
+
+func (example *Example) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalStrictStruct(example)
+}
+
+func (example *Example) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalStrictStruct(data, example)
+}
+
+func (value *Example) Validate(ctx context.Context) error {
+	return nil // TODO
+}

--- a/vendor/github.com/getkin/kin-openapi/openapi3/extension.go
+++ b/vendor/github.com/getkin/kin-openapi/openapi3/extension.go
@@ -1,0 +1,38 @@
+package openapi3
+
+import (
+	"github.com/getkin/kin-openapi/jsoninfo"
+)
+
+// ExtensionProps provides support for OpenAPI extensions.
+// It reads/writes all properties that begin with "x-".
+type ExtensionProps struct {
+	Extensions map[string]interface{} `json:"-" yaml:"-"`
+}
+
+// Assert that the type implements the interface
+var _ jsoninfo.StrictStruct = &ExtensionProps{}
+
+// EncodeWith will be invoked by package "jsoninfo"
+func (props *ExtensionProps) EncodeWith(encoder *jsoninfo.ObjectEncoder, value interface{}) error {
+	for k, v := range props.Extensions {
+		if err := encoder.EncodeExtension(k, v); err != nil {
+			return err
+		}
+	}
+	return encoder.EncodeStructFieldsAndExtensions(value)
+}
+
+// DecodeWith will be invoked by package "jsoninfo"
+func (props *ExtensionProps) DecodeWith(decoder *jsoninfo.ObjectDecoder, value interface{}) error {
+	if err := decoder.DecodeStructFieldsAndExtensions(value); err != nil {
+		return err
+	}
+	source := decoder.DecodeExtensionMap()
+	result := make(map[string]interface{}, len(source))
+	for k, v := range source {
+		result[k] = v
+	}
+	props.Extensions = result
+	return nil
+}

--- a/vendor/github.com/getkin/kin-openapi/openapi3/external_docs.go
+++ b/vendor/github.com/getkin/kin-openapi/openapi3/external_docs.go
@@ -1,0 +1,21 @@
+package openapi3
+
+import (
+	"github.com/getkin/kin-openapi/jsoninfo"
+)
+
+// ExternalDocs is specified by OpenAPI/Swagger standard version 3.0.
+type ExternalDocs struct {
+	ExtensionProps
+
+	Description string `json:"description,omitempty"`
+	URL         string `json:"url,omitempty"`
+}
+
+func (e *ExternalDocs) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalStrictStruct(e)
+}
+
+func (e *ExternalDocs) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalStrictStruct(data, e)
+}

--- a/vendor/github.com/getkin/kin-openapi/openapi3/header.go
+++ b/vendor/github.com/getkin/kin-openapi/openapi3/header.go
@@ -1,0 +1,128 @@
+package openapi3
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/getkin/kin-openapi/jsoninfo"
+	"github.com/go-openapi/jsonpointer"
+)
+
+type Headers map[string]*HeaderRef
+
+var _ jsonpointer.JSONPointable = (*Headers)(nil)
+
+func (h Headers) JSONLookup(token string) (interface{}, error) {
+	ref, ok := h[token]
+	if ref == nil || !ok {
+		return nil, fmt.Errorf("object has no field %q", token)
+	}
+
+	if ref.Ref != "" {
+		return &Ref{Ref: ref.Ref}, nil
+	}
+	return ref.Value, nil
+}
+
+// Header is specified by OpenAPI/Swagger 3.0 standard.
+// See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.0.md#headerObject
+type Header struct {
+	Parameter
+}
+
+var _ jsonpointer.JSONPointable = (*Header)(nil)
+
+func (value *Header) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalStrictStruct(data, value)
+}
+
+// SerializationMethod returns a header's serialization method.
+func (value *Header) SerializationMethod() (*SerializationMethod, error) {
+	style := value.Style
+	if style == "" {
+		style = SerializationSimple
+	}
+	explode := false
+	if value.Explode != nil {
+		explode = *value.Explode
+	}
+	return &SerializationMethod{Style: style, Explode: explode}, nil
+}
+
+func (value *Header) Validate(ctx context.Context) error {
+	if value.Name != "" {
+		return errors.New("header 'name' MUST NOT be specified, it is given in the corresponding headers map")
+	}
+	if value.In != "" {
+		return errors.New("header 'in' MUST NOT be specified, it is implicitly in header")
+	}
+
+	// Validate a parameter's serialization method.
+	sm, err := value.SerializationMethod()
+	if err != nil {
+		return err
+	}
+	if smSupported := false ||
+		sm.Style == SerializationSimple && !sm.Explode ||
+		sm.Style == SerializationSimple && sm.Explode; !smSupported {
+		e := fmt.Errorf("serialization method with style=%q and explode=%v is not supported by a header parameter", sm.Style, sm.Explode)
+		return fmt.Errorf("header schema is invalid: %v", e)
+	}
+
+	if (value.Schema == nil) == (value.Content == nil) {
+		e := fmt.Errorf("parameter must contain exactly one of content and schema: %v", value)
+		return fmt.Errorf("header schema is invalid: %v", e)
+	}
+	if schema := value.Schema; schema != nil {
+		if err := schema.Validate(ctx); err != nil {
+			return fmt.Errorf("header schema is invalid: %v", err)
+		}
+	}
+
+	if content := value.Content; content != nil {
+		if err := content.Validate(ctx); err != nil {
+			return fmt.Errorf("header content is invalid: %v", err)
+		}
+	}
+	return nil
+}
+
+func (value Header) JSONLookup(token string) (interface{}, error) {
+	switch token {
+	case "schema":
+		if value.Schema != nil {
+			if value.Schema.Ref != "" {
+				return &Ref{Ref: value.Schema.Ref}, nil
+			}
+			return value.Schema.Value, nil
+		}
+	case "name":
+		return value.Name, nil
+	case "in":
+		return value.In, nil
+	case "description":
+		return value.Description, nil
+	case "style":
+		return value.Style, nil
+	case "explode":
+		return value.Explode, nil
+	case "allowEmptyValue":
+		return value.AllowEmptyValue, nil
+	case "allowReserved":
+		return value.AllowReserved, nil
+	case "deprecated":
+		return value.Deprecated, nil
+	case "required":
+		return value.Required, nil
+	case "example":
+		return value.Example, nil
+	case "examples":
+		return value.Examples, nil
+	case "content":
+		return value.Content, nil
+	}
+
+	v, _, err := jsonpointer.GetForToken(value.ExtensionProps, token)
+	return v, err
+}

--- a/vendor/github.com/getkin/kin-openapi/openapi3/info.go
+++ b/vendor/github.com/getkin/kin-openapi/openapi3/info.go
@@ -1,0 +1,93 @@
+package openapi3
+
+import (
+	"context"
+	"errors"
+
+	"github.com/getkin/kin-openapi/jsoninfo"
+)
+
+// Info is specified by OpenAPI/Swagger standard version 3.0.
+type Info struct {
+	ExtensionProps
+	Title          string   `json:"title" yaml:"title"` // Required
+	Description    string   `json:"description,omitempty" yaml:"description,omitempty"`
+	TermsOfService string   `json:"termsOfService,omitempty" yaml:"termsOfService,omitempty"`
+	Contact        *Contact `json:"contact,omitempty" yaml:"contact,omitempty"`
+	License        *License `json:"license,omitempty" yaml:"license,omitempty"`
+	Version        string   `json:"version" yaml:"version"` // Required
+}
+
+func (value *Info) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalStrictStruct(value)
+}
+
+func (value *Info) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalStrictStruct(data, value)
+}
+
+func (value *Info) Validate(ctx context.Context) error {
+	if contact := value.Contact; contact != nil {
+		if err := contact.Validate(ctx); err != nil {
+			return err
+		}
+	}
+
+	if license := value.License; license != nil {
+		if err := license.Validate(ctx); err != nil {
+			return err
+		}
+	}
+
+	if value.Version == "" {
+		return errors.New("value of version must be a non-empty string")
+	}
+
+	if value.Title == "" {
+		return errors.New("value of title must be a non-empty string")
+	}
+
+	return nil
+}
+
+// Contact is specified by OpenAPI/Swagger standard version 3.0.
+type Contact struct {
+	ExtensionProps
+	Name  string `json:"name,omitempty" yaml:"name,omitempty"`
+	URL   string `json:"url,omitempty" yaml:"url,omitempty"`
+	Email string `json:"email,omitempty" yaml:"email,omitempty"`
+}
+
+func (value *Contact) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalStrictStruct(value)
+}
+
+func (value *Contact) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalStrictStruct(data, value)
+}
+
+func (value *Contact) Validate(ctx context.Context) error {
+	return nil
+}
+
+// License is specified by OpenAPI/Swagger standard version 3.0.
+type License struct {
+	ExtensionProps
+	Name string `json:"name" yaml:"name"` // Required
+	URL  string `json:"url,omitempty" yaml:"url,omitempty"`
+}
+
+func (value *License) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalStrictStruct(value)
+}
+
+func (value *License) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalStrictStruct(data, value)
+}
+
+func (value *License) Validate(ctx context.Context) error {
+	if value.Name == "" {
+		return errors.New("value of license name must be a non-empty string")
+	}
+	return nil
+}

--- a/vendor/github.com/getkin/kin-openapi/openapi3/link.go
+++ b/vendor/github.com/getkin/kin-openapi/openapi3/link.go
@@ -1,0 +1,55 @@
+package openapi3
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/getkin/kin-openapi/jsoninfo"
+	"github.com/go-openapi/jsonpointer"
+)
+
+type Links map[string]*LinkRef
+
+func (l Links) JSONLookup(token string) (interface{}, error) {
+	ref, ok := l[token]
+	if ok == false {
+		return nil, fmt.Errorf("object has no field %q", token)
+	}
+
+	if ref != nil && ref.Ref != "" {
+		return &Ref{Ref: ref.Ref}, nil
+	}
+	return ref.Value, nil
+}
+
+var _ jsonpointer.JSONPointable = (*Links)(nil)
+
+// Link is specified by OpenAPI/Swagger standard version 3.0.
+type Link struct {
+	ExtensionProps
+	OperationID  string                 `json:"operationId,omitempty" yaml:"operationId,omitempty"`
+	OperationRef string                 `json:"operationRef,omitempty" yaml:"operationRef,omitempty"`
+	Description  string                 `json:"description,omitempty" yaml:"description,omitempty"`
+	Parameters   map[string]interface{} `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	Server       *Server                `json:"server,omitempty" yaml:"server,omitempty"`
+	RequestBody  interface{}            `json:"requestBody,omitempty" yaml:"requestBody,omitempty"`
+}
+
+func (value *Link) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalStrictStruct(value)
+}
+
+func (value *Link) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalStrictStruct(data, value)
+}
+
+func (value *Link) Validate(ctx context.Context) error {
+	if value.OperationID == "" && value.OperationRef == "" {
+		return errors.New("missing operationId or operationRef on link")
+	}
+	if value.OperationID != "" && value.OperationRef != "" {
+		return fmt.Errorf("operationId %q and operationRef %q are mutually exclusive", value.OperationID, value.OperationRef)
+	}
+	return nil
+}

--- a/vendor/github.com/getkin/kin-openapi/openapi3/loader.go
+++ b/vendor/github.com/getkin/kin-openapi/openapi3/loader.go
@@ -1,0 +1,1027 @@
+package openapi3
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"path"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/ghodss/yaml"
+)
+
+func foundUnresolvedRef(ref string) error {
+	return fmt.Errorf("found unresolved ref: %q", ref)
+}
+
+func failedToResolveRefFragmentPart(value, what string) error {
+	return fmt.Errorf("failed to resolve %q in fragment in URI: %q", what, value)
+}
+
+// Loader helps deserialize an OpenAPIv3 document
+type Loader struct {
+	// IsExternalRefsAllowed enables visiting other files
+	IsExternalRefsAllowed bool
+
+	// ReadFromURIFunc allows overriding the any file/URL reading func
+	ReadFromURIFunc func(loader *Loader, url *url.URL) ([]byte, error)
+
+	Context context.Context
+
+	visitedPathItemRefs map[string]struct{}
+
+	visitedDocuments map[string]*T
+
+	visitedExample        map[*Example]struct{}
+	visitedHeader         map[*Header]struct{}
+	visitedLink           map[*Link]struct{}
+	visitedParameter      map[*Parameter]struct{}
+	visitedRequestBody    map[*RequestBody]struct{}
+	visitedResponse       map[*Response]struct{}
+	visitedSchema         map[*Schema]struct{}
+	visitedSecurityScheme map[*SecurityScheme]struct{}
+}
+
+// NewLoader returns an empty Loader
+func NewLoader() *Loader {
+	return &Loader{}
+}
+
+func (loader *Loader) resetVisitedPathItemRefs() {
+	loader.visitedPathItemRefs = make(map[string]struct{})
+}
+
+// LoadFromURI loads a spec from a remote URL
+func (loader *Loader) LoadFromURI(location *url.URL) (*T, error) {
+	loader.resetVisitedPathItemRefs()
+	return loader.loadFromURIInternal(location)
+}
+
+// LoadFromFile loads a spec from a local file path
+func (loader *Loader) LoadFromFile(location string) (*T, error) {
+	return loader.LoadFromURI(&url.URL{Path: filepath.ToSlash(location)})
+}
+
+func (loader *Loader) loadFromURIInternal(location *url.URL) (*T, error) {
+	data, err := loader.readURL(location)
+	if err != nil {
+		return nil, err
+	}
+	return loader.loadFromDataWithPathInternal(data, location)
+}
+
+func (loader *Loader) allowsExternalRefs(ref string) (err error) {
+	if !loader.IsExternalRefsAllowed {
+		err = fmt.Errorf("encountered disallowed external reference: %q", ref)
+	}
+	return
+}
+
+// loadSingleElementFromURI reads the data from ref and unmarshals to the passed element.
+func (loader *Loader) loadSingleElementFromURI(ref string, rootPath *url.URL, element interface{}) (*url.URL, error) {
+	if err := loader.allowsExternalRefs(ref); err != nil {
+		return nil, err
+	}
+
+	parsedURL, err := url.Parse(ref)
+	if err != nil {
+		return nil, err
+	}
+	if fragment := parsedURL.Fragment; fragment != "" {
+		return nil, fmt.Errorf("unexpected ref fragment %q", fragment)
+	}
+
+	resolvedPath, err := resolvePath(rootPath, parsedURL)
+	if err != nil {
+		return nil, fmt.Errorf("could not resolve path: %v", err)
+	}
+
+	data, err := loader.readURL(resolvedPath)
+	if err != nil {
+		return nil, err
+	}
+	if err := yaml.Unmarshal(data, element); err != nil {
+		return nil, err
+	}
+
+	return resolvedPath, nil
+}
+
+func (loader *Loader) readURL(location *url.URL) ([]byte, error) {
+	if f := loader.ReadFromURIFunc; f != nil {
+		return f(loader, location)
+	}
+
+	if location.Scheme != "" && location.Host != "" {
+		resp, err := http.Get(location.String())
+		if err != nil {
+			return nil, err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode > 399 {
+			return nil, fmt.Errorf("error loading %q: request returned status code %d", location.String(), resp.StatusCode)
+		}
+		return ioutil.ReadAll(resp.Body)
+	}
+	if location.Scheme != "" || location.Host != "" || location.RawQuery != "" {
+		return nil, fmt.Errorf("unsupported URI: %q", location.String())
+	}
+	return ioutil.ReadFile(location.Path)
+}
+
+// LoadFromData loads a spec from a byte array
+func (loader *Loader) LoadFromData(data []byte) (*T, error) {
+	loader.resetVisitedPathItemRefs()
+	doc := &T{}
+	if err := yaml.Unmarshal(data, doc); err != nil {
+		return nil, err
+	}
+	if err := loader.ResolveRefsIn(doc, nil); err != nil {
+		return nil, err
+	}
+	return doc, nil
+}
+
+// LoadFromDataWithPath takes the OpenAPI document data in bytes and a path where the resolver can find referred
+// elements and returns a *T with all resolved data or an error if unable to load data or resolve refs.
+func (loader *Loader) LoadFromDataWithPath(data []byte, location *url.URL) (*T, error) {
+	loader.resetVisitedPathItemRefs()
+	return loader.loadFromDataWithPathInternal(data, location)
+}
+
+func (loader *Loader) loadFromDataWithPathInternal(data []byte, location *url.URL) (*T, error) {
+	if loader.visitedDocuments == nil {
+		loader.visitedDocuments = make(map[string]*T)
+	}
+	uri := location.String()
+	if doc, ok := loader.visitedDocuments[uri]; ok {
+		return doc, nil
+	}
+
+	doc := &T{}
+	loader.visitedDocuments[uri] = doc
+
+	if err := yaml.Unmarshal(data, doc); err != nil {
+		return nil, err
+	}
+	if err := loader.ResolveRefsIn(doc, location); err != nil {
+		return nil, err
+	}
+
+	return doc, nil
+}
+
+// ResolveRefsIn expands references if for instance spec was just unmarshalled
+func (loader *Loader) ResolveRefsIn(doc *T, location *url.URL) (err error) {
+	if loader.visitedPathItemRefs == nil {
+		loader.resetVisitedPathItemRefs()
+	}
+
+	// Visit all components
+	components := doc.Components
+	for _, component := range components.Headers {
+		if err = loader.resolveHeaderRef(doc, component, location); err != nil {
+			return
+		}
+	}
+	for _, component := range components.Parameters {
+		if err = loader.resolveParameterRef(doc, component, location); err != nil {
+			return
+		}
+	}
+	for _, component := range components.RequestBodies {
+		if err = loader.resolveRequestBodyRef(doc, component, location); err != nil {
+			return
+		}
+	}
+	for _, component := range components.Responses {
+		if err = loader.resolveResponseRef(doc, component, location); err != nil {
+			return
+		}
+	}
+	for _, component := range components.Schemas {
+		if err = loader.resolveSchemaRef(doc, component, location); err != nil {
+			return
+		}
+	}
+	for _, component := range components.SecuritySchemes {
+		if err = loader.resolveSecuritySchemeRef(doc, component, location); err != nil {
+			return
+		}
+	}
+	for _, component := range components.Examples {
+		if err = loader.resolveExampleRef(doc, component, location); err != nil {
+			return
+		}
+	}
+	for _, component := range components.Callbacks {
+		if err = loader.resolveCallbackRef(doc, component, location); err != nil {
+			return
+		}
+	}
+
+	// Visit all operations
+	for entrypoint, pathItem := range doc.Paths {
+		if pathItem == nil {
+			continue
+		}
+		if err = loader.resolvePathItemRef(doc, entrypoint, pathItem, location); err != nil {
+			return
+		}
+	}
+
+	return
+}
+
+func join(basePath *url.URL, relativePath *url.URL) (*url.URL, error) {
+	if basePath == nil {
+		return relativePath, nil
+	}
+	newPath, err := url.Parse(basePath.String())
+	if err != nil {
+		return nil, fmt.Errorf("cannot copy path: %q", basePath.String())
+	}
+	newPath.Path = path.Join(path.Dir(newPath.Path), relativePath.Path)
+	return newPath, nil
+}
+
+func resolvePath(basePath *url.URL, componentPath *url.URL) (*url.URL, error) {
+	if componentPath.Scheme == "" && componentPath.Host == "" {
+		// support absolute paths
+		if componentPath.Path[0] == '/' {
+			return componentPath, nil
+		}
+		return join(basePath, componentPath)
+	}
+	return componentPath, nil
+}
+
+func isSingleRefElement(ref string) bool {
+	return !strings.Contains(ref, "#")
+}
+
+func (loader *Loader) resolveComponent(
+	doc *T,
+	ref string,
+	path *url.URL,
+	resolved interface{},
+) (
+	componentPath *url.URL,
+	err error,
+) {
+	if doc, ref, componentPath, err = loader.resolveRef(doc, ref, path); err != nil {
+		return nil, err
+	}
+
+	parsedURL, err := url.Parse(ref)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse reference: %q: %v", ref, parsedURL)
+	}
+	fragment := parsedURL.Fragment
+	if !strings.HasPrefix(fragment, "/") {
+		return nil, fmt.Errorf("expected fragment prefix '#/' in URI %q", ref)
+	}
+
+	drill := func(cursor interface{}) (interface{}, error) {
+		for _, pathPart := range strings.Split(fragment[1:], "/") {
+			pathPart = unescapeRefString(pathPart)
+
+			if cursor, err = drillIntoField(cursor, pathPart); err != nil {
+				e := failedToResolveRefFragmentPart(ref, pathPart)
+				return nil, fmt.Errorf("%s: %s", e.Error(), err.Error())
+			}
+			if cursor == nil {
+				return nil, failedToResolveRefFragmentPart(ref, pathPart)
+			}
+		}
+		return cursor, nil
+	}
+	var cursor interface{}
+	if cursor, err = drill(doc); err != nil {
+		if path == nil {
+			return nil, err
+		}
+		var err2 error
+		data, err2 := loader.readURL(path)
+		if err2 != nil {
+			return nil, err
+		}
+		if err2 = yaml.Unmarshal(data, &cursor); err2 != nil {
+			return nil, err
+		}
+		if cursor, err2 = drill(cursor); err2 != nil || cursor == nil {
+			return nil, err
+		}
+		err = nil
+	}
+
+	switch {
+	case reflect.TypeOf(cursor) == reflect.TypeOf(resolved):
+		reflect.ValueOf(resolved).Elem().Set(reflect.ValueOf(cursor).Elem())
+		return componentPath, nil
+
+	case reflect.TypeOf(cursor) == reflect.TypeOf(map[string]interface{}{}):
+		codec := func(got, expect interface{}) error {
+			enc, err := json.Marshal(got)
+			if err != nil {
+				return err
+			}
+			if err = json.Unmarshal(enc, expect); err != nil {
+				return err
+			}
+			return nil
+		}
+		if err := codec(cursor, resolved); err != nil {
+			return nil, fmt.Errorf("bad data in %q", ref)
+		}
+		return componentPath, nil
+
+	default:
+		return nil, fmt.Errorf("bad data in %q", ref)
+	}
+}
+
+func drillIntoField(cursor interface{}, fieldName string) (interface{}, error) {
+	// Special case due to multijson
+	if s, ok := cursor.(*SchemaRef); ok && fieldName == "additionalProperties" {
+		if ap := s.Value.AdditionalPropertiesAllowed; ap != nil {
+			return *ap, nil
+		}
+		return s.Value.AdditionalProperties, nil
+	}
+
+	switch val := reflect.Indirect(reflect.ValueOf(cursor)); val.Kind() {
+	case reflect.Map:
+		elementValue := val.MapIndex(reflect.ValueOf(fieldName))
+		if !elementValue.IsValid() {
+			return nil, fmt.Errorf("map key %q not found", fieldName)
+		}
+		return elementValue.Interface(), nil
+
+	case reflect.Slice:
+		i, err := strconv.ParseUint(fieldName, 10, 32)
+		if err != nil {
+			return nil, err
+		}
+		index := int(i)
+		if 0 > index || index >= val.Len() {
+			return nil, errors.New("slice index out of bounds")
+		}
+		return val.Index(index).Interface(), nil
+
+	case reflect.Struct:
+		hasFields := false
+		for i := 0; i < val.NumField(); i++ {
+			hasFields = true
+			field := val.Type().Field(i)
+			tagValue := field.Tag.Get("yaml")
+			yamlKey := strings.Split(tagValue, ",")[0]
+			if yamlKey == "-" {
+				tagValue := field.Tag.Get("multijson")
+				yamlKey = strings.Split(tagValue, ",")[0]
+			}
+			if yamlKey == fieldName {
+				return val.Field(i).Interface(), nil
+			}
+		}
+		// if cursor is a "ref wrapper" struct (e.g. RequestBodyRef),
+		if _, ok := val.Type().FieldByName("Value"); ok {
+			// try digging into its Value field
+			return drillIntoField(val.FieldByName("Value").Interface(), fieldName)
+		}
+		if hasFields {
+			if ff := val.Type().Field(0); ff.PkgPath == "" && ff.Name == "ExtensionProps" {
+				extensions := val.Field(0).Interface().(ExtensionProps).Extensions
+				if enc, ok := extensions[fieldName]; ok {
+					var dec interface{}
+					if err := json.Unmarshal(enc.(json.RawMessage), &dec); err != nil {
+						return nil, err
+					}
+					return dec, nil
+				}
+			}
+		}
+		return nil, fmt.Errorf("struct field %q not found", fieldName)
+
+	default:
+		return nil, errors.New("not a map, slice nor struct")
+	}
+}
+
+func (loader *Loader) resolveRef(doc *T, ref string, path *url.URL) (*T, string, *url.URL, error) {
+	if ref != "" && ref[0] == '#' {
+		return doc, ref, path, nil
+	}
+
+	if err := loader.allowsExternalRefs(ref); err != nil {
+		return nil, "", nil, err
+	}
+
+	parsedURL, err := url.Parse(ref)
+	if err != nil {
+		return nil, "", nil, fmt.Errorf("cannot parse reference: %q: %v", ref, parsedURL)
+	}
+	fragment := parsedURL.Fragment
+	parsedURL.Fragment = ""
+
+	var resolvedPath *url.URL
+	if resolvedPath, err = resolvePath(path, parsedURL); err != nil {
+		return nil, "", nil, fmt.Errorf("error resolving path: %v", err)
+	}
+
+	if doc, err = loader.loadFromURIInternal(resolvedPath); err != nil {
+		return nil, "", nil, fmt.Errorf("error resolving reference %q: %v", ref, err)
+	}
+
+	return doc, "#" + fragment, resolvedPath, nil
+}
+
+func (loader *Loader) resolveHeaderRef(doc *T, component *HeaderRef, documentPath *url.URL) (err error) {
+	if component != nil && component.Value != nil {
+		if loader.visitedHeader == nil {
+			loader.visitedHeader = make(map[*Header]struct{})
+		}
+		if _, ok := loader.visitedHeader[component.Value]; ok {
+			return nil
+		}
+		loader.visitedHeader[component.Value] = struct{}{}
+	}
+
+	if component == nil {
+		return errors.New("invalid header: value MUST be an object")
+	}
+	if ref := component.Ref; ref != "" {
+		if isSingleRefElement(ref) {
+			var header Header
+			if documentPath, err = loader.loadSingleElementFromURI(ref, documentPath, &header); err != nil {
+				return err
+			}
+			component.Value = &header
+		} else {
+			var resolved HeaderRef
+			componentPath, err := loader.resolveComponent(doc, ref, documentPath, &resolved)
+			if err != nil {
+				return err
+			}
+			if err := loader.resolveHeaderRef(doc, &resolved, componentPath); err != nil {
+				return err
+			}
+			component.Value = resolved.Value
+		}
+	}
+	value := component.Value
+	if value == nil {
+		return nil
+	}
+
+	if schema := value.Schema; schema != nil {
+		if err := loader.resolveSchemaRef(doc, schema, documentPath); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (loader *Loader) resolveParameterRef(doc *T, component *ParameterRef, documentPath *url.URL) (err error) {
+	if component != nil && component.Value != nil {
+		if loader.visitedParameter == nil {
+			loader.visitedParameter = make(map[*Parameter]struct{})
+		}
+		if _, ok := loader.visitedParameter[component.Value]; ok {
+			return nil
+		}
+		loader.visitedParameter[component.Value] = struct{}{}
+	}
+
+	if component == nil {
+		return errors.New("invalid parameter: value MUST be an object")
+	}
+	ref := component.Ref
+	if ref != "" {
+		if isSingleRefElement(ref) {
+			var param Parameter
+			if documentPath, err = loader.loadSingleElementFromURI(ref, documentPath, &param); err != nil {
+				return err
+			}
+			component.Value = &param
+		} else {
+			var resolved ParameterRef
+			componentPath, err := loader.resolveComponent(doc, ref, documentPath, &resolved)
+			if err != nil {
+				return err
+			}
+			if err := loader.resolveParameterRef(doc, &resolved, componentPath); err != nil {
+				return err
+			}
+			component.Value = resolved.Value
+		}
+	}
+	value := component.Value
+	if value == nil {
+		return nil
+	}
+
+	if value.Content != nil && value.Schema != nil {
+		return errors.New("cannot contain both schema and content in a parameter")
+	}
+	for _, contentType := range value.Content {
+		if schema := contentType.Schema; schema != nil {
+			if err := loader.resolveSchemaRef(doc, schema, documentPath); err != nil {
+				return err
+			}
+		}
+	}
+	if schema := value.Schema; schema != nil {
+		if err := loader.resolveSchemaRef(doc, schema, documentPath); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (loader *Loader) resolveRequestBodyRef(doc *T, component *RequestBodyRef, documentPath *url.URL) (err error) {
+	if component != nil && component.Value != nil {
+		if loader.visitedRequestBody == nil {
+			loader.visitedRequestBody = make(map[*RequestBody]struct{})
+		}
+		if _, ok := loader.visitedRequestBody[component.Value]; ok {
+			return nil
+		}
+		loader.visitedRequestBody[component.Value] = struct{}{}
+	}
+
+	if component == nil {
+		return errors.New("invalid requestBody: value MUST be an object")
+	}
+	if ref := component.Ref; ref != "" {
+		if isSingleRefElement(ref) {
+			var requestBody RequestBody
+			if documentPath, err = loader.loadSingleElementFromURI(ref, documentPath, &requestBody); err != nil {
+				return err
+			}
+			component.Value = &requestBody
+		} else {
+			var resolved RequestBodyRef
+			componentPath, err := loader.resolveComponent(doc, ref, documentPath, &resolved)
+			if err != nil {
+				return err
+			}
+			if err = loader.resolveRequestBodyRef(doc, &resolved, componentPath); err != nil {
+				return err
+			}
+			component.Value = resolved.Value
+		}
+	}
+	value := component.Value
+	if value == nil {
+		return nil
+	}
+
+	for _, contentType := range value.Content {
+		for name, example := range contentType.Examples {
+			if err := loader.resolveExampleRef(doc, example, documentPath); err != nil {
+				return err
+			}
+			contentType.Examples[name] = example
+		}
+		if schema := contentType.Schema; schema != nil {
+			if err := loader.resolveSchemaRef(doc, schema, documentPath); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (loader *Loader) resolveResponseRef(doc *T, component *ResponseRef, documentPath *url.URL) (err error) {
+	if component != nil && component.Value != nil {
+		if loader.visitedResponse == nil {
+			loader.visitedResponse = make(map[*Response]struct{})
+		}
+		if _, ok := loader.visitedResponse[component.Value]; ok {
+			return nil
+		}
+		loader.visitedResponse[component.Value] = struct{}{}
+	}
+
+	if component == nil {
+		return errors.New("invalid response: value MUST be an object")
+	}
+	ref := component.Ref
+	if ref != "" {
+		if isSingleRefElement(ref) {
+			var resp Response
+			if documentPath, err = loader.loadSingleElementFromURI(ref, documentPath, &resp); err != nil {
+				return err
+			}
+			component.Value = &resp
+		} else {
+			var resolved ResponseRef
+			componentPath, err := loader.resolveComponent(doc, ref, documentPath, &resolved)
+			if err != nil {
+				return err
+			}
+			if err := loader.resolveResponseRef(doc, &resolved, componentPath); err != nil {
+				return err
+			}
+			component.Value = resolved.Value
+		}
+	}
+	value := component.Value
+	if value == nil {
+		return nil
+	}
+
+	for _, header := range value.Headers {
+		if err := loader.resolveHeaderRef(doc, header, documentPath); err != nil {
+			return err
+		}
+	}
+	for _, contentType := range value.Content {
+		if contentType == nil {
+			continue
+		}
+		for name, example := range contentType.Examples {
+			if err := loader.resolveExampleRef(doc, example, documentPath); err != nil {
+				return err
+			}
+			contentType.Examples[name] = example
+		}
+		if schema := contentType.Schema; schema != nil {
+			if err := loader.resolveSchemaRef(doc, schema, documentPath); err != nil {
+				return err
+			}
+			contentType.Schema = schema
+		}
+	}
+	for _, link := range value.Links {
+		if err := loader.resolveLinkRef(doc, link, documentPath); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (loader *Loader) resolveSchemaRef(doc *T, component *SchemaRef, documentPath *url.URL) (err error) {
+	if component != nil && component.Value != nil {
+		if loader.visitedSchema == nil {
+			loader.visitedSchema = make(map[*Schema]struct{})
+		}
+		if _, ok := loader.visitedSchema[component.Value]; ok {
+			return nil
+		}
+		loader.visitedSchema[component.Value] = struct{}{}
+	}
+
+	if component == nil {
+		return errors.New("invalid schema: value MUST be an object")
+	}
+	ref := component.Ref
+	if ref != "" {
+		if isSingleRefElement(ref) {
+			var schema Schema
+			if documentPath, err = loader.loadSingleElementFromURI(ref, documentPath, &schema); err != nil {
+				return err
+			}
+			component.Value = &schema
+		} else {
+			var resolved SchemaRef
+			componentPath, err := loader.resolveComponent(doc, ref, documentPath, &resolved)
+			if err != nil {
+				return err
+			}
+			if err := loader.resolveSchemaRef(doc, &resolved, componentPath); err != nil {
+				return err
+			}
+			component.Value = resolved.Value
+		}
+	}
+	value := component.Value
+	if value == nil {
+		return nil
+	}
+
+	// ResolveRefs referred schemas
+	if v := value.Items; v != nil {
+		if err := loader.resolveSchemaRef(doc, v, documentPath); err != nil {
+			return err
+		}
+	}
+	for _, v := range value.Properties {
+		if err := loader.resolveSchemaRef(doc, v, documentPath); err != nil {
+			return err
+		}
+	}
+	if v := value.AdditionalProperties; v != nil {
+		if err := loader.resolveSchemaRef(doc, v, documentPath); err != nil {
+			return err
+		}
+	}
+	if v := value.Not; v != nil {
+		if err := loader.resolveSchemaRef(doc, v, documentPath); err != nil {
+			return err
+		}
+	}
+	for _, v := range value.AllOf {
+		if err := loader.resolveSchemaRef(doc, v, documentPath); err != nil {
+			return err
+		}
+	}
+	for _, v := range value.AnyOf {
+		if err := loader.resolveSchemaRef(doc, v, documentPath); err != nil {
+			return err
+		}
+	}
+	for _, v := range value.OneOf {
+		if err := loader.resolveSchemaRef(doc, v, documentPath); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (loader *Loader) resolveSecuritySchemeRef(doc *T, component *SecuritySchemeRef, documentPath *url.URL) (err error) {
+	if component != nil && component.Value != nil {
+		if loader.visitedSecurityScheme == nil {
+			loader.visitedSecurityScheme = make(map[*SecurityScheme]struct{})
+		}
+		if _, ok := loader.visitedSecurityScheme[component.Value]; ok {
+			return nil
+		}
+		loader.visitedSecurityScheme[component.Value] = struct{}{}
+	}
+
+	if component == nil {
+		return errors.New("invalid securityScheme: value MUST be an object")
+	}
+	if ref := component.Ref; ref != "" {
+		if isSingleRefElement(ref) {
+			var scheme SecurityScheme
+			if documentPath, err = loader.loadSingleElementFromURI(ref, documentPath, &scheme); err != nil {
+				return err
+			}
+			component.Value = &scheme
+		} else {
+			var resolved SecuritySchemeRef
+			componentPath, err := loader.resolveComponent(doc, ref, documentPath, &resolved)
+			if err != nil {
+				return err
+			}
+			if err := loader.resolveSecuritySchemeRef(doc, &resolved, componentPath); err != nil {
+				return err
+			}
+			component.Value = resolved.Value
+		}
+	}
+	return nil
+}
+
+func (loader *Loader) resolveExampleRef(doc *T, component *ExampleRef, documentPath *url.URL) (err error) {
+	if component != nil && component.Value != nil {
+		if loader.visitedExample == nil {
+			loader.visitedExample = make(map[*Example]struct{})
+		}
+		if _, ok := loader.visitedExample[component.Value]; ok {
+			return nil
+		}
+		loader.visitedExample[component.Value] = struct{}{}
+	}
+
+	if component == nil {
+		return errors.New("invalid example: value MUST be an object")
+	}
+	if ref := component.Ref; ref != "" {
+		if isSingleRefElement(ref) {
+			var example Example
+			if documentPath, err = loader.loadSingleElementFromURI(ref, documentPath, &example); err != nil {
+				return err
+			}
+			component.Value = &example
+		} else {
+			var resolved ExampleRef
+			componentPath, err := loader.resolveComponent(doc, ref, documentPath, &resolved)
+			if err != nil {
+				return err
+			}
+			if err := loader.resolveExampleRef(doc, &resolved, componentPath); err != nil {
+				return err
+			}
+			component.Value = resolved.Value
+		}
+	}
+	return nil
+}
+
+func (loader *Loader) resolveCallbackRef(doc *T, component *CallbackRef, documentPath *url.URL) (err error) {
+
+	if component == nil {
+		return errors.New("invalid callback: value MUST be an object")
+	}
+	if ref := component.Ref; ref != "" {
+		if isSingleRefElement(ref) {
+			var resolved Callback
+			if documentPath, err = loader.loadSingleElementFromURI(ref, documentPath, &resolved); err != nil {
+				return err
+			}
+			component.Value = &resolved
+		} else {
+			var resolved CallbackRef
+			componentPath, err := loader.resolveComponent(doc, ref, documentPath, &resolved)
+			if err != nil {
+				return err
+			}
+			if err := loader.resolveCallbackRef(doc, &resolved, componentPath); err != nil {
+				return err
+			}
+			component.Value = resolved.Value
+		}
+	}
+	value := component.Value
+	if value == nil {
+		return nil
+	}
+
+	for entrypoint, pathItem := range *value {
+		entrypoint, pathItem := entrypoint, pathItem
+		err = func() (err error) {
+			key := "-"
+			if documentPath != nil {
+				key = documentPath.EscapedPath()
+			}
+			key += entrypoint
+			if _, ok := loader.visitedPathItemRefs[key]; ok {
+				return nil
+			}
+			loader.visitedPathItemRefs[key] = struct{}{}
+
+			if pathItem == nil {
+				return errors.New("invalid path item: value MUST be an object")
+			}
+			ref := pathItem.Ref
+			if ref != "" {
+				if isSingleRefElement(ref) {
+					var p PathItem
+					if documentPath, err = loader.loadSingleElementFromURI(ref, documentPath, &p); err != nil {
+						return err
+					}
+					*pathItem = p
+				} else {
+					if doc, ref, documentPath, err = loader.resolveRef(doc, ref, documentPath); err != nil {
+						return
+					}
+
+					rest := strings.TrimPrefix(ref, "#/components/callbacks/")
+					if rest == ref {
+						return fmt.Errorf(`expected prefix "#/components/callbacks/" in URI %q`, ref)
+					}
+					id := unescapeRefString(rest)
+
+					definitions := doc.Components.Callbacks
+					if definitions == nil {
+						return failedToResolveRefFragmentPart(ref, "callbacks")
+					}
+					resolved := definitions[id]
+					if resolved == nil {
+						return failedToResolveRefFragmentPart(ref, id)
+					}
+
+					for _, p := range *resolved.Value {
+						*pathItem = *p
+						break
+					}
+				}
+			}
+			return loader.resolvePathItemRefContinued(doc, pathItem, documentPath)
+		}()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (loader *Loader) resolveLinkRef(doc *T, component *LinkRef, documentPath *url.URL) (err error) {
+	if component != nil && component.Value != nil {
+		if loader.visitedLink == nil {
+			loader.visitedLink = make(map[*Link]struct{})
+		}
+		if _, ok := loader.visitedLink[component.Value]; ok {
+			return nil
+		}
+		loader.visitedLink[component.Value] = struct{}{}
+	}
+
+	if component == nil {
+		return errors.New("invalid link: value MUST be an object")
+	}
+	if ref := component.Ref; ref != "" {
+		if isSingleRefElement(ref) {
+			var link Link
+			if documentPath, err = loader.loadSingleElementFromURI(ref, documentPath, &link); err != nil {
+				return err
+			}
+			component.Value = &link
+		} else {
+			var resolved LinkRef
+			componentPath, err := loader.resolveComponent(doc, ref, documentPath, &resolved)
+			if err != nil {
+				return err
+			}
+			if err := loader.resolveLinkRef(doc, &resolved, componentPath); err != nil {
+				return err
+			}
+			component.Value = resolved.Value
+		}
+	}
+	return nil
+}
+
+func (loader *Loader) resolvePathItemRef(doc *T, entrypoint string, pathItem *PathItem, documentPath *url.URL) (err error) {
+	key := "_"
+	if documentPath != nil {
+		key = documentPath.EscapedPath()
+	}
+	key += entrypoint
+	if _, ok := loader.visitedPathItemRefs[key]; ok {
+		return nil
+	}
+	loader.visitedPathItemRefs[key] = struct{}{}
+
+	if pathItem == nil {
+		return errors.New("invalid path item: value MUST be an object")
+	}
+	ref := pathItem.Ref
+	if ref != "" {
+		if isSingleRefElement(ref) {
+			var p PathItem
+			if documentPath, err = loader.loadSingleElementFromURI(ref, documentPath, &p); err != nil {
+				return err
+			}
+			*pathItem = p
+		} else {
+			if doc, ref, documentPath, err = loader.resolveRef(doc, ref, documentPath); err != nil {
+				return
+			}
+
+			rest := strings.TrimPrefix(ref, "#/paths/")
+			if rest == ref {
+				return fmt.Errorf(`expected prefix "#/paths/" in URI %q`, ref)
+			}
+			id := unescapeRefString(rest)
+
+			definitions := doc.Paths
+			if definitions == nil {
+				return failedToResolveRefFragmentPart(ref, "paths")
+			}
+			resolved := definitions[id]
+			if resolved == nil {
+				return failedToResolveRefFragmentPart(ref, id)
+			}
+
+			*pathItem = *resolved
+		}
+	}
+	return loader.resolvePathItemRefContinued(doc, pathItem, documentPath)
+}
+
+func (loader *Loader) resolvePathItemRefContinued(doc *T, pathItem *PathItem, documentPath *url.URL) (err error) {
+	for _, parameter := range pathItem.Parameters {
+		if err = loader.resolveParameterRef(doc, parameter, documentPath); err != nil {
+			return
+		}
+	}
+	for _, operation := range pathItem.Operations() {
+		for _, parameter := range operation.Parameters {
+			if err = loader.resolveParameterRef(doc, parameter, documentPath); err != nil {
+				return
+			}
+		}
+		if requestBody := operation.RequestBody; requestBody != nil {
+			if err = loader.resolveRequestBodyRef(doc, requestBody, documentPath); err != nil {
+				return
+			}
+		}
+		for _, response := range operation.Responses {
+			if err = loader.resolveResponseRef(doc, response, documentPath); err != nil {
+				return
+			}
+		}
+		for _, callback := range operation.Callbacks {
+			if err = loader.resolveCallbackRef(doc, callback, documentPath); err != nil {
+				return
+			}
+		}
+	}
+	return
+}
+
+func unescapeRefString(ref string) string {
+	return strings.Replace(strings.Replace(ref, "~1", "/", -1), "~0", "~", -1)
+}

--- a/vendor/github.com/getkin/kin-openapi/openapi3/media_type.go
+++ b/vendor/github.com/getkin/kin-openapi/openapi3/media_type.go
@@ -1,0 +1,100 @@
+package openapi3
+
+import (
+	"context"
+
+	"github.com/getkin/kin-openapi/jsoninfo"
+	"github.com/go-openapi/jsonpointer"
+)
+
+// MediaType is specified by OpenAPI/Swagger 3.0 standard.
+type MediaType struct {
+	ExtensionProps
+
+	Schema   *SchemaRef           `json:"schema,omitempty" yaml:"schema,omitempty"`
+	Example  interface{}          `json:"example,omitempty" yaml:"example,omitempty"`
+	Examples Examples             `json:"examples,omitempty" yaml:"examples,omitempty"`
+	Encoding map[string]*Encoding `json:"encoding,omitempty" yaml:"encoding,omitempty"`
+}
+
+var _ jsonpointer.JSONPointable = (*MediaType)(nil)
+
+func NewMediaType() *MediaType {
+	return &MediaType{}
+}
+
+func (mediaType *MediaType) WithSchema(schema *Schema) *MediaType {
+	if schema == nil {
+		mediaType.Schema = nil
+	} else {
+		mediaType.Schema = &SchemaRef{Value: schema}
+	}
+	return mediaType
+}
+
+func (mediaType *MediaType) WithSchemaRef(schema *SchemaRef) *MediaType {
+	mediaType.Schema = schema
+	return mediaType
+}
+
+func (mediaType *MediaType) WithExample(name string, value interface{}) *MediaType {
+	example := mediaType.Examples
+	if example == nil {
+		example = make(map[string]*ExampleRef)
+		mediaType.Examples = example
+	}
+	example[name] = &ExampleRef{
+		Value: NewExample(value),
+	}
+	return mediaType
+}
+
+func (mediaType *MediaType) WithEncoding(name string, enc *Encoding) *MediaType {
+	encoding := mediaType.Encoding
+	if encoding == nil {
+		encoding = make(map[string]*Encoding)
+		mediaType.Encoding = encoding
+	}
+	encoding[name] = enc
+	return mediaType
+}
+
+func (mediaType *MediaType) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalStrictStruct(mediaType)
+}
+
+func (mediaType *MediaType) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalStrictStruct(data, mediaType)
+}
+
+func (value *MediaType) Validate(ctx context.Context) error {
+	if value == nil {
+		return nil
+	}
+	if schema := value.Schema; schema != nil {
+		if err := schema.Validate(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (mediaType MediaType) JSONLookup(token string) (interface{}, error) {
+	switch token {
+	case "schema":
+		if mediaType.Schema != nil {
+			if mediaType.Schema.Ref != "" {
+				return &Ref{Ref: mediaType.Schema.Ref}, nil
+			}
+			return mediaType.Schema.Value, nil
+		}
+	case "example":
+		return mediaType.Example, nil
+	case "examples":
+		return mediaType.Examples, nil
+	case "encoding":
+		return mediaType.Encoding, nil
+	}
+	v, _, err := jsonpointer.GetForToken(mediaType.ExtensionProps, token)
+	return v, err
+}

--- a/vendor/github.com/getkin/kin-openapi/openapi3/openapi3.go
+++ b/vendor/github.com/getkin/kin-openapi/openapi3/openapi3.go
@@ -1,0 +1,105 @@
+package openapi3
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/getkin/kin-openapi/jsoninfo"
+)
+
+// T is the root of an OpenAPI v3 document
+type T struct {
+	ExtensionProps
+	OpenAPI      string               `json:"openapi" yaml:"openapi"` // Required
+	Components   Components           `json:"components,omitempty" yaml:"components,omitempty"`
+	Info         *Info                `json:"info" yaml:"info"`   // Required
+	Paths        Paths                `json:"paths" yaml:"paths"` // Required
+	Security     SecurityRequirements `json:"security,omitempty" yaml:"security,omitempty"`
+	Servers      Servers              `json:"servers,omitempty" yaml:"servers,omitempty"`
+	Tags         Tags                 `json:"tags,omitempty" yaml:"tags,omitempty"`
+	ExternalDocs *ExternalDocs        `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
+}
+
+func (doc *T) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalStrictStruct(doc)
+}
+
+func (doc *T) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalStrictStruct(data, doc)
+}
+
+func (doc *T) AddOperation(path string, method string, operation *Operation) {
+	paths := doc.Paths
+	if paths == nil {
+		paths = make(Paths)
+		doc.Paths = paths
+	}
+	pathItem := paths[path]
+	if pathItem == nil {
+		pathItem = &PathItem{}
+		paths[path] = pathItem
+	}
+	pathItem.SetOperation(method, operation)
+}
+
+func (doc *T) AddServer(server *Server) {
+	doc.Servers = append(doc.Servers, server)
+}
+
+func (value *T) Validate(ctx context.Context) error {
+	if value.OpenAPI == "" {
+		return errors.New("value of openapi must be a non-empty string")
+	}
+
+	// NOTE: only mention info/components/paths/... key in this func's errors.
+
+	{
+		wrap := func(e error) error { return fmt.Errorf("invalid components: %v", e) }
+		if err := value.Components.Validate(ctx); err != nil {
+			return wrap(err)
+		}
+	}
+
+	{
+		wrap := func(e error) error { return fmt.Errorf("invalid info: %v", e) }
+		if v := value.Info; v != nil {
+			if err := v.Validate(ctx); err != nil {
+				return wrap(err)
+			}
+		} else {
+			return wrap(errors.New("must be an object"))
+		}
+	}
+
+	{
+		wrap := func(e error) error { return fmt.Errorf("invalid paths: %v", e) }
+		if v := value.Paths; v != nil {
+			if err := v.Validate(ctx); err != nil {
+				return wrap(err)
+			}
+		} else {
+			return wrap(errors.New("must be an object"))
+		}
+	}
+
+	{
+		wrap := func(e error) error { return fmt.Errorf("invalid security: %v", e) }
+		if v := value.Security; v != nil {
+			if err := v.Validate(ctx); err != nil {
+				return wrap(err)
+			}
+		}
+	}
+
+	{
+		wrap := func(e error) error { return fmt.Errorf("invalid servers: %v", e) }
+		if v := value.Servers; v != nil {
+			if err := v.Validate(ctx); err != nil {
+				return wrap(err)
+			}
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/getkin/kin-openapi/openapi3/operation.go
+++ b/vendor/github.com/getkin/kin-openapi/openapi3/operation.go
@@ -1,0 +1,142 @@
+package openapi3
+
+import (
+	"context"
+	"errors"
+	"strconv"
+
+	"github.com/getkin/kin-openapi/jsoninfo"
+	"github.com/go-openapi/jsonpointer"
+)
+
+// Operation represents "operation" specified by" OpenAPI/Swagger 3.0 standard.
+type Operation struct {
+	ExtensionProps
+
+	// Optional tags for documentation.
+	Tags []string `json:"tags,omitempty" yaml:"tags,omitempty"`
+
+	// Optional short summary.
+	Summary string `json:"summary,omitempty" yaml:"summary,omitempty"`
+
+	// Optional description. Should use CommonMark syntax.
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	// Optional operation ID.
+	OperationID string `json:"operationId,omitempty" yaml:"operationId,omitempty"`
+
+	// Optional parameters.
+	Parameters Parameters `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+
+	// Optional body parameter.
+	RequestBody *RequestBodyRef `json:"requestBody,omitempty" yaml:"requestBody,omitempty"`
+
+	// Responses.
+	Responses Responses `json:"responses" yaml:"responses"` // Required
+
+	// Optional callbacks
+	Callbacks Callbacks `json:"callbacks,omitempty" yaml:"callbacks,omitempty"`
+
+	Deprecated bool `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
+
+	// Optional security requirements that overrides top-level security.
+	Security *SecurityRequirements `json:"security,omitempty" yaml:"security,omitempty"`
+
+	// Optional servers that overrides top-level servers.
+	Servers *Servers `json:"servers,omitempty" yaml:"servers,omitempty"`
+
+	ExternalDocs *ExternalDocs `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
+}
+
+var _ jsonpointer.JSONPointable = (*Operation)(nil)
+
+func NewOperation() *Operation {
+	return &Operation{}
+}
+
+func (operation *Operation) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalStrictStruct(operation)
+}
+
+func (operation *Operation) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalStrictStruct(data, operation)
+}
+
+func (operation Operation) JSONLookup(token string) (interface{}, error) {
+	switch token {
+	case "requestBody":
+		if operation.RequestBody != nil {
+			if operation.RequestBody.Ref != "" {
+				return &Ref{Ref: operation.RequestBody.Ref}, nil
+			}
+			return operation.RequestBody.Value, nil
+		}
+	case "tags":
+		return operation.Tags, nil
+	case "summary":
+		return operation.Summary, nil
+	case "description":
+		return operation.Description, nil
+	case "operationID":
+		return operation.OperationID, nil
+	case "parameters":
+		return operation.Parameters, nil
+	case "responses":
+		return operation.Responses, nil
+	case "callbacks":
+		return operation.Callbacks, nil
+	case "deprecated":
+		return operation.Deprecated, nil
+	case "security":
+		return operation.Security, nil
+	case "servers":
+		return operation.Servers, nil
+	case "externalDocs":
+		return operation.ExternalDocs, nil
+	}
+
+	v, _, err := jsonpointer.GetForToken(operation.ExtensionProps, token)
+	return v, err
+}
+
+func (operation *Operation) AddParameter(p *Parameter) {
+	operation.Parameters = append(operation.Parameters, &ParameterRef{
+		Value: p,
+	})
+}
+
+func (operation *Operation) AddResponse(status int, response *Response) {
+	responses := operation.Responses
+	if responses == nil {
+		responses = NewResponses()
+		operation.Responses = responses
+	}
+	code := "default"
+	if status != 0 {
+		code = strconv.FormatInt(int64(status), 10)
+	}
+	responses[code] = &ResponseRef{
+		Value: response,
+	}
+}
+
+func (value *Operation) Validate(ctx context.Context) error {
+	if v := value.Parameters; v != nil {
+		if err := v.Validate(ctx); err != nil {
+			return err
+		}
+	}
+	if v := value.RequestBody; v != nil {
+		if err := v.Validate(ctx); err != nil {
+			return err
+		}
+	}
+	if v := value.Responses; v != nil {
+		if err := v.Validate(ctx); err != nil {
+			return err
+		}
+	} else {
+		return errors.New("value of responses must be an object")
+	}
+	return nil
+}

--- a/vendor/github.com/getkin/kin-openapi/openapi3/parameter.go
+++ b/vendor/github.com/getkin/kin-openapi/openapi3/parameter.go
@@ -1,0 +1,305 @@
+package openapi3
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/getkin/kin-openapi/jsoninfo"
+	"github.com/go-openapi/jsonpointer"
+)
+
+type ParametersMap map[string]*ParameterRef
+
+var _ jsonpointer.JSONPointable = (*ParametersMap)(nil)
+
+func (p ParametersMap) JSONLookup(token string) (interface{}, error) {
+	ref, ok := p[token]
+	if ref == nil || ok == false {
+		return nil, fmt.Errorf("object has no field %q", token)
+	}
+
+	if ref.Ref != "" {
+		return &Ref{Ref: ref.Ref}, nil
+	}
+	return ref.Value, nil
+}
+
+// Parameters is specified by OpenAPI/Swagger 3.0 standard.
+type Parameters []*ParameterRef
+
+var _ jsonpointer.JSONPointable = (*Parameters)(nil)
+
+func (p Parameters) JSONLookup(token string) (interface{}, error) {
+	index, err := strconv.Atoi(token)
+	if err != nil {
+		return nil, err
+	}
+
+	if index < 0 || index >= len(p) {
+		return nil, fmt.Errorf("index %d out of bounds of array of length %d", index, len(p))
+	}
+
+	ref := p[index]
+
+	if ref != nil && ref.Ref != "" {
+		return &Ref{Ref: ref.Ref}, nil
+	}
+	return ref.Value, nil
+}
+
+func NewParameters() Parameters {
+	return make(Parameters, 0, 4)
+}
+
+func (parameters Parameters) GetByInAndName(in string, name string) *Parameter {
+	for _, item := range parameters {
+		if v := item.Value; v != nil {
+			if v.Name == name && v.In == in {
+				return v
+			}
+		}
+	}
+	return nil
+}
+
+func (value Parameters) Validate(ctx context.Context) error {
+	dupes := make(map[string]struct{})
+	for _, item := range value {
+		if v := item.Value; v != nil {
+			key := v.In + ":" + v.Name
+			if _, ok := dupes[key]; ok {
+				return fmt.Errorf("more than one %q parameter has name %q", v.In, v.Name)
+			}
+			dupes[key] = struct{}{}
+		}
+
+		if err := item.Validate(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Parameter is specified by OpenAPI/Swagger 3.0 standard.
+// See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.0.md#parameterObject
+type Parameter struct {
+	ExtensionProps
+	Name            string      `json:"name,omitempty" yaml:"name,omitempty"`
+	In              string      `json:"in,omitempty" yaml:"in,omitempty"`
+	Description     string      `json:"description,omitempty" yaml:"description,omitempty"`
+	Style           string      `json:"style,omitempty" yaml:"style,omitempty"`
+	Explode         *bool       `json:"explode,omitempty" yaml:"explode,omitempty"`
+	AllowEmptyValue bool        `json:"allowEmptyValue,omitempty" yaml:"allowEmptyValue,omitempty"`
+	AllowReserved   bool        `json:"allowReserved,omitempty" yaml:"allowReserved,omitempty"`
+	Deprecated      bool        `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
+	Required        bool        `json:"required,omitempty" yaml:"required,omitempty"`
+	Schema          *SchemaRef  `json:"schema,omitempty" yaml:"schema,omitempty"`
+	Example         interface{} `json:"example,omitempty" yaml:"example,omitempty"`
+	Examples        Examples    `json:"examples,omitempty" yaml:"examples,omitempty"`
+	Content         Content     `json:"content,omitempty" yaml:"content,omitempty"`
+}
+
+var _ jsonpointer.JSONPointable = (*Parameter)(nil)
+
+const (
+	ParameterInPath   = "path"
+	ParameterInQuery  = "query"
+	ParameterInHeader = "header"
+	ParameterInCookie = "cookie"
+)
+
+func NewPathParameter(name string) *Parameter {
+	return &Parameter{
+		Name:     name,
+		In:       ParameterInPath,
+		Required: true,
+	}
+}
+
+func NewQueryParameter(name string) *Parameter {
+	return &Parameter{
+		Name: name,
+		In:   ParameterInQuery,
+	}
+}
+
+func NewHeaderParameter(name string) *Parameter {
+	return &Parameter{
+		Name: name,
+		In:   ParameterInHeader,
+	}
+}
+
+func NewCookieParameter(name string) *Parameter {
+	return &Parameter{
+		Name: name,
+		In:   ParameterInCookie,
+	}
+}
+
+func (parameter *Parameter) WithDescription(value string) *Parameter {
+	parameter.Description = value
+	return parameter
+}
+
+func (parameter *Parameter) WithRequired(value bool) *Parameter {
+	parameter.Required = value
+	return parameter
+}
+
+func (parameter *Parameter) WithSchema(value *Schema) *Parameter {
+	if value == nil {
+		parameter.Schema = nil
+	} else {
+		parameter.Schema = &SchemaRef{
+			Value: value,
+		}
+	}
+	return parameter
+}
+
+func (parameter *Parameter) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalStrictStruct(parameter)
+}
+
+func (parameter *Parameter) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalStrictStruct(data, parameter)
+}
+
+func (value Parameter) JSONLookup(token string) (interface{}, error) {
+	switch token {
+	case "schema":
+		if value.Schema != nil {
+			if value.Schema.Ref != "" {
+				return &Ref{Ref: value.Schema.Ref}, nil
+			}
+			return value.Schema.Value, nil
+		}
+	case "name":
+		return value.Name, nil
+	case "in":
+		return value.In, nil
+	case "description":
+		return value.Description, nil
+	case "style":
+		return value.Style, nil
+	case "explode":
+		return value.Explode, nil
+	case "allowEmptyValue":
+		return value.AllowEmptyValue, nil
+	case "allowReserved":
+		return value.AllowReserved, nil
+	case "deprecated":
+		return value.Deprecated, nil
+	case "required":
+		return value.Required, nil
+	case "example":
+		return value.Example, nil
+	case "examples":
+		return value.Examples, nil
+	case "content":
+		return value.Content, nil
+	}
+
+	v, _, err := jsonpointer.GetForToken(value.ExtensionProps, token)
+	return v, err
+}
+
+// SerializationMethod returns a parameter's serialization method.
+// When a parameter's serialization method is not defined the method returns
+// the default serialization method corresponding to a parameter's location.
+func (parameter *Parameter) SerializationMethod() (*SerializationMethod, error) {
+	switch parameter.In {
+	case ParameterInPath, ParameterInHeader:
+		style := parameter.Style
+		if style == "" {
+			style = SerializationSimple
+		}
+		explode := false
+		if parameter.Explode != nil {
+			explode = *parameter.Explode
+		}
+		return &SerializationMethod{Style: style, Explode: explode}, nil
+	case ParameterInQuery, ParameterInCookie:
+		style := parameter.Style
+		if style == "" {
+			style = SerializationForm
+		}
+		explode := true
+		if parameter.Explode != nil {
+			explode = *parameter.Explode
+		}
+		return &SerializationMethod{Style: style, Explode: explode}, nil
+	default:
+		return nil, fmt.Errorf("unexpected parameter's 'in': %q", parameter.In)
+	}
+}
+
+func (value *Parameter) Validate(ctx context.Context) error {
+	if value.Name == "" {
+		return errors.New("parameter name can't be blank")
+	}
+	in := value.In
+	switch in {
+	case
+		ParameterInPath,
+		ParameterInQuery,
+		ParameterInHeader,
+		ParameterInCookie:
+	default:
+		return fmt.Errorf("parameter can't have 'in' value %q", value.In)
+	}
+
+	// Validate a parameter's serialization method.
+	sm, err := value.SerializationMethod()
+	if err != nil {
+		return err
+	}
+	var smSupported bool
+	switch {
+	case value.In == ParameterInPath && sm.Style == SerializationSimple && !sm.Explode,
+		value.In == ParameterInPath && sm.Style == SerializationSimple && sm.Explode,
+		value.In == ParameterInPath && sm.Style == SerializationLabel && !sm.Explode,
+		value.In == ParameterInPath && sm.Style == SerializationLabel && sm.Explode,
+		value.In == ParameterInPath && sm.Style == SerializationMatrix && !sm.Explode,
+		value.In == ParameterInPath && sm.Style == SerializationMatrix && sm.Explode,
+
+		value.In == ParameterInQuery && sm.Style == SerializationForm && sm.Explode,
+		value.In == ParameterInQuery && sm.Style == SerializationForm && !sm.Explode,
+		value.In == ParameterInQuery && sm.Style == SerializationSpaceDelimited && sm.Explode,
+		value.In == ParameterInQuery && sm.Style == SerializationSpaceDelimited && !sm.Explode,
+		value.In == ParameterInQuery && sm.Style == SerializationPipeDelimited && sm.Explode,
+		value.In == ParameterInQuery && sm.Style == SerializationPipeDelimited && !sm.Explode,
+		value.In == ParameterInQuery && sm.Style == SerializationDeepObject && sm.Explode,
+
+		value.In == ParameterInHeader && sm.Style == SerializationSimple && !sm.Explode,
+		value.In == ParameterInHeader && sm.Style == SerializationSimple && sm.Explode,
+
+		value.In == ParameterInCookie && sm.Style == SerializationForm && !sm.Explode,
+		value.In == ParameterInCookie && sm.Style == SerializationForm && sm.Explode:
+		smSupported = true
+	}
+	if !smSupported {
+		e := fmt.Errorf("serialization method with style=%q and explode=%v is not supported by a %s parameter", sm.Style, sm.Explode, in)
+		return fmt.Errorf("parameter %q schema is invalid: %v", value.Name, e)
+	}
+
+	if (value.Schema == nil) == (value.Content == nil) {
+		e := errors.New("parameter must contain exactly one of content and schema")
+		return fmt.Errorf("parameter %q schema is invalid: %v", value.Name, e)
+	}
+	if schema := value.Schema; schema != nil {
+		if err := schema.Validate(ctx); err != nil {
+			return fmt.Errorf("parameter %q schema is invalid: %v", value.Name, err)
+		}
+	}
+
+	if content := value.Content; content != nil {
+		if err := content.Validate(ctx); err != nil {
+			return fmt.Errorf("parameter %q content is invalid: %v", value.Name, err)
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/getkin/kin-openapi/openapi3/path_item.go
+++ b/vendor/github.com/getkin/kin-openapi/openapi3/path_item.go
@@ -1,0 +1,126 @@
+package openapi3
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/getkin/kin-openapi/jsoninfo"
+)
+
+type PathItem struct {
+	ExtensionProps
+	Ref         string     `json:"$ref,omitempty" yaml:"$ref,omitempty"`
+	Summary     string     `json:"summary,omitempty" yaml:"summary,omitempty"`
+	Description string     `json:"description,omitempty" yaml:"description,omitempty"`
+	Connect     *Operation `json:"connect,omitempty" yaml:"connect,omitempty"`
+	Delete      *Operation `json:"delete,omitempty" yaml:"delete,omitempty"`
+	Get         *Operation `json:"get,omitempty" yaml:"get,omitempty"`
+	Head        *Operation `json:"head,omitempty" yaml:"head,omitempty"`
+	Options     *Operation `json:"options,omitempty" yaml:"options,omitempty"`
+	Patch       *Operation `json:"patch,omitempty" yaml:"patch,omitempty"`
+	Post        *Operation `json:"post,omitempty" yaml:"post,omitempty"`
+	Put         *Operation `json:"put,omitempty" yaml:"put,omitempty"`
+	Trace       *Operation `json:"trace,omitempty" yaml:"trace,omitempty"`
+	Servers     Servers    `json:"servers,omitempty" yaml:"servers,omitempty"`
+	Parameters  Parameters `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+}
+
+func (pathItem *PathItem) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalStrictStruct(pathItem)
+}
+
+func (pathItem *PathItem) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalStrictStruct(data, pathItem)
+}
+
+func (pathItem *PathItem) Operations() map[string]*Operation {
+	operations := make(map[string]*Operation, 4)
+	if v := pathItem.Connect; v != nil {
+		operations[http.MethodConnect] = v
+	}
+	if v := pathItem.Delete; v != nil {
+		operations[http.MethodDelete] = v
+	}
+	if v := pathItem.Get; v != nil {
+		operations[http.MethodGet] = v
+	}
+	if v := pathItem.Head; v != nil {
+		operations[http.MethodHead] = v
+	}
+	if v := pathItem.Options; v != nil {
+		operations[http.MethodOptions] = v
+	}
+	if v := pathItem.Patch; v != nil {
+		operations[http.MethodPatch] = v
+	}
+	if v := pathItem.Post; v != nil {
+		operations[http.MethodPost] = v
+	}
+	if v := pathItem.Put; v != nil {
+		operations[http.MethodPut] = v
+	}
+	if v := pathItem.Trace; v != nil {
+		operations[http.MethodTrace] = v
+	}
+	return operations
+}
+
+func (pathItem *PathItem) GetOperation(method string) *Operation {
+	switch method {
+	case http.MethodConnect:
+		return pathItem.Connect
+	case http.MethodDelete:
+		return pathItem.Delete
+	case http.MethodGet:
+		return pathItem.Get
+	case http.MethodHead:
+		return pathItem.Head
+	case http.MethodOptions:
+		return pathItem.Options
+	case http.MethodPatch:
+		return pathItem.Patch
+	case http.MethodPost:
+		return pathItem.Post
+	case http.MethodPut:
+		return pathItem.Put
+	case http.MethodTrace:
+		return pathItem.Trace
+	default:
+		panic(fmt.Errorf("unsupported HTTP method %q", method))
+	}
+}
+
+func (pathItem *PathItem) SetOperation(method string, operation *Operation) {
+	switch method {
+	case http.MethodConnect:
+		pathItem.Connect = operation
+	case http.MethodDelete:
+		pathItem.Delete = operation
+	case http.MethodGet:
+		pathItem.Get = operation
+	case http.MethodHead:
+		pathItem.Head = operation
+	case http.MethodOptions:
+		pathItem.Options = operation
+	case http.MethodPatch:
+		pathItem.Patch = operation
+	case http.MethodPost:
+		pathItem.Post = operation
+	case http.MethodPut:
+		pathItem.Put = operation
+	case http.MethodTrace:
+		pathItem.Trace = operation
+	default:
+		panic(fmt.Errorf("unsupported HTTP method %q", method))
+	}
+}
+
+func (value *PathItem) Validate(ctx context.Context) error {
+	for _, operation := range value.Operations() {
+		if err := operation.Validate(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/getkin/kin-openapi/openapi3/paths.go
+++ b/vendor/github.com/getkin/kin-openapi/openapi3/paths.go
@@ -1,0 +1,127 @@
+package openapi3
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// Paths is specified by OpenAPI/Swagger standard version 3.0.
+type Paths map[string]*PathItem
+
+func (value Paths) Validate(ctx context.Context) error {
+	normalizedPaths := make(map[string]string)
+	for path, pathItem := range value {
+		if path == "" || path[0] != '/' {
+			return fmt.Errorf("path %q does not start with a forward slash (/)", path)
+		}
+
+		if pathItem == nil {
+			value[path] = &PathItem{}
+			pathItem = value[path]
+		}
+
+		normalizedPath, pathParamsCount := normalizeTemplatedPath(path)
+		if oldPath, ok := normalizedPaths[normalizedPath]; ok {
+			return fmt.Errorf("conflicting paths %q and %q", path, oldPath)
+		}
+		normalizedPaths[path] = path
+
+		var globalCount uint
+		for _, parameterRef := range pathItem.Parameters {
+			if parameterRef != nil {
+				if parameter := parameterRef.Value; parameter != nil && parameter.In == ParameterInPath {
+					globalCount++
+				}
+			}
+		}
+		for method, operation := range pathItem.Operations() {
+			var count uint
+			for _, parameterRef := range operation.Parameters {
+				if parameterRef != nil {
+					if parameter := parameterRef.Value; parameter != nil && parameter.In == ParameterInPath {
+						count++
+					}
+				}
+			}
+			if count+globalCount != pathParamsCount {
+				return fmt.Errorf("operation %s %s must define exactly all path parameters", method, path)
+			}
+		}
+
+		if err := pathItem.Validate(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Find returns a path that matches the key.
+//
+// The method ignores differences in template variable names (except possible "*" suffix).
+//
+// For example:
+//
+//   paths := openapi3.Paths {
+//     "/person/{personName}": &openapi3.PathItem{},
+//   }
+//   pathItem := path.Find("/person/{name}")
+//
+// would return the correct path item.
+func (paths Paths) Find(key string) *PathItem {
+	// Try directly access the map
+	pathItem := paths[key]
+	if pathItem != nil {
+		return pathItem
+	}
+
+	normalizedPath, expected := normalizeTemplatedPath(key)
+	for path, pathItem := range paths {
+		pathNormalized, got := normalizeTemplatedPath(path)
+		if got == expected && pathNormalized == normalizedPath {
+			return pathItem
+		}
+	}
+	return nil
+}
+
+func normalizeTemplatedPath(path string) (string, uint) {
+	if strings.IndexByte(path, '{') < 0 {
+		return path, 0
+	}
+
+	var buf strings.Builder
+	buf.Grow(len(path))
+
+	var (
+		cc         rune
+		count      uint
+		isVariable bool
+	)
+	for i, c := range path {
+		if isVariable {
+			if c == '}' {
+				// End path variables
+				// First append possible '*' before this character
+				// The character '}' will be appended
+				if i > 0 && cc == '*' {
+					buf.WriteRune(cc)
+				}
+				isVariable = false
+			} else {
+				// Skip this character
+				continue
+			}
+		} else if c == '{' {
+			// Begin path variable
+			// The character '{' will be appended
+			isVariable = true
+			count++
+		}
+
+		// Append the character
+		buf.WriteRune(c)
+		cc = c
+	}
+	return buf.String(), count
+}

--- a/vendor/github.com/getkin/kin-openapi/openapi3/refs.go
+++ b/vendor/github.com/getkin/kin-openapi/openapi3/refs.go
@@ -1,0 +1,288 @@
+package openapi3
+
+import (
+	"context"
+
+	"github.com/getkin/kin-openapi/jsoninfo"
+	"github.com/go-openapi/jsonpointer"
+)
+
+// Ref is specified by OpenAPI/Swagger 3.0 standard.
+type Ref struct {
+	Ref string `json:"$ref" yaml:"$ref"`
+}
+
+type CallbackRef struct {
+	Ref   string
+	Value *Callback
+}
+
+var _ jsonpointer.JSONPointable = (*CallbackRef)(nil)
+
+func (value *CallbackRef) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalRef(value.Ref, value.Value)
+}
+
+func (value *CallbackRef) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalRef(data, &value.Ref, &value.Value)
+}
+
+func (value *CallbackRef) Validate(ctx context.Context) error {
+	if v := value.Value; v != nil {
+		return v.Validate(ctx)
+	}
+	return foundUnresolvedRef(value.Ref)
+}
+
+func (value CallbackRef) JSONLookup(token string) (interface{}, error) {
+	if token == "$ref" {
+		return value.Ref, nil
+	}
+
+	ptr, _, err := jsonpointer.GetForToken(value.Value, token)
+	return ptr, err
+}
+
+type ExampleRef struct {
+	Ref   string
+	Value *Example
+}
+
+var _ jsonpointer.JSONPointable = (*ExampleRef)(nil)
+
+func (value *ExampleRef) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalRef(value.Ref, value.Value)
+}
+
+func (value *ExampleRef) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalRef(data, &value.Ref, &value.Value)
+}
+
+func (value *ExampleRef) Validate(ctx context.Context) error {
+	if v := value.Value; v != nil {
+		return v.Validate(ctx)
+	}
+	return foundUnresolvedRef(value.Ref)
+}
+
+func (value ExampleRef) JSONLookup(token string) (interface{}, error) {
+	if token == "$ref" {
+		return value.Ref, nil
+	}
+
+	ptr, _, err := jsonpointer.GetForToken(value.Value, token)
+	return ptr, err
+}
+
+type HeaderRef struct {
+	Ref   string
+	Value *Header
+}
+
+var _ jsonpointer.JSONPointable = (*HeaderRef)(nil)
+
+func (value *HeaderRef) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalRef(value.Ref, value.Value)
+}
+
+func (value *HeaderRef) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalRef(data, &value.Ref, &value.Value)
+}
+
+func (value *HeaderRef) Validate(ctx context.Context) error {
+	if v := value.Value; v != nil {
+		return v.Validate(ctx)
+	}
+	return foundUnresolvedRef(value.Ref)
+}
+
+func (value HeaderRef) JSONLookup(token string) (interface{}, error) {
+	if token == "$ref" {
+		return value.Ref, nil
+	}
+
+	ptr, _, err := jsonpointer.GetForToken(value.Value, token)
+	return ptr, err
+}
+
+type LinkRef struct {
+	Ref   string
+	Value *Link
+}
+
+func (value *LinkRef) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalRef(value.Ref, value.Value)
+}
+
+func (value *LinkRef) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalRef(data, &value.Ref, &value.Value)
+}
+
+func (value *LinkRef) Validate(ctx context.Context) error {
+	if v := value.Value; v != nil {
+		return v.Validate(ctx)
+	}
+	return foundUnresolvedRef(value.Ref)
+}
+
+type ParameterRef struct {
+	Ref   string
+	Value *Parameter
+}
+
+var _ jsonpointer.JSONPointable = (*ParameterRef)(nil)
+
+func (value *ParameterRef) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalRef(value.Ref, value.Value)
+}
+
+func (value *ParameterRef) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalRef(data, &value.Ref, &value.Value)
+}
+
+func (value *ParameterRef) Validate(ctx context.Context) error {
+	if v := value.Value; v != nil {
+		return v.Validate(ctx)
+	}
+	return foundUnresolvedRef(value.Ref)
+}
+
+func (value ParameterRef) JSONLookup(token string) (interface{}, error) {
+	if token == "$ref" {
+		return value.Ref, nil
+	}
+
+	ptr, _, err := jsonpointer.GetForToken(value.Value, token)
+	return ptr, err
+}
+
+type ResponseRef struct {
+	Ref   string
+	Value *Response
+}
+
+var _ jsonpointer.JSONPointable = (*ResponseRef)(nil)
+
+func (value *ResponseRef) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalRef(value.Ref, value.Value)
+}
+
+func (value *ResponseRef) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalRef(data, &value.Ref, &value.Value)
+}
+
+func (value *ResponseRef) Validate(ctx context.Context) error {
+	if v := value.Value; v != nil {
+		return v.Validate(ctx)
+	}
+	return foundUnresolvedRef(value.Ref)
+}
+
+func (value ResponseRef) JSONLookup(token string) (interface{}, error) {
+	if token == "$ref" {
+		return value.Ref, nil
+	}
+
+	ptr, _, err := jsonpointer.GetForToken(value.Value, token)
+	return ptr, err
+}
+
+type RequestBodyRef struct {
+	Ref   string
+	Value *RequestBody
+}
+
+var _ jsonpointer.JSONPointable = (*RequestBodyRef)(nil)
+
+func (value *RequestBodyRef) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalRef(value.Ref, value.Value)
+}
+
+func (value *RequestBodyRef) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalRef(data, &value.Ref, &value.Value)
+}
+
+func (value *RequestBodyRef) Validate(ctx context.Context) error {
+	if v := value.Value; v != nil {
+		return v.Validate(ctx)
+	}
+	return foundUnresolvedRef(value.Ref)
+}
+
+func (value RequestBodyRef) JSONLookup(token string) (interface{}, error) {
+	if token == "$ref" {
+		return value.Ref, nil
+	}
+
+	ptr, _, err := jsonpointer.GetForToken(value.Value, token)
+	return ptr, err
+}
+
+type SchemaRef struct {
+	Ref   string
+	Value *Schema
+}
+
+var _ jsonpointer.JSONPointable = (*SchemaRef)(nil)
+
+func NewSchemaRef(ref string, value *Schema) *SchemaRef {
+	return &SchemaRef{
+		Ref:   ref,
+		Value: value,
+	}
+}
+
+func (value *SchemaRef) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalRef(value.Ref, value.Value)
+}
+
+func (value *SchemaRef) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalRef(data, &value.Ref, &value.Value)
+}
+
+func (value *SchemaRef) Validate(ctx context.Context) error {
+	if v := value.Value; v != nil {
+		return v.Validate(ctx)
+	}
+	return foundUnresolvedRef(value.Ref)
+}
+
+func (value SchemaRef) JSONLookup(token string) (interface{}, error) {
+	if token == "$ref" {
+		return value.Ref, nil
+	}
+
+	ptr, _, err := jsonpointer.GetForToken(value.Value, token)
+	return ptr, err
+}
+
+type SecuritySchemeRef struct {
+	Ref   string
+	Value *SecurityScheme
+}
+
+var _ jsonpointer.JSONPointable = (*SecuritySchemeRef)(nil)
+
+func (value *SecuritySchemeRef) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalRef(value.Ref, value.Value)
+}
+
+func (value *SecuritySchemeRef) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalRef(data, &value.Ref, &value.Value)
+}
+
+func (value *SecuritySchemeRef) Validate(ctx context.Context) error {
+	if v := value.Value; v != nil {
+		return v.Validate(ctx)
+	}
+	return foundUnresolvedRef(value.Ref)
+}
+
+func (value SecuritySchemeRef) JSONLookup(token string) (interface{}, error) {
+	if token == "$ref" {
+		return value.Ref, nil
+	}
+
+	ptr, _, err := jsonpointer.GetForToken(value.Value, token)
+	return ptr, err
+}

--- a/vendor/github.com/getkin/kin-openapi/openapi3/request_body.go
+++ b/vendor/github.com/getkin/kin-openapi/openapi3/request_body.go
@@ -1,0 +1,107 @@
+package openapi3
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/getkin/kin-openapi/jsoninfo"
+	"github.com/go-openapi/jsonpointer"
+)
+
+type RequestBodies map[string]*RequestBodyRef
+
+var _ jsonpointer.JSONPointable = (*RequestBodyRef)(nil)
+
+func (r RequestBodies) JSONLookup(token string) (interface{}, error) {
+	ref, ok := r[token]
+	if ok == false {
+		return nil, fmt.Errorf("object has no field %q", token)
+	}
+
+	if ref != nil && ref.Ref != "" {
+		return &Ref{Ref: ref.Ref}, nil
+	}
+	return ref.Value, nil
+}
+
+// RequestBody is specified by OpenAPI/Swagger 3.0 standard.
+type RequestBody struct {
+	ExtensionProps
+	Description string  `json:"description,omitempty" yaml:"description,omitempty"`
+	Required    bool    `json:"required,omitempty" yaml:"required,omitempty"`
+	Content     Content `json:"content,omitempty" yaml:"content,omitempty"`
+}
+
+func NewRequestBody() *RequestBody {
+	return &RequestBody{}
+}
+
+func (requestBody *RequestBody) WithDescription(value string) *RequestBody {
+	requestBody.Description = value
+	return requestBody
+}
+
+func (requestBody *RequestBody) WithRequired(value bool) *RequestBody {
+	requestBody.Required = value
+	return requestBody
+}
+
+func (requestBody *RequestBody) WithContent(content Content) *RequestBody {
+	requestBody.Content = content
+	return requestBody
+}
+
+func (requestBody *RequestBody) WithSchemaRef(value *SchemaRef, consumes []string) *RequestBody {
+	requestBody.Content = NewContentWithSchemaRef(value, consumes)
+	return requestBody
+}
+
+func (requestBody *RequestBody) WithSchema(value *Schema, consumes []string) *RequestBody {
+	requestBody.Content = NewContentWithSchema(value, consumes)
+	return requestBody
+}
+
+func (requestBody *RequestBody) WithJSONSchemaRef(value *SchemaRef) *RequestBody {
+	requestBody.Content = NewContentWithJSONSchemaRef(value)
+	return requestBody
+}
+
+func (requestBody *RequestBody) WithJSONSchema(value *Schema) *RequestBody {
+	requestBody.Content = NewContentWithJSONSchema(value)
+	return requestBody
+}
+
+func (requestBody *RequestBody) WithFormDataSchemaRef(value *SchemaRef) *RequestBody {
+	requestBody.Content = NewContentWithFormDataSchemaRef(value)
+	return requestBody
+}
+
+func (requestBody *RequestBody) WithFormDataSchema(value *Schema) *RequestBody {
+	requestBody.Content = NewContentWithFormDataSchema(value)
+	return requestBody
+}
+
+func (requestBody *RequestBody) GetMediaType(mediaType string) *MediaType {
+	m := requestBody.Content
+	if m == nil {
+		return nil
+	}
+	return m[mediaType]
+}
+
+func (requestBody *RequestBody) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalStrictStruct(requestBody)
+}
+
+func (requestBody *RequestBody) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalStrictStruct(data, requestBody)
+}
+
+func (value *RequestBody) Validate(ctx context.Context) error {
+	if v := value.Content; v != nil {
+		if err := v.Validate(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/getkin/kin-openapi/openapi3/response.go
+++ b/vendor/github.com/getkin/kin-openapi/openapi3/response.go
@@ -1,0 +1,108 @@
+package openapi3
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/getkin/kin-openapi/jsoninfo"
+	"github.com/go-openapi/jsonpointer"
+)
+
+// Responses is specified by OpenAPI/Swagger 3.0 standard.
+type Responses map[string]*ResponseRef
+
+var _ jsonpointer.JSONPointable = (*Responses)(nil)
+
+func NewResponses() Responses {
+	r := make(Responses)
+	r["default"] = &ResponseRef{Value: NewResponse().WithDescription("")}
+	return r
+}
+
+func (responses Responses) Default() *ResponseRef {
+	return responses["default"]
+}
+
+func (responses Responses) Get(status int) *ResponseRef {
+	return responses[strconv.FormatInt(int64(status), 10)]
+}
+
+func (value Responses) Validate(ctx context.Context) error {
+	if len(value) == 0 {
+		return errors.New("the responses object MUST contain at least one response code")
+	}
+	for _, v := range value {
+		if err := v.Validate(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (responses Responses) JSONLookup(token string) (interface{}, error) {
+	ref, ok := responses[token]
+	if ok == false {
+		return nil, fmt.Errorf("invalid token reference: %q", token)
+	}
+
+	if ref != nil && ref.Ref != "" {
+		return &Ref{Ref: ref.Ref}, nil
+	}
+	return ref.Value, nil
+}
+
+// Response is specified by OpenAPI/Swagger 3.0 standard.
+type Response struct {
+	ExtensionProps
+	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
+	Headers     Headers `json:"headers,omitempty" yaml:"headers,omitempty"`
+	Content     Content `json:"content,omitempty" yaml:"content,omitempty"`
+	Links       Links   `json:"links,omitempty" yaml:"links,omitempty"`
+}
+
+func NewResponse() *Response {
+	return &Response{}
+}
+
+func (response *Response) WithDescription(value string) *Response {
+	response.Description = &value
+	return response
+}
+
+func (response *Response) WithContent(content Content) *Response {
+	response.Content = content
+	return response
+}
+
+func (response *Response) WithJSONSchema(schema *Schema) *Response {
+	response.Content = NewContentWithJSONSchema(schema)
+	return response
+}
+
+func (response *Response) WithJSONSchemaRef(schema *SchemaRef) *Response {
+	response.Content = NewContentWithJSONSchemaRef(schema)
+	return response
+}
+
+func (response *Response) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalStrictStruct(response)
+}
+
+func (response *Response) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalStrictStruct(data, response)
+}
+
+func (value *Response) Validate(ctx context.Context) error {
+	if value.Description == nil {
+		return errors.New("a short description of the response is required")
+	}
+
+	if content := value.Content; content != nil {
+		if err := content.Validate(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/getkin/kin-openapi/openapi3/schema.go
+++ b/vendor/github.com/getkin/kin-openapi/openapi3/schema.go
@@ -1,0 +1,1586 @@
+package openapi3
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"math/big"
+	"regexp"
+	"strconv"
+	"unicode/utf16"
+
+	"github.com/getkin/kin-openapi/jsoninfo"
+	"github.com/go-openapi/jsonpointer"
+)
+
+var (
+	// SchemaErrorDetailsDisabled disables printing of details about schema errors.
+	SchemaErrorDetailsDisabled = false
+
+	//SchemaFormatValidationDisabled disables validation of schema type formats.
+	SchemaFormatValidationDisabled = false
+
+	errSchema = errors.New("input does not match the schema")
+
+	// ErrOneOfConflict is the SchemaError Origin when data matches more than one oneOf schema
+	ErrOneOfConflict = errors.New("input matches more than one oneOf schemas")
+
+	// ErrSchemaInputNaN may be returned when validating a number
+	ErrSchemaInputNaN = errors.New("floating point NaN is not allowed")
+	// ErrSchemaInputInf may be returned when validating a number
+	ErrSchemaInputInf = errors.New("floating point Inf is not allowed")
+)
+
+// Float64Ptr is a helper for defining OpenAPI schemas.
+func Float64Ptr(value float64) *float64 {
+	return &value
+}
+
+// BoolPtr is a helper for defining OpenAPI schemas.
+func BoolPtr(value bool) *bool {
+	return &value
+}
+
+// Int64Ptr is a helper for defining OpenAPI schemas.
+func Int64Ptr(value int64) *int64 {
+	return &value
+}
+
+// Uint64Ptr is a helper for defining OpenAPI schemas.
+func Uint64Ptr(value uint64) *uint64 {
+	return &value
+}
+
+type Schemas map[string]*SchemaRef
+
+var _ jsonpointer.JSONPointable = (*Schemas)(nil)
+
+func (s Schemas) JSONLookup(token string) (interface{}, error) {
+	ref, ok := s[token]
+	if ref == nil || ok == false {
+		return nil, fmt.Errorf("object has no field %q", token)
+	}
+
+	if ref.Ref != "" {
+		return &Ref{Ref: ref.Ref}, nil
+	}
+	return ref.Value, nil
+}
+
+type SchemaRefs []*SchemaRef
+
+var _ jsonpointer.JSONPointable = (*SchemaRefs)(nil)
+
+func (s SchemaRefs) JSONLookup(token string) (interface{}, error) {
+	i, err := strconv.ParseUint(token, 10, 64)
+	if err != nil {
+		return nil, err
+	}
+
+	if i >= uint64(len(s)) {
+		return nil, fmt.Errorf("index out of range: %d", i)
+	}
+
+	ref := s[i]
+
+	if ref == nil || ref.Ref != "" {
+		return &Ref{Ref: ref.Ref}, nil
+	}
+	return ref.Value, nil
+}
+
+// Schema is specified by OpenAPI/Swagger 3.0 standard.
+type Schema struct {
+	ExtensionProps
+
+	OneOf        SchemaRefs    `json:"oneOf,omitempty" yaml:"oneOf,omitempty"`
+	AnyOf        SchemaRefs    `json:"anyOf,omitempty" yaml:"anyOf,omitempty"`
+	AllOf        SchemaRefs    `json:"allOf,omitempty" yaml:"allOf,omitempty"`
+	Not          *SchemaRef    `json:"not,omitempty" yaml:"not,omitempty"`
+	Type         string        `json:"type,omitempty" yaml:"type,omitempty"`
+	Title        string        `json:"title,omitempty" yaml:"title,omitempty"`
+	Format       string        `json:"format,omitempty" yaml:"format,omitempty"`
+	Description  string        `json:"description,omitempty" yaml:"description,omitempty"`
+	Enum         []interface{} `json:"enum,omitempty" yaml:"enum,omitempty"`
+	Default      interface{}   `json:"default,omitempty" yaml:"default,omitempty"`
+	Example      interface{}   `json:"example,omitempty" yaml:"example,omitempty"`
+	ExternalDocs *ExternalDocs `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
+
+	// Array-related, here for struct compactness
+	UniqueItems bool `json:"uniqueItems,omitempty" yaml:"uniqueItems,omitempty"`
+	// Number-related, here for struct compactness
+	ExclusiveMin bool `json:"exclusiveMinimum,omitempty" yaml:"exclusiveMinimum,omitempty"`
+	ExclusiveMax bool `json:"exclusiveMaximum,omitempty" yaml:"exclusiveMaximum,omitempty"`
+	// Properties
+	Nullable        bool        `json:"nullable,omitempty" yaml:"nullable,omitempty"`
+	ReadOnly        bool        `json:"readOnly,omitempty" yaml:"readOnly,omitempty"`
+	WriteOnly       bool        `json:"writeOnly,omitempty" yaml:"writeOnly,omitempty"`
+	AllowEmptyValue bool        `json:"allowEmptyValue,omitempty" yaml:"allowEmptyValue,omitempty"`
+	XML             interface{} `json:"xml,omitempty" yaml:"xml,omitempty"`
+	Deprecated      bool        `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
+
+	// Number
+	Min        *float64 `json:"minimum,omitempty" yaml:"minimum,omitempty"`
+	Max        *float64 `json:"maximum,omitempty" yaml:"maximum,omitempty"`
+	MultipleOf *float64 `json:"multipleOf,omitempty" yaml:"multipleOf,omitempty"`
+
+	// String
+	MinLength       uint64  `json:"minLength,omitempty" yaml:"minLength,omitempty"`
+	MaxLength       *uint64 `json:"maxLength,omitempty" yaml:"maxLength,omitempty"`
+	Pattern         string  `json:"pattern,omitempty" yaml:"pattern,omitempty"`
+	compiledPattern *regexp.Regexp
+
+	// Array
+	MinItems uint64     `json:"minItems,omitempty" yaml:"minItems,omitempty"`
+	MaxItems *uint64    `json:"maxItems,omitempty" yaml:"maxItems,omitempty"`
+	Items    *SchemaRef `json:"items,omitempty" yaml:"items,omitempty"`
+
+	// Object
+	Required                    []string       `json:"required,omitempty" yaml:"required,omitempty"`
+	Properties                  Schemas        `json:"properties,omitempty" yaml:"properties,omitempty"`
+	MinProps                    uint64         `json:"minProperties,omitempty" yaml:"minProperties,omitempty"`
+	MaxProps                    *uint64        `json:"maxProperties,omitempty" yaml:"maxProperties,omitempty"`
+	AdditionalPropertiesAllowed *bool          `multijson:"additionalProperties,omitempty" json:"-" yaml:"-"` // In this order...
+	AdditionalProperties        *SchemaRef     `multijson:"additionalProperties,omitempty" json:"-" yaml:"-"` // ...for multijson
+	Discriminator               *Discriminator `json:"discriminator,omitempty" yaml:"discriminator,omitempty"`
+}
+
+var _ jsonpointer.JSONPointable = (*Schema)(nil)
+
+func NewSchema() *Schema {
+	return &Schema{}
+}
+
+func (schema *Schema) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalStrictStruct(schema)
+}
+
+func (schema *Schema) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalStrictStruct(data, schema)
+}
+
+func (schema Schema) JSONLookup(token string) (interface{}, error) {
+	switch token {
+	case "additionalProperties":
+		if schema.AdditionalProperties != nil {
+			if schema.AdditionalProperties.Ref != "" {
+				return &Ref{Ref: schema.AdditionalProperties.Ref}, nil
+			}
+			return schema.AdditionalProperties.Value, nil
+		}
+	case "not":
+		if schema.Not != nil {
+			if schema.Not.Ref != "" {
+				return &Ref{Ref: schema.Not.Ref}, nil
+			}
+			return schema.Not.Value, nil
+		}
+	case "items":
+		if schema.Items != nil {
+			if schema.Items.Ref != "" {
+				return &Ref{Ref: schema.Items.Ref}, nil
+			}
+			return schema.Items.Value, nil
+		}
+	case "oneOf":
+		return schema.OneOf, nil
+	case "anyOf":
+		return schema.AnyOf, nil
+	case "allOf":
+		return schema.AllOf, nil
+	case "type":
+		return schema.Type, nil
+	case "title":
+		return schema.Title, nil
+	case "format":
+		return schema.Format, nil
+	case "description":
+		return schema.Description, nil
+	case "enum":
+		return schema.Enum, nil
+	case "default":
+		return schema.Default, nil
+	case "example":
+		return schema.Example, nil
+	case "externalDocs":
+		return schema.ExternalDocs, nil
+	case "additionalPropertiesAllowed":
+		return schema.AdditionalPropertiesAllowed, nil
+	case "uniqueItems":
+		return schema.UniqueItems, nil
+	case "exclusiveMin":
+		return schema.ExclusiveMin, nil
+	case "exclusiveMax":
+		return schema.ExclusiveMax, nil
+	case "nullable":
+		return schema.Nullable, nil
+	case "readOnly":
+		return schema.ReadOnly, nil
+	case "writeOnly":
+		return schema.WriteOnly, nil
+	case "allowEmptyValue":
+		return schema.AllowEmptyValue, nil
+	case "xml":
+		return schema.XML, nil
+	case "deprecated":
+		return schema.Deprecated, nil
+	case "min":
+		return schema.Min, nil
+	case "max":
+		return schema.Max, nil
+	case "multipleOf":
+		return schema.MultipleOf, nil
+	case "minLength":
+		return schema.MinLength, nil
+	case "maxLength":
+		return schema.MaxLength, nil
+	case "pattern":
+		return schema.Pattern, nil
+	case "minItems":
+		return schema.MinItems, nil
+	case "maxItems":
+		return schema.MaxItems, nil
+	case "required":
+		return schema.Required, nil
+	case "properties":
+		return schema.Properties, nil
+	case "minProps":
+		return schema.MinProps, nil
+	case "maxProps":
+		return schema.MaxProps, nil
+	case "discriminator":
+		return schema.Discriminator, nil
+	}
+
+	v, _, err := jsonpointer.GetForToken(schema.ExtensionProps, token)
+	return v, err
+}
+
+func (schema *Schema) NewRef() *SchemaRef {
+	return &SchemaRef{
+		Value: schema,
+	}
+}
+
+func NewOneOfSchema(schemas ...*Schema) *Schema {
+	refs := make([]*SchemaRef, 0, len(schemas))
+	for _, schema := range schemas {
+		refs = append(refs, &SchemaRef{Value: schema})
+	}
+	return &Schema{
+		OneOf: refs,
+	}
+}
+
+func NewAnyOfSchema(schemas ...*Schema) *Schema {
+	refs := make([]*SchemaRef, 0, len(schemas))
+	for _, schema := range schemas {
+		refs = append(refs, &SchemaRef{Value: schema})
+	}
+	return &Schema{
+		AnyOf: refs,
+	}
+}
+
+func NewAllOfSchema(schemas ...*Schema) *Schema {
+	refs := make([]*SchemaRef, 0, len(schemas))
+	for _, schema := range schemas {
+		refs = append(refs, &SchemaRef{Value: schema})
+	}
+	return &Schema{
+		AllOf: refs,
+	}
+}
+
+func NewBoolSchema() *Schema {
+	return &Schema{
+		Type: "boolean",
+	}
+}
+
+func NewFloat64Schema() *Schema {
+	return &Schema{
+		Type: "number",
+	}
+}
+
+func NewIntegerSchema() *Schema {
+	return &Schema{
+		Type: "integer",
+	}
+}
+
+func NewInt32Schema() *Schema {
+	return &Schema{
+		Type:   "integer",
+		Format: "int32",
+	}
+}
+
+func NewInt64Schema() *Schema {
+	return &Schema{
+		Type:   "integer",
+		Format: "int64",
+	}
+}
+
+func NewStringSchema() *Schema {
+	return &Schema{
+		Type: "string",
+	}
+}
+
+func NewDateTimeSchema() *Schema {
+	return &Schema{
+		Type:   "string",
+		Format: "date-time",
+	}
+}
+
+func NewUUIDSchema() *Schema {
+	return &Schema{
+		Type:   "string",
+		Format: "uuid",
+	}
+}
+
+func NewBytesSchema() *Schema {
+	return &Schema{
+		Type:   "string",
+		Format: "byte",
+	}
+}
+
+func NewArraySchema() *Schema {
+	return &Schema{
+		Type: "array",
+	}
+}
+
+func NewObjectSchema() *Schema {
+	return &Schema{
+		Type:       "object",
+		Properties: make(map[string]*SchemaRef),
+	}
+}
+
+func (schema *Schema) WithNullable() *Schema {
+	schema.Nullable = true
+	return schema
+}
+
+func (schema *Schema) WithMin(value float64) *Schema {
+	schema.Min = &value
+	return schema
+}
+
+func (schema *Schema) WithMax(value float64) *Schema {
+	schema.Max = &value
+	return schema
+}
+func (schema *Schema) WithExclusiveMin(value bool) *Schema {
+	schema.ExclusiveMin = value
+	return schema
+}
+
+func (schema *Schema) WithExclusiveMax(value bool) *Schema {
+	schema.ExclusiveMax = value
+	return schema
+}
+
+func (schema *Schema) WithEnum(values ...interface{}) *Schema {
+	schema.Enum = values
+	return schema
+}
+
+func (schema *Schema) WithDefault(defaultValue interface{}) *Schema {
+	schema.Default = defaultValue
+	return schema
+}
+
+func (schema *Schema) WithFormat(value string) *Schema {
+	schema.Format = value
+	return schema
+}
+
+func (schema *Schema) WithLength(i int64) *Schema {
+	n := uint64(i)
+	schema.MinLength = n
+	schema.MaxLength = &n
+	return schema
+}
+
+func (schema *Schema) WithMinLength(i int64) *Schema {
+	n := uint64(i)
+	schema.MinLength = n
+	return schema
+}
+
+func (schema *Schema) WithMaxLength(i int64) *Schema {
+	n := uint64(i)
+	schema.MaxLength = &n
+	return schema
+}
+
+func (schema *Schema) WithLengthDecodedBase64(i int64) *Schema {
+	n := uint64(i)
+	v := (n*8 + 5) / 6
+	schema.MinLength = v
+	schema.MaxLength = &v
+	return schema
+}
+
+func (schema *Schema) WithMinLengthDecodedBase64(i int64) *Schema {
+	n := uint64(i)
+	schema.MinLength = (n*8 + 5) / 6
+	return schema
+}
+
+func (schema *Schema) WithMaxLengthDecodedBase64(i int64) *Schema {
+	n := uint64(i)
+	schema.MinLength = (n*8 + 5) / 6
+	return schema
+}
+
+func (schema *Schema) WithPattern(pattern string) *Schema {
+	schema.Pattern = pattern
+	schema.compiledPattern = nil
+	return schema
+}
+
+func (schema *Schema) WithItems(value *Schema) *Schema {
+	schema.Items = &SchemaRef{
+		Value: value,
+	}
+	return schema
+}
+
+func (schema *Schema) WithMinItems(i int64) *Schema {
+	n := uint64(i)
+	schema.MinItems = n
+	return schema
+}
+
+func (schema *Schema) WithMaxItems(i int64) *Schema {
+	n := uint64(i)
+	schema.MaxItems = &n
+	return schema
+}
+
+func (schema *Schema) WithUniqueItems(unique bool) *Schema {
+	schema.UniqueItems = unique
+	return schema
+}
+
+func (schema *Schema) WithProperty(name string, propertySchema *Schema) *Schema {
+	return schema.WithPropertyRef(name, &SchemaRef{
+		Value: propertySchema,
+	})
+}
+
+func (schema *Schema) WithPropertyRef(name string, ref *SchemaRef) *Schema {
+	properties := schema.Properties
+	if properties == nil {
+		properties = make(map[string]*SchemaRef)
+		schema.Properties = properties
+	}
+	properties[name] = ref
+	return schema
+}
+
+func (schema *Schema) WithProperties(properties map[string]*Schema) *Schema {
+	result := make(map[string]*SchemaRef, len(properties))
+	for k, v := range properties {
+		result[k] = &SchemaRef{
+			Value: v,
+		}
+	}
+	schema.Properties = result
+	return schema
+}
+
+func (schema *Schema) WithMinProperties(i int64) *Schema {
+	n := uint64(i)
+	schema.MinProps = n
+	return schema
+}
+
+func (schema *Schema) WithMaxProperties(i int64) *Schema {
+	n := uint64(i)
+	schema.MaxProps = &n
+	return schema
+}
+
+func (schema *Schema) WithAnyAdditionalProperties() *Schema {
+	schema.AdditionalProperties = nil
+	t := true
+	schema.AdditionalPropertiesAllowed = &t
+	return schema
+}
+
+func (schema *Schema) WithAdditionalProperties(v *Schema) *Schema {
+	if v == nil {
+		schema.AdditionalProperties = nil
+	} else {
+		schema.AdditionalProperties = &SchemaRef{
+			Value: v,
+		}
+	}
+	return schema
+}
+
+func (schema *Schema) IsEmpty() bool {
+	if schema.Type != "" || schema.Format != "" || len(schema.Enum) != 0 ||
+		schema.UniqueItems || schema.ExclusiveMin || schema.ExclusiveMax ||
+		schema.Nullable || schema.ReadOnly || schema.WriteOnly || schema.AllowEmptyValue ||
+		schema.Min != nil || schema.Max != nil || schema.MultipleOf != nil ||
+		schema.MinLength != 0 || schema.MaxLength != nil || schema.Pattern != "" ||
+		schema.MinItems != 0 || schema.MaxItems != nil ||
+		len(schema.Required) != 0 ||
+		schema.MinProps != 0 || schema.MaxProps != nil {
+		return false
+	}
+	if n := schema.Not; n != nil && !n.Value.IsEmpty() {
+		return false
+	}
+	if ap := schema.AdditionalProperties; ap != nil && !ap.Value.IsEmpty() {
+		return false
+	}
+	if apa := schema.AdditionalPropertiesAllowed; apa != nil && !*apa {
+		return false
+	}
+	if items := schema.Items; items != nil && !items.Value.IsEmpty() {
+		return false
+	}
+	for _, s := range schema.Properties {
+		if !s.Value.IsEmpty() {
+			return false
+		}
+	}
+	for _, s := range schema.OneOf {
+		if !s.Value.IsEmpty() {
+			return false
+		}
+	}
+	for _, s := range schema.AnyOf {
+		if !s.Value.IsEmpty() {
+			return false
+		}
+	}
+	for _, s := range schema.AllOf {
+		if !s.Value.IsEmpty() {
+			return false
+		}
+	}
+	return true
+}
+
+func (value *Schema) Validate(ctx context.Context) error {
+	return value.validate(ctx, []*Schema{})
+}
+
+func (schema *Schema) validate(ctx context.Context, stack []*Schema) (err error) {
+	for _, existing := range stack {
+		if existing == schema {
+			return
+		}
+	}
+	stack = append(stack, schema)
+
+	if schema.ReadOnly && schema.WriteOnly {
+		return errors.New("a property MUST NOT be marked as both readOnly and writeOnly being true")
+	}
+
+	for _, item := range schema.OneOf {
+		v := item.Value
+		if v == nil {
+			return foundUnresolvedRef(item.Ref)
+		}
+		if err = v.validate(ctx, stack); err == nil {
+			return
+		}
+	}
+
+	for _, item := range schema.AnyOf {
+		v := item.Value
+		if v == nil {
+			return foundUnresolvedRef(item.Ref)
+		}
+		if err = v.validate(ctx, stack); err != nil {
+			return
+		}
+	}
+
+	for _, item := range schema.AllOf {
+		v := item.Value
+		if v == nil {
+			return foundUnresolvedRef(item.Ref)
+		}
+		if err = v.validate(ctx, stack); err != nil {
+			return
+		}
+	}
+
+	if ref := schema.Not; ref != nil {
+		v := ref.Value
+		if v == nil {
+			return foundUnresolvedRef(ref.Ref)
+		}
+		if err = v.validate(ctx, stack); err != nil {
+			return
+		}
+	}
+
+	schemaType := schema.Type
+	switch schemaType {
+	case "":
+	case "boolean":
+	case "number":
+		if format := schema.Format; len(format) > 0 {
+			switch format {
+			case "float", "double":
+			default:
+				if !SchemaFormatValidationDisabled {
+					return unsupportedFormat(format)
+				}
+			}
+		}
+	case "integer":
+		if format := schema.Format; len(format) > 0 {
+			switch format {
+			case "int32", "int64":
+			default:
+				if !SchemaFormatValidationDisabled {
+					return unsupportedFormat(format)
+				}
+			}
+		}
+	case "string":
+		if format := schema.Format; len(format) > 0 {
+			switch format {
+			// Supported by OpenAPIv3.0.1:
+			case "byte", "binary", "date", "date-time", "password":
+				// In JSON Draft-07 (not validated yet though):
+			case "regex":
+			case "time", "email", "idn-email":
+			case "hostname", "idn-hostname", "ipv4", "ipv6":
+			case "uri", "uri-reference", "iri", "iri-reference", "uri-template":
+			case "json-pointer", "relative-json-pointer":
+			default:
+				// Try to check for custom defined formats
+				if _, ok := SchemaStringFormats[format]; !ok && !SchemaFormatValidationDisabled {
+					return unsupportedFormat(format)
+				}
+			}
+		}
+		if schema.Pattern != "" {
+			if err = schema.compilePattern(); err != nil {
+				return err
+			}
+		}
+	case "array":
+		if schema.Items == nil {
+			return errors.New("when schema type is 'array', schema 'items' must be non-null")
+		}
+	case "object":
+	default:
+		return fmt.Errorf("unsupported 'type' value %q", schemaType)
+	}
+
+	if ref := schema.Items; ref != nil {
+		v := ref.Value
+		if v == nil {
+			return foundUnresolvedRef(ref.Ref)
+		}
+		if err = v.validate(ctx, stack); err != nil {
+			return
+		}
+	}
+
+	for _, ref := range schema.Properties {
+		v := ref.Value
+		if v == nil {
+			return foundUnresolvedRef(ref.Ref)
+		}
+		if err = v.validate(ctx, stack); err != nil {
+			return
+		}
+	}
+
+	if ref := schema.AdditionalProperties; ref != nil {
+		v := ref.Value
+		if v == nil {
+			return foundUnresolvedRef(ref.Ref)
+		}
+		if err = v.validate(ctx, stack); err != nil {
+			return
+		}
+	}
+
+	return
+}
+
+func (schema *Schema) IsMatching(value interface{}) bool {
+	settings := newSchemaValidationSettings(FailFast())
+	return schema.visitJSON(settings, value) == nil
+}
+
+func (schema *Schema) IsMatchingJSONBoolean(value bool) bool {
+	settings := newSchemaValidationSettings(FailFast())
+	return schema.visitJSON(settings, value) == nil
+}
+
+func (schema *Schema) IsMatchingJSONNumber(value float64) bool {
+	settings := newSchemaValidationSettings(FailFast())
+	return schema.visitJSON(settings, value) == nil
+}
+
+func (schema *Schema) IsMatchingJSONString(value string) bool {
+	settings := newSchemaValidationSettings(FailFast())
+	return schema.visitJSON(settings, value) == nil
+}
+
+func (schema *Schema) IsMatchingJSONArray(value []interface{}) bool {
+	settings := newSchemaValidationSettings(FailFast())
+	return schema.visitJSON(settings, value) == nil
+}
+
+func (schema *Schema) IsMatchingJSONObject(value map[string]interface{}) bool {
+	settings := newSchemaValidationSettings(FailFast())
+	return schema.visitJSON(settings, value) == nil
+}
+
+func (schema *Schema) VisitJSON(value interface{}, opts ...SchemaValidationOption) error {
+	settings := newSchemaValidationSettings(opts...)
+	return schema.visitJSON(settings, value)
+}
+
+func (schema *Schema) visitJSON(settings *schemaValidationSettings, value interface{}) (err error) {
+	switch value := value.(type) {
+	case nil:
+		return schema.visitJSONNull(settings)
+	case float64:
+		if math.IsNaN(value) {
+			return ErrSchemaInputNaN
+		}
+		if math.IsInf(value, 0) {
+			return ErrSchemaInputInf
+		}
+	}
+
+	if schema.IsEmpty() {
+		return
+	}
+	if err = schema.visitSetOperations(settings, value); err != nil {
+		return
+	}
+
+	switch value := value.(type) {
+	case nil:
+		return schema.visitJSONNull(settings)
+	case bool:
+		return schema.visitJSONBoolean(settings, value)
+	case float64:
+		return schema.visitJSONNumber(settings, value)
+	case string:
+		return schema.visitJSONString(settings, value)
+	case []interface{}:
+		return schema.visitJSONArray(settings, value)
+	case map[string]interface{}:
+		return schema.visitJSONObject(settings, value)
+	default:
+		return &SchemaError{
+			Value:       value,
+			Schema:      schema,
+			SchemaField: "type",
+			Reason:      fmt.Sprintf("unhandled value of type %T", value),
+		}
+	}
+}
+
+func (schema *Schema) visitSetOperations(settings *schemaValidationSettings, value interface{}) (err error) {
+	if enum := schema.Enum; len(enum) != 0 {
+		for _, v := range enum {
+			if value == v {
+				return
+			}
+		}
+		if settings.failfast {
+			return errSchema
+		}
+		return &SchemaError{
+			Value:       value,
+			Schema:      schema,
+			SchemaField: "enum",
+			Reason:      "value is not one of the allowed values",
+		}
+	}
+
+	if ref := schema.Not; ref != nil {
+		v := ref.Value
+		if v == nil {
+			return foundUnresolvedRef(ref.Ref)
+		}
+		var oldfailfast bool
+		oldfailfast, settings.failfast = settings.failfast, true
+		err := v.visitJSON(settings, value)
+		settings.failfast = oldfailfast
+		if err == nil {
+			if settings.failfast {
+				return errSchema
+			}
+			return &SchemaError{
+				Value:       value,
+				Schema:      schema,
+				SchemaField: "not",
+			}
+		}
+	}
+
+	if v := schema.OneOf; len(v) > 0 {
+		ok := 0
+		for _, item := range v {
+			v := item.Value
+			if v == nil {
+				return foundUnresolvedRef(item.Ref)
+			}
+			var oldfailfast bool
+			oldfailfast, settings.failfast = settings.failfast, true
+			err := v.visitJSON(settings, value)
+			settings.failfast = oldfailfast
+			if err == nil {
+				if schema.Discriminator != nil {
+					pn := schema.Discriminator.PropertyName
+					if valuemap, okcheck := value.(map[string]interface{}); okcheck {
+						if discriminatorVal, okcheck := valuemap[pn]; okcheck == true {
+							mapref, okcheck := schema.Discriminator.Mapping[discriminatorVal.(string)]
+							if okcheck && mapref == item.Ref {
+								ok++
+							}
+						}
+					}
+				} else {
+					ok++
+				}
+			}
+		}
+		if ok != 1 {
+			if settings.failfast {
+				return errSchema
+			}
+			e := &SchemaError{
+				Value:       value,
+				Schema:      schema,
+				SchemaField: "oneOf",
+			}
+			if ok > 1 {
+				e.Origin = ErrOneOfConflict
+			}
+			return e
+		}
+	}
+
+	if v := schema.AnyOf; len(v) > 0 {
+		ok := false
+		for _, item := range v {
+			v := item.Value
+			if v == nil {
+				return foundUnresolvedRef(item.Ref)
+			}
+			var oldfailfast bool
+			oldfailfast, settings.failfast = settings.failfast, true
+			err := v.visitJSON(settings, value)
+			settings.failfast = oldfailfast
+			if err == nil {
+				ok = true
+				break
+			}
+		}
+		if !ok {
+			if settings.failfast {
+				return errSchema
+			}
+			return &SchemaError{
+				Value:       value,
+				Schema:      schema,
+				SchemaField: "anyOf",
+			}
+		}
+	}
+
+	for _, item := range schema.AllOf {
+		v := item.Value
+		if v == nil {
+			return foundUnresolvedRef(item.Ref)
+		}
+		var oldfailfast bool
+		oldfailfast, settings.failfast = settings.failfast, false
+		err := v.visitJSON(settings, value)
+		settings.failfast = oldfailfast
+		if err != nil {
+			if settings.failfast {
+				return errSchema
+			}
+			return &SchemaError{
+				Value:       value,
+				Schema:      schema,
+				SchemaField: "allOf",
+				Origin:      err,
+			}
+		}
+	}
+	return
+}
+
+func (schema *Schema) visitJSONNull(settings *schemaValidationSettings) (err error) {
+	if schema.Nullable {
+		return
+	}
+	if settings.failfast {
+		return errSchema
+	}
+	return &SchemaError{
+		Value:       nil,
+		Schema:      schema,
+		SchemaField: "nullable",
+		Reason:      "Value is not nullable",
+	}
+}
+
+func (schema *Schema) VisitJSONBoolean(value bool) error {
+	settings := newSchemaValidationSettings()
+	return schema.visitJSONBoolean(settings, value)
+}
+
+func (schema *Schema) visitJSONBoolean(settings *schemaValidationSettings, value bool) (err error) {
+	if schemaType := schema.Type; schemaType != "" && schemaType != "boolean" {
+		return schema.expectedType(settings, "boolean")
+	}
+	return
+}
+
+func (schema *Schema) VisitJSONNumber(value float64) error {
+	settings := newSchemaValidationSettings()
+	return schema.visitJSONNumber(settings, value)
+}
+
+func (schema *Schema) visitJSONNumber(settings *schemaValidationSettings, value float64) error {
+	var me MultiError
+	schemaType := schema.Type
+	if schemaType == "integer" {
+		if bigFloat := big.NewFloat(value); !bigFloat.IsInt() {
+			if settings.failfast {
+				return errSchema
+			}
+			err := &SchemaError{
+				Value:       value,
+				Schema:      schema,
+				SchemaField: "type",
+				Reason:      "Value must be an integer",
+			}
+			if !settings.multiError {
+				return err
+			}
+			me = append(me, err)
+		}
+	} else if schemaType != "" && schemaType != "number" {
+		return schema.expectedType(settings, "number, integer")
+	}
+
+	// "exclusiveMinimum"
+	if v := schema.ExclusiveMin; v && !(*schema.Min < value) {
+		if settings.failfast {
+			return errSchema
+		}
+		err := &SchemaError{
+			Value:       value,
+			Schema:      schema,
+			SchemaField: "exclusiveMinimum",
+			Reason:      fmt.Sprintf("number must be more than %g", *schema.Min),
+		}
+		if !settings.multiError {
+			return err
+		}
+		me = append(me, err)
+	}
+
+	// "exclusiveMaximum"
+	if v := schema.ExclusiveMax; v && !(*schema.Max > value) {
+		if settings.failfast {
+			return errSchema
+		}
+		err := &SchemaError{
+			Value:       value,
+			Schema:      schema,
+			SchemaField: "exclusiveMaximum",
+			Reason:      fmt.Sprintf("number must be less than %g", *schema.Max),
+		}
+		if !settings.multiError {
+			return err
+		}
+		me = append(me, err)
+	}
+
+	// "minimum"
+	if v := schema.Min; v != nil && !(*v <= value) {
+		if settings.failfast {
+			return errSchema
+		}
+		err := &SchemaError{
+			Value:       value,
+			Schema:      schema,
+			SchemaField: "minimum",
+			Reason:      fmt.Sprintf("number must be at least %g", *v),
+		}
+		if !settings.multiError {
+			return err
+		}
+		me = append(me, err)
+	}
+
+	// "maximum"
+	if v := schema.Max; v != nil && !(*v >= value) {
+		if settings.failfast {
+			return errSchema
+		}
+		err := &SchemaError{
+			Value:       value,
+			Schema:      schema,
+			SchemaField: "maximum",
+			Reason:      fmt.Sprintf("number must be most %g", *v),
+		}
+		if !settings.multiError {
+			return err
+		}
+		me = append(me, err)
+	}
+
+	// "multipleOf"
+	if v := schema.MultipleOf; v != nil {
+		// "A numeric instance is valid only if division by this keyword's
+		//    value results in an integer."
+		if bigFloat := big.NewFloat(value / *v); !bigFloat.IsInt() {
+			if settings.failfast {
+				return errSchema
+			}
+			err := &SchemaError{
+				Value:       value,
+				Schema:      schema,
+				SchemaField: "multipleOf",
+			}
+			if !settings.multiError {
+				return err
+			}
+			me = append(me, err)
+		}
+	}
+
+	if len(me) > 0 {
+		return me
+	}
+
+	return nil
+}
+
+func (schema *Schema) VisitJSONString(value string) error {
+	settings := newSchemaValidationSettings()
+	return schema.visitJSONString(settings, value)
+}
+
+func (schema *Schema) visitJSONString(settings *schemaValidationSettings, value string) error {
+	if schemaType := schema.Type; schemaType != "" && schemaType != "string" {
+		return schema.expectedType(settings, "string")
+	}
+
+	var me MultiError
+
+	// "minLength" and "maxLength"
+	minLength := schema.MinLength
+	maxLength := schema.MaxLength
+	if minLength != 0 || maxLength != nil {
+		// JSON schema string lengths are UTF-16, not UTF-8!
+		length := int64(0)
+		for _, r := range value {
+			if utf16.IsSurrogate(r) {
+				length += 2
+			} else {
+				length++
+			}
+		}
+		if minLength != 0 && length < int64(minLength) {
+			if settings.failfast {
+				return errSchema
+			}
+			err := &SchemaError{
+				Value:       value,
+				Schema:      schema,
+				SchemaField: "minLength",
+				Reason:      fmt.Sprintf("minimum string length is %d", minLength),
+			}
+			if !settings.multiError {
+				return err
+			}
+			me = append(me, err)
+		}
+		if maxLength != nil && length > int64(*maxLength) {
+			if settings.failfast {
+				return errSchema
+			}
+			err := &SchemaError{
+				Value:       value,
+				Schema:      schema,
+				SchemaField: "maxLength",
+				Reason:      fmt.Sprintf("maximum string length is %d", *maxLength),
+			}
+			if !settings.multiError {
+				return err
+			}
+			me = append(me, err)
+		}
+	}
+
+	// "pattern"
+	if schema.Pattern != "" && schema.compiledPattern == nil {
+		var err error
+		if err = schema.compilePattern(); err != nil {
+			if !settings.multiError {
+				return err
+			}
+			me = append(me, err)
+		}
+	}
+	if cp := schema.compiledPattern; cp != nil && !cp.MatchString(value) {
+		err := &SchemaError{
+			Value:       value,
+			Schema:      schema,
+			SchemaField: "pattern",
+			Reason:      fmt.Sprintf("string doesn't match the regular expression %q", schema.Pattern),
+		}
+		if !settings.multiError {
+			return err
+		}
+		me = append(me, err)
+	}
+
+	// "format"
+	var formatErr string
+	if format := schema.Format; format != "" {
+		if f, ok := SchemaStringFormats[format]; ok {
+			switch {
+			case f.regexp != nil && f.callback == nil:
+				if cp := f.regexp; !cp.MatchString(value) {
+					formatErr = fmt.Sprintf("string doesn't match the format %q (regular expression %q)", format, cp.String())
+				}
+			case f.regexp == nil && f.callback != nil:
+				if err := f.callback(value); err != nil {
+					formatErr = err.Error()
+				}
+			default:
+				formatErr = fmt.Sprintf("corrupted entry %q in SchemaStringFormats", format)
+			}
+		}
+	}
+	if formatErr != "" {
+		err := &SchemaError{
+			Value:       value,
+			Schema:      schema,
+			SchemaField: "format",
+			Reason:      formatErr,
+		}
+		if !settings.multiError {
+			return err
+		}
+		me = append(me, err)
+
+	}
+
+	if len(me) > 0 {
+		return me
+	}
+
+	return nil
+}
+
+func (schema *Schema) VisitJSONArray(value []interface{}) error {
+	settings := newSchemaValidationSettings()
+	return schema.visitJSONArray(settings, value)
+}
+
+func (schema *Schema) visitJSONArray(settings *schemaValidationSettings, value []interface{}) error {
+	if schemaType := schema.Type; schemaType != "" && schemaType != "array" {
+		return schema.expectedType(settings, "array")
+	}
+
+	var me MultiError
+
+	lenValue := int64(len(value))
+
+	// "minItems"
+	if v := schema.MinItems; v != 0 && lenValue < int64(v) {
+		if settings.failfast {
+			return errSchema
+		}
+		err := &SchemaError{
+			Value:       value,
+			Schema:      schema,
+			SchemaField: "minItems",
+			Reason:      fmt.Sprintf("minimum number of items is %d", v),
+		}
+		if !settings.multiError {
+			return err
+		}
+		me = append(me, err)
+	}
+
+	// "maxItems"
+	if v := schema.MaxItems; v != nil && lenValue > int64(*v) {
+		if settings.failfast {
+			return errSchema
+		}
+		err := &SchemaError{
+			Value:       value,
+			Schema:      schema,
+			SchemaField: "maxItems",
+			Reason:      fmt.Sprintf("maximum number of items is %d", *v),
+		}
+		if !settings.multiError {
+			return err
+		}
+		me = append(me, err)
+	}
+
+	// "uniqueItems"
+	if sliceUniqueItemsChecker == nil {
+		sliceUniqueItemsChecker = isSliceOfUniqueItems
+	}
+	if v := schema.UniqueItems; v && !sliceUniqueItemsChecker(value) {
+		if settings.failfast {
+			return errSchema
+		}
+		err := &SchemaError{
+			Value:       value,
+			Schema:      schema,
+			SchemaField: "uniqueItems",
+			Reason:      "duplicate items found",
+		}
+		if !settings.multiError {
+			return err
+		}
+		me = append(me, err)
+	}
+
+	// "items"
+	if itemSchemaRef := schema.Items; itemSchemaRef != nil {
+		itemSchema := itemSchemaRef.Value
+		if itemSchema == nil {
+			return foundUnresolvedRef(itemSchemaRef.Ref)
+		}
+		for i, item := range value {
+			if err := itemSchema.visitJSON(settings, item); err != nil {
+				err = markSchemaErrorIndex(err, i)
+				if !settings.multiError {
+					return err
+				}
+				if itemMe, ok := err.(MultiError); ok {
+					me = append(me, itemMe...)
+				} else {
+					me = append(me, err)
+				}
+			}
+		}
+	}
+
+	if len(me) > 0 {
+		return me
+	}
+
+	return nil
+}
+
+func (schema *Schema) VisitJSONObject(value map[string]interface{}) error {
+	settings := newSchemaValidationSettings()
+	return schema.visitJSONObject(settings, value)
+}
+
+func (schema *Schema) visitJSONObject(settings *schemaValidationSettings, value map[string]interface{}) error {
+	if schemaType := schema.Type; schemaType != "" && schemaType != "object" {
+		return schema.expectedType(settings, "object")
+	}
+
+	var me MultiError
+
+	// "properties"
+	properties := schema.Properties
+	lenValue := int64(len(value))
+
+	// "minProperties"
+	if v := schema.MinProps; v != 0 && lenValue < int64(v) {
+		if settings.failfast {
+			return errSchema
+		}
+		err := &SchemaError{
+			Value:       value,
+			Schema:      schema,
+			SchemaField: "minProperties",
+			Reason:      fmt.Sprintf("there must be at least %d properties", v),
+		}
+		if !settings.multiError {
+			return err
+		}
+		me = append(me, err)
+	}
+
+	// "maxProperties"
+	if v := schema.MaxProps; v != nil && lenValue > int64(*v) {
+		if settings.failfast {
+			return errSchema
+		}
+		err := &SchemaError{
+			Value:       value,
+			Schema:      schema,
+			SchemaField: "maxProperties",
+			Reason:      fmt.Sprintf("there must be at most %d properties", *v),
+		}
+		if !settings.multiError {
+			return err
+		}
+		me = append(me, err)
+	}
+
+	// "additionalProperties"
+	var additionalProperties *Schema
+	if ref := schema.AdditionalProperties; ref != nil {
+		additionalProperties = ref.Value
+	}
+	for k, v := range value {
+		if properties != nil {
+			propertyRef := properties[k]
+			if propertyRef != nil {
+				p := propertyRef.Value
+				if p == nil {
+					return foundUnresolvedRef(propertyRef.Ref)
+				}
+				if err := p.visitJSON(settings, v); err != nil {
+					if settings.failfast {
+						return errSchema
+					}
+					err = markSchemaErrorKey(err, k)
+					if !settings.multiError {
+						return err
+					}
+					if v, ok := err.(MultiError); ok {
+						me = append(me, v...)
+						continue
+					}
+					me = append(me, err)
+				}
+				continue
+			}
+		}
+		allowed := schema.AdditionalPropertiesAllowed
+		if additionalProperties != nil || allowed == nil || (allowed != nil && *allowed) {
+			if additionalProperties != nil {
+				if err := additionalProperties.visitJSON(settings, v); err != nil {
+					if settings.failfast {
+						return errSchema
+					}
+					err = markSchemaErrorKey(err, k)
+					if !settings.multiError {
+						return err
+					}
+					if v, ok := err.(MultiError); ok {
+						me = append(me, v...)
+						continue
+					}
+					me = append(me, err)
+				}
+			}
+			continue
+		}
+		if settings.failfast {
+			return errSchema
+		}
+		err := &SchemaError{
+			Value:       value,
+			Schema:      schema,
+			SchemaField: "properties",
+			Reason:      fmt.Sprintf("property %q is unsupported", k),
+		}
+		if !settings.multiError {
+			return err
+		}
+		me = append(me, err)
+	}
+
+	// "required"
+	for _, k := range schema.Required {
+		if _, ok := value[k]; !ok {
+			if s := schema.Properties[k]; s != nil && s.Value.ReadOnly && settings.asreq {
+				continue
+			}
+			if s := schema.Properties[k]; s != nil && s.Value.WriteOnly && settings.asrep {
+				continue
+			}
+			if settings.failfast {
+				return errSchema
+			}
+			err := markSchemaErrorKey(&SchemaError{
+				Value:       value,
+				Schema:      schema,
+				SchemaField: "required",
+				Reason:      fmt.Sprintf("property %q is missing", k),
+			}, k)
+			if !settings.multiError {
+				return err
+			}
+			me = append(me, err)
+		}
+	}
+
+	if len(me) > 0 {
+		return me
+	}
+
+	return nil
+}
+
+func (schema *Schema) expectedType(settings *schemaValidationSettings, typ string) error {
+	if settings.failfast {
+		return errSchema
+	}
+	return &SchemaError{
+		Value:       typ,
+		Schema:      schema,
+		SchemaField: "type",
+		Reason:      "Field must be set to " + schema.Type + " or not be present",
+	}
+}
+
+func (schema *Schema) compilePattern() (err error) {
+	if schema.compiledPattern, err = regexp.Compile(schema.Pattern); err != nil {
+		return &SchemaError{
+			Schema:      schema,
+			SchemaField: "pattern",
+			Reason:      fmt.Sprintf("cannot compile pattern %q: %v", schema.Pattern, err),
+		}
+	}
+	return nil
+}
+
+type SchemaError struct {
+	Value       interface{}
+	reversePath []string
+	Schema      *Schema
+	SchemaField string
+	Reason      string
+	Origin      error
+}
+
+func markSchemaErrorKey(err error, key string) error {
+	if v, ok := err.(*SchemaError); ok {
+		v.reversePath = append(v.reversePath, key)
+		return v
+	}
+	if v, ok := err.(MultiError); ok {
+		for _, e := range v {
+			_ = markSchemaErrorKey(e, key)
+		}
+		return v
+	}
+	return err
+}
+
+func markSchemaErrorIndex(err error, index int) error {
+	if v, ok := err.(*SchemaError); ok {
+		v.reversePath = append(v.reversePath, strconv.FormatInt(int64(index), 10))
+		return v
+	}
+	if v, ok := err.(MultiError); ok {
+		for _, e := range v {
+			_ = markSchemaErrorIndex(e, index)
+		}
+		return v
+	}
+	return err
+}
+
+func (err *SchemaError) JSONPointer() []string {
+	reversePath := err.reversePath
+	path := append([]string(nil), reversePath...)
+	for left, right := 0, len(path)-1; left < right; left, right = left+1, right-1 {
+		path[left], path[right] = path[right], path[left]
+	}
+	return path
+}
+
+func (err *SchemaError) Error() string {
+	if err.Origin != nil {
+		return err.Origin.Error()
+	}
+
+	buf := bytes.NewBuffer(make([]byte, 0, 256))
+	if len(err.reversePath) > 0 {
+		buf.WriteString(`Error at "`)
+		reversePath := err.reversePath
+		for i := len(reversePath) - 1; i >= 0; i-- {
+			buf.WriteByte('/')
+			buf.WriteString(reversePath[i])
+		}
+		buf.WriteString(`": `)
+	}
+	reason := err.Reason
+	if reason == "" {
+		buf.WriteString(`Doesn't match schema "`)
+		buf.WriteString(err.SchemaField)
+		buf.WriteString(`"`)
+	} else {
+		buf.WriteString(reason)
+	}
+	if !SchemaErrorDetailsDisabled {
+		buf.WriteString("\nSchema:\n  ")
+		encoder := json.NewEncoder(buf)
+		encoder.SetIndent("  ", "  ")
+		if err := encoder.Encode(err.Schema); err != nil {
+			panic(err)
+		}
+		buf.WriteString("\nValue:\n  ")
+		if err := encoder.Encode(err.Value); err != nil {
+			panic(err)
+		}
+	}
+	return buf.String()
+}
+
+func isSliceOfUniqueItems(xs []interface{}) bool {
+	s := len(xs)
+	m := make(map[string]struct{}, s)
+	for _, x := range xs {
+		// The input slice is coverted from a JSON string, there shall
+		// have no error when covert it back.
+		key, _ := json.Marshal(&x)
+		m[string(key)] = struct{}{}
+	}
+	return s == len(m)
+}
+
+// SliceUniqueItemsChecker is an function used to check if an given slice
+// have unique items.
+type SliceUniqueItemsChecker func(items []interface{}) bool
+
+// By default using predefined func isSliceOfUniqueItems which make use of
+// json.Marshal to generate a key for map used to check if a given slice
+// have unique items.
+var sliceUniqueItemsChecker SliceUniqueItemsChecker = isSliceOfUniqueItems
+
+// RegisterArrayUniqueItemsChecker is used to register a customized function
+// used to check if JSON array have unique items.
+func RegisterArrayUniqueItemsChecker(fn SliceUniqueItemsChecker) {
+	sliceUniqueItemsChecker = fn
+}
+
+func unsupportedFormat(format string) error {
+	return fmt.Errorf("unsupported 'format' value %q", format)
+}

--- a/vendor/github.com/getkin/kin-openapi/openapi3/schema_formats.go
+++ b/vendor/github.com/getkin/kin-openapi/openapi3/schema_formats.go
@@ -1,0 +1,105 @@
+package openapi3
+
+import (
+	"fmt"
+	"net"
+	"regexp"
+)
+
+const (
+	// FormatOfStringForUUIDOfRFC4122 is an optional predefined format for UUID v1-v5 as specified by RFC4122
+	FormatOfStringForUUIDOfRFC4122 = `^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`
+)
+
+//FormatCallback custom check on exotic formats
+type FormatCallback func(Val string) error
+
+type Format struct {
+	regexp   *regexp.Regexp
+	callback FormatCallback
+}
+
+//SchemaStringFormats allows for validating strings format
+var SchemaStringFormats = make(map[string]Format, 8)
+
+//DefineStringFormat Defines a new regexp pattern for a given format
+func DefineStringFormat(name string, pattern string) {
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		err := fmt.Errorf("format %q has invalid pattern %q: %v", name, pattern, err)
+		panic(err)
+	}
+	SchemaStringFormats[name] = Format{regexp: re}
+}
+
+// DefineStringFormatCallback adds a validation function for a specific schema format entry
+func DefineStringFormatCallback(name string, callback FormatCallback) {
+	SchemaStringFormats[name] = Format{callback: callback}
+}
+
+func validateIP(ip string) (*net.IP, error) {
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		return nil, &SchemaError{
+			Value:  ip,
+			Reason: "Not an IP address",
+		}
+	}
+	return &parsed, nil
+}
+
+func validateIPv4(ip string) error {
+	parsed, err := validateIP(ip)
+	if err != nil {
+		return err
+	}
+
+	if parsed.To4() == nil {
+		return &SchemaError{
+			Value:  ip,
+			Reason: "Not an IPv4 address (it's IPv6)",
+		}
+	}
+	return nil
+}
+func validateIPv6(ip string) error {
+	parsed, err := validateIP(ip)
+	if err != nil {
+		return err
+	}
+
+	if parsed.To4() != nil {
+		return &SchemaError{
+			Value:  ip,
+			Reason: "Not an IPv6 address (it's IPv4)",
+		}
+	}
+	return nil
+}
+
+func init() {
+	// This pattern catches only some suspiciously wrong-looking email addresses.
+	// Use DefineStringFormat(...) if you need something stricter.
+	DefineStringFormat("email", `^[^@]+@[^@<>",\s]+$`)
+
+	// Base64
+	// The pattern supports base64 and b./ase64url. Padding ('=') is supported.
+	DefineStringFormat("byte", `(^$|^[a-zA-Z0-9+/\-_]*=*$)`)
+
+	// date
+	DefineStringFormat("date", `^[0-9]{4}-(0[0-9]|10|11|12)-([0-2][0-9]|30|31)$`)
+
+	// date-time
+	DefineStringFormat("date-time", `^[0-9]{4}-(0[0-9]|10|11|12)-([0-2][0-9]|30|31)T[0-9]{2}:[0-9]{2}:[0-9]{2}(.[0-9]+)?(Z|(\+|-)[0-9]{2}:[0-9]{2})?$`)
+
+}
+
+// DefineIPv4Format opts in ipv4 format validation on top of OAS 3 spec
+func DefineIPv4Format() {
+	DefineStringFormatCallback("ipv4", validateIPv4)
+}
+
+// DefineIPv6Format opts in ipv6 format validation on top of OAS 3 spec
+func DefineIPv6Format() {
+	DefineStringFormatCallback("ipv6", validateIPv6)
+}

--- a/vendor/github.com/getkin/kin-openapi/openapi3/schema_validation_settings.go
+++ b/vendor/github.com/getkin/kin-openapi/openapi3/schema_validation_settings.go
@@ -1,0 +1,34 @@
+package openapi3
+
+// SchemaValidationOption describes options a user has when validating request / response bodies.
+type SchemaValidationOption func(*schemaValidationSettings)
+
+type schemaValidationSettings struct {
+	failfast     bool
+	multiError   bool
+	asreq, asrep bool // exclusive (XOR) fields
+}
+
+// FailFast returns schema validation errors quicker.
+func FailFast() SchemaValidationOption {
+	return func(s *schemaValidationSettings) { s.failfast = true }
+}
+
+func MultiErrors() SchemaValidationOption {
+	return func(s *schemaValidationSettings) { s.multiError = true }
+}
+
+func VisitAsRequest() SchemaValidationOption {
+	return func(s *schemaValidationSettings) { s.asreq, s.asrep = true, false }
+}
+func VisitAsResponse() SchemaValidationOption {
+	return func(s *schemaValidationSettings) { s.asreq, s.asrep = false, true }
+}
+
+func newSchemaValidationSettings(opts ...SchemaValidationOption) *schemaValidationSettings {
+	settings := &schemaValidationSettings{}
+	for _, opt := range opts {
+		opt(settings)
+	}
+	return settings
+}

--- a/vendor/github.com/getkin/kin-openapi/openapi3/security_requirements.go
+++ b/vendor/github.com/getkin/kin-openapi/openapi3/security_requirements.go
@@ -1,0 +1,43 @@
+package openapi3
+
+import (
+	"context"
+)
+
+type SecurityRequirements []SecurityRequirement
+
+func NewSecurityRequirements() *SecurityRequirements {
+	return &SecurityRequirements{}
+}
+
+func (srs *SecurityRequirements) With(securityRequirement SecurityRequirement) *SecurityRequirements {
+	*srs = append(*srs, securityRequirement)
+	return srs
+}
+
+func (value SecurityRequirements) Validate(ctx context.Context) error {
+	for _, item := range value {
+		if err := item.Validate(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type SecurityRequirement map[string][]string
+
+func NewSecurityRequirement() SecurityRequirement {
+	return make(SecurityRequirement)
+}
+
+func (security SecurityRequirement) Authenticate(provider string, scopes ...string) SecurityRequirement {
+	if len(scopes) == 0 {
+		scopes = []string{} // Forces the variable to be encoded as an array instead of null
+	}
+	security[provider] = scopes
+	return security
+}
+
+func (value SecurityRequirement) Validate(ctx context.Context) error {
+	return nil
+}

--- a/vendor/github.com/getkin/kin-openapi/openapi3/security_scheme.go
+++ b/vendor/github.com/getkin/kin-openapi/openapi3/security_scheme.go
@@ -1,0 +1,241 @@
+package openapi3
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/getkin/kin-openapi/jsoninfo"
+	"github.com/go-openapi/jsonpointer"
+)
+
+type SecuritySchemes map[string]*SecuritySchemeRef
+
+func (s SecuritySchemes) JSONLookup(token string) (interface{}, error) {
+	ref, ok := s[token]
+	if ref == nil || ok == false {
+		return nil, fmt.Errorf("object has no field %q", token)
+	}
+
+	if ref.Ref != "" {
+		return &Ref{Ref: ref.Ref}, nil
+	}
+	return ref.Value, nil
+}
+
+var _ jsonpointer.JSONPointable = (*SecuritySchemes)(nil)
+
+type SecurityScheme struct {
+	ExtensionProps
+
+	Type             string      `json:"type,omitempty" yaml:"type,omitempty"`
+	Description      string      `json:"description,omitempty" yaml:"description,omitempty"`
+	Name             string      `json:"name,omitempty" yaml:"name,omitempty"`
+	In               string      `json:"in,omitempty" yaml:"in,omitempty"`
+	Scheme           string      `json:"scheme,omitempty" yaml:"scheme,omitempty"`
+	BearerFormat     string      `json:"bearerFormat,omitempty" yaml:"bearerFormat,omitempty"`
+	Flows            *OAuthFlows `json:"flows,omitempty" yaml:"flows,omitempty"`
+	OpenIdConnectUrl string      `json:"openIdConnectUrl,omitempty" yaml:"openIdConnectUrl,omitempty"`
+}
+
+func NewSecurityScheme() *SecurityScheme {
+	return &SecurityScheme{}
+}
+
+func NewCSRFSecurityScheme() *SecurityScheme {
+	return &SecurityScheme{
+		Type: "apiKey",
+		In:   "header",
+		Name: "X-XSRF-TOKEN",
+	}
+}
+
+func NewOIDCSecurityScheme(oidcUrl string) *SecurityScheme {
+	return &SecurityScheme{
+		Type:             "openIdConnect",
+		OpenIdConnectUrl: oidcUrl,
+	}
+}
+
+func NewJWTSecurityScheme() *SecurityScheme {
+	return &SecurityScheme{
+		Type:         "http",
+		Scheme:       "bearer",
+		BearerFormat: "JWT",
+	}
+}
+
+func (ss *SecurityScheme) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalStrictStruct(ss)
+}
+
+func (ss *SecurityScheme) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalStrictStruct(data, ss)
+}
+
+func (ss *SecurityScheme) WithType(value string) *SecurityScheme {
+	ss.Type = value
+	return ss
+}
+
+func (ss *SecurityScheme) WithDescription(value string) *SecurityScheme {
+	ss.Description = value
+	return ss
+}
+
+func (ss *SecurityScheme) WithName(value string) *SecurityScheme {
+	ss.Name = value
+	return ss
+}
+
+func (ss *SecurityScheme) WithIn(value string) *SecurityScheme {
+	ss.In = value
+	return ss
+}
+
+func (ss *SecurityScheme) WithScheme(value string) *SecurityScheme {
+	ss.Scheme = value
+	return ss
+}
+
+func (ss *SecurityScheme) WithBearerFormat(value string) *SecurityScheme {
+	ss.BearerFormat = value
+	return ss
+}
+
+func (value *SecurityScheme) Validate(ctx context.Context) error {
+	hasIn := false
+	hasBearerFormat := false
+	hasFlow := false
+	switch value.Type {
+	case "apiKey":
+		hasIn = true
+	case "http":
+		scheme := value.Scheme
+		switch scheme {
+		case "bearer":
+			hasBearerFormat = true
+		case "basic", "negotiate", "digest":
+		default:
+			return fmt.Errorf("security scheme of type 'http' has invalid 'scheme' value %q", scheme)
+		}
+	case "oauth2":
+		hasFlow = true
+	case "openIdConnect":
+		if value.OpenIdConnectUrl == "" {
+			return fmt.Errorf("no OIDC URL found for openIdConnect security scheme %q", value.Name)
+		}
+	default:
+		return fmt.Errorf("security scheme 'type' can't be %q", value.Type)
+	}
+
+	// Validate "in" and "name"
+	if hasIn {
+		switch value.In {
+		case "query", "header", "cookie":
+		default:
+			return fmt.Errorf("security scheme of type 'apiKey' should have 'in'. It can be 'query', 'header' or 'cookie', not %q", value.In)
+		}
+		if value.Name == "" {
+			return errors.New("security scheme of type 'apiKey' should have 'name'")
+		}
+	} else if len(value.In) > 0 {
+		return fmt.Errorf("security scheme of type %q can't have 'in'", value.Type)
+	} else if len(value.Name) > 0 {
+		return errors.New("security scheme of type 'apiKey' can't have 'name'")
+	}
+
+	// Validate "format"
+	// "bearerFormat" is an arbitrary string so we only check if the scheme supports it
+	if !hasBearerFormat && len(value.BearerFormat) > 0 {
+		return fmt.Errorf("security scheme of type %q can't have 'bearerFormat'", value.Type)
+	}
+
+	// Validate "flow"
+	if hasFlow {
+		flow := value.Flows
+		if flow == nil {
+			return fmt.Errorf("security scheme of type %q should have 'flows'", value.Type)
+		}
+		if err := flow.Validate(ctx); err != nil {
+			return fmt.Errorf("security scheme 'flow' is invalid: %v", err)
+		}
+	} else if value.Flows != nil {
+		return fmt.Errorf("security scheme of type %q can't have 'flows'", value.Type)
+	}
+	return nil
+}
+
+type OAuthFlows struct {
+	ExtensionProps
+	Implicit          *OAuthFlow `json:"implicit,omitempty" yaml:"implicit,omitempty"`
+	Password          *OAuthFlow `json:"password,omitempty" yaml:"password,omitempty"`
+	ClientCredentials *OAuthFlow `json:"clientCredentials,omitempty" yaml:"clientCredentials,omitempty"`
+	AuthorizationCode *OAuthFlow `json:"authorizationCode,omitempty" yaml:"authorizationCode,omitempty"`
+}
+
+type oAuthFlowType int
+
+const (
+	oAuthFlowTypeImplicit oAuthFlowType = iota
+	oAuthFlowTypePassword
+	oAuthFlowTypeClientCredentials
+	oAuthFlowAuthorizationCode
+)
+
+func (flows *OAuthFlows) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalStrictStruct(flows)
+}
+
+func (flows *OAuthFlows) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalStrictStruct(data, flows)
+}
+
+func (flows *OAuthFlows) Validate(ctx context.Context) error {
+	if v := flows.Implicit; v != nil {
+		return v.Validate(ctx, oAuthFlowTypeImplicit)
+	}
+	if v := flows.Password; v != nil {
+		return v.Validate(ctx, oAuthFlowTypePassword)
+	}
+	if v := flows.ClientCredentials; v != nil {
+		return v.Validate(ctx, oAuthFlowTypeClientCredentials)
+	}
+	if v := flows.AuthorizationCode; v != nil {
+		return v.Validate(ctx, oAuthFlowAuthorizationCode)
+	}
+	return errors.New("no OAuth flow is defined")
+}
+
+type OAuthFlow struct {
+	ExtensionProps
+	AuthorizationURL string            `json:"authorizationUrl,omitempty" yaml:"authorizationUrl,omitempty"`
+	TokenURL         string            `json:"tokenUrl,omitempty" yaml:"tokenUrl,omitempty"`
+	RefreshURL       string            `json:"refreshUrl,omitempty" yaml:"refreshUrl,omitempty"`
+	Scopes           map[string]string `json:"scopes" yaml:"scopes"`
+}
+
+func (flow *OAuthFlow) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalStrictStruct(flow)
+}
+
+func (flow *OAuthFlow) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalStrictStruct(data, flow)
+}
+
+func (flow *OAuthFlow) Validate(ctx context.Context, typ oAuthFlowType) error {
+	if typ == oAuthFlowAuthorizationCode || typ == oAuthFlowTypeImplicit {
+		if v := flow.AuthorizationURL; v == "" {
+			return errors.New("an OAuth flow is missing 'authorizationUrl in authorizationCode or implicit '")
+		}
+	}
+	if typ != oAuthFlowTypeImplicit {
+		if v := flow.TokenURL; v == "" {
+			return errors.New("an OAuth flow is missing 'tokenUrl in not implicit'")
+		}
+	}
+	if v := flow.Scopes; v == nil {
+		return errors.New("an OAuth flow is missing 'scopes'")
+	}
+	return nil
+}

--- a/vendor/github.com/getkin/kin-openapi/openapi3/serialization_method.go
+++ b/vendor/github.com/getkin/kin-openapi/openapi3/serialization_method.go
@@ -1,0 +1,17 @@
+package openapi3
+
+const (
+	SerializationSimple         = "simple"
+	SerializationLabel          = "label"
+	SerializationMatrix         = "matrix"
+	SerializationForm           = "form"
+	SerializationSpaceDelimited = "spaceDelimited"
+	SerializationPipeDelimited  = "pipeDelimited"
+	SerializationDeepObject     = "deepObject"
+)
+
+// SerializationMethod describes a serialization method of HTTP request's parameters and body.
+type SerializationMethod struct {
+	Style   string
+	Explode bool
+}

--- a/vendor/github.com/getkin/kin-openapi/openapi3/server.go
+++ b/vendor/github.com/getkin/kin-openapi/openapi3/server.go
@@ -1,0 +1,175 @@
+package openapi3
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"net/url"
+	"strings"
+
+	"github.com/getkin/kin-openapi/jsoninfo"
+)
+
+// Servers is specified by OpenAPI/Swagger standard version 3.0.
+type Servers []*Server
+
+// Validate ensures servers are per the OpenAPIv3 specification.
+func (value Servers) Validate(ctx context.Context) error {
+	for _, v := range value {
+		if err := v.Validate(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (servers Servers) MatchURL(parsedURL *url.URL) (*Server, []string, string) {
+	rawURL := parsedURL.String()
+	if i := strings.IndexByte(rawURL, '?'); i >= 0 {
+		rawURL = rawURL[:i]
+	}
+	for _, server := range servers {
+		pathParams, remaining, ok := server.MatchRawURL(rawURL)
+		if ok {
+			return server, pathParams, remaining
+		}
+	}
+	return nil, nil, ""
+}
+
+// Server is specified by OpenAPI/Swagger standard version 3.0.
+type Server struct {
+	ExtensionProps
+	URL         string                     `json:"url" yaml:"url"`
+	Description string                     `json:"description,omitempty" yaml:"description,omitempty"`
+	Variables   map[string]*ServerVariable `json:"variables,omitempty" yaml:"variables,omitempty"`
+}
+
+func (server *Server) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalStrictStruct(server)
+}
+
+func (server *Server) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalStrictStruct(data, server)
+}
+
+func (server Server) ParameterNames() ([]string, error) {
+	pattern := server.URL
+	var params []string
+	for len(pattern) > 0 {
+		i := strings.IndexByte(pattern, '{')
+		if i < 0 {
+			break
+		}
+		pattern = pattern[i+1:]
+		i = strings.IndexByte(pattern, '}')
+		if i < 0 {
+			return nil, errors.New("missing '}'")
+		}
+		params = append(params, strings.TrimSpace(pattern[:i]))
+		pattern = pattern[i+1:]
+	}
+	return params, nil
+}
+
+func (server Server) MatchRawURL(input string) ([]string, string, bool) {
+	pattern := server.URL
+	var params []string
+	for len(pattern) > 0 {
+		c := pattern[0]
+		if len(pattern) == 1 && c == '/' {
+			break
+		}
+		if c == '{' {
+			// Find end of pattern
+			i := strings.IndexByte(pattern, '}')
+			if i < 0 {
+				return nil, "", false
+			}
+			pattern = pattern[i+1:]
+
+			// Find next matching pattern character or next '/' whichever comes first
+			np := -1
+			if len(pattern) > 0 {
+				np = strings.IndexByte(input, pattern[0])
+			}
+			ns := strings.IndexByte(input, '/')
+
+			if np < 0 {
+				i = ns
+			} else if ns < 0 {
+				i = np
+			} else {
+				i = int(math.Min(float64(np), float64(ns)))
+			}
+			if i < 0 {
+				i = len(input)
+			}
+			params = append(params, input[:i])
+			input = input[i:]
+			continue
+		}
+		if len(input) == 0 || input[0] != c {
+			return nil, "", false
+		}
+		pattern = pattern[1:]
+		input = input[1:]
+	}
+	if input == "" {
+		input = "/"
+	}
+	if input[0] != '/' {
+		return nil, "", false
+	}
+	return params, input, true
+}
+
+func (value *Server) Validate(ctx context.Context) (err error) {
+	if value.URL == "" {
+		return errors.New("value of url must be a non-empty string")
+	}
+	opening, closing := strings.Count(value.URL, "{"), strings.Count(value.URL, "}")
+	if opening != closing {
+		return errors.New("server URL has mismatched { and }")
+	}
+	if opening != len(value.Variables) {
+		return errors.New("server has undeclared variables")
+	}
+	for name, v := range value.Variables {
+		if !strings.Contains(value.URL, fmt.Sprintf("{%s}", name)) {
+			return errors.New("server has undeclared variables")
+		}
+		if err = v.Validate(ctx); err != nil {
+			return
+		}
+	}
+	return
+}
+
+// ServerVariable is specified by OpenAPI/Swagger standard version 3.0.
+type ServerVariable struct {
+	ExtensionProps
+	Enum        []string `json:"enum,omitempty" yaml:"enum,omitempty"`
+	Default     string   `json:"default,omitempty" yaml:"default,omitempty"`
+	Description string   `json:"description,omitempty" yaml:"description,omitempty"`
+}
+
+func (serverVariable *ServerVariable) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalStrictStruct(serverVariable)
+}
+
+func (serverVariable *ServerVariable) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalStrictStruct(data, serverVariable)
+}
+
+func (value *ServerVariable) Validate(ctx context.Context) error {
+	if value.Default == "" {
+		data, err := value.MarshalJSON()
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("field default is required in %s", data)
+	}
+	return nil
+}

--- a/vendor/github.com/getkin/kin-openapi/openapi3/tag.go
+++ b/vendor/github.com/getkin/kin-openapi/openapi3/tag.go
@@ -1,0 +1,31 @@
+package openapi3
+
+import "github.com/getkin/kin-openapi/jsoninfo"
+
+// Tags is specified by OpenAPI/Swagger 3.0 standard.
+type Tags []*Tag
+
+func (tags Tags) Get(name string) *Tag {
+	for _, tag := range tags {
+		if tag.Name == name {
+			return tag
+		}
+	}
+	return nil
+}
+
+// Tag is specified by OpenAPI/Swagger 3.0 standard.
+type Tag struct {
+	ExtensionProps
+	Name         string        `json:"name,omitempty" yaml:"name,omitempty"`
+	Description  string        `json:"description,omitempty" yaml:"description,omitempty"`
+	ExternalDocs *ExternalDocs `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
+}
+
+func (t *Tag) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalStrictStruct(t)
+}
+
+func (t *Tag) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalStrictStruct(data, t)
+}


### PR DESCRIPTION
## Description
Scraping Mappings for API documentation to relay through ambassador-agent.

I'm using https://github.com/getkin/kin-openapi to parse, validate and edit the OpenAPI JSON documents. In other implementations, the raw document used to be manually parsed and edited...

Compared to the Edge Stack Developer Portal, the ambassador-agent WILL NOT:
- Enforce a filter protection for accessing the API docs path.
- Scrape the legacy and deprecated `/.ambassador-internal/` path. (Unless this is the `Mapping.spec.docs` value)
- Filter which services are scraped by namespaces or labels.
- Consider any DevPortal CRD settings.
- Query the docs endpoint by going through Ambassador's route.
- Delete a known API doc if the service stops responding after it's been scraped at least once.
- Update after/and-every 30 seconds. Instead, the agent will trigger and wait for the scraping when booting up, then update once every minute if there is data in the cache.

Sample snapshot:
```
{
    "Consul": {},
    "Deltas": "...",
    "APIDocs": [
        {
            "data": "eyJjb21wb25lbnRzIjp7fSwiaW5mbyI6eyJkZXNjcmlwdGlvbiI6IlF1b3RlIFNlcnZpY2UgQVBJIiwidGl0bGUiOiJRdW90ZSBTZXJ2aWNlIEFQSSIsInZlcnNpb24iOiIwLjEuMCJ9LCJvcGVuYXBpIjoiMy4wLjAiLCJwYXRocyI6eyIvIjp7ImdldCI6eyJyZXNwb25zZXMiOnsiMjAwIjp7ImNvbnRlbnQiOnsiYXBwbGljYXRpb24vanNvbiI6eyJzY2hlbWEiOnsicHJvcGVydGllcyI6eyJxdW90ZSI6eyJ0eXBlIjoic3RyaW5nIn0sInNlcnZlciI6eyJ0eXBlIjoic3RyaW5nIn0sInRpbWUiOnsidHlwZSI6InN0cmluZyJ9fSwidHlwZSI6Im9iamVjdCJ9fX0sImRlc2NyaXB0aW9uIjoiQSBKU09OIG9iamVjdCB3aXRoIGEgcXVvdGUgYW5kIHNvbWUgYWRkaXRpb25hbCBtZXRhZGF0YS4ifX0sInN1bW1hcnkiOiJSZXR1cm4gYSByYW5kb21seSBzZWxlY3RlZCBxdW90ZS4ifX0sIi9kZWJ1Zy8iOnsiZ2V0Ijp7InJlc3BvbnNlcyI6eyIyMDAiOnsiY29udGVudCI6eyJhcHBsaWNhdGlvbi9qc29uIjp7InNjaGVtYSI6eyJwcm9wZXJ0aWVzIjp7ImhlYWRlcnMiOnsidHlwZSI6Im9iamVjdCJ9LCJob3N0Ijp7InR5cGUiOiJzdHJpbmcifSwicHJvdG8iOnsidHlwZSI6InN0cmluZyJ9LCJyZW1vdGVhZGRyIjp7InR5cGUiOiJzdHJpbmcifSwic2VydmVyIjp7InR5cGUiOiJzdHJpbmcifSwidGltZSI6eyJ0eXBlIjoic3RyaW5nIn0sInVybCI6eyJ0eXBlIjoib2JqZWN0In19LCJ0eXBlIjoib2JqZWN0In19fSwiZGVzY3JpcHRpb24iOiJBIEpTT04gb2JqZWN0IHdpdGggZGVidWcgaW5mb3JtYXRpb24gYWJvdXQgdGhlIHJlcXVlc3QgYW5kIGFkZGl0aW9uYWwgbWV0YWRhdGEuIn19LCJzdW1tYXJ5IjoiUmV0dXJuIGRlYnVnIGluZm9ybWF0aW9uIGFib3V0IHRoZSByZXF1ZXN0LiJ9fX0sInNlcnZlcnMiOlt7InVybCI6Ii9iYWNrZW5kIn1dfQ==",
            "kind": "OpenAPI",
            "apiVersion": "v3",
            "metadata": {
                "name": "quote-backend.ambassador",
                "creationTimestamp": null
            },
            "targetRef": {
                "uid": "f4cae546-fc8e-4599-baef-97d55f41d910",
                "kind": "Mapping",
                "name": "quote-backend",
                "namespace": "ambassador",
                "apiVersion": "getambassador.io/v2",
                "resourceVersion": "2569"
            }
        }
    ],
    "Kubernetes": "...",
    "AmbassadorMeta": "..."
}
```

## Related Issues
None

## Testing
Manual and unit tests.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `CHANGELOG.md`.
   
   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations
 
 - [x] This is unlikely to impact how Ambassador performs at scale.
 
   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability
 
 - [x] My change is adequately tested.
 
   Remember when considering testing:
    + LEGACY MODE TESTS DO NOT RUN FOR EVERY PR. If your change is affected by legacy mode, you need
      to run legacy-mode tests manually (set `AMBASSADOR_LEGACY_MODE=true` and run the tests).
      (This will be fixed soon.)
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points
 
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
