### PR TITLE
[v1.14.0] Changelog date update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 ### Emissary Ingress and Ambassador Edge Stack
 
 - Change: Logs now include subsecond time resolutions, rather than just seconds.
-- Change: Update from Envoy 1.15 to 1.17
+- Change: Update from Envoy 1.15 to 1.17.3
 - Change: `AMBASSADOR_ENVOY_API_VERSION` now defaults to `V3`
 - Feature: You can now set `allow_chunked_length` in the Ambassador Module to configure the same value in Envoy.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 ## RELEASE NOTES
 
-## [1.14.0] (TBD)
+## [1.14.0] August 19, 2021
 [1.14.0]: https://github.com/emissary-ingress/emissary/compare/v1.13.10...v1.14.0
 
 ### Emissary Ingress and Ambassador Edge Stack


### PR DESCRIPTION
Changelog date updates for 1.14.0

Reviewers: The only changes in this PR should be updating the changelog entry for 1.14.0 to the date it was released.

If there are any other changes, the PR creator should note the reason.