### PR TITLE
[v1.14.1] Release Branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,13 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 (no changes yet)
 
+## [1.14.1] (TBD)
+[1.14.1]: https://github.com/emissary-ingress/emissary/compare/v1.14.0...v1.14.1
+
+### Emissary Ingress and Ambassador Edge Stack
+
+(no changes yet)
+
 ## [1.14.0] August 19, 2021
 [1.14.0]: https://github.com/emissary-ingress/emissary/compare/v1.13.10...v1.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 ## RELEASE NOTES
 
-## [1.14.1] (TBD)
+## [1.14.1] August 24, 2021
 [1.14.1]: https://github.com/emissary-ingress/emissary/compare/v1.14.0...v1.14.1
 
 ### Emissary Ingress and Ambassador Edge Stack
@@ -73,7 +73,6 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
   - CVE-2021-32779
   - CVE-2021-32781
   - CVE-2021-32778
-  - CVE-2021-32780
 
 ## [1.14.0] August 19, 2021
 [1.14.0]: https://github.com/emissary-ingress/emissary/compare/v1.13.10...v1.14.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,14 +68,12 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 ### Emissary Ingress and Ambassador Edge Stack
 
-(no changes yet)
-
-## [1.14.1] (TBD)
-[1.14.1]: https://github.com/emissary-ingress/emissary/compare/v1.14.0...v1.14.1
-
-### Emissary Ingress and Ambassador Edge Stack
-
-(no changes yet)
+- Change: Update Envoy with security patches to fix the following CVEs
+  - CVE-2021-32777
+  - CVE-2021-32779
+  - CVE-2021-32781
+  - CVE-2021-32778
+  - CVE-2021-32780
 
 ## [1.14.0] August 19, 2021
 [1.14.0]: https://github.com/emissary-ingress/emissary/compare/v1.13.10...v1.14.0

--- a/_cxx/envoy.mk
+++ b/_cxx/envoy.mk
@@ -6,7 +6,7 @@ ENVOY_TEST_LABEL ?= //test/...
 
 # IF YOU MESS WITH ANY OF THESE VALUES, YOU MUST RUN `make update-base`.
   ENVOY_REPO ?= $(if $(IS_PRIVATE),git@github.com:datawire/envoy-private.git,git://github.com/datawire/envoy.git)
-  ENVOY_COMMIT ?= d4dd111f1143f413f0ffb6cddbffffc3a863038c
+  ENVOY_COMMIT ?= 7a33e53fd3d3c4befa53030797f344fcacaa61f4
   ENVOY_COMPILATION_MODE ?= opt
   # Increment BASE_ENVOY_RELVER on changes to `docker/base-envoy/Dockerfile`, or Envoy recipes.
   # You may reset BASE_ENVOY_RELVER when adjusting ENVOY_COMMIT.

--- a/charts/charts.mk
+++ b/charts/charts.mk
@@ -52,7 +52,7 @@ chart-push-ci: push-preflight
 .PHONY: chart-push-ci
 
 release/chart/prep-aes-rc: push-preflight
-	@[ $(IS_PRIVATE) ] && (echo "this is a private repo, not pushing any manifests" && exit 1)
+	@([ $(IS_PRIVATE) ] && (echo "this is a private repo, not pushing any manifests" && exit 1)) || true
 	@echo ">>> This will dirty your local tree and should only be run in CI"
 	@echo ">>> If running locally, you'll probably want to run make chart-clean after running this"
 	@[ -n "${CHART_VERSION_SUFFIX}" ] || (echo "CHART_VERSION_SUFFIX must be set for non-GA pushes" && exit 1)


### PR DESCRIPTION

All commits that are going out in 1.14.1 release **must** be on rel/v1.14.1.
This will allow the appropriate CI to run.

To get the hotfix changes onto this branch you can do one of the following:
    * use rel/v1.14.1 as the development branch for the fix
    * land (or have already landed) hotfix changes on release/v1.14 branch, and merge release/v1.14 into rel/v1.14.1
    * cherry-pick hotfix commits from ambassador.git to rel/v1.14.1

It is okay if you've already landed the hotfix changes on release/v1.14 branch,
reviewers just need to validate that the hotfix commits are in the tree for rel/v1.14.1,
and all the appropriate changelog updates exist.

## REVIEWERS MUST CHECK THAT:
* hotfix commits are on rel/v1.14.1
* CHANGELOG updates are on rel/v1.14.1
