### PR TITLE
[1.13.x] Set headers per-Mapping for canary configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,13 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 ## RELEASE NOTES
 
+## [1.13.11] (TBD)
+[1.13.11]: https://github.com/emissary-ingress/emissary/compare/v1.13.10...v1.13.11
+
+### Emissary Ingress and Ambassador Edge Stack
+
+- Bugfix: Headers added or removed as part of `Mapping`s in a canary configuration will no longer clobber each other.
+
 ## [1.13.10] July 28, 2021
 [1.13.10]: https://github.com/emissary-ingress/emissary/compare/v1.13.9...v1.13.10
 
@@ -80,7 +87,7 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 ### Ambassador Edge Stack only
 
-- Bugfix: The `Mapping` resource can now specify `docs.timeout_ms` to set the timeout when the 
+- Bugfix: The `Mapping` resource can now specify `docs.timeout_ms` to set the timeout when the
   Dev Portal is fetching API specifications.
 - Bugfix: The Dev Portal will now strip HTML tags when displaying search results, showing just
   the actual content of the search result.

--- a/python/ambassador/envoy/v2/v2route.py
+++ b/python/ambassador/envoy/v2/v2route.py
@@ -192,21 +192,21 @@ class V2Route(Cacheable):
         if len(typed_per_filter_config) > 0:
             self['typed_per_filter_config'] = typed_per_filter_config
 
-        request_headers_to_add = group.get('add_request_headers', None)
+        request_headers_to_add = mapping.get('add_request_headers', None)
         if request_headers_to_add:
             self['request_headers_to_add'] = self.generate_headers_to_add(request_headers_to_add)
 
-        response_headers_to_add = group.get('add_response_headers', None)
+        response_headers_to_add = mapping.get('add_response_headers', None)
         if response_headers_to_add:
             self['response_headers_to_add'] = self.generate_headers_to_add(response_headers_to_add)
 
-        request_headers_to_remove = group.get('remove_request_headers', None)
+        request_headers_to_remove = mapping.get('remove_request_headers', None)
         if request_headers_to_remove:
             if type(request_headers_to_remove) != list:
                 request_headers_to_remove = [ request_headers_to_remove ]
             self['request_headers_to_remove'] = request_headers_to_remove
 
-        response_headers_to_remove = group.get('remove_response_headers', None)
+        response_headers_to_remove = mapping.get('remove_response_headers', None)
         if response_headers_to_remove:
             if type(response_headers_to_remove) != list:
                 response_headers_to_remove = [ response_headers_to_remove ]

--- a/python/ambassador/envoy/v3/v3route.py
+++ b/python/ambassador/envoy/v3/v3route.py
@@ -179,21 +179,21 @@ class V3Route(Cacheable):
         if len(typed_per_filter_config) > 0:
             self['typed_per_filter_config'] = typed_per_filter_config
 
-        request_headers_to_add = group.get('add_request_headers', None)
+        request_headers_to_add = mapping.get('add_request_headers', None)
         if request_headers_to_add:
             self['request_headers_to_add'] = self.generate_headers_to_add(request_headers_to_add)
 
-        response_headers_to_add = group.get('add_response_headers', None)
+        response_headers_to_add = mapping.get('add_response_headers', None)
         if response_headers_to_add:
             self['response_headers_to_add'] = self.generate_headers_to_add(response_headers_to_add)
 
-        request_headers_to_remove = group.get('remove_request_headers', None)
+        request_headers_to_remove = mapping.get('remove_request_headers', None)
         if request_headers_to_remove:
             if type(request_headers_to_remove) != list:
                 request_headers_to_remove = [ request_headers_to_remove ]
             self['request_headers_to_remove'] = request_headers_to_remove
 
-        response_headers_to_remove = group.get('remove_response_headers', None)
+        response_headers_to_remove = mapping.get('remove_response_headers', None)
         if response_headers_to_remove:
             if type(response_headers_to_remove) != list:
                 response_headers_to_remove = [ response_headers_to_remove ]

--- a/python/ambassador/ir/irhttpmappinggroup.py
+++ b/python/ambassador/ir/irhttpmappinggroup.py
@@ -21,8 +21,6 @@ class IRHTTPMappingGroup (IRBaseMappingGroup):
     host_redirect: Optional[IRBaseMapping]
     shadow: List[IRBaseMapping]
     rewrite: str
-    add_request_headers: Dict[str, str]
-    add_response_headers: Dict[str, str]
 
     CoreMappingKeys: ClassVar[Dict[str, bool]] = {
         'bypass_auth': True,
@@ -53,15 +51,17 @@ class IRHTTPMappingGroup (IRBaseMappingGroup):
 
     DoNotFlattenKeys: ClassVar[Dict[str, bool]] = dict(CoreMappingKeys)
     DoNotFlattenKeys.update({
-        'add_request_headers': True,    # do this manually.
-        'add_response_headers': True,   # do this manually.
+        'add_request_headers': True,       # use per-mapping.
+        'add_response_headers': True,      # use per-mapping.
+        'remove_request_headers': True,    # use per-mapping.
+        'remove_response_headers': True,   # use per-mapping.
         'cluster': True,
         'cluster_key': True,
         'host': True,
         'kind': True,
         'location': True,
         'name': True,
-        'resolver': True,               # can't flatten the resolver...
+        'resolver': True,                  # can't flatten the resolver...
         'rkey': True,
         'route_weight': True,
         'service': True,
@@ -289,8 +289,6 @@ class IRHTTPMappingGroup (IRBaseMappingGroup):
         :return: a list of the IRClusters this Group uses
         """
 
-        add_request_headers: Dict[str, Any] = {}
-        add_response_headers: Dict[str, Any] = {}
         metadata_labels: Dict[str, str] = {}
 
         for mapping in sorted(self.mappings, key=lambda m: m.route_weight):
@@ -308,17 +306,9 @@ class IRHTTPMappingGroup (IRBaseMappingGroup):
 
                 self[k] = mapping[k]
 
-            add_request_headers.update(mapping.get('add_request_headers', {}))
-            add_response_headers.update(mapping.get('add_response_headers', {}))
-
             # Should we have higher weights win over lower if there are conflicts?
             # Should we disallow conflicts?
             metadata_labels.update(mapping.get('metadata_labels') or {})
-
-        if add_request_headers:
-            self.add_request_headers = add_request_headers
-        if add_response_headers:
-            self.add_response_headers = add_response_headers
 
         if metadata_labels:
             self.metadata_labels = metadata_labels

--- a/python/tests/gold/plain/snapshots/econf.json
+++ b/python/tests/gold/plain/snapshots/econf.json
@@ -100,6 +100,114 @@
         "dns_lookup_family": "V4_ONLY",
         "lb_policy": "ROUND_ROBIN",
         "load_assignment": {
+          "cluster_name": "cluster_http___plain_canaryaddreqheaders-0",
+          "endpoints": [
+            {
+              "lb_endpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "address": "plain-canaryaddreqheadersmapping-grpc-grpc-canary.plain-namespace",
+                        "port_value": 80,
+                        "protocol": "TCP"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "name": "cluster_http___plain_canaryaddreqheaders-0",
+        "type": "STRICT_DNS"
+      },
+      {
+        "connect_timeout": "3.000s",
+        "dns_lookup_family": "V4_ONLY",
+        "lb_policy": "ROUND_ROBIN",
+        "load_assignment": {
+          "cluster_name": "cluster_http___plain_canaryaddreqheaders-1",
+          "endpoints": [
+            {
+              "lb_endpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "address": "plain-canaryaddreqheadersmapping-grpc-grpc.plain-namespace",
+                        "port_value": 80,
+                        "protocol": "TCP"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "name": "cluster_http___plain_canaryaddreqheaders-1",
+        "type": "STRICT_DNS"
+      },
+      {
+        "connect_timeout": "3.000s",
+        "dns_lookup_family": "V4_ONLY",
+        "lb_policy": "ROUND_ROBIN",
+        "load_assignment": {
+          "cluster_name": "cluster_http___plain_canaryaddreqheaders-2",
+          "endpoints": [
+            {
+              "lb_endpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "address": "plain-canaryaddreqheadersmapping-http-http-canary.plain-namespace",
+                        "port_value": 80,
+                        "protocol": "TCP"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "name": "cluster_http___plain_canaryaddreqheaders-2",
+        "type": "STRICT_DNS"
+      },
+      {
+        "connect_timeout": "3.000s",
+        "dns_lookup_family": "V4_ONLY",
+        "lb_policy": "ROUND_ROBIN",
+        "load_assignment": {
+          "cluster_name": "cluster_http___plain_canaryaddreqheaders-3",
+          "endpoints": [
+            {
+              "lb_endpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socket_address": {
+                        "address": "plain-canaryaddreqheadersmapping-http-http.plain-namespace",
+                        "port_value": 80,
+                        "protocol": "TCP"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "name": "cluster_http___plain_canaryaddreqheaders-3",
+        "type": "STRICT_DNS"
+      },
+      {
+        "connect_timeout": "3.000s",
+        "dns_lookup_family": "V4_ONLY",
+        "lb_policy": "ROUND_ROBIN",
+        "load_assignment": {
           "cluster_name": "cluster_http___plain_canarydiffmapping_g-0",
           "endpoints": [
             {
@@ -4648,6 +4756,254 @@
                                   "upgrade_type": "websocket"
                                 }
                               ]
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "headers": [
+                                {
+                                  "exact_match": "https",
+                                  "name": "x-forwarded-proto"
+                                }
+                              ],
+                              "prefix": "/CanaryAddReqHeadersMapping-HTTP/",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 50
+                                },
+                                "runtime_key": "routing.traffic_shift.cluster_http___plain_canaryaddreqheaders-2"
+                              }
+                            },
+                            "request_headers_to_add": [
+                              {
+                                "append": true,
+                                "header": {
+                                  "key": "zoo",
+                                  "value": "tigers"
+                                }
+                              }
+                            ],
+                            "route": {
+                              "cluster": "cluster_http___plain_canaryaddreqheaders-2",
+                              "prefix_rewrite": "/",
+                              "priority": null,
+                              "timeout": "3.000s"
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "prefix": "/CanaryAddReqHeadersMapping-HTTP/",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 50
+                                },
+                                "runtime_key": "routing.traffic_shift.cluster_http___plain_canaryaddreqheaders-2"
+                              }
+                            },
+                            "request_headers_to_add": [
+                              {
+                                "append": true,
+                                "header": {
+                                  "key": "zoo",
+                                  "value": "tigers"
+                                }
+                              }
+                            ],
+                            "route": {
+                              "cluster": "cluster_http___plain_canaryaddreqheaders-2",
+                              "prefix_rewrite": "/",
+                              "priority": null,
+                              "timeout": "3.000s"
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "headers": [
+                                {
+                                  "exact_match": "https",
+                                  "name": "x-forwarded-proto"
+                                }
+                              ],
+                              "prefix": "/CanaryAddReqHeadersMapping-HTTP/",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                },
+                                "runtime_key": "routing.traffic_shift.cluster_http___plain_canaryaddreqheaders-3"
+                              }
+                            },
+                            "request_headers_to_add": [
+                              {
+                                "append": true,
+                                "header": {
+                                  "key": "zoo",
+                                  "value": "lions"
+                                }
+                              }
+                            ],
+                            "route": {
+                              "cluster": "cluster_http___plain_canaryaddreqheaders-3",
+                              "prefix_rewrite": "/",
+                              "priority": null,
+                              "timeout": "3.000s"
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "prefix": "/CanaryAddReqHeadersMapping-HTTP/",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                },
+                                "runtime_key": "routing.traffic_shift.cluster_http___plain_canaryaddreqheaders-3"
+                              }
+                            },
+                            "request_headers_to_add": [
+                              {
+                                "append": true,
+                                "header": {
+                                  "key": "zoo",
+                                  "value": "lions"
+                                }
+                              }
+                            ],
+                            "route": {
+                              "cluster": "cluster_http___plain_canaryaddreqheaders-3",
+                              "prefix_rewrite": "/",
+                              "priority": null,
+                              "timeout": "3.000s"
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "headers": [
+                                {
+                                  "exact_match": "https",
+                                  "name": "x-forwarded-proto"
+                                }
+                              ],
+                              "prefix": "/CanaryAddReqHeadersMapping-GRPC/",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 50
+                                },
+                                "runtime_key": "routing.traffic_shift.cluster_http___plain_canaryaddreqheaders-0"
+                              }
+                            },
+                            "request_headers_to_add": [
+                              {
+                                "append": true,
+                                "header": {
+                                  "key": "zoo",
+                                  "value": "tigers"
+                                }
+                              }
+                            ],
+                            "route": {
+                              "cluster": "cluster_http___plain_canaryaddreqheaders-0",
+                              "prefix_rewrite": "/",
+                              "priority": null,
+                              "timeout": "3.000s"
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "prefix": "/CanaryAddReqHeadersMapping-GRPC/",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 50
+                                },
+                                "runtime_key": "routing.traffic_shift.cluster_http___plain_canaryaddreqheaders-0"
+                              }
+                            },
+                            "request_headers_to_add": [
+                              {
+                                "append": true,
+                                "header": {
+                                  "key": "zoo",
+                                  "value": "tigers"
+                                }
+                              }
+                            ],
+                            "route": {
+                              "cluster": "cluster_http___plain_canaryaddreqheaders-0",
+                              "prefix_rewrite": "/",
+                              "priority": null,
+                              "timeout": "3.000s"
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "headers": [
+                                {
+                                  "exact_match": "https",
+                                  "name": "x-forwarded-proto"
+                                }
+                              ],
+                              "prefix": "/CanaryAddReqHeadersMapping-GRPC/",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                },
+                                "runtime_key": "routing.traffic_shift.cluster_http___plain_canaryaddreqheaders-1"
+                              }
+                            },
+                            "request_headers_to_add": [
+                              {
+                                "append": true,
+                                "header": {
+                                  "key": "zoo",
+                                  "value": "lions"
+                                }
+                              }
+                            ],
+                            "route": {
+                              "cluster": "cluster_http___plain_canaryaddreqheaders-1",
+                              "prefix_rewrite": "/",
+                              "priority": null,
+                              "timeout": "3.000s"
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "prefix": "/CanaryAddReqHeadersMapping-GRPC/",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                },
+                                "runtime_key": "routing.traffic_shift.cluster_http___plain_canaryaddreqheaders-1"
+                              }
+                            },
+                            "request_headers_to_add": [
+                              {
+                                "append": true,
+                                "header": {
+                                  "key": "zoo",
+                                  "value": "lions"
+                                }
+                              }
+                            ],
+                            "route": {
+                              "cluster": "cluster_http___plain_canaryaddreqheaders-1",
+                              "prefix_rewrite": "/",
+                              "priority": null,
+                              "timeout": "3.000s"
                             }
                           },
                           {

--- a/python/tests/kat/t_mappingtests.py
+++ b/python/tests/kat/t_mappingtests.py
@@ -919,6 +919,58 @@ add_request_headers:
                 assert r.backend.request.headers['foo'] == ['FooF','Foo']
 
 
+class CanaryAddReqHeadersMapping(MappingTest):
+
+    parent: AmbassadorTest
+    target: ServiceType
+    canary: ServiceType
+
+    @classmethod
+    def variants(cls):
+        for v in variants(ServiceType):
+            yield cls(v, v.clone("canary"), name="{self.target.name}")
+
+    def init(self, target: ServiceType, canary: ServiceType):
+        MappingTest.init(self, target)
+        self.canary = canary
+
+    def config(self):
+        yield self.target, self.format("""
+---
+apiVersion: ambassador/v1
+kind: Mapping
+name:  {self.name}
+prefix: /{self.name}/
+service: http://{self.target.path.fqdn}
+add_request_headers:
+    zoo: lions
+""")
+        yield self.canary, self.format("""
+---
+apiVersion: ambassador/v1
+kind: Mapping
+name:  {self.name}-canary
+prefix: /{self.name}/
+service: http://{self.canary.path.fqdn}
+weight: 50
+add_request_headers:
+    zoo: tigers
+""")
+
+    def queries(self):
+        for i in range(100):
+            yield Query(self.parent.url(self.name + "/"))
+
+    def check(self):
+        expected_zoo_header_values = {
+            self.target.path.k8s: ['lions'],
+            self.canary.path.k8s: ['tigers'],
+        }
+
+        for r in self.results:
+            assert r.backend.request.headers['zoo'] == expected_zoo_header_values.get(r.backend.name), f'#{r.backend.name} does not have the correct header value'
+
+
 class LinkerdHeaderMapping(AmbassadorTest):
     target: ServiceType
 


### PR DESCRIPTION
## Description

This change is a cherry-pick of #3622 against `release/v1.13`.

## Related Issues
* #3622
* https://github.com/knative/serving/issues/11572

## Testing

A new plain test, `CanaryAddReqHeadersMapping`, has been added to address this use case.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `CHANGELOG.md`.
   
   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations
 
 - [x] This is unlikely to impact how Ambassador performs at scale.
 
   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability
 
 - [x] My change is adequately tested.
 
   Remember when considering testing:
    + LEGACY MODE TESTS DO NOT RUN FOR EVERY PR. If your change is affected by legacy mode, you need
      to run legacy-mode tests manually (set `AMBASSADOR_LEGACY_MODE=true` and run the tests).
      (This will be fixed soon.)
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points
 
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
