### PR TITLE
[2.0.1] CHANGELOG + fixes from 1.13.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,13 +73,20 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 ## [2.0.1-ea] (TBD)
 [2.0.1-ea]: https://github.com/emissary-ingress/emissary/compare/v2.0.0-ea...v2.0.1-ea
 
-### Emissary Ingress
-
 We're pleased to introduce Emissary 2.0.1 as a developer preview. The 2.X family introduces a number of changes to allow Emissary to more gracefully handle larger installations, reduce global configuration to better handle multitenant or multiorganizational installations, reduce memory footprint, and improve performance. We welcome feedback!! Join us on <a href="https://a8r.io/slack">Slack</a> and let us know what you think.
+
+### Emissary Ingress
 
 - Feature: The optional `statsPrefix` element of the `AmbassadorListener` CRD now determines the prefix of HTTP statistics emitted for a specific `AmbassadorListener`.
 - Feature: Ambassador Agent reports sidecar process information and Mapping OpenAPI documentation to Ambassador Cloud to provide more visibility into services and clusters.
 - Change: Logs now include subsecond time resolutions, rather than just seconds.
+- Change: Envoy-configuration snapshots get saved (as `ambex-#.json`) in `/ambassador/snapshots`.
+  The number of snapshots is controlled by the `AMBASSADOR_AMBEX_SNAPSHOT_COUNT` environment
+  variable; set it to 0 to disable. The default is 30.
+- Change: Set `AMBASSADOR_AMBEX_NO_RATELIMIT` to `true` to completely disable ratelimiting Envoy
+  reconfiguration under memory pressure. This can help performance with the endpoint or Consul
+  resolvers, but could make OOMkills more likely with large configurations. The default is `false`,
+  meaning that the rate limiter is active.
 
 ## [2.0.0-ea] June 24, 2021
 [2.0.0-ea]: https://github.com/emissary-ingress/emissary/compare/v1.13.8...v2.0.0-ea
@@ -102,6 +109,37 @@ We're pleased to introduce Emissary 2.0.0 as a developer preview. The 2.X family
 - Change: The edgectl CLI tool has been deprecated, please use the `emissary-ingress` helm chart instead.
 
 [#2888]: https://github.com/datawire/ambassador/issues/2888
+
+## [1.13.11] (TBD)
+[1.13.11]: https://github.com/emissary-ingress/emissary/compare/v1.13.10...v1.13.11
+
+### Emissary Ingress and Ambassador Edge Stack
+
+- Change: Logs now include subsecond time resolutions, rather than just seconds.
+
+## [1.13.10] July 28, 2021
+[1.13.10]: https://github.com/emissary-ingress/emissary/compare/v1.13.9...v1.13.10
+
+### Emissary Ingress and Ambassador Edge Stack
+
+- Bugfix: Fixed a regression when specifying a comma separated string for `cors.origins` on the
+  `Mapping` resource. ([#3609])
+- Change: Envoy-configuration snapshots get saved (as `ambex-#.json`) in `/ambassador/snapshots`.
+  The number of snapshots is controlled by the `AMBASSADOR_AMBEX_SNAPSHOT_COUNT` environment
+  variable; set it to 0 to disable. The default is 30.
+- Change: Set `AMBASSADOR_AMBEX_NO_RATELIMIT` to `true` to completely disable ratelimiting Envoy
+  reconfiguration under memory pressure. This can help performance with the endpoint or Consul
+  resolvers, but could make OOMkills more likely with large configurations. The default is `false`,
+  meaning that the rate limiter is active.
+
+### Ambassador Edge Stack only
+
+- Bugfix: The `Mapping` resource can now specify `docs.timeout_ms` to set the timeout when the 
+  Dev Portal is fetching API specifications.
+- Bugfix: The Dev Portal will now strip HTML tags when displaying search results, showing just
+  the actual content of the search result.
+- Change: Consul certificate-rotation logging now includes the fingerprints and validity
+  timestamps of certificates being rotated.
 
 ## [1.13.8] June 08, 2021
 [1.13.8]: https://github.com/emissary-ingress/emissary/compare/v1.13.7...v1.13.8

--- a/cmd/ambex/main.go
+++ b/cmd/ambex/main.go
@@ -601,6 +601,8 @@ func (l loggerv3) OnFetchResponse(req *v3discovery.DiscoveryRequest, res *v3disc
 	l.Infof("V3 Fetch response: %v -> %v", req, res)
 }
 
+// NOTE WELL: this Main() does NOT RUN from entrypoint! This one is only relevant if you
+// explicitly run Ambex by hand.
 func Main(ctx context.Context, Version string, rawArgs ...string) error {
 	usage := memory.GetMemoryUsage()
 	go usage.Watch(ctx)


### PR DESCRIPTION
One fix from 1.13.10, plus the CHANGELOG updates we need.

- Allow disabling the ambex ratelimiter
- CHANGELOG

 - [x] I made sure to update `CHANGELOG.md`.
 - [x] This is unlikely to impact how Ambassador performs at scale.
 - [ ] My change is adequately tested.
 - [x] I didn't need to update `DEVELOPING.md`.

