### PR TITLE
fix ambassador cli in a hacky way

### DIFF
--- a/python/ambassador_cli/ambassador.py
+++ b/python/ambassador_cli/ambassador.py
@@ -262,7 +262,7 @@ def dump(config_dir_path: Parameter.REQUIRED, *,
         with v3_timer:
             if dump_v3:
                 v3config = V3Config(ir)
-                diagconfig = v3config
+                diagconfigv3 = v3config
                 od['v3'] = v3config.as_dict()
         diag_timer = Timer("diag")
         with diag_timer:
@@ -275,9 +275,11 @@ def dump(config_dir_path: Parameter.REQUIRED, *,
                 diag = Diagnostics(ir, econf)
                 diagv3 = Diagnostics(ir, econfv3)
                 od['diag'] = diag.as_dict()
-                od['elements'] = econf.elements
+                # Something in here is of type set which really upsets the json dumper
+                # od['elements'] = econf.elements
                 od['diagv3'] = diagv3.as_dict()
-                od['elementsv3'] = econfv3.elements
+                # Something in here is of type set which really upsets the json dumper
+                # od['elementsv3'] = econfv3.elements
 
         features_timer = Timer("features")
         with features_timer:


### PR DESCRIPTION
Signed-off-by: Alix Cook <alixcook@datawire.io>

## Description
The ambassador CLI is currently totatlly borked when you run it with --diagd or --everything

That's.... bad. This is my 2 second way to fix it, and hopefully we can spend more time to get rid of those commented out things next week.

## Related Issues

n/a

## Testing

Ran the cli locally

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `CHANGELOG.md`.

   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations

 - [ ] This is unlikely to impact how Ambassador performs at scale.

   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability

 - [ ] My change is adequately tested.

   Remember when considering testing:
    + LEGACY MODE TESTS DO NOT RUN FOR EVERY PR. If your change is affected by legacy mode, you need
      to run legacy-mode tests manually (set `AMBASSADOR_LEGACY_MODE=true` and run the tests).
      (This will be fixed soon.)
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points

 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
