### PR TITLE
Fix letter_range all

### DIFF
--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -471,6 +471,8 @@ pytest: docker/$(LCNAME).docker.push.remote docker/kat-client.docker.push.remote
 	@echo "KAT_CLIENT_DOCKER_IMAGE=$$KAT_CLIENT_DOCKER_IMAGE"
 	@echo "KAT_SERVER_DOCKER_IMAGE=$$KAT_SERVER_DOCKER_IMAGE"
 	@echo "DEV_KUBECONFIG=$$DEV_KUBECONFIG"
+	@echo "KAT_RUN_MODE=$$KAT_RUN_MODE"
+	@echo "PYTEST_ARGS=$$PYTEST_ARGS"
 	. $(OSS_HOME)/venv/bin/activate; \
 		$(OSS_HOME)/builder/builder.sh pytest-local
 .PHONY: pytest

--- a/python/tests/kat/conftest.py
+++ b/python/tests/kat/conftest.py
@@ -8,3 +8,5 @@ letter_range = None
 def pytest_configure(config):
     global letter_range
     letter_range = config.getoption('--letter-range')
+
+    print(f"pytest selecting tests in letter range {letter_range}")

--- a/python/tests/kat/t_mappingtests.py
+++ b/python/tests/kat/t_mappingtests.py
@@ -305,7 +305,7 @@ name:  {self.name}
 hostname: "*"
 prefix: /{self.name}/status/
 rewrite: /status/
-service: httpbin.plain-namespace
+service: httpbin.default
 """)
 
     def queries(self):
@@ -341,7 +341,7 @@ name:  {self.name}
 hostname: "*"
 prefix: /{self.name}/status/
 rewrite: /status/
-service: httpbin.plain-namespace
+service: httpbin.default
 """)
 
     def queries(self):
@@ -370,7 +370,7 @@ name:  {self.name}
 hostname: "*"
 prefix: /{self.name}/status/
 rewrite: /status/
-service: httpbin.plain-namespace
+service: httpbin.default
 """)
 
     def queries(self):
@@ -474,7 +474,7 @@ kind: AmbassadorMapping
 name:  {self.name}
 hostname: "*"
 prefix: /{self.name}/
-service: websocket-echo-server.plain-namespace
+service: websocket-echo-server.default
 use_websocket: true
 """)
 
@@ -804,7 +804,7 @@ kind: AmbassadorMapping
 name:  {self.name}
 hostname: "*"
 prefix: /{self.name}/
-service: httpbin.plain-namespace
+service: httpbin.default
 add_response_headers:
     koo:
         append: False
@@ -877,7 +877,7 @@ kind: AmbassadorMapping
 name:  {self.name}
 hostname: "*"
 prefix: /{self.name}/
-service: httpbin.plain-namespace
+service: httpbin.default
 remove_request_headers:
 - zoo
 - aoo
@@ -1092,7 +1092,7 @@ metadata:
   name: thisisaverylongservicenameoverwithsixythreecharacters123456789
 spec:
   type: ExternalName
-  externalName: httpbin.plain-namespace.svc.cluster.local
+  externalName: httpbin.default.svc.cluster.local
 ---
 apiVersion: x.getambassador.io/v3alpha1
 kind: AmbassadorMapping

--- a/python/tests/kat/t_tls.py
+++ b/python/tests/kat/t_tls.py
@@ -403,10 +403,10 @@ spec:
 #     secret: test-tls-secret
 # """)
 
-        # Use self.target _here_, because we want the httpbin mapping to
-        # be annotated on the service, not the Ambassador. Also, you don't
-        # need to include the ambassador_id unless you need some special
-        # ambassador_id that isn't something that kat already knows about.
+        # Use self.target _here_, because we want the mapping to be annotated
+        # on the service, not the Ambassador. Also, you don't need to include 
+        # the ambassador_id unless you need some special ambassador_id that
+        # isn't something that kat already knows about.
         #
         # If the test were more complex, we'd probably need to do some sort
         # of mangling for the mapping name and prefix. For this simple test,

--- a/python/tests/kat/test_ambassador.py
+++ b/python/tests/kat/test_ambassador.py
@@ -8,6 +8,10 @@ from abstract_tests import AmbassadorTest
 
 # Import all the real tests from other files, to make it easier to pick and choose during development.
 
+if letter_range not in ["all", "ah", "ip", "qz"]:
+    print("Unknown test file name letter range: %s!" % letter_range)
+    sys.exit(1)
+
 if letter_range in ["all","ah"]:
 	import t_basics
 	import t_circuitbreaker
@@ -51,9 +55,6 @@ if letter_range in ["all","qz"]:
 	import t_tcpmapping
 	import t_tls
 	import t_tracing
-else:
-  print("Unknown test file name letter range: %s!" % letter_range)
-  sys.exit(1)
 
 # pytest will find this because Runner is a toplevel callable object in a file
 # that pytest is willing to look inside.

--- a/python/tests/kat/test_ambassador.py
+++ b/python/tests/kat/test_ambassador.py
@@ -25,7 +25,8 @@ if letter_range in ["all","ah"]:
 	import t_headerrouting
 	import t_headerswithunderscoresaction
 	import t_hosts
-elif letter_range in ["all","ip"]:
+
+if letter_range in ["all","ip"]:
 	import t_ingress
 	import t_ip_allow_deny
 	import t_listeneridletimeout
@@ -37,7 +38,8 @@ elif letter_range in ["all","ip"]:
     # t_plain include t_mappingtests and t_optiontests as imports
     # these tests require each other and need to be executed as a set
 	import t_plain
-elif letter_range in ["all","qz"]:
+
+if letter_range in ["all","qz"]:
 	import t_queryparameter_routing
 	import t_ratelimit
 	import t_redirect


### PR DESCRIPTION
Make `--letter_range=all` be all pytests, rather than actually being just the A-H pytests.

Also add some logging about what's actually going on.

Signed-off-by: Flynn <flynn@datawire.io>

- [x] I don't need to update `CHANGELOG.md`.
- [x] This is unlikely to impact how Ambassador performs at scale.
- [x] My change is adequately tested.
- [x] I don't need to update `DEVELOPING.md`.

