### PR TITLE
[v2.0.2-ea] Changelog date update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 ## RELEASE NOTES
 
-## [2.0.2-ea] (TBD)
+## [2.0.2-ea] August 24, 2021
 [2.0.2-ea]: https://github.com/emissary-ingress/emissary/compare/v2.0.1-ea...v2.0.2-ea
 
 ### Emissary Ingress

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,9 +75,11 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 ### Emissary Ingress
 
-- Change: Logs now include subsecond time resolutions, rather than just seconds.
-- Change: Update from Envoy 1.15 to 1.17.3
-- Change: `AMBASSADOR_ENVOY_API_VERSION` now defaults to `V3`
+- - Change: Update Envoy from 1.15 to 1.17.4 with security patches to fix the following CVEs
+  - CVE-2021-32777
+  - CVE-2021-32779
+  - CVE-2021-32781
+  - CVE-2021-32778
 - Feature: You can now set `allow_chunked_length` in the Ambassador Module to configure the same value in Envoy.
 - Change: Envoy-configuration snapshots get saved (as `ambex-#.json`) in `/ambassador/snapshots`.
   The number of snapshots is controlled by the `AMBASSADOR_AMBEX_SNAPSHOT_COUNT` environment


### PR DESCRIPTION
Changelog date updates for 2.0.2-ea

Reviewers: The only changes in this PR should be updating the changelog entry for 2.0.2-ea to the date it was released.

If there are any other changes, the PR creator should note the reason.