### PR TITLE
Update quote service yaml rel/v1.13

### DIFF
--- a/docs/yaml/quickstart/qotm.yaml
+++ b/docs/yaml/quickstart/qotm.yaml
@@ -3,7 +3,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: quote
-  namespace: ambassador
 spec:
   replicas: 1
   selector:
@@ -18,7 +17,7 @@ spec:
     spec:
       containers:
       - name: backend
-        image: docker.io/datawire/quote:0.4.1
+        image: docker.io/datawire/quote:0.5.0
         ports:
         - name: http
           containerPort: 8080
@@ -27,17 +26,16 @@ apiVersion: v1
 kind: Service
 metadata:
   name: quote
-  namespace: ambassador
   annotations:
         a8r.io/description: "Quote of the moment service"
         a8r.io/owner: "No owner"
         a8r.io/chat: "#ambassador"
-        a8r.io/bugs: "https://github.com/datawire/qotm/issues"
-        a8r.io/documentation: "https://github.com/datawire/qotm/blob/master/README.md"
-        a8r.io/repository: "https://github.com/datawire/qotm"
+        a8r.io/bugs: "https://github.com/datawire/quote/issues"
+        a8r.io/documentation: "https://github.com/datawire/quote/blob/master/README.md"
+        a8r.io/repository: "https://github.com/datawire/quote"
         a8r.io/support: "http://a8r.io/Slack"
-        a8r.io/runbook: "https://github.com/datawire/qotm/blob/master/README.md"
-        a8r.io/incidents: "https://github.com/datawire/qotm/issues"
+        a8r.io/runbook: "https://github.com/datawire/quote/blob/master/README.md"
+        a8r.io/incidents: "https://github.com/datawire/quote/issues"
         a8r.io/dependencies: "None"
 spec:
   ports:


### PR DESCRIPTION
Signed-off-by: AliceProxy <aliceproxy@protonmail.com>

## Description

- Updated the version of the quote service to 0.5.0 in the yaml. This 0.5.0 release has been out for some time but the yaml was never updated.

- Updated the a8r/io annotations to point at the quote.git repository instead of qotm.git since that was the wrong repository for where this image is built from.

- Removes the `ambassador` namespace in favor of `default` to match `2.0` documentation (and Emissary installs that do not create the `ambassador` namespace)
