### PR TITLE
fix flakey kat test

### DIFF
--- a/python/tests/kat/t_hosts.py
+++ b/python/tests/kat/t_hosts.py
@@ -954,7 +954,7 @@ spec:
         # so we get a generic alert=40 ("handshake_failure").
         yield Query(**base, maxTLSv="v1.2", error="tls: handshake failure")
         # TLS 1.3 added a dedicated alert=116 ("certificate_required") for that scenario.
-        yield Query(**base, minTLSv="v1.3", error=(["tls: certificate required"] + (["write: connection reset by peer"] if bug_clientcert_reset else [])))
+        yield Query(**base, minTLSv="v1.3", error=(["tls: certificate required"] + (["write: connection reset by peer", "write: broken pipe"] if bug_clientcert_reset else [])))
 
         # Check that it's validating the client cert against the CA cert.
         yield Query(**base,
@@ -1081,7 +1081,7 @@ spec:
         # so we get a generic alert=40 ("handshake_failure").
         yield Query(**base, maxTLSv="v1.2", error="tls: handshake failure")
         # TLS 1.3 added a dedicated alert=116 ("certificate_required") for that scenario.
-        yield Query(**base, minTLSv="v1.3", error=(["tls: certificate required"] + (["write: connection reset by peer"] if bug_clientcert_reset else [])))
+        yield Query(**base, minTLSv="v1.3", error=(["tls: certificate required"] + (["write: connection reset by peer", "write: broken pipe"] if bug_clientcert_reset else [])))
 
         # Check that it's validating the client cert against the CA cert.
         yield Query(**base,


### PR DESCRIPTION
## Description
A test in CI is breaking because it is receiving a slightly different error message than expected. This test expects "connection reset by peer" but is instead getting "broken pipe". The actual error message it is getting means roughly the same thing and this difference can happen if the server never receives TCP FIN.

## The Fix
Add "broken pipe" to the list of expected error messages.