### PR TITLE
automate updates to apro

### DIFF
--- a/.github/workflows/promote-rc.yml
+++ b/.github/workflows/promote-rc.yml
@@ -14,6 +14,8 @@ jobs:
       AWS_EC2_METADATA_DISABLED: true
       DEV_REGISTRY: ${{ secrets.DEV_REGISTRY }}
       RELEASE_REGISTRY: ${{ secrets.RELEASE_REGISTRY }}
+      APRO_REPO_TARGET: ${{ secrets.APRO_REPO_TARGET }}
+      GIT_API_KEY: ${{ secrets.GH_API_KEY }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -23,6 +25,12 @@ jobs:
         with:
           username: ${{ secrets.GH_DOCKER_RELEASE_USERNAME }}
           password: ${{ secrets.GH_DOCKER_RELEASE_PASSWORD }}
+      - name: "make release/prep-rc"
+        run: |
+          git config --global user.email "dev@datawire.io"
+          git contig --global user.name "d6e-automaton"
+          git config --global "url.https://$GIT_API_KEY@github.com.insteadOf" https://github.com
+          make release/prep-rc
       - name: "make release/promote-oss/dev-to-rc"
         run: |
           make release/promote-oss/dev-to-rc

--- a/.github/workflows/promote-rc.yml
+++ b/.github/workflows/promote-rc.yml
@@ -27,10 +27,12 @@ jobs:
           password: ${{ secrets.GH_DOCKER_RELEASE_PASSWORD }}
       - name: "make release/promote-oss/dev-to-rc"
         run: |
+          make release/promote-oss/dev-to-rc
+      - name: Update emissary tag in apro
+        run: |
           git config --global user.email "dev@datawire.io"
           git config --global user.name "d6e-automaton"
           git config --global "url.https://$GIT_API_KEY@github.com.insteadOf" https://github.com
-          make release/promote-oss/dev-to-rc
           make release/promote-oss/rc-update-apro
       - name: Extract RC Info
         shell: bash

--- a/.github/workflows/promote-rc.yml
+++ b/.github/workflows/promote-rc.yml
@@ -54,6 +54,8 @@ jobs:
     env:
       GIT_API_KEY: ${{ secrets.GH_API_KEY }}
       APRO_REPO_TARGET: ${{ secrets.APRO_REPO_TARGET }}
+      GIT_USER_NAME: ${{ secrets.GH_AUTO_USER }}
+      GIT_USER_EMAIL: ${{ secrets.GH_AUTO_EMAIL }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -61,8 +63,8 @@ jobs:
       - name: "setup git config"
         run: |
           set -x
-          git config --global user.email "dev@datawire.io"
-          git config --global user.name "d6e-automaton"
+          git config --global user.email "$GIT_USER_EMAIL"
+          git config --global user.name "$GIT_USER_NAME"
           git config --global "url.https://$GIT_API_KEY@github.com.insteadOf" https://github.com
       - name: Update emissary tag in apro
         run: |

--- a/.github/workflows/promote-rc.yml
+++ b/.github/workflows/promote-rc.yml
@@ -28,7 +28,7 @@ jobs:
       - name: "make release/promote-oss/dev-to-rc"
         run: |
           git config --global user.email "dev@datawire.io"
-          git contig --global user.name "d6e-automaton"
+          git config --global user.name "d6e-automaton"
           git config --global "url.https://$GIT_API_KEY@github.com.insteadOf" https://github.com
           make release/promote-oss/dev-to-rc
       - name: Extract RC Info

--- a/.github/workflows/promote-rc.yml
+++ b/.github/workflows/promote-rc.yml
@@ -31,11 +31,11 @@ jobs:
           git config --global user.name "d6e-automaton"
           git config --global "url.https://$GIT_API_KEY@github.com.insteadOf" https://github.com
           make release/promote-oss/dev-to-rc
+          make release/promote-oss/rc-update-apro
       - name: Extract RC Info
         shell: bash
         run: |
           make release/rc/print-test-artifacts >> $GITHUB_ENV
-
       - name: Slack notification
         if: always()
         uses: edge/simple-slack-notify@master

--- a/.github/workflows/promote-rc.yml
+++ b/.github/workflows/promote-rc.yml
@@ -25,14 +25,11 @@ jobs:
         with:
           username: ${{ secrets.GH_DOCKER_RELEASE_USERNAME }}
           password: ${{ secrets.GH_DOCKER_RELEASE_PASSWORD }}
-      - name: "make release/prep-rc"
+      - name: "make release/promote-oss/dev-to-rc"
         run: |
           git config --global user.email "dev@datawire.io"
           git contig --global user.name "d6e-automaton"
           git config --global "url.https://$GIT_API_KEY@github.com.insteadOf" https://github.com
-          make release/prep-rc
-      - name: "make release/promote-oss/dev-to-rc"
-        run: |
           make release/promote-oss/dev-to-rc
       - name: Extract RC Info
         shell: bash

--- a/.github/workflows/promote-rc.yml
+++ b/.github/workflows/promote-rc.yml
@@ -55,9 +55,15 @@ jobs:
       GIT_API_KEY: ${{ secrets.GH_API_KEY }}
       APRO_REPO_TARGET: ${{ secrets.APRO_REPO_TARGET }}
     steps:
-      - name: Update emissary tag in apro
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: "setup git config"
         run: |
+          set -x
           git config --global user.email "dev@datawire.io"
           git config --global user.name "d6e-automaton"
           git config --global "url.https://$GIT_API_KEY@github.com.insteadOf" https://github.com
+      - name: Update emissary tag in apro
+        run: |
           make release/promote-oss/rc-update-apro

--- a/.github/workflows/promote-rc.yml
+++ b/.github/workflows/promote-rc.yml
@@ -14,8 +14,6 @@ jobs:
       AWS_EC2_METADATA_DISABLED: true
       DEV_REGISTRY: ${{ secrets.DEV_REGISTRY }}
       RELEASE_REGISTRY: ${{ secrets.RELEASE_REGISTRY }}
-      APRO_REPO_TARGET: ${{ secrets.APRO_REPO_TARGET }}
-      GIT_API_KEY: ${{ secrets.GH_API_KEY }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -28,12 +26,6 @@ jobs:
       - name: "make release/promote-oss/dev-to-rc"
         run: |
           make release/promote-oss/dev-to-rc
-      - name: Update emissary tag in apro
-        run: |
-          git config --global user.email "dev@datawire.io"
-          git config --global user.name "d6e-automaton"
-          git config --global "url.https://$GIT_API_KEY@github.com.insteadOf" https://github.com
-          make release/promote-oss/rc-update-apro
       - name: Extract RC Info
         shell: bash
         run: |
@@ -54,3 +46,18 @@ jobs:
              { "title": "Branch", "value": "${env.GITHUB_REF}", "short": true },
              { "title": "Action URL", "value": "${env.GITHUB_SERVER_URL}/${env.GITHUB_REPOSITORY}/actions/runs/${env.GITHUB_RUN_ID}"}
             ]
+
+  update-apro-with-rc:
+    runs-on: ubuntu-latest
+    needs: promote-to-rc
+    name: update-apro-with-rc
+    env:
+      GIT_API_KEY: ${{ secrets.GH_API_KEY }}
+      APRO_REPO_TARGET: ${{ secrets.APRO_REPO_TARGET }}
+    steps:
+      - name: Update emissary tag in apro
+        run: |
+          git config --global user.email "dev@datawire.io"
+          git config --global user.name "d6e-automaton"
+          git config --global "url.https://$GIT_API_KEY@github.com.insteadOf" https://github.com
+          make release/promote-oss/rc-update-apro

--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -793,6 +793,8 @@ release/promote-oss/dev-to-rc:
 		$(MAKE) VERSION_OVERRIDE=$${veroverride} push-manifests  ; \
 		$(MAKE) VERSION_OVERRIDE=$${veroverride} publish-docs-yaml ; \
 		$(MAKE) clean-manifests ; \
+		gavers=$$(echo $(RELEASE_VERSION) | sed 's/-rc.*//'); \
+		$(OSS_HOME)/releng/01-release-rc-update-apro v$(RELEASE_VERSION) $${gavers}; \
 	}
 .PHONY: release/promote-oss/dev-to-rc
 
@@ -922,7 +924,6 @@ release/prep-rc:
 	@[[ -z "$(IS_DIRTY)" ]] || (printf '$(RED)ERROR: tree must be clean\n'; exit 1)
 	@AWS_S3_BUCKET=$(AWS_S3_BUCKET) RELEASE_REGISTRY=$(RELEASE_REGISTRY) IMAGE_NAME=$(LCNAME) \
 		$(OSS_HOME)/releng/01-release-prep-rc $(VERSIONS_YAML_VER_STRIPPED)-rc.$(RC_NUMBER)
-	$(OSS_HOME)/releng/01-release-rc-update-apro v$(VERSIONS_YAML_VER_STRIPPED)-rc.$(RC_NUMBER) v$(VERSIONS_YAML_VER_STRIPPED)
 .PHONY: release/prep-rc
 
 release/go:

--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -793,10 +793,12 @@ release/promote-oss/dev-to-rc:
 		$(MAKE) VERSION_OVERRIDE=$${veroverride} push-manifests  ; \
 		$(MAKE) VERSION_OVERRIDE=$${veroverride} publish-docs-yaml ; \
 		$(MAKE) clean-manifests ; \
-		gavers=$$(echo $(RELEASE_VERSION) | sed 's/-rc.*//'); \
-		$(OSS_HOME)/releng/01-release-rc-update-apro v$(RELEASE_VERSION) $${gavers}; \
 	}
 .PHONY: release/promote-oss/dev-to-rc
+
+release/promote-oss/rc-update-apro:
+	$(OSS_HOME)/releng/01-release-rc-update-apro v$(RELEASE_VERSION) v$(VERSIONS_YAML_VERSION)
+.PHONY: release/promote-oss/rc-update-apro
 
 release/print-test-artifacts:
 	@set -e; { \

--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -922,6 +922,7 @@ release/prep-rc:
 	@[[ -z "$(IS_DIRTY)" ]] || (printf '$(RED)ERROR: tree must be clean\n'; exit 1)
 	@AWS_S3_BUCKET=$(AWS_S3_BUCKET) RELEASE_REGISTRY=$(RELEASE_REGISTRY) IMAGE_NAME=$(LCNAME) \
 		$(OSS_HOME)/releng/01-release-prep-rc $(VERSIONS_YAML_VER_STRIPPED)-rc.$(RC_NUMBER)
+	$(OSS_HOME)/releng/01-release-rc-update-apro v$(VERSIONS_YAML_VER_STRIPPED)-rc.$(RC_NUMBER) v$(VERSIONS_YAML_VER_STRIPPED)
 .PHONY: release/prep-rc
 
 release/go:

--- a/releng/01-release-prep-rc
+++ b/releng/01-release-prep-rc
@@ -12,7 +12,7 @@ fi
 
 commit=$(git rev-parse HEAD)
 
-${CURR_DIR}/release-wait-for-commit --commit $commit --s3-key dev-builds
+#${CURR_DIR}/release-wait-for-commit --commit $commit --s3-key dev-builds
 
 git tag -m v$rc_tag -a v$rc_tag
 git push origin v$rc_tag

--- a/releng/01-release-prep-rc
+++ b/releng/01-release-prep-rc
@@ -12,7 +12,7 @@ fi
 
 commit=$(git rev-parse HEAD)
 
-#${CURR_DIR}/release-wait-for-commit --commit $commit --s3-key dev-builds
+${CURR_DIR}/release-wait-for-commit --commit $commit --s3-key dev-builds
 
 git tag -m v$rc_tag -a v$rc_tag
 git push origin v$rc_tag

--- a/releng/01-release-rc-update-apro
+++ b/releng/01-release-rc-update-apro
@@ -10,6 +10,10 @@ if [ -z "$2" ]; then
     exit -1
 fi
 
+if [ -z "$APRO_REPO_TARGET" ]; then
+    echo "APRO_REPO_TARGET not set. This should be set in the environment"
+fi
+
 # remove existing apro-prep-rc in case this is being run
 # locally on a long lived dev machine
 if [ -d "/tmp/apro-prep-rc" ]; then
@@ -17,7 +21,7 @@ if [ -d "/tmp/apro-prep-rc" ]; then
 fi
 
 # get a fresh copy of apro
-git clone git@github.com:datawire/apro.git /tmp/apro-prep-rc
+git clone git@github.com:$APRO_REPO_TARGET /tmp/apro-prep-rc
 pushd /tmp/apro-prep-rc
 
 # checkout or create proper rel branch
@@ -29,6 +33,9 @@ if [ ! $(git checkout rel/$2) ]; then
         *"v2."*)
             git checkout master
             ;;
+        *)
+            echo "Not intelligent enough to find branch that tracks $2 parent releases"
+            exit 1
     esac
 
     git checkout -b rel/$2
@@ -38,7 +45,4 @@ fi
 CURRENT_EMISSARY_TAG=$(grep 'imageTag' emissaryInfo.yml | sed 's/imageTag://g' | xargs)
 sed 's/$CURRENT_EMISSARY_TAG/$1/g' emissaryInfo.yml
 git commit -s -m "(from CI) bump emissary version to latest RC"
-# TODO: use that cool push hook
-
-# launch PR
-# TODO: maybe another hook for this?
+git --set-upstream push origin rel/$2

--- a/releng/01-release-rc-update-apro
+++ b/releng/01-release-rc-update-apro
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+if [ -z "$1" ]; then
+    echo "First argument must be RC tag"
+    exit -1
+fi
+
+if [ -z "$2" ]; then
+    echo "Second argument must be a GA tag"
+    exit -1
+fi
+
+# remove existing apro-prep-rc in case this is being run
+# locally on a long lived dev machine
+if [ -d "/tmp/apro-prep-rc" ]; then
+    rm -rf /tmp/apro-prep-rc
+fi
+
+# get a fresh copy of apro
+git clone git@github.com:datawire/apro.git /tmp/apro-prep-rc
+pushd /tmp/apro-prep-rc
+
+# checkout or create proper rel branch
+if [ ! $(git checkout rel/$2) ]; then
+    case $2 in
+        *"v1."*)
+            git checkout ltr
+            ;;
+        *"v2."*)
+            git checkout master
+            ;;
+    esac
+
+    git checkout -b rel/$2
+fi
+
+# set emissary tag into apro
+CURRENT_EMISSARY_TAG=$(grep 'imageTag' emissaryInfo.yml | sed 's/imageTag://g' | xargs)
+sed 's/$CURRENT_EMISSARY_TAG/$1/g' emissaryInfo.yml
+git commit -s -m "(from CI) bump emissary version to latest RC"
+# TODO: use that cool push hook
+
+# launch PR
+# TODO: maybe another hook for this?

--- a/releng/01-release-rc-update-apro
+++ b/releng/01-release-rc-update-apro
@@ -12,6 +12,7 @@ fi
 
 if [ -z "$APRO_REPO_TARGET" ]; then
     echo "APRO_REPO_TARGET not set. This should be set in the environment"
+    exit -1
 fi
 
 # remove existing apro-prep-rc in case this is being run

--- a/releng/01-release-rc-update-apro
+++ b/releng/01-release-rc-update-apro
@@ -45,4 +45,4 @@ fi
 CURRENT_EMISSARY_TAG=$(grep 'imageTag' emissaryInfo.yml | sed 's/imageTag://g' | xargs)
 sed 's/$CURRENT_EMISSARY_TAG/$1/g' emissaryInfo.yml
 git commit -s -m "(from CI) bump emissary version to latest RC"
-git --set-upstream push origin rel/$2
+git push --set-upstream origin rel/$2


### PR DESCRIPTION
## Description
The enclosed modifications consist of the following
- a script that creates the relevant rel/vX.Y branch in apro if need be, bumps the emissary version referenced within, and then pushes the update
- commands calling this script in release/promote-oss/dev-to-rc

The script was tested locally, and is being merged to the shared iterative development branch so that we can improve upon it as we continue working on the other bits that need to be altered for the release pipeline.