### PR TITLE
fix: Remove TLSContext error when absent

### DIFF
--- a/python/ambassador_diag/diagd.py
+++ b/python/ambassador_diag/diagd.py
@@ -70,6 +70,8 @@ __version__ = Version
 
 boot_time = datetime.datetime.now()
 
+no_tls_errors = parse_bool(os.environ.get('AMBASSADOR_MISSING_TLS_OK', 'false'))
+
 # allows 10 concurrent users, with a request timeout of 60 seconds
 tvars_cache = ExpiringDict(max_len=10, max_age_seconds=60)
 
@@ -1838,7 +1840,8 @@ class AmbassadorEventWatcher(threading.Thread):
 
         if tls_count:
             env_status.OK('TLS', f'{tls_count} TLSContext{" is" if (tls_count == 1) else "s are"} active')
-        else:
+
+        if no_tls_errors:
             chime_failures['no TLS contexts'] = True
             env_status.failure('TLS', "No TLSContexts are active")
 


### PR DESCRIPTION
## Description
If we configure the ingress controller to terminate SSL at the load
balancer (example AWS L7 ELB or ALB), then we see an error on the
ambassador diagnostics page "No TLSContexts are active"

It is better to not have these errors in such cases.

## Related Issues
- https://github.com/emissary-ingress/emissary/issues/2138
- https://github.com/emissary-ingress/emissary/issues/2139

## Testing
A few sentences describing what testing you've done, e.g., manual tests, automated tests, deployed in production, etc.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `CHANGELOG.md`.
   
   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations
 
 - [x] This is unlikely to impact how Ambassador performs at scale.
 
   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability
 
 - [ ] My change is adequately tested.
 
   Remember when considering testing:
    + LEGACY MODE TESTS DO NOT RUN FOR EVERY PR. If your change is affected by legacy mode, you need
      to run legacy-mode tests manually (set `AMBASSADOR_LEGACY_MODE=true` and run the tests).
      (This will be fixed soon.)
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points
 
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
