### PR TITLE
[v1.14.1] Changelog date update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,14 +68,12 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 ### Emissary Ingress and Ambassador Edge Stack
 
-(no changes yet)
-
-## [1.14.1] (TBD)
-[1.14.1]: https://github.com/emissary-ingress/emissary/compare/v1.14.0...v1.14.1
-
-### Emissary Ingress and Ambassador Edge Stack
-
-(no changes yet)
+- Change: Update Envoy with security patches to fix the following CVEs
+  - CVE-2021-32777
+  - CVE-2021-32779
+  - CVE-2021-32781
+  - CVE-2021-32778
+  - CVE-2021-32780
 
 ## [1.14.0] August 19, 2021
 [1.14.0]: https://github.com/emissary-ingress/emissary/compare/v1.13.10...v1.14.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 ## RELEASE NOTES
 
-## [1.14.1] (TBD)
+## [1.14.1] August 24, 2021
 [1.14.1]: https://github.com/emissary-ingress/emissary/compare/v1.14.0...v1.14.1
 
 ### Emissary Ingress and Ambassador Edge Stack


### PR DESCRIPTION
Changelog date updates for 1.14.1

Reviewers: The only changes in this PR should be updating the changelog entry for 1.14.1 to the date it was released.

If there are any other changes, the PR creator should note the reason.