### PR TITLE
[v1.13.10] Changelog date update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 ## RELEASE NOTES
 
-## [1.13.10] (TBD)
+## [1.13.10] July 28, 2021
 [1.13.10]: https://github.com/emissary-ingress/emissary/compare/v1.13.9...v1.13.10
 
 ### Emissary Ingress and Ambassador Edge Stack


### PR DESCRIPTION
Changelog date updates for 1.13.10

Reviewers: The only changes in this PR should be updating the changelog entry for 1.13.10 to the date it was released.

If there are any other changes, the PR creator should note the reason.