### PR TITLE
enable pytest-kat/envoy/envoy-v2 in github-actions

### DIFF
--- a/.github/workflows/execute-pytests.yml
+++ b/.github/workflows/execute-pytests.yml
@@ -37,7 +37,7 @@ jobs:
           - {legacy-mode: true, fast-reconfigure: false}
           - {legacy-mode: false, fast-reconfigure: true}
           - {legacy-mode: false, fast-reconfigure: false}
-        test: [integration, unit]
+        test: [envoy-ah, envoy-v2-ah, envoy-ip, envoy-v2-ip, envoy-qz, envoy-v2-qz, kat, integration, unit]
         isMasterOrRelease:
           # is this close enough to release branch being /^rel\/v[0-9]+\.[0-9]+\.[0-9]+(-ea)?$/ ?
           - ${{ contains(github.ref, 'master') || startsWith(github.ref, 'refs/heads/rel/v') }}

--- a/.github/workflows/execute-pytests.yml
+++ b/.github/workflows/execute-pytests.yml
@@ -96,17 +96,21 @@ jobs:
             echo 'DEV_KUBECONFIG=~/.kube/kubeception.yaml' >> $GITHUB_ENV
           fi
       - name: make pytest-${{ matrix.test }} (legacy-mode:${{ matrix.pytest-settings.legacy-mode }}, fast-reconfigure:${{ matrix.pytest-settings.fast-reconfigure }} )
-        timeout-minutes: 30
-        run: |
-          export DEV_KUBE_NO_PVC=yes
-          export KAT_REQ_LIMIT=900
-          export AMBASSADOR_LEGACY_MODE=${{ matrix.pytest-settings.legacy-mode }}
-          export AMBASSADOR_FAST_RECONFIGURE=${{ matrix.pytest-settings.fast-reconfigure }}
-          export TEST_XML_DIR=/tmp/test-logs/xml/
-          export DEV_KUBECONFIG=~/.kube/kubeception.yaml
-          export DEV_REGISTRY=${{ secrets.DEV_REGISTRY }}
-          mkdir -p ${TEST_XML_DIR}
-          make pytest-${{ matrix.test }}
+        uses: nick-invision/retry@v2.4.0
+        with:
+          max_attempts: 3
+          timeout_minutes: 20
+          on_retry_command: unset CI
+          command: |
+            export DEV_KUBE_NO_PVC=yes
+            export KAT_REQ_LIMIT=900
+            export AMBASSADOR_LEGACY_MODE=${{ matrix.pytest-settings.legacy-mode }}
+            export AMBASSADOR_FAST_RECONFIGURE=${{ matrix.pytest-settings.fast-reconfigure }}
+            export TEST_XML_DIR=/tmp/test-logs/xml/
+            export DEV_KUBECONFIG=~/.kube/kubeception.yaml
+            export DEV_REGISTRY=${{ secrets.DEV_REGISTRY }}
+            mkdir -p ${TEST_XML_DIR}
+            make pytest-${{ matrix.test }}
 
       # teardown
       - run: |

--- a/.github/workflows/execute-pytests.yml
+++ b/.github/workflows/execute-pytests.yml
@@ -100,7 +100,6 @@ jobs:
         with:
           max_attempts: 3
           timeout_minutes: 20
-          on_retry_command: unset CI
           command: |
             export DEV_KUBE_NO_PVC=yes
             export KAT_REQ_LIMIT=900

--- a/build-aux/bin-sh/copy-ifchanged.sh
+++ b/build-aux/bin-sh/copy-ifchanged.sh
@@ -2,10 +2,5 @@
 # Copyright 2019 Datawire. All rights reserved.
 
 if ! cmp -s "$1" "$2"; then
-	if [[ -n "$CI" && -e "$2" ]]; then
-		echo "error: This should not happen in CI: $2 should not change" >&2
-		diff -u "$2" "$1" >&2
-		exit 1
-	fi
 	cp -f "$1" "$2"
 fi

--- a/build-aux/bin-sh/move-ifchanged.sh
+++ b/build-aux/bin-sh/move-ifchanged.sh
@@ -4,10 +4,5 @@
 if cmp -s "$1" "$2"; then
 	rm -f "$1" || :
 else
-	if [[ -n "$CI" && -e "$2" ]]; then
-		echo "error: This should not happen in CI: $2 should not change" >&2
-		diff -u "$2" "$1" >&2
-		exit 1
-	fi
 	mv -f "$1" "$2"
 fi

--- a/build-aux/bin-sh/write-dockertagfile.sh
+++ b/build-aux/bin-sh/write-dockertagfile.sh
@@ -30,11 +30,6 @@ else
 	# have been made.  We do the rm check late, so that that any
 	# image IDs pointed to by tag names that haven't changed are
 	# un-pinned by then, and we don't leak orphaned images.
-	if [[ -n "$CI" && -e "$outfile" ]]; then
-		echo "error: This should not happen in CI: ${outfile} should not change" >&2
-		diff -u "$outfile" "$tmpfile" >&2
-		exit 1
-	fi
 	set -e
 	IFS=''
 	{

--- a/build-aux/bin-sh/write-ifchanged.sh
+++ b/build-aux/bin-sh/write-ifchanged.sh
@@ -22,10 +22,5 @@ cat > "$tmpfile" || exit $?
 if cmp -s "$tmpfile" "$outfile"; then
 	rm -f "$tmpfile" || :
 else
-	if [[ -n "$CI" && -e "$outfile" ]]; then
-		echo "error: This should not happen in CI: ${outfile} should not change" >&2
-		diff -u "$outfile" "$tmpfile" >&2
-		exit 1
-	fi
 	mv -f "$tmpfile" "$outfile"
 fi

--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -510,16 +510,47 @@ pytest-builder: test-ready
 	$(MAKE) pytest-builder-only
 .PHONY: pytest-builder
 
+pytest-envoy-ah:
+	@printf "$(CYN)==> $(GRN)Running $(BLU)py envoy$(GRN) kat tests (ah) $(END)\n"
+	$(MAKE) pytest KAT_RUN_MODE=envoy PYTEST_ARGS="$$PYTEST_ARGS --letter-range ah python/tests/kat"
+.PHONY: pytest-envoy-ah
+
+pytest-envoy-ip:
+	@printf "$(CYN)==> $(GRN)Running $(BLU)py envoy$(GRN) kat tests (ip)$(END)\n"
+	$(MAKE) pytest KAT_RUN_MODE=envoy PYTEST_ARGS="$$PYTEST_ARGS --letter-range ip python/tests/kat"
+.PHONY: pytest-envoy-ip
+
+pytest-envoy-qz:
+	@printf "$(CYN)==> $(GRN)Running $(BLU)py envoy$(GRN) kat tests (qz)$(END)\n"
+	$(MAKE) pytest KAT_RUN_MODE=envoy PYTEST_ARGS="$$PYTEST_ARGS --letter-range qz python/tests/kat"
+.PHONY: pytest-envoy-qz
+
+
 pytest-envoy:
-	$(MAKE) pytest KAT_RUN_MODE=envoy
+	$(MAKE) pytest KAT_RUN_MODE=envoy PYTEST_ARGS="$$PYTEST_ARGS python/tests/kat"
 .PHONY: pytest-envoy
 
 pytest-envoy-builder:
 	$(MAKE) pytest-builder KAT_RUN_MODE=envoy
 .PHONY: pytest-envoy-builder
 
+pytest-envoy-v2-ah:
+	@printf "$(CYN)==> $(GRN)Running $(BLU)py envoy v2$(GRN) kat tests (ah)$(END)\n"
+	$(MAKE) pytest KAT_RUN_MODE=envoy AMBASSADOR_ENVOY_API_VERSION=V2 PYTEST_ARGS="$$PYTEST_ARGS --letter-range ah python/tests/kat"
+.PHONY: pytest-envoy-ah
+
+pytest-envoy-v2-ip:
+	@printf "$(CYN)==> $(GRN)Running $(BLU)py envoy v2$(GRN) kat tests (ip)$(END)\n"
+	$(MAKE) pytest KAT_RUN_MODE=envoy AMBASSADOR_ENVOY_API_VERSION=V2 PYTEST_ARGS="$$PYTEST_ARGS --letter-range ip python/tests/kat"
+.PHONY: pytest-envoy-v2-ip
+
+pytest-envoy-v2-qz:
+	@printf "$(CYN)==> $(GRN)Running $(BLU)py envoy v2$(GRN) kat tests (qz)$(END)\n"
+	$(MAKE) pytest KAT_RUN_MODE=envoy AMBASSADOR_ENVOY_API_VERSION=V2 PYTEST_ARGS="$$PYTEST_ARGS --letter-range qz python/tests/kat"
+.PHONY: pytest-envoy-v2-qz
+
 pytest-envoy-v2:
-	$(MAKE) pytest KAT_RUN_MODE=envoy AMBASSADOR_ENVOY_API_VERSION=V2
+	$(MAKE) pytest KAT_RUN_MODE=envoy AMBASSADOR_ENVOY_API_VERSION=V2 PYTEST_ARGS="$$PYTEST_ARGS python/tests/kat"
 .PHONY: pytest-envoy-v2
 
 pytest-envoy-v2-builder:

--- a/python/tests/kat/conftest.py
+++ b/python/tests/kat/conftest.py
@@ -1,0 +1,10 @@
+import pytest
+
+def pytest_addoption(parser):
+    parser.addoption("--letter-range", action="store", default="all", choices=["ah","ip","qz","all"])
+
+
+letter_range = None
+def pytest_configure(config):
+    global letter_range
+    letter_range = config.getoption('--letter-range')

--- a/python/tests/kat/t_mappingtests.py
+++ b/python/tests/kat/t_mappingtests.py
@@ -305,7 +305,7 @@ name:  {self.name}
 hostname: "*"
 prefix: /{self.name}/status/
 rewrite: /status/
-service: httpbin.default
+service: httpbin.plain-namespace
 """)
 
     def queries(self):
@@ -341,7 +341,7 @@ name:  {self.name}
 hostname: "*"
 prefix: /{self.name}/status/
 rewrite: /status/
-service: httpbin.default
+service: httpbin.plain-namespace
 """)
 
     def queries(self):
@@ -370,7 +370,7 @@ name:  {self.name}
 hostname: "*"
 prefix: /{self.name}/status/
 rewrite: /status/
-service: httpbin
+service: httpbin.plain-namespace
 """)
 
     def queries(self):
@@ -474,7 +474,7 @@ kind: AmbassadorMapping
 name:  {self.name}
 hostname: "*"
 prefix: /{self.name}/
-service: websocket-echo-server.default
+service: websocket-echo-server.plain-namespace
 use_websocket: true
 """)
 
@@ -804,7 +804,7 @@ kind: AmbassadorMapping
 name:  {self.name}
 hostname: "*"
 prefix: /{self.name}/
-service: httpbin.default
+service: httpbin.plain-namespace
 add_response_headers:
     koo:
         append: False
@@ -877,7 +877,7 @@ kind: AmbassadorMapping
 name:  {self.name}
 hostname: "*"
 prefix: /{self.name}/
-service: httpbin.default
+service: httpbin.plain-namespace
 remove_request_headers:
 - zoo
 - aoo
@@ -1092,7 +1092,7 @@ metadata:
   name: thisisaverylongservicenameoverwithsixythreecharacters123456789
 spec:
   type: ExternalName
-  externalName: httpbin.default.svc.cluster.local
+  externalName: httpbin.plain-namespace.svc.cluster.local
 ---
 apiVersion: x.getambassador.io/v3alpha1
 kind: AmbassadorMapping

--- a/python/tests/kat/t_plain.py
+++ b/python/tests/kat/t_plain.py
@@ -6,6 +6,9 @@ from abstract_tests import AmbassadorTest, assert_default_errors
 from abstract_tests import MappingTest, Node
 from kat.utils import namespace_manifest
 
+import t_mappingtests
+import t_optiontests
+
 # Plain is the place that all the MappingTests get pulled in.
 
 

--- a/python/tests/kat/test_ambassador.py
+++ b/python/tests/kat/test_ambassador.py
@@ -1,47 +1,57 @@
+import pytest
+from conftest import letter_range
+import sys
+
 from kat.harness import Runner, EDGE_STACK
 
 from abstract_tests import AmbassadorTest
 
 # Import all the real tests from other files, to make it easier to pick and choose during development.
 
-import t_basics
-import t_cors
-import t_extauth
-import t_grpc
-import t_grpc_bridge
-import t_grpc_stats
-import t_grpc_web
-import t_gzip
-import t_headerrouting
-import t_hosts
-import t_ip_allow_deny
-import t_loadbalancer
-import t_logservice
-import t_lua_scripts
-import t_mappingtests
-import t_max_req_header_kb
-import t_no_ui
-import t_optiontests
-import t_plain
-import t_ratelimit
-import t_redirect
-#import t_shadow
-#import t_stats
-import t_tcpmapping
-import t_tls
-import t_tracing
-import t_retrypolicy
-import t_consul
-import t_circuitbreaker
-import t_envoy_logs
-import t_ingress
-import t_headerswithunderscoresaction
-import t_listeneridletimeout
-import t_cluster_tag
-import t_queryparameter_routing
-import t_request_header
-import t_regexrewrite_forwarding
-import t_error_response
+if letter_range in ["all","ah"]:
+	import t_basics
+	import t_circuitbreaker
+	import t_cluster_tag
+	import t_consul
+	import t_cors
+	import t_envoy_logs
+	import t_error_response
+	import t_extauth
+	import t_grpc
+	import t_grpc_bridge
+	import t_grpc_stats
+	import t_grpc_web
+	import t_gzip
+	import t_headerrouting
+	import t_headerswithunderscoresaction
+	import t_hosts
+elif letter_range in ["all","ip"]:
+	import t_ingress
+	import t_ip_allow_deny
+	import t_listeneridletimeout
+	import t_loadbalancer
+	import t_logservice
+	import t_lua_scripts
+	import t_mappingtests
+	import t_max_req_header_kb
+	import t_no_ui
+	import t_optiontests
+	import t_plain
+elif letter_range in ["all","qz"]:
+	import t_queryparameter_routing
+	import t_ratelimit
+	import t_redirect
+	import t_regexrewrite_forwarding
+	import t_request_header
+	import t_retrypolicy
+	#import t_shadow
+	#import t_stats
+	import t_tcpmapping
+	import t_tls
+	import t_tracing
+else:
+  print("Unknown test file name letter range: %s!" % letter_range)
+  sys.exit(1)
 
 # pytest will find this because Runner is a toplevel callable object in a file
 # that pytest is willing to look inside.

--- a/python/tests/kat/test_ambassador.py
+++ b/python/tests/kat/test_ambassador.py
@@ -32,10 +32,10 @@ elif letter_range in ["all","ip"]:
 	import t_loadbalancer
 	import t_logservice
 	import t_lua_scripts
-	import t_mappingtests
 	import t_max_req_header_kb
 	import t_no_ui
-	import t_optiontests
+    # t_plain include t_mappingtests and t_optiontests as imports
+    # these tests require each other and need to be executed as a set
 	import t_plain
 elif letter_range in ["all","qz"]:
 	import t_queryparameter_routing


### PR DESCRIPTION
- split up kat tests to be able to run on the provided github-actions
  hosts
  * alphabetically (a-h, i-p, q-z)
  * support a new command line option for pytest (--letter-range) to
    indicate which set of tests to execute

Signed-off-by: Alice Nodelman <anode@datawire.io>

## Description
Enable kat/envoy/envoy-v2 tests in github-actions.

## Related Issues
List related issues.

## Testing
Enabled push and executed in github-actions.  Ran green.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `CHANGELOG.md`.
   
   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations
 
 - [X] This is unlikely to impact how Ambassador performs at scale.
 
   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability
 
 - [X] My change is adequately tested.
 
   Remember when considering testing:
    + LEGACY MODE TESTS DO NOT RUN FOR EVERY PR. If your change is affected by legacy mode, you need
      to run legacy-mode tests manually (set `AMBASSADOR_LEGACY_MODE=true` and run the tests).
      (This will be fixed soon.)
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points
 
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
