### PR TITLE
[1.13.10] Allow disabling Ambex ratelimiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,10 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 - Change: Envoy-configuration snapshots get saved (as ambex-#.json) in /ambassador/snapshots. The number of snapshots is
   controlled by the `AMBASSADOR_AMBEX_SNAPSHOT_COUNT` environment variable; set it to 0 to disable. The default is 30.
+- Change: Set `AMBASSADOR_AMBEX_NO_RATELIMIT` to `true` to completely disable ratelimiting Envoy
+  reconfiguration under memory pressure. This can help performance with the endpoint or Consul resolvers,
+  but could make OOMkills more likely with large configurations. The default is `false`, meaning that
+  the rate limiter is active.
 - Bugfix: Fixed a regression when specifying a comma separated string for `cors.origins` on the `Mapping` resource
 
 ### Ambassador Edge Stack

--- a/cmd/ambex/main.go
+++ b/cmd/ambex/main.go
@@ -715,6 +715,8 @@ func (l loggerv3) OnFetchResponse(req *v3discovery.DiscoveryRequest, res *v3disc
 	l.Debugf("V3 Fetch response: %v -> %v", req, res)
 }
 
+// NOTE WELL: this Main() does NOT RUN from entrypoint! This one is only relevant if you
+// explicitly run Ambex by hand.
 func Main(ctx context.Context, Version string, rawArgs ...string) error {
 	usage := memory.GetMemoryUsage()
 	go usage.Watch(ctx)

--- a/cmd/ambex/ratelimit.go
+++ b/cmd/ambex/ratelimit.go
@@ -6,7 +6,8 @@ import (
 	"strconv"
 	"time"
 
-	_debug "github.com/datawire/ambassador/pkg/debug"
+	"github.com/datawire/ambassador/pkg/debug"
+	"github.com/datawire/dlib/dlog"
 )
 
 // An Update encapsulates everything needed to perform an update (of envoy configuration). The
@@ -32,17 +33,29 @@ func Updater(ctx context.Context, updates <-chan Update, getUsage MemoryGetter) 
 }
 
 type debugInfo struct {
-	Times      []time.Time `json:"times"`
-	StaleCount int         `json:"staleCount"`
-	StaleMax   int         `json:"staleMax"`
-	Synced     bool        `json:"synced"`
+	Times              []time.Time `json:"times"`
+	StaleCount         int         `json:"staleCount"`
+	StaleMax           int         `json:"staleMax"`
+	Synced             bool        `json:"synced"`
+	DisableRatelimiter bool        `json:"disableRatelimiter"`
 }
 
 func updaterWithTicker(ctx context.Context, updates <-chan Update, getUsage MemoryGetter,
 	drainTime time.Duration, ticker *time.Ticker, clock func() time.Time) error {
 
-	dbg := _debug.FromContext(ctx)
+	dbg := debug.FromContext(ctx)
 	info := dbg.Value("envoyReconfigs")
+
+	// Is the rate-limiter meant to be active at all?
+	disableRatelimiter, err := strconv.ParseBool(os.Getenv("AMBASSADOR_AMBEX_NO_RATELIMIT"))
+
+	if err != nil {
+		disableRatelimiter = false
+	}
+
+	if disableRatelimiter {
+		dlog.Info(ctx, "snapshot ratelimiter DISABLED")
+	}
 
 	// This slice holds the times of any updates we have made. This lets us compute how many stale
 	// configs are being held in memory since we can filter this list down to just those times that
@@ -57,7 +70,7 @@ func updaterWithTicker(ctx context.Context, updates <-chan Update, getUsage Memo
 	for {
 		// The basic idea here is that we wakeup whenever we either a) get a new snapshot to update,
 		// or b) the timer ticks. In case a) we update the "latest" variable so that it always holds
-		// the most recent desired Ufpdate. In either case, we filter the list of updateTimes so we
+		// the most recent desired Update. In either case, we filter the list of updateTimes so we
 		// know exactly how many updates are in memory, and then based on that we decide whether we
 		// can do another reconfig or whether we should wait until the next (tick|update) whichever
 		// happens first.
@@ -83,6 +96,11 @@ func updaterWithTicker(ctx context.Context, updates <-chan Update, getUsage Memo
 		updateTimes = gcUpdateTimes(updateTimes, now, drainTime)
 
 		usagePercent := getUsage()
+
+		if disableRatelimiter {
+			usagePercent = 0
+		}
+
 		var maxStaleReconfigs int
 		switch {
 		case usagePercent >= 90:
@@ -114,7 +132,7 @@ func updaterWithTicker(ctx context.Context, updates <-chan Update, getUsage Memo
 
 		staleReconfigs := len(updateTimes)
 
-		info.Store(debugInfo{updateTimes, staleReconfigs, maxStaleReconfigs, pushed})
+		info.Store(debugInfo{updateTimes, staleReconfigs, maxStaleReconfigs, pushed, disableRatelimiter})
 
 		// Decide if we have enough capacity left to perform a reconfig.
 		if maxStaleReconfigs > 0 && staleReconfigs >= maxStaleReconfigs {
@@ -141,7 +159,7 @@ func updaterWithTicker(ctx context.Context, updates <-chan Update, getUsage Memo
 		log.Infof("Pushing snapshot %+v", latest.Version)
 		pushed = true
 
-		info.Store(debugInfo{updateTimes, staleReconfigs, maxStaleReconfigs, pushed})
+		info.Store(debugInfo{updateTimes, staleReconfigs, maxStaleReconfigs, pushed, disableRatelimiter})
 	}
 }
 


### PR DESCRIPTION
Completely disable the `ambex` ratelimiter when `AMBASSADOR_AMBEX_NO_RATELIMIT` is set to `true`
(or anything else that `strconv.ParseBool` will consider true). Now that configuration uses CDS,
RDS, and EDS rather than just LDS, this should generally mostly be safe, and can potentially be
a significant help for installations using the `KubernetesEndpointResolver` or the
`ConsulResolver` -- though, of course, it will make OOMKills more likely.

## Testing

I tested this by hand, by modifying `entrypoint/main.go` to supply `func () int { return 95 }` as
the memory-usage getter to the `ambex` goroutine, then applying and deleting a dummy `Mapping`.
With `AMBASSADOR_AMBEX_NO_RATELIMIT`, reconfiguration is snappy; without it, at 95% simulated
memory usage, reconfiguration is basically glacial.

Unit test to follow, after I think a bit more about what - if anything - I want to clean up here.
This is immediately going into a hotfix, though.

## Checklist

 - [x] I made sure to update `CHANGELOG.md`.
 - [x] This is *very likely* to impact how Ambassador performs at scale, but that's the point,
       and that's why I'm not changing defaults (yet).
 - [x] My change is adequately tested.
 - [ ] I'm not sure that the way I tested this warrants a note in `DEVELOPING.md`...
