### PR TITLE
Support starting a release with untracked files

### DIFF
--- a/releng/lib/__init__.py
+++ b/releng/lib/__init__.py
@@ -6,6 +6,7 @@ from typing import Any, List
 from os import getenv
 
 from .gitutil import git_check_clean as git_check_clean  # Stop mypy complaining about implicit reexport
+from .gitutil import parse_bool as parse_bool  # Stop mypy complaining about implicit reexport
 from .gitutil import git_add as git_add # Stop mypy complaining about implicit reexport
 from .uiutil import run_txtcapture
 

--- a/releng/lib/__init__.py
+++ b/releng/lib/__init__.py
@@ -6,8 +6,8 @@ from typing import Any, List
 from os import getenv
 
 from .gitutil import git_check_clean as git_check_clean  # Stop mypy complaining about implicit reexport
-from .uiutil import run_txtcapture
 from .gitutil import git_add as git_add # Stop mypy complaining about implicit reexport
+from .uiutil import run_txtcapture
 
 # These are some regular expressions to validate and parse
 # X.Y.Z[-rc.N] versions.

--- a/releng/lib/gitutil.py
+++ b/releng/lib/gitutil.py
@@ -56,13 +56,20 @@ def git_add(filename: str) -> None:
     run(['git', 'add', '--', filename])
 
 
-def git_check_clean(allow_staged: bool = False) -> None:
+def git_check_clean(allow_staged: bool = False, allow_untracked: bool = False) -> None:
     """
     Use `git status --porcelain` to check if the working tree is dirty.
     If allow_staged is True, allow staged files, but no unstaged changes.
+    If allow_untracked is True, allow untracked files.
     """
 
-    out = run_capture(['git', 'status', '--porcelain'])
+    cmdvec = [ 'git', 'status', '--porcelain' ]
+
+    if allow_untracked:
+        cmdvec += [ "--untracked-files=no" ]
+
+    out = run_capture(cmdvec)
+
     if out:
         # Can we allow staged changes?
         if not allow_staged:

--- a/releng/lib/gitutil.py
+++ b/releng/lib/gitutil.py
@@ -3,8 +3,36 @@ from typing import Optional, Union
 import http.client
 import json
 
+from distutils.util import strtobool
+
 from .uiutil import run
 from .uiutil import run_txtcapture as run_capture
+
+
+# parse_bool is lifted from python/ambassador/utils.py -- it's just too useful.
+def parse_bool(s: Optional[Union[str, bool]]) -> bool:
+    """ 
+    Parse a boolean value from a string. T, True, Y, y, 1 return True;
+    other things return False.
+    """
+
+    # If `s` is already a bool, return its value.
+    #
+    # This allows a caller to not know or care whether their value is already
+    # a boolean, or if it is a string that needs to be parsed below.
+    if isinstance(s, bool):
+        return s
+
+    # If we didn't get anything at all, return False.
+    if not s:
+        return False
+
+    # OK, we got _something_, so try strtobool.
+    try:
+        return strtobool(s)
+    except ValueError:
+        return False
+
 
 def has_open_pr(gh_repo: str, base: str, branchname: str) -> bool:
     conn = http.client.HTTPSConnection("api.github.com")

--- a/releng/lib/gitutil.py
+++ b/releng/lib/gitutil.py
@@ -1,8 +1,10 @@
-from .uiutil import run
-from .uiutil import run_txtcapture as run_capture
+from typing import Optional, Union
+
 import http.client
 import json
 
+from .uiutil import run
+from .uiutil import run_txtcapture as run_capture
 
 def has_open_pr(gh_repo: str, base: str, branchname: str) -> bool:
     conn = http.client.HTTPSConnection("api.github.com")

--- a/releng/start-sanity-check
+++ b/releng/start-sanity-check
@@ -14,7 +14,7 @@ import os.path
 from os import getenv
 from contextlib import contextmanager
 
-from lib import assert_eq, git_check_clean, vX, vY, re_ga
+from lib import assert_eq, git_check_clean, parse_bool, vX, vY, re_ga
 from lib.uiutil import Checker, CheckResult, run
 from lib.uiutil import run_txtcapture as run_capture
 
@@ -22,7 +22,7 @@ from lib.uiutil import run_txtcapture as run_capture
 DEFAULT_REPO = 'git@github.com:emissary-ingress/emissary'
 
 
-def main(next_ver: str, quiet: bool = False) -> int:
+def main(next_ver: str, quiet: bool = False, allow_untracked: bool = False) -> int:
     print(f'Starting work on "v{next_ver}"...')
     print()
     remote_repo = getenv('AMBASSADOR_RELEASE_REPO_OVERRIDE')
@@ -56,7 +56,7 @@ def main(next_ver: str, quiet: bool = False) -> int:
             raise Exception(f"Not in {toplevel}")
 
     with check("You're in a clean checkout"):
-        git_check_clean()
+        git_check_clean(allow_untracked=allow_untracked)
 
     # Cache the name of our remote...
     remote_name = f'{remote_repo}.git' if is_private else 'origin'
@@ -128,6 +128,8 @@ if __name__ == '__main__':
     args = sys.argv[1:]
     quiet = False
 
+    allow_untracked = parse_bool(getenv("ALLOW_UNTRACKED", "false"))
+
     if args and (args[0] == '--quiet'):
         quiet = True
         args.pop(0)
@@ -136,4 +138,4 @@ if __name__ == '__main__':
         sys.stderr.write(f"Usage: {os.path.basename(sys.argv[0])} X.Y.Z\n")
         sys.exit(2)
 
-    sys.exit(main(next_ver=args[0], quiet=quiet))
+    sys.exit(main(next_ver=args[0], quiet=quiet, allow_untracked=allow_untracked))

--- a/releng/start-sanity-check
+++ b/releng/start-sanity-check
@@ -4,12 +4,15 @@ cut an RC from; that you're in the right repo, that you're on the
 right branch, that all of the subtrees are up-to-date...
 """
 
-import os.path
-from os import getenv
+from typing import Generator
+
 import sys
 import time
+
+import os.path
+
+from os import getenv
 from contextlib import contextmanager
-from typing import Generator
 
 from lib import assert_eq, git_check_clean, vX, vY, re_ga
 from lib.uiutil import Checker, CheckResult, run

--- a/releng/start-update-version
+++ b/releng/start-update-version
@@ -92,7 +92,7 @@ def main(next_ver: str, today: datetime.date, quiet: bool=False, commit: bool = 
                     "--base", orig_branch,
                     "--title", f"[v{next_ver}] Prep work for next scheduled release",
                     "--body", f"Updates for next version {next_ver}",
-                    "--reviewer", "kflynn,rhs,esmet,acookin"])
+                    "--reviewer", "emissary-ingress/emissary-maintainers"])
 
     if checker.ok:
         print(f'Update complete. Merge PR back to target branch ASAP')


### PR DESCRIPTION
If `ALLOW_UNTRACKED` is `true`, allow starting a release with untracked files in the repo.
Also fix the review assignment when starting a new release.

- Reorder imports.
- Add parse_bool
- Support ALLOW_UNTRACKED environment variable when starting a new version.
- Update reviewers when starting a new release.
