### PR TITLE
Allow overriding the stats_prefix for an AmbassadorListener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,9 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 ### Emissary Ingress
 
-(no changes yet)
+We're pleased to introduce Emissary 2.0.1 as a developer preview. The 2.X family introduces a number of changes to allow Emissary to more gracefully handle larger installations, reduce global configuration to better handle multitenant or multiorganizational installations, reduce memory footprint, and improve performance. We welcome feedback!! Join us on <a href="https://a8r.io/slack">Slack</a> and let us know what you think.
+
+- Feature: The optional `statsPrefix` element of the `AmbassadorListener` CRD now determines the prefix of HTTP statistics emitted for a specific `AmbassadorListener`.
 
 ## [2.0.0-ea] June 24, 2021
 [2.0.0-ea]: https://github.com/emissary-ingress/emissary/compare/v1.13.8...v2.0.0-ea

--- a/charts/emissary-ingress/crds/x.getambassador.io_ambassadorlisteners.yaml
+++ b/charts/emissary-ingress/crds/x.getambassador.io_ambassadorlisteners.yaml
@@ -21,6 +21,9 @@ spec:
   - JSONPath: .spec.protocolStack
     name: Stack
     type: string
+  - JSONPath: .spec.statsPrefix
+    name: StatsPrefix
+    type: string
   - JSONPath: .spec.securityModel
     name: Security
     type: string
@@ -143,6 +146,9 @@ spec:
               - XFP
               - SECURE
               - INSECURE
+              type: string
+            statsPrefix:
+              description: 'StatsPrefix specifies the prefix for statistics sent by Envoy about this AmbassadorListener. The default depends on the protocol: "ingress-http", "ingress-https", "ingress-tls-$port", or "ingress-$port".'
               type: string
           required:
           - hostBinding

--- a/manifests/emissary/ambassador-crds.yaml
+++ b/manifests/emissary/ambassador-crds.yaml
@@ -1783,6 +1783,9 @@ spec:
   - JSONPath: .spec.protocolStack
     name: Stack
     type: string
+  - JSONPath: .spec.statsPrefix
+    name: StatsPrefix
+    type: string
   - JSONPath: .spec.securityModel
     name: Security
     type: string
@@ -1905,6 +1908,9 @@ spec:
               - XFP
               - SECURE
               - INSECURE
+              type: string
+            statsPrefix:
+              description: 'StatsPrefix specifies the prefix for statistics sent by Envoy about this AmbassadorListener. The default depends on the protocol: "ingress-http", "ingress-https", "ingress-tls-$port", or "ingress-$port".'
               type: string
           required:
           - hostBinding

--- a/manifests/emissary/emissary-crds.yaml
+++ b/manifests/emissary/emissary-crds.yaml
@@ -1783,6 +1783,9 @@ spec:
   - JSONPath: .spec.protocolStack
     name: Stack
     type: string
+  - JSONPath: .spec.statsPrefix
+    name: StatsPrefix
+    type: string
   - JSONPath: .spec.securityModel
     name: Security
     type: string
@@ -1905,6 +1908,9 @@ spec:
               - XFP
               - SECURE
               - INSECURE
+              type: string
+            statsPrefix:
+              description: 'StatsPrefix specifies the prefix for statistics sent by Envoy about this AmbassadorListener. The default depends on the protocol: "ingress-http", "ingress-https", "ingress-tls-$port", or "ingress-$port".'
               type: string
           required:
           - hostBinding

--- a/pkg/api/getambassador.io/v3alpha1/listener_types.go
+++ b/pkg/api/getambassador.io/v3alpha1/listener_types.go
@@ -158,6 +158,11 @@ type AmbassadorListenerSpec struct {
 	// +kubebuilder:validation:Required
 	SecurityModel SecurityModelType `json:"securityModel"`
 
+	// StatsPrefix specifies the prefix for statistics sent by Envoy about this
+	// AmbassadorListener. The default depends on the protocol: "ingress-http",
+	// "ingress-https", "ingress-tls-$port", or "ingress-$port".
+	StatsPrefix string `json:"statsPrefix,omitempty"`
+
 	// L7Depth specifies how many layer 7 load balancers are between us and the edge of
 	// the network.
 	L7Depth int32 `json:"l7Depth,omitempty"`
@@ -173,6 +178,7 @@ type AmbassadorListenerSpec struct {
 // +kubebuilder:printcolumn:name="Port",type=string,JSONPath=`.spec.port`
 // +kubebuilder:printcolumn:name="Protocol",type=string,JSONPath=`.spec.protocol`
 // +kubebuilder:printcolumn:name="Stack",type=string,JSONPath=`.spec.protocolStack`
+// +kubebuilder:printcolumn:name="StatsPrefix",type=string,JSONPath=`.spec.statsPrefix`
 // +kubebuilder:printcolumn:name="Security",type=string,JSONPath=`.spec.securityModel`
 // +kubebuilder:printcolumn:name="L7Depth",type=string,JSONPath=`.spec.l7Depth`
 type AmbassadorListener struct {

--- a/python/ambassador/envoy/v2/v2listener.py
+++ b/python/ambassador/envoy/v2/v2listener.py
@@ -136,6 +136,7 @@ class V2Listener(dict):
         self.listener_filters: List[dict] = []
         self.traffic_direction: str = "UNSPECIFIED"
         self._irlistener = irlistener   # We cache the IRListener to use its match method later
+        self._stats_prefix = irlistener.statsPrefix
         self._security_model: str = irlistener.securityModel
         self._l7_depth: int = irlistener.get('l7Depth', 0)
         self._insecure_only: bool = False
@@ -369,7 +370,7 @@ class V2Listener(dict):
     # V2Listener's http_connection_manager filter.
     def base_http_config(self) -> Dict[str, Any]:
         base_http_config: Dict[str, Any] = {
-            'stat_prefix': 'ingress_http',
+            'stat_prefix': self._stats_prefix,
             'access_log': self.access_log(),
             'http_filters': [],
             'normalize_path': True
@@ -564,7 +565,7 @@ class V2Listener(dict):
                     'name': 'envoy.filters.network.tcp_proxy',
                     'typed_config': {
                         '@type': 'type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy',
-                        'stat_prefix': 'ingress_tcp_%d' % irgroup.port,
+                        'stat_prefix': self._stats_prefix,
                         'weighted_clusters': {
                             'clusters': clusters
                         }

--- a/python/ambassador/envoy/v3/v3listener.py
+++ b/python/ambassador/envoy/v3/v3listener.py
@@ -136,6 +136,7 @@ class V3Listener(dict):
         self.listener_filters: List[dict] = []
         self.traffic_direction: str = "UNSPECIFIED"
         self._irlistener = irlistener   # We cache the IRListener to use its match method later
+        self._stats_prefix = irlistener.statsPrefix
         self._security_model: str = irlistener.securityModel
         self._l7_depth: int = irlistener.get('l7Depth', 0)
         self._insecure_only: bool = False
@@ -369,7 +370,7 @@ class V3Listener(dict):
     # V3Listener's http_connection_manager filter.
     def base_http_config(self) -> Dict[str, Any]:
         base_http_config: Dict[str, Any] = {
-            'stat_prefix': 'ingress_http',
+            'stat_prefix': self._stats_prefix,
             'access_log': self.access_log(),
             'http_filters': [],
             'normalize_path': True
@@ -573,7 +574,7 @@ class V3Listener(dict):
                     'name': 'envoy.filters.network.tcp_proxy',
                     'typed_config': {
                         '@type': 'type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy',
-                        'stat_prefix': 'ingress_tcp_%d' % irgroup.port,
+                        'stat_prefix': self._stats_prefix,
                         'weighted_clusters': {
                             'clusters': clusters
                         }

--- a/python/tests/gold/acceptancegrpcbridgetest/snapshots/econf.json
+++ b/python/tests/gold/acceptancegrpcbridgetest/snapshots/econf.json
@@ -302,7 +302,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -531,7 +531,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -780,7 +780,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1009,7 +1009,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }

--- a/python/tests/gold/acceptancegrpctest/snapshots/econf.json
+++ b/python/tests/gold/acceptancegrpctest/snapshots/econf.json
@@ -299,7 +299,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -525,7 +525,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -771,7 +771,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -997,7 +997,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }

--- a/python/tests/gold/acceptancegrpcwebtest/snapshots/econf.json
+++ b/python/tests/gold/acceptancegrpcwebtest/snapshots/econf.json
@@ -302,7 +302,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -531,7 +531,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -780,7 +780,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1009,7 +1009,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }

--- a/python/tests/gold/ambassadoridtest/snapshots/econf.json
+++ b/python/tests/gold/ambassadoridtest/snapshots/econf.json
@@ -386,7 +386,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -700,7 +700,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1034,7 +1034,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1348,7 +1348,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }

--- a/python/tests/gold/authenticationgrpctest/snapshots/econf.json
+++ b/python/tests/gold/authenticationgrpctest/snapshots/econf.json
@@ -472,7 +472,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -844,7 +844,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1236,7 +1236,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1608,7 +1608,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }

--- a/python/tests/gold/authenticationheaderrouting/snapshots/econf.json
+++ b/python/tests/gold/authenticationheaderrouting/snapshots/econf.json
@@ -504,7 +504,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -882,7 +882,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1280,7 +1280,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1658,7 +1658,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }

--- a/python/tests/gold/authenticationhttpbufferedtest/snapshots/econf.json
+++ b/python/tests/gold/authenticationhttpbufferedtest/snapshots/econf.json
@@ -541,7 +541,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -965,7 +965,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1409,7 +1409,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1833,7 +1833,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }

--- a/python/tests/gold/authenticationhttpfailuremodeallowtest/snapshots/econf.json
+++ b/python/tests/gold/authenticationhttpfailuremodeallowtest/snapshots/econf.json
@@ -436,7 +436,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -755,7 +755,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1094,7 +1094,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1413,7 +1413,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }

--- a/python/tests/gold/authenticationhttppartialbuffertest/snapshots/econf.json
+++ b/python/tests/gold/authenticationhttppartialbuffertest/snapshots/econf.json
@@ -450,7 +450,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -783,7 +783,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1136,7 +1136,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1469,7 +1469,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }

--- a/python/tests/gold/authenticationtest/snapshots/econf.json
+++ b/python/tests/gold/authenticationtest/snapshots/econf.json
@@ -444,7 +444,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -789,7 +789,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1154,7 +1154,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1499,7 +1499,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }

--- a/python/tests/gold/authenticationtestv1/snapshots/econf.json
+++ b/python/tests/gold/authenticationtestv1/snapshots/econf.json
@@ -513,7 +513,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -916,7 +916,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1339,7 +1339,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1742,7 +1742,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }

--- a/python/tests/gold/authenticationwebsockettest/snapshots/econf.json
+++ b/python/tests/gold/authenticationwebsockettest/snapshots/econf.json
@@ -428,7 +428,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -757,7 +757,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1106,7 +1106,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1435,7 +1435,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }

--- a/python/tests/gold/circuitbreakingtcptest/snapshots/econf.json
+++ b/python/tests/gold/circuitbreakingtcptest/snapshots/econf.json
@@ -290,7 +290,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -472,7 +472,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -674,7 +674,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -856,7 +856,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }

--- a/python/tests/gold/clustertagtest/snapshots/econf.json
+++ b/python/tests/gold/clustertagtest/snapshots/econf.json
@@ -653,7 +653,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1099,7 +1099,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1565,7 +1565,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -2011,7 +2011,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }

--- a/python/tests/gold/empty/snapshots/econf.json
+++ b/python/tests/gold/empty/snapshots/econf.json
@@ -227,7 +227,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -409,7 +409,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -611,7 +611,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -793,7 +793,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }

--- a/python/tests/gold/envoylogjsontest/snapshots/econf.json
+++ b/python/tests/gold/envoylogjsontest/snapshots/econf.json
@@ -230,7 +230,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -415,7 +415,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -620,7 +620,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -805,7 +805,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }

--- a/python/tests/gold/envoylogtest/snapshots/econf.json
+++ b/python/tests/gold/envoylogtest/snapshots/econf.json
@@ -227,7 +227,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -409,7 +409,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -611,7 +611,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -793,7 +793,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }

--- a/python/tests/gold/globalcircuitbreakingtest/snapshots/econf.json
+++ b/python/tests/gold/globalcircuitbreakingtest/snapshots/econf.json
@@ -396,7 +396,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -666,7 +666,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -956,7 +956,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1226,7 +1226,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }

--- a/python/tests/gold/globalcorstest/snapshots/econf.json
+++ b/python/tests/gold/globalcorstest/snapshots/econf.json
@@ -492,7 +492,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -912,7 +912,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1352,7 +1352,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1772,7 +1772,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }

--- a/python/tests/gold/gzipminimumconfigtest/snapshots/econf.json
+++ b/python/tests/gold/gzipminimumconfigtest/snapshots/econf.json
@@ -314,7 +314,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -556,7 +556,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -818,7 +818,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1060,7 +1060,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }

--- a/python/tests/gold/gzipnotsupportedcontenttypetest/snapshots/econf.json
+++ b/python/tests/gold/gzipnotsupportedcontenttypetest/snapshots/econf.json
@@ -316,7 +316,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -560,7 +560,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -824,7 +824,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1068,7 +1068,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }

--- a/python/tests/gold/gziptest/snapshots/econf.json
+++ b/python/tests/gold/gziptest/snapshots/econf.json
@@ -316,7 +316,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -560,7 +560,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -824,7 +824,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1068,7 +1068,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }

--- a/python/tests/gold/hostcrdcleartext/snapshots/econf.json
+++ b/python/tests/gold/hostcrdcleartext/snapshots/econf.json
@@ -301,7 +301,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -527,7 +527,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }

--- a/python/tests/gold/hostcrdclientcertcrossnamespace/snapshots/econf.json
+++ b/python/tests/gold/hostcrdclientcertcrossnamespace/snapshots/econf.json
@@ -289,7 +289,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -527,7 +527,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -764,7 +764,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1002,7 +1002,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }

--- a/python/tests/gold/hostcrdclientcertsamenamespace/snapshots/econf.json
+++ b/python/tests/gold/hostcrdclientcertsamenamespace/snapshots/econf.json
@@ -289,7 +289,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -527,7 +527,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }

--- a/python/tests/gold/hostcrddouble/snapshots/econf.json
+++ b/python/tests/gold/hostcrddouble/snapshots/econf.json
@@ -389,7 +389,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1101,7 +1101,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1386,7 +1386,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1674,7 +1674,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1948,7 +1948,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -2660,7 +2660,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -2945,7 +2945,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -3233,7 +3233,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }

--- a/python/tests/gold/hostcrdforcedstar/snapshots/econf.json
+++ b/python/tests/gold/hostcrdforcedstar/snapshots/econf.json
@@ -286,7 +286,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -684,7 +684,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -915,7 +915,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1167,7 +1167,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1565,7 +1565,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1796,7 +1796,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }

--- a/python/tests/gold/hostcrdmanualcontext/snapshots/econf.json
+++ b/python/tests/gold/hostcrdmanualcontext/snapshots/econf.json
@@ -289,7 +289,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -525,7 +525,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -762,7 +762,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -998,7 +998,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }

--- a/python/tests/gold/hostcrdno8080/snapshots/econf.json
+++ b/python/tests/gold/hostcrdno8080/snapshots/econf.json
@@ -225,7 +225,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -393,7 +393,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }

--- a/python/tests/gold/hostcrdrootredirectcongratulations/snapshots/econf.json
+++ b/python/tests/gold/hostcrdrootredirectcongratulations/snapshots/econf.json
@@ -221,7 +221,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -412,7 +412,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -608,7 +608,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -799,7 +799,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }

--- a/python/tests/gold/hostcrdrootredirectre2mapping/snapshots/econf.json
+++ b/python/tests/gold/hostcrdrootredirectre2mapping/snapshots/econf.json
@@ -299,7 +299,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -541,7 +541,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -788,7 +788,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1030,7 +1030,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }

--- a/python/tests/gold/hostcrdrootredirectslashmapping/snapshots/econf.json
+++ b/python/tests/gold/hostcrdrootredirectslashmapping/snapshots/econf.json
@@ -289,7 +289,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -521,7 +521,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -758,7 +758,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -990,7 +990,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }

--- a/python/tests/gold/hostcrdseparatetlscontext/snapshots/econf.json
+++ b/python/tests/gold/hostcrdseparatetlscontext/snapshots/econf.json
@@ -289,7 +289,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -525,7 +525,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -762,7 +762,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -998,7 +998,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }

--- a/python/tests/gold/hostcrdsingle/snapshots/econf.json
+++ b/python/tests/gold/hostcrdsingle/snapshots/econf.json
@@ -289,7 +289,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -521,7 +521,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -758,7 +758,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -990,7 +990,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }

--- a/python/tests/gold/hostcrdtlsconfig/snapshots/econf.json
+++ b/python/tests/gold/hostcrdtlsconfig/snapshots/econf.json
@@ -289,7 +289,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -525,7 +525,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -762,7 +762,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -998,7 +998,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }

--- a/python/tests/gold/linkerdheadermapping/snapshots/econf.json
+++ b/python/tests/gold/linkerdheadermapping/snapshots/econf.json
@@ -634,7 +634,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1142,7 +1142,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1670,7 +1670,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -2178,7 +2178,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }

--- a/python/tests/gold/listeneridletimeout/snapshots/econf.json
+++ b/python/tests/gold/listeneridletimeout/snapshots/econf.json
@@ -301,7 +301,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -530,7 +530,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -779,7 +779,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1008,7 +1008,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }

--- a/python/tests/gold/logservicetest/snapshots/econf.json
+++ b/python/tests/gold/logservicetest/snapshots/econf.json
@@ -353,7 +353,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -607,7 +607,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -881,7 +881,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1135,7 +1135,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }

--- a/python/tests/gold/plain/snapshots/econf.json
+++ b/python/tests/gold/plain/snapshots/econf.json
@@ -8089,7 +8089,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -13567,7 +13567,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -19065,7 +19065,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -24543,7 +24543,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }

--- a/python/tests/gold/ratelimitv0test/snapshots/econf.json
+++ b/python/tests/gold/ratelimitv0test/snapshots/econf.json
@@ -485,7 +485,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -870,7 +870,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1275,7 +1275,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1660,7 +1660,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }

--- a/python/tests/gold/ratelimitv1test/snapshots/econf.json
+++ b/python/tests/gold/ratelimitv1test/snapshots/econf.json
@@ -381,7 +381,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -662,7 +662,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -963,7 +963,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1244,7 +1244,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }

--- a/python/tests/gold/ratelimitv1withtlstest/snapshots/econf.json
+++ b/python/tests/gold/ratelimitv1withtlstest/snapshots/econf.json
@@ -402,7 +402,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -683,7 +683,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -984,7 +984,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1265,7 +1265,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }

--- a/python/tests/gold/retrypolicytest/snapshots/econf.json
+++ b/python/tests/gold/retrypolicytest/snapshots/econf.json
@@ -382,7 +382,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -692,7 +692,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1022,7 +1022,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1332,7 +1332,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }

--- a/python/tests/gold/saferegexmapping/snapshots/econf.json
+++ b/python/tests/gold/saferegexmapping/snapshots/econf.json
@@ -346,7 +346,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -620,7 +620,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -914,7 +914,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1188,7 +1188,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }

--- a/python/tests/gold/servernametest/snapshots/econf.json
+++ b/python/tests/gold/servernametest/snapshots/econf.json
@@ -298,7 +298,7 @@
                     ]
                   },
                   "server_name": "test-server",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -524,7 +524,7 @@
                     ]
                   },
                   "server_name": "test-server",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -770,7 +770,7 @@
                     ]
                   },
                   "server_name": "test-server",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -996,7 +996,7 @@
                     ]
                   },
                   "server_name": "test-server",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }

--- a/python/tests/gold/tcpmappingtest/snapshots/econf.json
+++ b/python/tests/gold/tcpmappingtest/snapshots/econf.json
@@ -340,7 +340,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -649,7 +649,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -779,7 +779,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -927,7 +927,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -982,7 +982,7 @@
                 "name": "envoy.filters.network.tcp_proxy",
                 "typed_config": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                  "stat_prefix": "ingress_tcp_6789",
+                  "stat_prefix": "ingress_tls_6789",
                   "weighted_clusters": {
                     "clusters": [
                       {
@@ -1025,7 +1025,7 @@
                 "name": "envoy.filters.network.tcp_proxy",
                 "typed_config": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                  "stat_prefix": "ingress_tcp_6789",
+                  "stat_prefix": "ingress_tls_6789",
                   "weighted_clusters": {
                     "clusters": [
                       {
@@ -1068,7 +1068,7 @@
                 "name": "envoy.filters.network.tcp_proxy",
                 "typed_config": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                  "stat_prefix": "ingress_tcp_6789",
+                  "stat_prefix": "ingress_tls_6789",
                   "weighted_clusters": {
                     "clusters": [
                       {

--- a/python/tests/gold/tracingexternalauthtest/snapshots/econf.json
+++ b/python/tests/gold/tracingexternalauthtest/snapshots/econf.json
@@ -449,7 +449,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "tracing": {},
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
@@ -773,7 +773,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "tracing": {},
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
@@ -1117,7 +1117,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "tracing": {},
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
@@ -1441,7 +1441,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "tracing": {},
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0

--- a/python/tests/gold/tracingtest/snapshots/econf.json
+++ b/python/tests/gold/tracingtest/snapshots/econf.json
@@ -330,7 +330,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "tracing": {
                     "custom_tags": [
                       {
@@ -571,7 +571,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "tracing": {
                     "custom_tags": [
                       {
@@ -832,7 +832,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "tracing": {
                     "custom_tags": [
                       {
@@ -1073,7 +1073,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "tracing": {
                     "custom_tags": [
                       {

--- a/python/tests/gold/tracingtestsampling/snapshots/econf.json
+++ b/python/tests/gold/tracingtestsampling/snapshots/econf.json
@@ -330,7 +330,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "tracing": {
                     "overall_sampling": {
                       "value": 10
@@ -566,7 +566,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "tracing": {
                     "overall_sampling": {
                       "value": 10
@@ -822,7 +822,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "tracing": {
                     "overall_sampling": {
                       "value": 10
@@ -1058,7 +1058,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "tracing": {
                     "overall_sampling": {
                       "value": 10

--- a/python/tests/gold/tracingtestshorttraceid/snapshots/econf.json
+++ b/python/tests/gold/tracingtestshorttraceid/snapshots/econf.json
@@ -330,7 +330,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "tracing": {},
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
@@ -562,7 +562,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "tracing": {},
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
@@ -814,7 +814,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "tracing": {},
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
@@ -1046,7 +1046,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "tracing": {},
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0

--- a/python/tests/gold/tracingtestzipkinv2/snapshots/econf.json
+++ b/python/tests/gold/tracingtestzipkinv2/snapshots/econf.json
@@ -330,7 +330,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "tracing": {},
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
@@ -562,7 +562,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "tracing": {},
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
@@ -814,7 +814,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "tracing": {},
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
@@ -1046,7 +1046,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "tracing": {},
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0

--- a/python/tests/gold/unsaferegexmapping/snapshots/econf.json
+++ b/python/tests/gold/unsaferegexmapping/snapshots/econf.json
@@ -346,7 +346,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -620,7 +620,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -914,7 +914,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }
@@ -1188,7 +1188,7 @@
                     ]
                   },
                   "server_name": "envoy",
-                  "stat_prefix": "ingress_http",
+                  "stat_prefix": "ingress_https",
                   "use_remote_address": true,
                   "xff_num_trusted_hops": 0
                 }

--- a/python/tests/test_ambassadorlistener_statsprefix.py
+++ b/python/tests/test_ambassadorlistener_statsprefix.py
@@ -1,0 +1,172 @@
+from utils import econf_compile, econf_foreach_listener, econf_foreach_listener_chain, EnvoyHCMInfo, EnvoyTCPInfo, SUPPORTED_ENVOY_VERSIONS
+
+import pytest
+import json
+
+# This manifest set is from a test setup Flynn used when testing this by hand.
+manifests = '''
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: tls-cert
+  namespace: default
+type: kubernetes.io/tls
+data:
+  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNzRENDQVpnQ0NRRFd2TnRjRzNpelZEQU5CZ2txaGtpRzl3MEJBUXNGQURBYU1SZ3dGZ1lEVlFRRERBOWgKYldKaGMzTmhaRzl5TFdObGNuUXdIaGNOTWpFd056QTRNakF5T0RNd1doY05Nakl3TnpBNE1qQXlPRE13V2pBYQpNUmd3RmdZRFZRUUREQTloYldKaGMzTmhaRzl5TFdObGNuUXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQ1pVbXhqT1lrTWlKRm0yZSttZDlMelNwd0oxSWlic1lUWHp5a1NiMExZYlNqcG5jMGoKV0dWMEppOXdlU3FSSFFPMHM4NUZreENzT2s1K2ZCWDFJOTYra1Z2V3NyeWgwcDlsdjI3ZUpHZFp1Q1ZsSmR3cApuYnBaWFF6R3JjWVVaeTA2WEVWOGxkaFdOSVhMazc1bmxsWmE5M2xjajRXRzNTRHpzT2MrdEtWaEtNaG9QSkVaClVGbXNxZ080dm8yZkJxYk0zNXhBT3lFSHhodXgvVlNLeVIxbHN0S0dsd25icGliZDc2UUZCdWYwbHN2bEJRTFAKV2xiRW8zZzI0NWxMNFhMWjg2UURoaTJseTdSNFN5em4yZ2E2TjZYQWNxMjFYTzNQUzhPaFp6d2J1cGpEMHRadApxL0JjY01kTElXbm9zVmlpc0FVdElLUHpCbjVkNFhBaGRtVnhBZ01CQUFFd0RRWUpLb1pJaHZjTkFRRUxCUUFECmdnRUJBSmFONUVxcTlqMi9IVnJWWk9wT3BuWVRSZlU0OU1pNDlvbkF1ZjlmQk9tR3dlMHBWSmpqTVlyQW9kZ1IKYWVyUHVWUlBEWGRzZXczejJkMjliRzBMVTJTdEpBMEY0Z05vWTY0bGVZUTN0RjFDUmxsczdKaWVWelN1RVVyUwpLZjZiaWJ0aUlLSU4waEdTV3R2YU04ZXhqb2Y3ZGUyeWFLNEVPeE1pQmJyZkFPNnJ6MXgzc1ovOENGTnp3OXNRClhCNWpZSWhNZWhsb2xhR0U5RGNydUdrbStFQ3ZCNjZkajFNcm5UamVJcWc4QnN4Wm5WYlZ4cDlUZTJRZ2hyTmkKckVySndjV1NSU3lUZzBEZXdUektYQUx2aW5iRTliZ3pNdFhNSEhkUmZQYUMvWmFCTUd1QXExeWJTOUV3M2MvWgo1dk00aFdOaHU5MS9DSmN5UVJHdlJRWXFiZTA9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+  tls.key: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb3dJQkFBS0NBUUVBbVZKc1l6bUpESWlSWnRudnBuZlM4MHFjQ2RTSW03R0UxODhwRW05QzJHMG82WjNOCkkxaGxkQ1l2Y0hrcWtSMER0TFBPUlpNUXJEcE9mbndWOVNQZXZwRmIxcks4b2RLZlpiOXUzaVJuV2JnbFpTWGMKS1oyNldWME14cTNHRkdjdE9seEZmSlhZVmpTRnk1TytaNVpXV3ZkNVhJK0ZodDBnODdEblByU2xZU2pJYUR5UgpHVkJacktvRHVMNk5ud2Ftek4rY1FEc2hCOFlic2YxVWlza2RaYkxTaHBjSjI2WW0zZStrQlFibjlKYkw1UVVDCnoxcFd4S040TnVPWlMrRnkyZk9rQTRZdHBjdTBlRXNzNTlvR3VqZWx3SEt0dFZ6dHowdkRvV2M4RzdxWXc5TFcKYmF2d1hIREhTeUZwNkxGWW9yQUZMU0NqOHdaK1hlRndJWFpsY1FJREFRQUJBb0lCQUdlaVNOVUE3TnZsNjdKRAptVE5DUnZwZjhmekxCZE9IT0MzUFB3blEzclAvaE9uejJkY01SdmN0WUY5NzV3UFRRcy8vd1d0UnJyRmJiL2NhCjFKU3dQRDAvYjM0OXJqY0xjT2FMY05zQ2JFRStzVGdmVVNOb0U2K1hyNjBUaEpJQjg1WkJERTdiMGpEaXE1VWgKTmxBNlZBQ0V5aW1BY1ZicFhQNmJFcE5WODNzcDFBUEUrc2xpUWVrMHBWK2VJcFNuWGNkMWRNbjdhcHNuYmR3MgpBbDErRDBiTkJweUNSd1dCMm81dmh0ZzIrcndaQUNOdTFQdmJGc0g5bURGUit2elJBT1oycFRDMzRwWDBhcktECnUyMGFMTU1PT2NETWN0bWp2OHJrcVJVRWt6aTNuV0ljWVVVYXFKVG1Ub2RLZlRobXhsbGx5aDg5UVAzUG8raEwKYWk0b0VJa0NnWUVBeUcvQ2xaa3g4WHF3M0NrZXJrZlZoTm83OHIxWFVFRFE3U3dMUUllaHo1Ri9iRU9WRS8yUgpJeGFZQkx2alMwRkRzY0s3TkpPeU9kTVBpU1VNcHdMSC9kNnNrWjA2QWRTVllPbUJpNUFCMUJNZXk1b0cvSmtXClpzSm42Q3g5aEJUZTVzQnRCUWQ1K1phUXU4aDBhUFcwcFh3b1h5aW1JejNpZ3Vxdk1Dc3plNU1DZ1lFQXc5TWQKY2ZmK1FhbmxqMnVpcmcxbnljMFVkN1h6ekFZRXVMUERPdHltcm1SSU9BNGl4c3JzMzRmbVE4STc4cXpDMnhmNQpEdlJPNTNzMW9XSHNzbXdxcmgzQ0RVaDF2UEVEcHVqR3dLd2E4bE1yQ2piWDhtYk1ibVNyelBuczVWeVhXaEhFCkN3VHNPV3RleUZ3OVFkZTR1K011SEYzSHB0SHFvZlRFTGZJRXBXc0NnWUVBdVBPM3dFZGVlSTlZUjYrQjZodkwKQVE1SHB4UGtUOStmYWxyci94Mm95RnBnRkV6QWNYUFh5Mkw3MzlKb1NIYnV1a2NRYTlHbDhnbTZHamtmMWJTUgpTc2VBd2RVdFE2Y2dPQThBUlFJYlRkQmU2RTAzQ1R0U0dueGxXUzVFbSs2T1NLdGpiZkthTVI4b2FyN3IvRFpOCi9TMzJLdWpkZFVPVGttNXdQYWgvbHhVQ2dZQmh3N0dNcDZJQmlGKzZaYU5YUUF3VC9OWCtHaEg0UnZ6dWRaaS8KZDArait4N3ZGV2VaVmRCQ25PZUI1cVBsT1Frak51bTU1SkRNRW9BbzdPbXQva0Nrb3VpeGx2NW84TzdBMHEvLwpteXpzMUViRmw3SGlMQjVkOHRhdXhBdllTb3lwZy9zYkFUOHFQNGVYZ2kxM0JNc095cEhIeWE0V2cvQ2ZJTU1jCnFScFd0d0tCZ0hYRjVSWUo4alpLTnE2bHI5TVZhZFRXdkpRZ01VbHR0UWlaM3ZrMmc0S09Kc1NWdWtEbjFpZysKQ0NKZUU2VS9OS0N3ejJSMXBjSWVET3dwek9IYzJWNkt4Z0RYZUYyVWsvMjMydlB3aXRjVExhS2hsTTlDOGNLcwp6RGlJcVFkZDRLdFhDajc4S040TlhHZ1hJdVdXOHZERFY4Q05wQm45eUlUUXFST3NRSHRrCi0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg==
+---
+apiVersion: x.getambassador.io/v3alpha1
+kind: AmbassadorListener
+metadata:
+  name: ambassador-https-listener
+  namespace: default
+spec:
+  port: 8443
+  protocol: HTTPS
+  securityModel: XFP
+  hostBinding:
+    namespace:
+      from: ALL
+---
+apiVersion: x.getambassador.io/v3alpha1
+kind: AmbassadorListener
+metadata:
+  name: ambassador-http-listener
+  namespace: default
+spec:
+  port: 8080
+  protocol: HTTP
+  securityModel: XFP
+  hostBinding:
+    namespace:
+      from: ALL
+---
+apiVersion: x.getambassador.io/v3alpha1
+kind: AmbassadorListener
+metadata:
+  name: ambassador-alternate-listener
+  namespace: default
+spec:
+  port: 8888
+  protocol: HTTPS
+  securityModel: XFP
+  statsPrefix: alternate
+  hostBinding:
+    namespace:
+      from: ALL
+---
+apiVersion: x.getambassador.io/v3alpha1
+kind: AmbassadorListener
+metadata:
+  name: ambassador-tls-listener
+  namespace: default
+spec:
+  port: 9999
+  protocol: TLS
+  securityModel: SECURE
+  hostBinding:
+    namespace:
+      from: ALL
+---
+apiVersion: x.getambassador.io/v3alpha1
+kind: AmbassadorMapping
+metadata:
+  name: quote-backend
+  namespace: default
+spec:
+  prefix: /backend/
+  service: quote
+  hostname: '*'
+---
+apiVersion: x.getambassador.io/v3alpha1
+kind: AmbassadorTCPMapping
+metadata:
+  name: tls-backend
+  namespace: default
+spec:
+  port: 9999
+  service: quote
+---
+apiVersion: x.getambassador.io/v3alpha1
+kind: AmbassadorTCPMapping
+metadata:
+  name: tcp-backend
+  namespace: default
+spec:
+  port: 9998
+  service: quote
+---
+apiVersion: x.getambassador.io/v3alpha1
+kind: AmbassadorMapping
+metadata:
+  name: quote-backend
+  namespace: default
+spec:
+  prefix: /backend/
+  service: quote
+  hostname: '*'
+---
+apiVersion: x.getambassador.io/v3alpha1
+kind: AmbassadorHost
+metadata:
+  name: wildcard-host
+  namespace: default
+spec:
+  hostname: "*"
+  acmeProvider:
+    authority: none
+  tlsSecret:
+    name: tls-cert
+'''
+
+
+def check_filter(abbrev, typed_config, expected_stat_prefix):
+    stat_prefix = typed_config.get("stat_prefix", "UNKNOWN")
+
+    print(f"------ {abbrev}, stat_prefix {stat_prefix}")
+
+    assert stat_prefix == expected_stat_prefix, f"wanted stat_prefix {expected_stat_prefix}, got {stat_prefix}"
+
+def check_listener(listener, envoy_version):
+    port = listener["address"]["socket_address"]["port_value"]
+
+    got_count = len(listener["filter_chains"])
+    got_plural = "" if (got_count == 1) else "s"
+
+    print(f"---- Listener @ {port}, {got_count} chain{got_plural}:")
+
+    # In this test, we can derive chain counts, protocols, and expected stat_prefix from 
+    # the port number. Ports 8443 and 8888 do HTTP and HTTPS, so they need two chains.
+    # Ports < 9000 use HTTP, not TCP. 
+
+    check_info = {
+        8080: ( "HCM", 1, EnvoyHCMInfo, "ingress_http" ),
+        8443: ( "HCM", 2, EnvoyHCMInfo, "ingress_https" ),
+        8888: ( "HCM", 2, EnvoyHCMInfo, "alternate" ),
+        9998: ( "TCP", 1, EnvoyTCPInfo, "ingress_tcp_9998" ),
+        9999: ( "TCP", 1, EnvoyTCPInfo, "ingress_tls_9999" )
+    }
+
+    abbrev, chain_count, filter_info, expected_stat_prefix = check_info[port]
+
+    # Here's wishing Python had really good anonymous functions...
+    def checker(typed_config):
+        return check_filter(abbrev, typed_config, expected_stat_prefix)
+
+    econf_foreach_listener_chain(
+        listener, checker, chain_count=chain_count,
+        need_name=filter_info[envoy_version].name, 
+        need_type=filter_info[envoy_version].type)
+
+@pytest.mark.compilertest
+def test_ambassadorlistener_stats_prefix():
+    # For each Envoy version we support...
+    for v in SUPPORTED_ENVOY_VERSIONS:
+        print(f"\n-- Envoy {v}:")
+
+        # ...compile an Envoy config...
+        econf = econf_compile(manifests, envoy_version=v)
+
+        # ...and make sure everything looks good.
+        econf_foreach_listener(econf, check_listener, envoy_version=v, listener_count=5)


### PR DESCRIPTION
`AmbassadorListener.spec.statsPrefix` determines the stats prefix for a	given AmbassadorListener.
If not present,	the default depends on the protocol configured for a given AmbassadorListener:

- If HTTPS is configured, use `ingress_https`;
- Otherwise, if	HTTP is configured, use	`ingress_http`;
- Otherwise, if	TLS is configured, use `ingress_tls_$port`;
- Otherwise, use `ingress_tcp_$port`.

 - [x] I made sure to update `CHANGELOG.md`.
 - [x] This is unlikely to impact how Ambassador performs at scale.
 - [x] My change is adequately tested.
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
