### PR TITLE
[1.14] Expose per_connection_buffer_limit_bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,9 +80,8 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 ### Emissary Ingress and Ambassador Edge Stack
 
 - Change: Logs now include subsecond time resolutions, rather than just seconds.
-- Change: Update from Envoy 1.15 to 1.17.3
-- Change: `AMBASSADOR_ENVOY_API_VERSION` now defaults to `V3`
-- Feature: You can now set `allow_chunked_length` in the Ambassador Module to configure the same value in Envoy.
+- Change: Envoy's default 1MiB buffer limit can now be changed by setting `buffer_limit_bytes`
+  in the `Module` resource.
 
 ## [1.13.10] July 28, 2021
 [1.13.10]: https://github.com/emissary-ingress/emissary/compare/v1.13.9...v1.13.10

--- a/python/ambassador/envoy/v2/v2listener.py
+++ b/python/ambassador/envoy/v2/v2listener.py
@@ -1224,7 +1224,7 @@ class V2Listener(dict):
         }
         # We only want to add the buffer limit setting to the listener if specified in the module. Otherwise, we want to leave it unset and allow Envoys Default 1MiB setting.
         if 'buffer_limit_bytes' in self.config.ir.ambassador_module and self.config.ir.ambassador_module.buffer_limit_bytes != None:
-            listener.__setitem__("per_connection_buffer_limit_bytes", self.config.ir.ambassador_module.buffer_limit_bytes)
+            listener["per_connection_buffer_limit_bytes"] = self.config.ir.ambassador_module.buffer_limit_bytes
         return listener
 
 

--- a/python/ambassador/envoy/v2/v2listener.py
+++ b/python/ambassador/envoy/v2/v2listener.py
@@ -1220,7 +1220,7 @@ class V2Listener(dict):
             "address": self.address,
             "filter_chains": self.filter_chains,
             "listener_filters": self.listener_filters,
-            "traffic_direction": self.traffic_direction,
+            "traffic_direction": self.traffic_direction
         }
         # We only want to add the buffer limit setting to the listener if specified in the module. Otherwise, we want to leave it unset and allow Envoys Default 1MiB setting.
         if 'buffer_limit_bytes' in self.config.ir.ambassador_module and self.config.ir.ambassador_module.buffer_limit_bytes != None:

--- a/python/ambassador/envoy/v2/v2listener.py
+++ b/python/ambassador/envoy/v2/v2listener.py
@@ -836,6 +836,9 @@ class V2Listener(dict):
         self.http_filters: List[dict] = []
         self.listener_filters: List[dict] = []
         self.traffic_direction: str = "UNSPECIFIED"
+        # Envoy has a default value of 1 MiB for per_connection_buffer_limit_bytes ion the background
+        # Use the default unless specified in the Module
+        self.per_connection_buffer_limit_bytes = 1048576
 
         # It's important from a performance perspective to wrap debug log statements
         # with this check so we don't end up generating log strings (or even JSON
@@ -968,6 +971,10 @@ class V2Listener(dict):
 
         if 'server_name' in self.config.ir.ambassador_module:
             self.base_http_config["server_name"] = self.config.ir.ambassador_module.server_name
+
+        # Modify the default value of buffer_limit_bytes for later use if found in the module
+        if 'buffer_limit_bytes' in self.config.ir.ambassador_module:
+            self.per_connection_buffer_limit_bytes = self.config.ir.ambassador_module.buffer_limit_bytes
 
         listener_idle_timeout_ms = self.config.ir.ambassador_module.get('listener_idle_timeout_ms', None)
         if listener_idle_timeout_ms:
@@ -1220,7 +1227,8 @@ class V2Listener(dict):
             "address": self.address,
             "filter_chains": self.filter_chains,
             "listener_filters": self.listener_filters,
-            "traffic_direction": self.traffic_direction
+            "traffic_direction": self.traffic_direction,
+            "per_connection_buffer_limit_bytes": self.per_connection_buffer_limit_bytes
         }
 
     def pretty(self) -> dict:

--- a/python/ambassador/envoy/v3/v3listener.py
+++ b/python/ambassador/envoy/v3/v3listener.py
@@ -1273,7 +1273,7 @@ class V3Listener(dict):
         }
         # We only want to add the buffer limit setting to the listener if specified in the module. Otherwise, we want to leave it unset and allow Envoys Default 1MiB setting.
         if 'buffer_limit_bytes' in self.config.ir.ambassador_module and self.config.ir.ambassador_module.buffer_limit_bytes != None:
-            listener.__setitem__("per_connection_buffer_limit_bytes", self.config.ir.ambassador_module.buffer_limit_bytes)
+            listener["per_connection_buffer_limit_bytes"] = self.config.ir.ambassador_module.buffer_limit_bytes
         return listener
 
     def pretty(self) -> dict:

--- a/python/ambassador/envoy/v3/v3listener.py
+++ b/python/ambassador/envoy/v3/v3listener.py
@@ -861,6 +861,9 @@ class V3Listener(dict):
         self.http_filters: List[dict] = []
         self.listener_filters: List[dict] = []
         self.traffic_direction: str = "UNSPECIFIED"
+        # Envoy has a default value of 1 MiB for per_connection_buffer_limit_bytes ion the background
+        # Use the default unless specified in the Module
+        self.per_connection_buffer_limit_bytes = 1048576
 
         # It's important from a performance perspective to wrap debug log statements
         # with this check so we don't end up generating log strings (or even JSON
@@ -997,6 +1000,10 @@ class V3Listener(dict):
 
         if 'server_name' in self.config.ir.ambassador_module:
             self.base_http_config["server_name"] = self.config.ir.ambassador_module.server_name
+
+        # Modify the default value of buffer_limit_bytes for later use if found in the module
+        if 'buffer_limit_bytes' in self.config.ir.ambassador_module:
+            self.per_connection_buffer_limit_bytes = self.config.ir.ambassador_module.buffer_limit_bytes
 
         listener_idle_timeout_ms = self.config.ir.ambassador_module.get('listener_idle_timeout_ms', None)
         if listener_idle_timeout_ms:
@@ -1269,7 +1276,8 @@ class V3Listener(dict):
             "address": self.address,
             "filter_chains": self.filter_chains,
             "listener_filters": self.listener_filters,
-            "traffic_direction": self.traffic_direction
+            "traffic_direction": self.traffic_direction,
+            "per_connection_buffer_limit_bytes": self.buffer_limit_bytes
         }
 
     def pretty(self) -> dict:

--- a/python/ambassador/envoy/v3/v3listener.py
+++ b/python/ambassador/envoy/v3/v3listener.py
@@ -861,9 +861,6 @@ class V3Listener(dict):
         self.http_filters: List[dict] = []
         self.listener_filters: List[dict] = []
         self.traffic_direction: str = "UNSPECIFIED"
-        # Envoy has a default value of 1 MiB for per_connection_buffer_limit_bytes ion the background
-        # Use the default unless specified in the Module
-        self.per_connection_buffer_limit_bytes = 1048576
 
         # It's important from a performance perspective to wrap debug log statements
         # with this check so we don't end up generating log strings (or even JSON
@@ -1000,10 +997,6 @@ class V3Listener(dict):
 
         if 'server_name' in self.config.ir.ambassador_module:
             self.base_http_config["server_name"] = self.config.ir.ambassador_module.server_name
-
-        # Modify the default value of buffer_limit_bytes for later use if found in the module
-        if 'buffer_limit_bytes' in self.config.ir.ambassador_module:
-            self.per_connection_buffer_limit_bytes = self.config.ir.ambassador_module.buffer_limit_bytes
 
         listener_idle_timeout_ms = self.config.ir.ambassador_module.get('listener_idle_timeout_ms', None)
         if listener_idle_timeout_ms:

--- a/python/ambassador/envoy/v3/v3listener.py
+++ b/python/ambassador/envoy/v3/v3listener.py
@@ -1277,7 +1277,7 @@ class V3Listener(dict):
             "filter_chains": self.filter_chains,
             "listener_filters": self.listener_filters,
             "traffic_direction": self.traffic_direction,
-            "per_connection_buffer_limit_bytes": self.buffer_limit_bytes
+            "per_connection_buffer_limit_bytes": self.per_connection_buffer_limit_bytes
         }
 
     def pretty(self) -> dict:

--- a/python/ambassador/envoy/v3/v3listener.py
+++ b/python/ambassador/envoy/v3/v3listener.py
@@ -1269,7 +1269,7 @@ class V3Listener(dict):
             "address": self.address,
             "filter_chains": self.filter_chains,
             "listener_filters": self.listener_filters,
-            "traffic_direction": self.traffic_direction,
+            "traffic_direction": self.traffic_direction
         }
         # We only want to add the buffer limit setting to the listener if specified in the module. Otherwise, we want to leave it unset and allow Envoys Default 1MiB setting.
         if 'buffer_limit_bytes' in self.config.ir.ambassador_module and self.config.ir.ambassador_module.buffer_limit_bytes != None:

--- a/python/ambassador/envoy/v3/v3listener.py
+++ b/python/ambassador/envoy/v3/v3listener.py
@@ -1271,14 +1271,17 @@ class V3Listener(dict):
             })
 
     def as_dict(self) -> dict:
-        return {
+        listener = {
             "name": self.name,
             "address": self.address,
             "filter_chains": self.filter_chains,
             "listener_filters": self.listener_filters,
             "traffic_direction": self.traffic_direction,
-            "per_connection_buffer_limit_bytes": self.per_connection_buffer_limit_bytes
         }
+        # We only want to add the buffer limit setting to the listener if specified in the module. Otherwise, we want to leave it unset and allow Envoys Default 1MiB setting.
+        if 'buffer_limit_bytes' in self.config.ir.ambassador_module and self.config.ir.ambassador_module.buffer_limit_bytes != None:
+            listener.__setitem__("per_connection_buffer_limit_bytes", self.config.ir.ambassador_module.buffer_limit_bytes)
+        return listener
 
     def pretty(self) -> dict:
         return { "name": self.name,

--- a/python/ambassador/ir/ir.py
+++ b/python/ambassador/ir/ir.py
@@ -921,7 +921,7 @@ class IR:
 
         od['custom_ambassador_id'] = bool(self.ambassador_id != 'default')
 
-        od['buffer_limit_bytes'] = self.ambassador_module.get('buffer_limit_bytes', 1048576) # The default Envoy size is 1 MiB if not defined
+        od['buffer_limit_bytes'] = self.ambassador_module.get('buffer_limit_bytes', None)
 
         default_port = Constants.SERVICE_PORT_HTTPS if tls_termination_count else Constants.SERVICE_PORT_HTTP
 

--- a/python/ambassador/ir/ir.py
+++ b/python/ambassador/ir/ir.py
@@ -921,6 +921,8 @@ class IR:
 
         od['custom_ambassador_id'] = bool(self.ambassador_id != 'default')
 
+        od['buffer_limit_bytes'] = self.ambassador_module.get('buffer_limit_bytes', 1048576) # The default Envoy size is 1 MiB if not defined
+
         default_port = Constants.SERVICE_PORT_HTTPS if tls_termination_count else Constants.SERVICE_PORT_HTTP
 
         od['custom_listener_port'] = bool(self.ambassador_module.service_port != default_port)

--- a/python/ambassador/ir/irambassador.py
+++ b/python/ambassador/ir/irambassador.py
@@ -32,6 +32,7 @@ class IRAmbassador (IRResource):
         'admin_port',
         'auth_enabled',
         'allow_chunked_length',
+        'buffer_limit_bytes', 
         'circuit_breakers',
         'cluster_idle_timeout_ms',
         'cluster_max_connection_lifetime_ms',

--- a/python/tests/kat/t_bufferlimitbytes.py
+++ b/python/tests/kat/t_bufferlimitbytes.py
@@ -1,0 +1,38 @@
+from kat.harness import Query
+from abstract_tests import AmbassadorTest, ServiceType, HTTP
+import json
+
+class BufferLimitBytesTest(AmbassadorTest):
+    target: ServiceType
+
+    def init(self):
+        self.target = HTTP(name="target")
+
+    # Test generating config with an increased buffer and that the lua body() funciton runs to buffer the request body
+    def config(self):
+        yield self, self.format("""
+---
+apiVersion: ambassador/v1
+kind:  Module
+name:  ambassador
+config:
+  buffer_limit_bytes: 5242880
+  lua_scripts: |
+      function envoy_on_request(request_handle)
+        request_handle:headers():add("buffered", "true")
+      end
+---
+apiVersion: ambassador/v1
+kind:  Mapping
+name:  {self.target.path.k8s}-foo
+prefix: /foo/
+service: {self.target.path.fqdn}
+""")
+
+    def queries(self):
+        yield Query(self.url("target/"))
+
+    def check(self):
+        assert self.results[0].status == 200
+        assert "buffered" in self.results[0].headers
+

--- a/python/tests/kat/t_bufferlimitbytes.py
+++ b/python/tests/kat/t_bufferlimitbytes.py
@@ -31,7 +31,7 @@ service: {self.target.path.fqdn}
 
     def queries(self):
         yield Query(self.url("foo/"))
-        yield Query(self.url("ambassador/v0/diag/")      
+        yield Query(self.url("ambassador/v0/diag/"))   
 
     def check(self):
         assert self.results[0].status == 200

--- a/python/tests/kat/t_bufferlimitbytes.py
+++ b/python/tests/kat/t_bufferlimitbytes.py
@@ -12,17 +12,17 @@ class BufferLimitBytesTest(AmbassadorTest):
     def config(self):
         yield self, self.format("""
 ---
-apiVersion: ambassador/v1
+apiVersion: ambassador/v2
 kind:  Module
 name:  ambassador
 config:
   buffer_limit_bytes: 5242880
-    lua_scripts: |
-      function envoy_on_request(request_handle)
-        request_handle:headers():add("request_body_size", request_handle:body():length())
-      end
+  lua_scripts: |
+    function envoy_on_request(request_handle)
+      request_handle:headers():add("request_body_size", request_handle:body():length())
+    end
 ---
-apiVersion: ambassador/v1
+apiVersion: ambassador/v2
 kind:  Mapping
 name:  {self.target.path.k8s}-foo
 prefix: /foo/

--- a/python/tests/kat/t_bufferlimitbytes.py
+++ b/python/tests/kat/t_bufferlimitbytes.py
@@ -17,9 +17,9 @@ kind:  Module
 name:  ambassador
 config:
   buffer_limit_bytes: 5242880
-  lua_scripts: |
+    lua_scripts: |
       function envoy_on_request(request_handle)
-        request_handle:headers():add("buffered", "true")
+        request_handle:headers():add("request_body_size", request_handle:body():length())
       end
 ---
 apiVersion: ambassador/v1
@@ -35,6 +35,5 @@ service: {self.target.path.fqdn}
 
     def check(self):
         assert self.results[0].status == 200
-        assert "buffered" in self.results[0].headers
         assert self.results[1].status == 200
 

--- a/python/tests/kat/t_bufferlimitbytes.py
+++ b/python/tests/kat/t_bufferlimitbytes.py
@@ -30,9 +30,11 @@ service: {self.target.path.fqdn}
 """)
 
     def queries(self):
-        yield Query(self.url("target/"))
+        yield Query(self.url("foo/"))
+        yield Query(self.url("ambassador/v0/diag/")      
 
     def check(self):
         assert self.results[0].status == 200
         assert "buffered" in self.results[0].headers
+        assert self.results[1].status == 200
 

--- a/python/tests/kat/test_ambassador.py
+++ b/python/tests/kat/test_ambassador.py
@@ -43,6 +43,7 @@ import t_request_header
 import t_regexrewrite_forwarding
 import t_error_response
 import t_chunked_length
+import t_bufferlimitbytes
 
 # pytest will find this because Runner is a toplevel callable object in a file
 # that pytest is willing to look inside.

--- a/python/tests/test_buffer_limit_bytes.py
+++ b/python/tests/test_buffer_limit_bytes.py
@@ -105,16 +105,13 @@ prefix: /test/
 service: test:9999
 """
     econf = _get_envoy_config(yaml, version='V2')
-    key_found = False
 
     conf = econf.as_dict()
 
     for listener in conf['static_resources']['listeners']:
         per_connection_buffer_limit_bytes = listener.get('per_connection_buffer_limit_bytes', None)
         assert per_connection_buffer_limit_bytes is None, \
-            f"per_connection_buffer_limit_bytes WRONGLY found on listener (should not exist): {listener.name}"
-        key_found = True
-    assert not key_found, 'per_connection_buffer_limit_bytes should not exist in the envoy config when disabled'
+            f"per_connection_buffer_limit_bytes found on listener (should not exist unless configured in the module): {listener.name}"
 
 
 @pytest.mark.compilertest
@@ -128,13 +125,10 @@ prefix: /test/
 service: test:9999
 """
     econf = _get_envoy_config(yaml)
-    key_found = False
 
     conf = econf.as_dict()
 
     for listener in conf['static_resources']['listeners']:
         per_connection_buffer_limit_bytes = listener.get('per_connection_buffer_limit_bytes', None)
         assert per_connection_buffer_limit_bytes is None, \
-            f"per_connection_buffer_limit_bytes WRONGLY found on listener (should not exist): {listener.name}"
-        key_found = True
-    assert not key_found, 'per_connection_buffer_limit_bytes should not exist in the envoy config when disabled'
+            f"per_connection_buffer_limit_bytes found on listener (should not exist unless configured in the module): {listener.name}"

--- a/python/tests/test_buffer_limit_bytes.py
+++ b/python/tests/test_buffer_limit_bytes.py
@@ -1,0 +1,148 @@
+import logging
+
+import pytest
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s test %(levelname)s: %(message)s",
+    datefmt='%Y-%m-%d %H:%M:%S'
+)
+
+logger = logging.getLogger("ambassador")
+
+from ambassador import Config, IR, EnvoyConfig
+from ambassador.fetch import ResourceFetcher
+from ambassador.utils import NullSecretHandler
+
+
+def _get_envoy_config(yaml, version='V3'):
+    aconf = Config()
+    fetcher = ResourceFetcher(logger, aconf)
+    fetcher.parse_yaml(yaml)
+    aconf.load_all(fetcher.sorted())
+    secret_handler = NullSecretHandler(logger, None, None, "0")
+    ir = IR(aconf, file_checker=lambda path: True, secret_handler=secret_handler)
+
+    assert ir
+
+    return EnvoyConfig.generate(ir, version)
+
+
+@pytest.mark.compilertest
+def test_setting_buffer_limit():
+    yaml = """
+---
+apiVersion: getambassador.io/v2
+kind: Module
+name: ambassador
+config:
+  buffer_limit_bytes: 5242880
+---
+apiVersion: getambassador.io/v2
+kind: Mapping
+name: ambassador
+prefix: /test/
+service: test:9999
+"""
+    econf = _get_envoy_config(yaml, version='V2')
+    expected = 5242880
+    key_found = False
+
+    conf = econf.as_dict()
+
+    for listener in conf['static_resources']['listeners']:
+        per_connection_buffer_limit_bytes = listener.get('per_connection_buffer_limit_bytes', None)
+        assert per_connection_buffer_limit_bytes is not None, \
+            f"per_connection_buffer_limit_bytes not found on listener: {listener.name}"
+        print(f"Found per_connection_buffer_limit_bytes = {per_connection_buffer_limit_bytes}")
+        key_found = True
+        assert expected == int(per_connection_buffer_limit_bytes), \
+            "per_connection_buffer_limit_bytes must equal the value set on the ambassador Module"
+    assert key_found, 'per_connection_buffer_limit_bytes must be found in the envoy config'
+
+
+@pytest.mark.compilertest
+def test_setting_buffer_limit_V3():
+    yaml = """
+---
+apiVersion: getambassador.io/v2
+kind: Module
+name: ambassador
+config:
+  buffer_limit_bytes: 5242880
+---
+apiVersion: getambassador.io/v2
+kind: Mapping
+name: ambassador
+prefix: /test/
+service: test:9999
+"""
+    econf = _get_envoy_config(yaml)
+    expected = 5242880
+    key_found = False
+
+    conf = econf.as_dict()
+
+    for listener in conf['static_resources']['listeners']:
+        per_connection_buffer_limit_bytes = listener.get('per_connection_buffer_limit_bytes', None)
+        assert per_connection_buffer_limit_bytes is not None, \
+            f"per_connection_buffer_limit_bytes not found on listener: {listener.name}"
+        print(f"Found per_connection_buffer_limit_bytes = {per_connection_buffer_limit_bytes}")
+        key_found = True
+        assert expected == int(per_connection_buffer_limit_bytes), \
+            "per_connection_buffer_limit_bytes must equal the value set on the ambassador Module"
+    assert key_found, 'per_connection_buffer_limit_bytes must be found in the envoy config'
+
+# Tests that the default value of per_connection_buffer_limit_bytes is 1MiB when no Module config
+@pytest.mark.compilertest
+def test_default_buffer_limit():
+    yaml = """
+---
+apiVersion: getambassador.io/v2
+kind: Mapping
+name: ambassador
+prefix: /test/
+service: test:9999
+"""
+    econf = _get_envoy_config(yaml, version='V2')
+    expected = 1048576
+    key_found = False
+
+    conf = econf.as_dict()
+
+    for listener in conf['static_resources']['listeners']:
+        per_connection_buffer_limit_bytes = listener.get('per_connection_buffer_limit_bytes', None)
+        assert per_connection_buffer_limit_bytes is not None, \
+            f"per_connection_buffer_limit_bytes not found on listener: {listener.name}"
+        print(f"Found per_connection_buffer_limit_bytes = {per_connection_buffer_limit_bytes}")
+        key_found = True
+        assert expected == int(per_connection_buffer_limit_bytes), \
+            "per_connection_buffer_limit_bytes must equal the value set on the ambassador Module"
+    assert key_found, 'per_connection_buffer_limit_bytes must be found in the envoy config'
+
+
+@pytest.mark.compilertest
+def test_default_buffer_limit_V3():
+    yaml = """
+---
+apiVersion: getambassador.io/v2
+kind: Mapping
+name: ambassador
+prefix: /test/
+service: test:9999
+"""
+    econf = _get_envoy_config(yaml)
+    expected = 1048576
+    key_found = False
+
+    conf = econf.as_dict()
+
+    for listener in conf['static_resources']['listeners']:
+        per_connection_buffer_limit_bytes = listener.get('per_connection_buffer_limit_bytes', None)
+        assert per_connection_buffer_limit_bytes is not None, \
+            f"per_connection_buffer_limit_bytes not found on listener: {listener.name}"
+        print(f"Found per_connection_buffer_limit_bytes = {per_connection_buffer_limit_bytes}")
+        key_found = True
+        assert expected == int(per_connection_buffer_limit_bytes), \
+            "per_connection_buffer_limit_bytes must equal the value set on the ambassador Module"
+    assert key_found, 'per_connection_buffer_limit_bytes must be found in the envoy config'

--- a/python/tests/test_buffer_limit_bytes.py
+++ b/python/tests/test_buffer_limit_bytes.py
@@ -136,5 +136,5 @@ service: test:9999
         per_connection_buffer_limit_bytes = listener.get('per_connection_buffer_limit_bytes', None)
         assert per_connection_buffer_limit_bytes is None, \
             f"per_connection_buffer_limit_bytes WRONGLY found on listener (should not exist): {listener.name}"
-        key_found = True"
+        key_found = True
     assert not key_found, 'per_connection_buffer_limit_bytes should not exist in the envoy config when disabled'

--- a/python/tests/test_buffer_limit_bytes.py
+++ b/python/tests/test_buffer_limit_bytes.py
@@ -93,7 +93,7 @@ service: test:9999
             "per_connection_buffer_limit_bytes must equal the value set on the ambassador Module"
     assert key_found, 'per_connection_buffer_limit_bytes must be found in the envoy config'
 
-# Tests that the default value of per_connection_buffer_limit_bytes is 1MiB when no Module config
+# Tests that the default value of per_connection_buffer_limit_bytes is disabled when there is not Module config for it.
 @pytest.mark.compilertest
 def test_default_buffer_limit():
     yaml = """
@@ -105,20 +105,16 @@ prefix: /test/
 service: test:9999
 """
     econf = _get_envoy_config(yaml, version='V2')
-    expected = 1048576
     key_found = False
 
     conf = econf.as_dict()
 
     for listener in conf['static_resources']['listeners']:
         per_connection_buffer_limit_bytes = listener.get('per_connection_buffer_limit_bytes', None)
-        assert per_connection_buffer_limit_bytes is not None, \
-            f"per_connection_buffer_limit_bytes not found on listener: {listener.name}"
-        print(f"Found per_connection_buffer_limit_bytes = {per_connection_buffer_limit_bytes}")
+        assert per_connection_buffer_limit_bytes is None, \
+            f"per_connection_buffer_limit_bytes WRONGLY found on listener (should not exist): {listener.name}"
         key_found = True
-        assert expected == int(per_connection_buffer_limit_bytes), \
-            "per_connection_buffer_limit_bytes must equal the value set on the ambassador Module"
-    assert key_found, 'per_connection_buffer_limit_bytes must be found in the envoy config'
+    assert not key_found, 'per_connection_buffer_limit_bytes should not exist in the envoy config when disabled'
 
 
 @pytest.mark.compilertest
@@ -132,17 +128,13 @@ prefix: /test/
 service: test:9999
 """
     econf = _get_envoy_config(yaml)
-    expected = 1048576
     key_found = False
 
     conf = econf.as_dict()
 
     for listener in conf['static_resources']['listeners']:
         per_connection_buffer_limit_bytes = listener.get('per_connection_buffer_limit_bytes', None)
-        assert per_connection_buffer_limit_bytes is not None, \
-            f"per_connection_buffer_limit_bytes not found on listener: {listener.name}"
-        print(f"Found per_connection_buffer_limit_bytes = {per_connection_buffer_limit_bytes}")
-        key_found = True
-        assert expected == int(per_connection_buffer_limit_bytes), \
-            "per_connection_buffer_limit_bytes must equal the value set on the ambassador Module"
-    assert key_found, 'per_connection_buffer_limit_bytes must be found in the envoy config'
+        assert per_connection_buffer_limit_bytes is None, \
+            f"per_connection_buffer_limit_bytes WRONGLY found on listener (should not exist): {listener.name}"
+        key_found = True"
+    assert not key_found, 'per_connection_buffer_limit_bytes should not exist in the envoy config when disabled'


### PR DESCRIPTION
Signed-off-by: AliceProxy <aliceproxy@protonmail.com>

## Description
Makes the Envoy setting `per_connection_buffer_limit_bytes` configurable via the `Module`. The default is 1 MiB enforced by Envoy when not specified.

## Testing
I did some manual testing to verify the envoy config generated and that the listeners were not noticeably impacted. Wrote some tests as well to check the Envoy config and try requests.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `CHANGELOG.md`.
   
   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations
 
 - [x] This is unlikely to impact how Ambassador performs at scale.
 
   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability
 
 - [x] My change is adequately tested.
 
   Remember when considering testing:
    + LEGACY MODE TESTS DO NOT RUN FOR EVERY PR. If your change is affected by legacy mode, you need
      to run legacy-mode tests manually (set `AMBASSADOR_LEGACY_MODE=true` and run the tests).
      (This will be fixed soon.)
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points
 
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
