### PR TITLE
Lookup API docs using mapping.Spec.Hostname

### DIFF
--- a/pkg/agent/api_docs.go
+++ b/pkg/agent/api_docs.go
@@ -124,7 +124,11 @@ func (a *APIDocsStore) scrape(ctx context.Context, mappings []*v3alpha1.Ambassad
 		}
 		mappingHeaders := buildMappingRequestHeaders(mapping.Spec.Headers)
 		mappingPrefix := mapping.Spec.Prefix
-		mappingHost := mapping.Spec.Host
+		// Lookup the Hostname first since it is more restrictive, otherwise fallback on the Host attribute
+		mappingHostname := mapping.Spec.Hostname
+		if mappingHostname == "" || mappingHostname == "*" {
+			mappingHostname = mapping.Spec.Host
+		}
 
 		dm := &docMappingRef{
 			Ref: &kates.ObjectReference{
@@ -147,7 +151,7 @@ func (a *APIDocsStore) scrape(ctx context.Context, mappings []*v3alpha1.Ambassad
 				continue
 			}
 			dlog.Debugf(ctx, "'url' specified: querying %s", parsedURL)
-			doc = a.getDoc(ctx, parsedURL, "", mappingHeaders, mappingHost, "", false)
+			doc = a.getDoc(ctx, parsedURL, "", mappingHeaders, mappingHostname, "", false)
 		} else {
 			mappingsDocsURL, err := extractQueryableDocsURL(mapping)
 			if err != nil {
@@ -155,7 +159,7 @@ func (a *APIDocsStore) scrape(ctx context.Context, mappings []*v3alpha1.Ambassad
 				continue
 			}
 			dlog.Debugf(ctx, "'url' specified: querying %s", mappingsDocsURL)
-			doc = a.getDoc(ctx, mappingsDocsURL, mappingHost, mappingHeaders, mappingHost, mappingPrefix, true)
+			doc = a.getDoc(ctx, mappingsDocsURL, mappingHostname, mappingHeaders, mappingHostname, mappingPrefix, true)
 		}
 
 		if doc != nil {

--- a/pkg/agent/api_docs_test.go
+++ b/pkg/agent/api_docs_test.go
@@ -114,7 +114,8 @@ func TestAPIDocsStore(t *testing.T) {
 							DisplayName: "docs-display-name",
 							Path:        "/docs-location",
 						},
-						Host: "mapping-hostname",
+						Host:     "mapping-host",
+						Hostname: "mapping-hostname",
 					},
 					ObjectMeta: kates.ObjectMeta{
 						Name:      "some-endpoint",
@@ -157,6 +158,7 @@ func TestAPIDocsStore(t *testing.T) {
 						Docs: &v3alpha1.DocsInfo{
 							URL: "https://external-url",
 						},
+						Hostname: "*",
 					},
 					ObjectMeta: kates.ObjectMeta{
 						Name:      "some-endpoint",


### PR DESCRIPTION
## Description
I was a little bit confused about the new `hostname` attribute on `AmbassadorMapping`s. Turns out, it seems preferred to lookup a service using this `hostname` since it's more restrictive than the old `Mapping.host` attribute.

## Related Issues
None.

## Testing
Unit and manual tests.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `CHANGELOG.md`.
   
   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations
 
 - [x] This is unlikely to impact how Ambassador performs at scale.
 
   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability
 
 - [x] My change is adequately tested.
 
   Remember when considering testing:
    + LEGACY MODE TESTS DO NOT RUN FOR EVERY PR. If your change is affected by legacy mode, you need
      to run legacy-mode tests manually (set `AMBASSADOR_LEGACY_MODE=true` and run the tests).
      (This will be fixed soon.)
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points
 
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
