### PR TITLE
Hotfix tweaks

### DIFF
--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -879,7 +879,7 @@ release/promote-oss/to-hotfix:
 			PROMOTE_FROM_VERSION="$$dev_version" \
 			PROMOTE_FROM_REPO=$(DEV_REGISTRY) \
 			PROMOTE_TO_VERSION="$$hotfix_tag" \
-			PROMOTE_CHANNEL=hotfix \
+			PROMOTE_CHANNEL=hotfix ;\
 		chartsuffix=$$hotfix_tag ;\
 		chartsuffix=$${chartsuffix#*-} ;\
 		export AWS_ACCESS_KEY_ID=$$(keybase fs read /keybase/team/datawireio/secrets/aws.s3-bot.cli-credentials | grep 'aws_access_key_id' | sed 's/aws_access_key_id=//g') ;\

--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -882,7 +882,7 @@ release/promote-oss/to-hotfix:
 		$(MAKE) release/promote-oss/.main \
 			PROMOTE_FROM_VERSION="$$dev_version" \
 			PROMOTE_FROM_REPO=$(DEV_REGISTRY) \
-			PROMOTE_TO_VERSION="$$hotfix_tag" \
+			PROMOTE_TO_VERSION=$$(echo "$$hotfix_tag" | tr '+' '-') \
 			PROMOTE_CHANNEL=hotfix ;\
 		chartsuffix=$$hotfix_tag ;\
 		chartsuffix=$${chartsuffix#*-} ;\

--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -862,10 +862,10 @@ release/promote-oss/pr-to-passed-ci:
 
 release/promote-oss/to-hotfix:
 	@test -n "$(RELEASE_REGISTRY)" || (printf "$${RELEASE_REGISTRY_ERR}\n"; exit 1)
-	@set -e; { \
-		docker login -u `keybase fs read /keybase/team/datawireio/secrets/dockerhub.webui.d6eautomaton.username` \
-					 -p `keybase fs read /keybase/team/datawireio/secrets/dockerhub.webui.d6eautomaton.password` ;\
-		hotfix_tag=`git describe --tags --exact --match '*-hf*' | sed 's/^v//g'` ;\
+	@set -ex; { \
+		docker login -u $$(keybase fs read /keybase/team/datawireio/secrets/dockerhub.webui.d6eautomaton.username) \
+					 -p $$(keybase fs read /keybase/team/datawireio/secrets/dockerhub.webui.d6eautomaton.password) ;\
+		hotfix_tag=$$(git describe --tags --exact --match '*-hf*' | sed 's/^v//g') ;\
 		[[ "$(RELEASE_VERSION)" =~ ^[0-9]+\.[0-9]+\.[0-9]+-hf\.\[0-9]+\+[0-9]+$$ ]] || (printf '$(RED)ERROR: tag %s does not look like a hotfix tag\n' "$$hotfix_tag"; exit 1) ;\
 		commit=$$(git rev-parse HEAD) ;\
 		$(OSS_HOME)/releng/release-wait-for-commit --commit $$commit --s3-key passed-pr ;\
@@ -882,8 +882,8 @@ release/promote-oss/to-hotfix:
 			PROMOTE_CHANNEL=hotfix \
 		chartsuffix=$$hotfix_tag ;\
 		chartsuffix=$${chartsuffix#*-} ;\
-		export AWS_ACCESS_KEY_ID=`keybase fs read /keybase/team/datawireio/secrets/aws.s3-bot.cli-credentials | grep 'aws_access_key_id' | sed 's/aws_access_key_id=//g'` ;\
-		export AWS_SECRET_ACCESS_KEY=`keybase fs read /keybase/team/datawireio/secrets/aws.s3-bot.cli-credentials  | grep 'aws_secret_access_key'` ;\
+		export AWS_ACCESS_KEY_ID=$$(keybase fs read /keybase/team/datawireio/secrets/aws.s3-bot.cli-credentials | grep 'aws_access_key_id' | sed 's/aws_access_key_id=//g') ;\
+		export AWS_SECRET_ACCESS_KEY=$$(keybase fs read /keybase/team/datawireio/secrets/aws.s3-bot.cli-credentials  | grep 'aws_secret_access_key') ;\
 		$(MAKE) \
 			CHART_VERSION_SUFFIX=-$$chartsuffix \
 			IMAGE_TAG=$${hotfix_tag} \

--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -864,11 +864,11 @@ release/promote-oss/to-hotfix:
 	@test -n "$(RELEASE_REGISTRY)" || (printf "$${RELEASE_REGISTRY_ERR}\n"; exit 1)
 	@set -e; { \
 		docker login -u `keybase fs read /keybase/team/datawireio/secrets/dockerhub.webui.d6eautomaton.username` \
-					 -p `keybase fs read /keybase/team/datawireio/secrets/dockerhub.webui.d6eautomaton.password` ; \
-		hotfix_tag=`git describe --tags --exact --match '*-hf*' | sed 's/^v//g'` ; \
+					 -p `keybase fs read /keybase/team/datawireio/secrets/dockerhub.webui.d6eautomaton.password` ;\
+		hotfix_tag=`git describe --tags --exact --match '*-hf*' | sed 's/^v//g'` ;\
 		[[ "$(RELEASE_VERSION)" =~ ^[0-9]+\.[0-9]+\.[0-9]+-hf\.\[0-9]+\+[0-9]+$$ ]] || (printf '$(RED)ERROR: tag %s does not look like a hotfix tag\n' "$$hotfix_tag"; exit 1) ;\
 		commit=$$(git rev-parse HEAD) ;\
-		$(OSS_HOME)/releng/release-wait-for-commit --commit $$commit --s3-key passed-pr ; \
+		$(OSS_HOME)/releng/release-wait-for-commit --commit $$commit --s3-key passed-pr ;\
 		dev_version=$$(aws s3 cp s3://datawire-static-files/passed-pr/$$commit -) ;\
 		if [ -z "$$dev_version" ]; then \
 			printf "$(RED)==> found no passed dev version for $$commit in S3...$(END)\n" ;\
@@ -880,21 +880,21 @@ release/promote-oss/to-hotfix:
 			PROMOTE_FROM_REPO=$(DEV_REGISTRY) \
 			PROMOTE_TO_VERSION="$$hotfix_tag" \
 			PROMOTE_CHANNEL=hotfix \
-		chartsuffix=$$hotfix_tag ; \
-		chartsuffix=$${chartsuffix#*-} ; \
-		export AWS_ACCESS_KEY_ID=`keybase fs read /keybase/team/datawireio/secrets/aws.s3-bot.cli-credentials | grep 'aws_access_key_id' | sed 's/aws_access_key_id=//g'`; \
-		export AWS_SECRET_ACCESS_KEY=`keybase fs read /keybase/team/datawireio/secrets/aws.s3-bot.cli-credentials  | grep 'aws_secret_access_key' ; \
+		chartsuffix=$$hotfix_tag ;\
+		chartsuffix=$${chartsuffix#*-} ;\
+		export AWS_ACCESS_KEY_ID=`keybase fs read /keybase/team/datawireio/secrets/aws.s3-bot.cli-credentials | grep 'aws_access_key_id' | sed 's/aws_access_key_id=//g'` ;\
+		export AWS_SECRET_ACCESS_KEY=`keybase fs read /keybase/team/datawireio/secrets/aws.s3-bot.cli-credentials  | grep 'aws_secret_access_key' ;\
 		$(MAKE) \
 			CHART_VERSION_SUFFIX=-$$chartsuffix \
 			IMAGE_TAG=$${hotfix_tag} \
 			IMAGE_REPO="$(RELEASE_REGISTRY)/$(LCNAME)" \
-			chart-push-ci ; \
-		$(MAKE) update-yaml --always-make; \
-		$(MAKE) VERSION_OVERRIDE=$${hotfix_tag} push-manifests  ; \
-		$(MAKE) VERSION_OVERRIDE=$${hotfix_tag} publish-docs-yaml ; \
-		$(MAKE) clean-manifests ; \
-	    ; \
-		docker logout ; \
+			chart-push-ci ;\
+		$(MAKE) update-yaml --always-make ;\
+		$(MAKE) VERSION_OVERRIDE=$${hotfix_tag} push-manifests ;\
+		$(MAKE) VERSION_OVERRIDE=$${hotfix_tag} publish-docs-yaml ;\
+		$(MAKE) clean-manifests ;\
+	    ;\
+		docker logout ;\
 	}
 .PHONY: release/promote-oss/to-hotfix
 

--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -883,7 +883,7 @@ release/promote-oss/to-hotfix:
 		chartsuffix=$$hotfix_tag ;\
 		chartsuffix=$${chartsuffix#*-} ;\
 		export AWS_ACCESS_KEY_ID=`keybase fs read /keybase/team/datawireio/secrets/aws.s3-bot.cli-credentials | grep 'aws_access_key_id' | sed 's/aws_access_key_id=//g'` ;\
-		export AWS_SECRET_ACCESS_KEY=`keybase fs read /keybase/team/datawireio/secrets/aws.s3-bot.cli-credentials  | grep 'aws_secret_access_key' ;\
+		export AWS_SECRET_ACCESS_KEY=`keybase fs read /keybase/team/datawireio/secrets/aws.s3-bot.cli-credentials  | grep 'aws_secret_access_key'` ;\
 		$(MAKE) \
 			CHART_VERSION_SUFFIX=-$$chartsuffix \
 			IMAGE_TAG=$${hotfix_tag} \

--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -863,23 +863,23 @@ release/promote-oss/pr-to-passed-ci:
 release/promote-oss/to-hotfix:
 	@test -n "$(RELEASE_REGISTRY)" || (printf "$${RELEASE_REGISTRY_ERR}\n"; exit 1)
 	@set -e; { \
-	  docker login -u `keybase fs read /keybase/team/datawireio/secrets/dockerhub.webui.d6eautomaton.username` \
-		-p `keybase fs read /keybase/team/datawireio/secrets/dockerhub.webui.d6eautomaton.password` ; \
-	  hotfix_tag=`git describe --tags --exact --match '*-hf*' | sed 's/^v//g'` ; \
-	  [[ "$(RELEASE_VERSION)" =~ ^[0-9]+\.[0-9]+\.[0-9]+-hf\.\[0-9]+\+[0-9]+$$ ]] || (printf '$(RED)ERROR: tag %s does not look like a hotfix tag\n' "$$hotfix_tag"; exit 1) ;\
-	  commit=$$(git rev-parse HEAD) ;\
-	  $(OSS_HOME)/releng/release-wait-for-commit --commit $$commit --s3-key passed-pr ; \
-	  dev_version=$$(aws s3 cp s3://datawire-static-files/passed-pr/$$commit -) ;\
-	  if [ -z "$$dev_version" ]; then \
-		  printf "$(RED)==> found no passed dev version for $$commit in S3...$(END)\n" ;\
-		  exit 1 ;\
-      fi ;\
- 	  printf "$(CYN)==> $(GRN)found version $(BLU)$$dev_version$(GRN) for $(BLU)$$commit$(GRN) in S3...$(END)\n" ;\
-	  $(MAKE) release/promote-oss/.main \
-	    PROMOTE_FROM_VERSION="$$dev_version" \
-		PROMOTE_FROM_REPO=$(DEV_REGISTRY) \
-	    PROMOTE_TO_VERSION="$$hotfix_tag" \
-	    PROMOTE_CHANNEL=hotfix \
+		docker login -u `keybase fs read /keybase/team/datawireio/secrets/dockerhub.webui.d6eautomaton.username` \
+					 -p `keybase fs read /keybase/team/datawireio/secrets/dockerhub.webui.d6eautomaton.password` ; \
+		hotfix_tag=`git describe --tags --exact --match '*-hf*' | sed 's/^v//g'` ; \
+		[[ "$(RELEASE_VERSION)" =~ ^[0-9]+\.[0-9]+\.[0-9]+-hf\.\[0-9]+\+[0-9]+$$ ]] || (printf '$(RED)ERROR: tag %s does not look like a hotfix tag\n' "$$hotfix_tag"; exit 1) ;\
+		commit=$$(git rev-parse HEAD) ;\
+		$(OSS_HOME)/releng/release-wait-for-commit --commit $$commit --s3-key passed-pr ; \
+		dev_version=$$(aws s3 cp s3://datawire-static-files/passed-pr/$$commit -) ;\
+		if [ -z "$$dev_version" ]; then \
+			printf "$(RED)==> found no passed dev version for $$commit in S3...$(END)\n" ;\
+			exit 1 ;\
+		fi ;\
+		printf "$(CYN)==> $(GRN)found version $(BLU)$$dev_version$(GRN) for $(BLU)$$commit$(GRN) in S3...$(END)\n" ;\
+		$(MAKE) release/promote-oss/.main \
+			PROMOTE_FROM_VERSION="$$dev_version" \
+			PROMOTE_FROM_REPO=$(DEV_REGISTRY) \
+			PROMOTE_TO_VERSION="$$hotfix_tag" \
+			PROMOTE_CHANNEL=hotfix \
 		chartsuffix=$$hotfix_tag ; \
 		chartsuffix=$${chartsuffix#*-} ; \
 		export AWS_ACCESS_KEY_ID=`keybase fs read /keybase/team/datawireio/secrets/aws.s3-bot.cli-credentials | grep 'aws_access_key_id' | sed 's/aws_access_key_id=//g'`; \

--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -893,7 +893,6 @@ release/promote-oss/to-hotfix:
 		$(MAKE) VERSION_OVERRIDE=$${hotfix_tag} push-manifests ;\
 		$(MAKE) VERSION_OVERRIDE=$${hotfix_tag} publish-docs-yaml ;\
 		$(MAKE) clean-manifests ;\
-	    ;\
 		docker logout ;\
 	}
 .PHONY: release/promote-oss/to-hotfix

--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -887,7 +887,7 @@ release/promote-oss/to-hotfix:
 		chartsuffix=$$hotfix_tag ;\
 		chartsuffix=$${chartsuffix#*-} ;\
 		export AWS_ACCESS_KEY_ID=$$(keybase fs read /keybase/team/datawireio/secrets/aws.s3-bot.cli-credentials | grep 'aws_access_key_id' | sed 's/aws_access_key_id=//g') ;\
-		export AWS_SECRET_ACCESS_KEY=$$(keybase fs read /keybase/team/datawireio/secrets/aws.s3-bot.cli-credentials  | grep 'aws_secret_access_key') ;\
+		export AWS_SECRET_ACCESS_KEY=$$(keybase fs read /keybase/team/datawireio/secrets/aws.s3-bot.cli-credentials  | grep 'aws_secret_access_key' | sed 's/aws_secret_access_key=//g') ;\
 		$(MAKE) \
 			CHART_VERSION_SUFFIX=-$$chartsuffix \
 			IMAGE_TAG=$${hotfix_tag} \


### PR DESCRIPTION
Best reviewed commit-by-commit. This is all cleanup of details for the 1.x hotfix process (and, soon, the 2.x
hotfix process too).

- Clean up indentation.
- Consistent ;\
- Fix missing `
- Use $$( ) instead of `` (it's slightly easier to catch a missing close-paren than a missing backtick).
- Missing semicolon
- Drop excess ;
- Allow overriding the hotfix commitish using HOTFIX_COMMIT. Fix a couple of other small things (e.g. an excess `\` in the regex).
- Fix push tag.
- Fix AWS secret key assignment.
