### PR TITLE
Add an AMBASSADOR_GRPC_METRICS_SINK environment variable.

### DIFF
--- a/cmd/example-envoy-metrics-sink/main.go
+++ b/cmd/example-envoy-metrics-sink/main.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"io"
+	"log"
+	"net"
+
+	v2 "github.com/datawire/ambassador/pkg/api/envoy/service/metrics/v2"
+	"github.com/golang/protobuf/jsonpb"
+	"google.golang.org/grpc"
+)
+
+func main() {
+	grpcServer := grpc.NewServer()
+	v2.RegisterMetricsServiceServer(grpcServer, New())
+
+	l, err := net.Listen("tcp", ":8123")
+	if err != nil {
+		log.Fatalf("failed to listen: %v", err)
+	}
+
+	log.Println("Listening on tcp://localhost:8123")
+	grpcServer.Serve(l)
+}
+
+type server struct {
+	marshaler jsonpb.Marshaler
+}
+
+var _ v2.MetricsServiceServer = &server{}
+
+// New ...
+func New() v2.MetricsServiceServer {
+	return &server{
+		marshaler: jsonpb.Marshaler{
+			Indent: "  ",
+		},
+	}
+}
+
+func (s *server) StreamMetrics(stream v2.MetricsService_StreamMetricsServer) error {
+	log.Println("Started stream")
+	for {
+		in, err := stream.Recv()
+		log.Println("Received value")
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		str, _ := s.marshaler.MarshalToString(in)
+		log.Println(str)
+	}
+}

--- a/python/ambassador/envoy/v2/v2bootstrap.py
+++ b/python/ambassador/envoy/v2/v2bootstrap.py
@@ -109,6 +109,8 @@ class V2Bootstrap(dict):
         #     assert ratelimit.cluster
         #     clusters.append(V2Cluster(config, ratelimit.cluster))
 
+        stats_sinks = []
+
         if config.ir.statsd['enabled']:
             if config.ir.statsd['dogstatsd']:
                 name = 'envoy.stat_sinks.dog_statsd'
@@ -124,28 +126,90 @@ class V2Bootstrap(dict):
                 name = 'envoy.stats_sinks.statsd'
                 typename = 'type.googleapis.com/envoy.config.metrics.v2.StatsdSink'
 
-            self['stats_sinks'] = [
-                {
-                    'name': name,
-                    'typed_config': {
-                        '@type': typename,
-                        'address': {
-                            'socket_address': {
-                                'protocol': 'UDP',
-                                'address': config.ir.statsd['ip'],
-                                'port_value': 8125
-                            }
+            stats_sinks.append({
+                'name': name,
+                'typed_config': {
+                    '@type': typename,
+                    'address': {
+                        'socket_address': {
+                            'protocol': 'UDP',
+                            'address': config.ir.statsd['ip'],
+                            'port_value': 8125
                         }
                     }
                 }
-            ]
+            })
 
             self['stats_flush_interval'] = {
                 'seconds': config.ir.statsd['interval']
             }
 
+        grpcSink = os.environ.get("AMBASSADOR_GRPC_METRICS_SINK")
+        if grpcSink:
+            try:
+                host, port = split_host_port(grpcSink)
+                valid = True
+            except ValueError as ex:
+                config.ir.logger.error("AMBASSADOR_GRPC_METRICS_SINK value %s is invalid: %s" % (grpcSink, ex))
+                valid = False
+
+            if valid:
+                stats_sinks.append({
+                    'name': "envoy.metrics_service",
+                    'typed_config': {
+                        '@type': 'type.googleapis.com/envoy.config.metrics.v2.MetricsServiceConfig',
+                        'grpc_service': {
+                            'envoy_grpc': {
+                                'cluster_name': 'envoy_metrics_service'
+                            }
+                        }
+                    }
+                })
+
+                clusters.append({
+                    "name": "envoy_metrics_service",
+                    "type": "strict_dns",
+                    "connect_timeout": "1s",
+                    "http2_protocol_options": {},
+                    "lb_policy": "ROUND_ROBIN",
+                    "load_assignment": {
+                        "cluster_name": "envoy_metrics_service",
+                        "endpoints": [
+                            {
+                                "lb_endpoints": [
+                                    {
+                                        "endpoint": {
+                                            "address": {
+                                                "socket_address": {
+                                                    "address": host,
+                                                    "port_value": port,
+                                                    "protocol": "TCP"
+                                                }
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                })
+
+        if stats_sinks:
+            self['stats_sinks'] = stats_sinks
         self['static_resources']['clusters'] = clusters
 
     @classmethod
     def generate(cls, config: 'V2Config') -> None:
         config.bootstrap = V2Bootstrap(config)
+
+def split_host_port(value):
+    parts = value.split(":")
+    if len(parts) == 1:
+        host = parts[0]
+        port = 80
+    elif len(parts) == 2:
+        host = parts[0]
+        port = int(parts[1])
+    else:
+        raise ValueError("too many colons")
+    return host, port


### PR DESCRIPTION
## Description
Add a quick and hopefully not too dirty way to configure envoy to point to send metrics to a GRPC metrics sink.

## Testing

I tested this manually by pointing ambassador at the example GRPC metrics sink included in the commit.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `CHANGELOG.md`.
   
   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations
 
 - [ ] This is unlikely to impact how Ambassador performs at scale.
 
   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability
 
 - [ ] My change is adequately tested.
 
   Remember when considering testing:
    + LEGACY MODE TESTS DO NOT RUN FOR EVERY PR. If your change is affected by legacy mode, you need
      to run legacy-mode tests manually (set `AMBASSADOR_LEGACY_MODE=true` and run the tests).
      (This will be fixed soon.)
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points
 
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
