### PR TITLE
[wip] plain envoy config on startup

### DIFF
--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -338,6 +338,9 @@ push: docker/kat-client.docker.push.remote
 push: docker/kat-server.docker.push.remote
 .PHONY: push
 
+push-em: docker/$(LCNAME).docker.push.remote
+.PHONY: push-em
+
 push-dev: docker/$(LCNAME).docker.tag.local docker/$(LCNAME)-ea.docker.tag.local
 	@set -e; { \
 		if [ -n "$(IS_DIRTY)" ]; then \

--- a/cmd/entrypoint/demomode.go
+++ b/cmd/entrypoint/demomode.go
@@ -42,7 +42,7 @@ func bootDemoMode(ctx context.Context, group *dgroup.Group, ambwatch *acp.Ambass
 					// a snapshot, so that it'll actually take Ambassador to ready status.
 					ambwatch.NoteSnapshotSent()
 					time.Sleep(5 * time.Millisecond)
-					ambwatch.NoteSnapshotProcessed()
+					ambwatch.NoteSnapshotProcessed(true)
 					break
 				}
 			}

--- a/cmd/entrypoint/fake.go
+++ b/cmd/entrypoint/fake.go
@@ -232,7 +232,7 @@ type SnapshotEntry struct {
 func (f *Fake) notifySnapshot(ctx context.Context, disp SnapshotDisposition, snapJSON []byte) {
 	if disp == SnapshotReady {
 		if f.config.EnvoyConfig {
-			notifyReconfigWebhooksFunc(ctx, &noopNotable{}, false)
+			notifyReconfigWebhooksFunc(ctx, &noopNotable{}, false, true)
 			f.appendEnvoyConfig()
 		}
 	}

--- a/cmd/entrypoint/notify_test.go
+++ b/cmd/entrypoint/notify_test.go
@@ -13,7 +13,8 @@ import (
 func TestNotifyWebhookUrlConnectionRefused(t *testing.T) {
 	ctx := context.Background()
 
-	assert.False(t, notifyWebhookUrl(ctx, "test", "http://localhost:5555"))
+	ok, _ := notifyWebhookUrl(ctx, "test", "http://localhost:5555")
+	assert.False(t, ok)
 }
 
 // Check that we panic if we do not get a properly formed http response of some kind such as an EOF.

--- a/pkg/acp/ambassador.go
+++ b/pkg/acp/ambassador.go
@@ -116,11 +116,11 @@ func (w *AmbassadorWatcher) NoteSnapshotSent() {
 }
 
 // NoteSnapshotProcessed will note that a snapshot has been processed.
-func (w *AmbassadorWatcher) NoteSnapshotProcessed() {
+func (w *AmbassadorWatcher) NoteSnapshotProcessed(bootstrapped bool) {
 	w.mutex.Lock()
 	defer w.mutex.Unlock()
 
-	w.dw.NoteSnapshotProcessed()
+	w.dw.NoteSnapshotProcessed(bootstrapped)
 
 	// Is this is the very first time we've processed a snapshot?
 	if w.state == envoyNotStarted {

--- a/pkg/acp/ambassador_test.go
+++ b/pkg/acp/ambassador_test.go
@@ -72,7 +72,7 @@ func TestAmbassadorHappyPath(t *testing.T) {
 
 	// Mark the snapshot processed.
 	m.stepSec(10)
-	m.aw.NoteSnapshotProcessed()
+	m.aw.NoteSnapshotProcessed(true)
 	m.check(3, 30, true, false)
 
 	// Fetch readiness.
@@ -98,7 +98,7 @@ func TestAmbassadorUnrealisticallyHappy(t *testing.T) {
 	// try it. We expect to see alive and ready here.
 	m.stepSec(10)
 	m.aw.NoteSnapshotSent()
-	m.aw.NoteSnapshotProcessed()
+	m.aw.NoteSnapshotProcessed(true)
 	m.aw.FetchEnvoyReady(context.Background())
 	m.check(2, 20, true, true)
 

--- a/pkg/acp/diagd_test.go
+++ b/pkg/acp/diagd_test.go
@@ -70,7 +70,7 @@ func TestDiagdHappyPath(t *testing.T) {
 	m.stepSec(30)
 
 	// Mark the snapshot processed. We should now be ready.
-	m.dw.NoteSnapshotProcessed()
+	m.dw.NoteSnapshotProcessed(true)
 	m.check(3, 40, true, true)
 }
 
@@ -101,7 +101,7 @@ func TestDiagdVerySlowlySent(t *testing.T) {
 	// Not very useful, but if we mark the snapshot processed, we should snap
 	// to alive and ready.
 	m.stepSec(1)
-	m.dw.NoteSnapshotProcessed()
+	m.dw.NoteSnapshotProcessed(true)
 	m.check(2, 602, true, true)
 }
 
@@ -142,7 +142,7 @@ func TestDiagdSlowlyProcessed(t *testing.T) {
 	// Mark the snapshot processed after another 10s. This should take
 	// us to alive and ready.
 	m.stepSec(10)
-	m.dw.NoteSnapshotProcessed()
+	m.dw.NoteSnapshotProcessed(true)
 	m.check(3, 20, true, true)
 
 	// Send another snapshot after 40s (to take us to an even minute).


### PR DESCRIPTION
Signed-off-by: Alix Cook <alixcook@datawire.io>

## Description

Untested change to enable plain envoy config so that ambassador can report itself as "alive"

You can manually observe what happens on startup if the ambassador config generates invalid envoy config by applying a mapping that looks something like this:
```
---
apiVersion: x.getambassador.io/v3alpha1
kind: AmbassadorMapping
metadata:
  name: quote-backend
  namespace: ambassador
spec:
  hostname: "*"
  prefix: /backend/
  service: quote
  retry_policy:
    retry_on: 5xx
    per_try_timeout: 5ms
```

The basic idea is that if, on startup, the envoy config is invalid, the ambassador pod will remain "up" (i.e. it's liveness probes succeed so it won't get killed by the kubelet), but will not report "ready" until it can a generate a valid envoy config from the ambassador configuration.

## Related Issues
#3768

## Checklist

 - [ ] I made sure to update `CHANGELOG.md`.
 - [x] This is unlikely to impact how Ambassador performs at scale.
 - [ ] My change is adequately tested.
 - [x] I didn't need to update `DEVELOPING.md`.