### PR TITLE
add "job-promote-passed-ci-build" to github-actions

### DIFF
--- a/.github/workflows/job-promote-to-passed.yml
+++ b/.github/workflows/job-promote-to-passed.yml
@@ -1,0 +1,33 @@
+name: job-promote-to-passed
+on:
+  workflow_run:
+    workflows:
+      #- chart-test # only executed on chart changes, can't depend on it
+      - gotest
+      - generate
+      - lint-test
+      - pytest
+      - job-image
+    types:
+      - completed
+
+jobs:
+  promote-to-passed:
+    runs-on: ubuntu-latest
+    name: job-promote-to-passed
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.GH_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.GH_AWS_SECRET_ACCESS_KEY }}
+      AWS_EC2_METADATA_DISABLED: true
+      AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Workflow Run Wait (Execute if all dependent workflows complete successfully)
+        uses: ahmadnassri/action-workflow-run-wait@v1.4.2
+        with:
+          timeout: 2700000 #45 min in ms
+      - name: "promote build to passed"
+        run: |
+          make release/promote-oss/dev-to-passed-ci


### PR DESCRIPTION
- only execute when all tests have passed green
  * doesn't depend upon chart-test, since this test only executes on
    chart changes so we can't assume it will always be run

## Description
Include job-promotion in github-actions.

## Related Issues
List related issues.

## Testing
Tested against github, was green.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `CHANGELOG.md`.
   
   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations
 
 - [X] This is unlikely to impact how Ambassador performs at scale.
 
   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability
 
 - [X] My change is adequately tested.
 
   Remember when considering testing:
    + LEGACY MODE TESTS DO NOT RUN FOR EVERY PR. If your change is affected by legacy mode, you need
      to run legacy-mode tests manually (set `AMBASSADOR_LEGACY_MODE=true` and run the tests).
      (This will be fixed soon.)
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points
 
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
