### PR TITLE
Logging fixes from 1.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ We're pleased to introduce Emissary 2.0.1 as a developer preview. The 2.X family
 
 - Feature: The optional `statsPrefix` element of the `AmbassadorListener` CRD now determines the prefix of HTTP statistics emitted for a specific `AmbassadorListener`.
 - Feature: Ambassador Agent reports sidecar process information and Mapping OpenAPI documentation to Ambassador Cloud to provide more visibility into services and clusters.
+- Change: Logs now include subsecond time resolutions, rather than just seconds.
 
 ## [2.0.0-ea] June 24, 2021
 [2.0.0-ea]: https://github.com/emissary-ingress/emissary/compare/v1.13.8...v2.0.0-ea

--- a/pkg/busy/busy.go
+++ b/pkg/busy/busy.go
@@ -1,4 +1,7 @@
 // Package busy implements a dispatcher for BusyBox-style multi-call binaries.
+//
+// BUG(lukeshu): Global state is bad, but this package has global state in the form of the global
+// log level.
 package busy
 
 import (
@@ -19,58 +22,50 @@ type Command struct {
 	Run   func(ctx context.Context, version string, args ...string) error
 }
 
+// logrusLogger is a global (rather than simply being a variable within the Main() function) for the
+// sole purpose of allowing the global program-wide log level to be fussed with at runtime.
+//
+// If you find yourself adding any other access to this blob of global state:
+//
+//     Stop.  You don't want more global state.  I (LukeShu) promise you there's a better way to do
+//     whatever you're attempting, and that adding more global state is not what you really want.
 var logrusLogger *logrus.Logger
-var logrusFormatter logrus.Formatter
 
-func jsonLoggingEnabled() bool {
-	if v, err := strconv.ParseBool(os.Getenv("AMBASSADOR_JSON_LOGGING")); err == nil && v {
-		return true
-	}
-
-	return false
-}
-
-// The golang `init` function here just calls the exported Init function below.
 func init() {
-	Init()
+	testInit()
 }
 
-// Init initializes our logger. We expose this function for tests.
-func Init() {
+// testInit is separate from init() so that it can be explicitly called from the tests.
+func testInit() {
 	logrusLogger = logrus.New()
-	if jsonLoggingEnabled() {
-		logrusFormatter = &logrus.JSONFormatter{
+	if useJSON, _ := strconv.ParseBool(os.Getenv("AMBASSADOR_JSON_LOGGING")); useJSON {
+		logrusLogger.SetFormatter(&logrus.JSONFormatter{
 			TimestampFormat: "2006-01-02 15:04:05",
-		}
-		logrusLogger.SetFormatter(logrusFormatter)
+		})
 	} else {
-		logrusFormatter = &logrus.TextFormatter{
+		logrusLogger.SetFormatter(&logrus.TextFormatter{
 			TimestampFormat: "2006-01-02 15:04:05",
 			FullTimestamp:   true,
-		}
-		logrusLogger.SetFormatter(logrusFormatter)
+		})
 	}
 	logrusLogger.SetReportCaller(true)
 }
 
+// SetLogLevel sets the global program-wide log level.
+//
+// BUG(lukeshu): SetLogLevel mutates global state, and global state is bad.
 func SetLogLevel(lvl logrus.Level) {
 	logrusLogger.SetLevel(lvl)
 }
 
+// GetLogLevel gets the global program-wide log level.
+//
+// BUG(lukeshu): GetLogLevel accesses global state, and global state is bad.
 func GetLogLevel() logrus.Level {
 	return logrusLogger.GetLevel()
 }
 
-var rootLogger dlog.Logger
-
-func GetRootLogger() dlog.Logger {
-	return rootLogger
-}
-
-func GetLogrusFormatter() logrus.Formatter {
-	return logrusFormatter
-}
-
+// Main should be called from your actual main() function.
 func Main(binName, humanName string, version string, cmds map[string]Command) {
 	name := filepath.Base(os.Args[0])
 	if name == binName && len(os.Args) > 1 {
@@ -83,11 +78,11 @@ func Main(binName, humanName string, version string, cmds map[string]Command) {
 		cmd.Setup()
 	}
 
-	rootLogger = dlog.WrapLogrus(logrusLogger).
+	logger := dlog.WrapLogrus(logrusLogger).
 		WithField("PID", os.Getpid()).
 		WithField("CMD", name)
-	ctx := dlog.WithLogger(context.Background(), rootLogger)
-	dlog.SetFallbackLogger(rootLogger.WithField("oops-i-did-not-pass-context-correctly", true))
+	ctx := dlog.WithLogger(context.Background(), logger)
+	dlog.SetFallbackLogger(logger.WithField("oops-i-did-not-pass-context-correctly", true))
 
 	if cmdOk {
 		if err := cmd.Run(ctx, version, os.Args[1:]...); err != nil {

--- a/pkg/busy/busy.go
+++ b/pkg/busy/busy.go
@@ -40,11 +40,11 @@ func testInit() {
 	logrusLogger = logrus.New()
 	if useJSON, _ := strconv.ParseBool(os.Getenv("AMBASSADOR_JSON_LOGGING")); useJSON {
 		logrusLogger.SetFormatter(&logrus.JSONFormatter{
-			TimestampFormat: "2006-01-02 15:04:05",
+			TimestampFormat: "2006-01-02 15:04:05.0000",
 		})
 	} else {
 		logrusLogger.SetFormatter(&logrus.TextFormatter{
-			TimestampFormat: "2006-01-02 15:04:05",
+			TimestampFormat: "2006-01-02 15:04:05.0000",
 			FullTimestamp:   true,
 		})
 	}

--- a/pkg/busy/busy.go
+++ b/pkg/busy/busy.go
@@ -82,7 +82,7 @@ func Main(binName, humanName string, version string, cmds map[string]Command) {
 		WithField("PID", os.Getpid()).
 		WithField("CMD", name)
 	ctx := dlog.WithLogger(context.Background(), logger)
-	dlog.SetFallbackLogger(logger.WithField("oops-i-did-not-pass-context-correctly", true))
+	dlog.SetFallbackLogger(logger.WithField("oops-i-did-not-pass-context-correctly", "THIS IS A BUG"))
 
 	if cmdOk {
 		if err := cmd.Run(ctx, version, os.Args[1:]...); err != nil {

--- a/pkg/busy/busy_test.go
+++ b/pkg/busy/busy_test.go
@@ -16,7 +16,7 @@ func TestLoggingTextFormatterDefault(t *testing.T) {
 	if !assert.True(t, isTextFormatter) {
 		return
 	}
-	assert.Equal(t, "2006-01-02 15:04:05", fm.TimestampFormat)
+	assert.Equal(t, "2006-01-02 15:04:05.0000", fm.TimestampFormat)
 	assert.True(t, fm.FullTimestamp)
 }
 
@@ -28,5 +28,5 @@ func TestLoggingJsonFormatter(t *testing.T) {
 	if !assert.True(t, isJSONFormatter) {
 		return
 	}
-	assert.Equal(t, "2006-01-02 15:04:05", fm.TimestampFormat)
+	assert.Equal(t, "2006-01-02 15:04:05.0000", fm.TimestampFormat)
 }

--- a/pkg/busy/busy_test.go
+++ b/pkg/busy/busy_test.go
@@ -10,21 +10,23 @@ import (
 
 func TestLoggingTextFormatterDefault(t *testing.T) {
 	os.Unsetenv("AMBASSADOR_JSON_LOGGING")
-	Init()
+	testInit()
 
-	formatter := GetLogrusFormatter()
-	fm, isTextFormatter := formatter.(*logrus.TextFormatter)
-	assert.True(t, isTextFormatter)
+	fm, isTextFormatter := logrusLogger.Formatter.(*logrus.TextFormatter)
+	if !assert.True(t, isTextFormatter) {
+		return
+	}
 	assert.Equal(t, "2006-01-02 15:04:05", fm.TimestampFormat)
 	assert.True(t, fm.FullTimestamp)
 }
 
 func TestLoggingJsonFormatter(t *testing.T) {
 	os.Setenv("AMBASSADOR_JSON_LOGGING", "true")
-	Init()
+	testInit()
 
-	formatter := GetLogrusFormatter()
-	fm, isJSONFormatter := formatter.(*logrus.JSONFormatter)
-	assert.True(t, isJSONFormatter)
+	fm, isJSONFormatter := logrusLogger.Formatter.(*logrus.JSONFormatter)
+	if !assert.True(t, isJSONFormatter) {
+		return
+	}
 	assert.Equal(t, "2006-01-02 15:04:05", fm.TimestampFormat)
 }


### PR DESCRIPTION
This is a cherry-pick of @LukeShu's PR 2742 from `release/v1.13` onto `master`.

- pkg/busy: Clean up
- pkg/busy: Have the logger include sub-second precision in the timestamps
- pkg/busy: Be clearer that not passing the Context correctly is a bug

 - [x] I made sure to update `CHANGELOG.md`.
 - [x] This is unlikely to impact how Ambassador performs at scale.
 - [x] My change is adequately tested.
 - [x] I didn't need to update `DEVELOPING.md`.
