### PR TITLE
Create a timeout field for docs endpoint

### DIFF
--- a/charts/ambassador/crds/getambassador.io_devportals.yaml
+++ b/charts/ambassador/crds/getambassador.io_devportals.yaml
@@ -63,6 +63,9 @@ spec:
                   service:
                     description: Service is the service being documented
                     type: string
+                  timeout_ms:
+                    description: Timeout speifies the amount of time devportal will wait for the downstream service to report an openapi spec back
+                    type: integer
                   url:
                     description: URL is the URL used for obtaining docs
                     type: string

--- a/charts/ambassador/crds/getambassador.io_devportals.yaml
+++ b/charts/ambassador/crds/getambassador.io_devportals.yaml
@@ -64,7 +64,7 @@ spec:
                     description: Service is the service being documented
                     type: string
                   timeout_ms:
-                    description: Timeout speifies the amount of time devportal will wait for the downstream service to report an openapi spec back
+                    description: Timeout specifies the amount of time devportal will wait for the downstream service to report an openapi spec back
                     type: integer
                   url:
                     description: URL is the URL used for obtaining docs

--- a/charts/ambassador/crds/getambassador.io_mappings.yaml
+++ b/charts/ambassador/crds/getambassador.io_mappings.yaml
@@ -164,6 +164,8 @@ spec:
                   type: boolean
                 path:
                   type: string
+                timeout_ms:
+                  type: integer
                 url:
                   type: string
               type: object

--- a/docs/yaml/ambassador/ambassador-crds.yaml
+++ b/docs/yaml/ambassador/ambassador-crds.yaml
@@ -232,7 +232,7 @@ spec:
                     description: Service is the service being documented
                     type: string
                   timeout_ms:
-                    description: Timeout speifies the amount of time devportal will wait for the downstream service to report an openapi spec back
+                    description: Timeout specifies the amount of time devportal will wait for the downstream service to report an openapi spec back
                     type: integer
                   url:
                     description: URL is the URL used for obtaining docs

--- a/docs/yaml/ambassador/ambassador-crds.yaml
+++ b/docs/yaml/ambassador/ambassador-crds.yaml
@@ -231,6 +231,9 @@ spec:
                   service:
                     description: Service is the service being documented
                     type: string
+                  timeout_ms:
+                    description: Timeout speifies the amount of time devportal will wait for the downstream service to report an openapi spec back
+                    type: integer
                   url:
                     description: URL is the URL used for obtaining docs
                     type: string
@@ -868,6 +871,8 @@ spec:
                   type: boolean
                 path:
                   type: string
+                timeout_ms:
+                  type: integer
                 url:
                   type: string
               type: object

--- a/docs/yaml/ambassador/ambassador-rbac-prometheus.yaml
+++ b/docs/yaml/ambassador/ambassador-rbac-prometheus.yaml
@@ -296,7 +296,7 @@ spec:
                     description: Service is the service being documented
                     type: string
                   timeout_ms:
-                    description: Timeout speifies the amount of time devportal will wait for the downstream service to report an openapi spec back
+                    description: Timeout specifies the amount of time devportal will wait for the downstream service to report an openapi spec back
                     type: integer
                   url:
                     description: URL is the URL used for obtaining docs

--- a/docs/yaml/ambassador/ambassador-rbac-prometheus.yaml
+++ b/docs/yaml/ambassador/ambassador-rbac-prometheus.yaml
@@ -295,6 +295,9 @@ spec:
                   service:
                     description: Service is the service being documented
                     type: string
+                  timeout_ms:
+                    description: Timeout speifies the amount of time devportal will wait for the downstream service to report an openapi spec back
+                    type: integer
                   url:
                     description: URL is the URL used for obtaining docs
                     type: string
@@ -932,6 +935,8 @@ spec:
                   type: boolean
                 path:
                   type: string
+                timeout_ms:
+                  type: integer
                 url:
                   type: string
               type: object

--- a/manifests/ambassador/ambassador-crds.yaml
+++ b/manifests/ambassador/ambassador-crds.yaml
@@ -232,7 +232,7 @@ spec:
                     description: Service is the service being documented
                     type: string
                   timeout_ms:
-                    description: Timeout speifies the amount of time devportal will wait for the downstream service to report an openapi spec back
+                    description: Timeout specifies the amount of time devportal will wait for the downstream service to report an openapi spec back
                     type: integer
                   url:
                     description: URL is the URL used for obtaining docs

--- a/manifests/ambassador/ambassador-crds.yaml
+++ b/manifests/ambassador/ambassador-crds.yaml
@@ -231,6 +231,9 @@ spec:
                   service:
                     description: Service is the service being documented
                     type: string
+                  timeout_ms:
+                    description: Timeout speifies the amount of time devportal will wait for the downstream service to report an openapi spec back
+                    type: integer
                   url:
                     description: URL is the URL used for obtaining docs
                     type: string
@@ -868,6 +871,8 @@ spec:
                   type: boolean
                 path:
                   type: string
+                timeout_ms:
+                  type: integer
                 url:
                   type: string
               type: object

--- a/pkg/api/getambassador.io/v2/devportal_types.go
+++ b/pkg/api/getambassador.io/v2/devportal_types.go
@@ -54,6 +54,10 @@ type DevPortalDocsSpec struct {
 
 	// URL is the URL used for obtaining docs
 	URL string `json:"url,omitempty"`
+
+	// Timeout speifies the amount of time devportal will wait
+	// for the downstream service to report an openapi spec back
+	Timeout int `json:"timeout_ms,omitempty"`
 }
 
 // DevPortalSearchSpec allows configuration over search functionality for the DevPortal

--- a/pkg/api/getambassador.io/v2/devportal_types.go
+++ b/pkg/api/getambassador.io/v2/devportal_types.go
@@ -55,7 +55,7 @@ type DevPortalDocsSpec struct {
 	// URL is the URL used for obtaining docs
 	URL string `json:"url,omitempty"`
 
-	// Timeout speifies the amount of time devportal will wait
+	// Timeout specifies the amount of time devportal will wait
 	// for the downstream service to report an openapi spec back
 	Timeout int `json:"timeout_ms,omitempty"`
 }

--- a/pkg/api/getambassador.io/v2/mapping_types.go
+++ b/pkg/api/getambassador.io/v2/mapping_types.go
@@ -135,6 +135,7 @@ type DocsInfo struct {
 	URL         string `json:"url,omitempty"`
 	Ignored     *bool  `json:"ignored,omitempty"`
 	DisplayName string `json:"display_name,omitempty"`
+	Timeout     int    `json:"timeout_ms,omitempty"`
 }
 
 // These are separate types partly because it makes it easier to think about

--- a/python/tests/test_irmapping.py
+++ b/python/tests/test_irmapping.py
@@ -1,0 +1,57 @@
+import copy
+import logging
+import sys
+
+import pytest
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s test %(levelname)s: %(message)s",
+    datefmt='%Y-%m-%d %H:%M:%S'
+)
+
+logger = logging.getLogger("ambassador")
+
+from ambassador import Config, IR
+from ambassador.fetch import ResourceFetcher
+from ambassador.utils import NullSecretHandler
+
+def _get_ir_config(yaml):
+    aconf = Config()
+    fetcher = ResourceFetcher(logger, aconf)
+    fetcher.parse_yaml(yaml)
+    aconf.load_all(fetcher.sorted())
+
+    secret_handler = NullSecretHandler(logger, None, None, "0")
+    ir = IR(aconf, file_checker=lambda path: True, secret_handler=secret_handler)
+
+    assert ir
+    return ir
+
+
+@pytest.mark.compilertest
+def test_ir_mapping():
+    yaml = """
+apiVersion: getambassador.io/v2
+kind: Mapping
+name: slowsvc-slow
+namespace: ambassador
+prefix: /slow/
+service: slowsvc
+timeout_ms: 1000
+docs:
+  path: /endpoint
+  display_name: "slow service"
+  timeout_ms: 8000
+"""
+
+    conf = _get_ir_config(yaml)
+    all_mappings = []
+    for i in conf.groups.values():
+        all_mappings = all_mappings + i.mappings
+
+    slowsvc_mappings = [x for x in all_mappings if x['name'] == 'slowsvc-slow']
+    assert(len(slowsvc_mappings) == 1)
+    print(slowsvc_mappings[0].as_dict())
+    assert(slowsvc_mappings[0].docs['timeout_ms'] == 8000)
+


### PR DESCRIPTION
## Description
Adds a new field to the mapping CRD allowing the user to configure a timeout for a service's documentation endpoints.
This PR contains the additional schema field as well as a config generation unit test.

## Related Issues
This PR correlates to upcoming changes to apro to fix issue #2722

## Testing
- The complete change across emissary and apro was manually tested with a [slow to respond service](https://github.com/aidanhahn/slowsvc)
- Unit tests were added in this PR for config generation

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `CHANGELOG.md`.
   (This change does not seem to warrant a CHANGELOG.md update)
   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations
 
 - [x] This is unlikely to impact how Ambassador performs at scale.
 
   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability
 
 - [x] My change is adequately tested.
 
   Remember when considering testing:
    + LEGACY MODE TESTS DO NOT RUN FOR EVERY PR. If your change is affected by legacy mode, you need
      to run legacy-mode tests manually (set `AMBASSADOR_LEGACY_MODE=true` and run the tests).
      (This will be fixed soon.)
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points
 
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
