### PR TITLE
[1.13.10] Exclude hotfix tags when looking at versions

### DIFF
--- a/builder/builder.sh
+++ b/builder/builder.sh
@@ -315,8 +315,8 @@ module_version() {
         dirty=""
     fi
     # The _previous_ tag, plus a git delta, like 'v1.13.3-117-g2434c437f'... or, if we're _on_
-    # a tag, just something like 'v1.13.3'.
-    GIT_DESCRIPTION=$(git describe --tags --match 'v*')
+    # a tag, just something like 'v1.13.3'. Don't let hotfix tags appear here.
+    GIT_DESCRIPTION=$(git describe --tags --match 'v*' --exclude '*-hf.*')
     echo GIT_DESCRIPTION="\"$GIT_DESCRIPTION\""
 
     # Do we have a '-' in our GIT_DESCRIPTION?


### PR DESCRIPTION
Exclude `-hf.*` tags when using `git describe` to figure out our version number.