### PR TITLE
CI Workflow to open repatriation PR

### DIFF
--- a/.github/workflows/promote-rc.yml
+++ b/.github/workflows/promote-rc.yml
@@ -61,11 +61,13 @@ jobs:
         with:
           fetch-depth: 0
       - name: "setup git config"
+        shell: bash
         run: |
           set -x
           git config --global user.email "$GIT_USER_EMAIL"
           git config --global user.name "$GIT_USER_NAME"
           git config --global "url.https://$GIT_API_KEY@github.com.insteadOf" https://github.com
       - name: Update emissary tag in apro
+        shell: bash
         run: |
           make release/promote-oss/rc-update-apro

--- a/.github/workflows/repatriate.yml
+++ b/.github/workflows/repatriate.yml
@@ -28,7 +28,7 @@ jobs:
           git config --global user.email "$GIT_USER_EMAIL"
           git config --global user.name "$GIT_USER_NAME"
           git config --global "url.https://$GIT_API_KEY@github.com.insteadof" https://github.com
-          git checkout -b ci-repatriate-changes-to-master-${JOB_ID} release/v1.14
+          git checkout -b ci-repatriate-changes-to-master-${JOB_ID} origin/release/v1.14
           git cherry-pick ${GITHUB_REF}..${GH_TAIL_REF}
           git push --set-upstream origin ci-repatriate-changes-to-master-${JOB_ID}
       - name: Repatriate branch PR

--- a/.github/workflows/repatriate.yml
+++ b/.github/workflows/repatriate.yml
@@ -1,0 +1,53 @@
+name: repatriate-to-lts
+on:
+  push:
+    branches:
+      - master
+      - aidanhahn/ci-repatriate-pr
+
+jobs:
+  repatriate-to-lts:
+    runs-on: ubuntu-latest
+    name: repatriate-to-lts
+    env:
+      JOB_ID: ${{ github.job }}
+      PUSH_ID: ${{ github.event.push_id }}
+      GH_TAIL_REF: ${{ github.event.before }}
+      GIT_API_KEY: ${{ secrets.GH_API_KEY }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GIT_USER_NAME: ${{ secrets.GH_AUTO_USER }}
+      GIT_USER_EMAIL: ${{ secrets.GH_AUTO_EMAIL }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Make repatriate branch
+        shell: bash
+        run: |
+          set -x
+          git config --global user.email "$GIT_USER_EMAIL"
+          git config --global user.name "$GIT_USER_NAME"
+          git config --global "url.https://$GIT_API_KEY@github.com.insteadof" https://github.com
+          git checkout -b ci-repatriate-changes-to-master-${JOB_ID} release/v1.14
+          git cherry-pick ${GITHUB_REF}..${GH_TAIL_REF}
+          git push --set-upstream origin ci-repatriate-changes-to-master-${JOB_ID}
+      - name: Repatriate branch PR
+        shell: bash
+        run: |
+          set -x
+          echo "${GITHUB_TOKEN}" | gh auth login --with-token
+          gh pr create --reviewer emissary-ingress/emissary-maintainers \
+                       --title '[CI] repatriate changes from push ${PUSH_ID}' \
+                       --body 'This PR contains chhanges from push to master ${PUSH_ID}'
+      - name: Slack notification
+        if: always()
+        uses: edge/simple-slack-notify@master
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          status: ${{ job.status }}
+          success_text: 'Created repatriation PR for push to master: ${PUSH_ID}'
+          failure_text: 'Couldn't cleanly repatriate changes for push to master: ${PUSH_ID}'
+          fields: |
+            [{ "title": "Repository", "value": "${env.GITHUB_REPOSITORY}", "short": true },
+             { "title": "Branch", "value": "${env.GITHUB_REF}", "short": true}]

--- a/.github/workflows/repatriate.yml
+++ b/.github/workflows/repatriate.yml
@@ -3,14 +3,14 @@ on:
   push:
     branches:
       - master
-      - aidanhahn/ci-repatriate-pr
 
 jobs:
   repatriate-to-lts:
     runs-on: ubuntu-latest
     name: repatriate-to-lts
     env:
-      JOB_ID: ${{ github.job }}
+      REF: ${{ github.ref }}
+      RUN: ${{ github.run_id }}
       PUSH_ID: ${{ github.event.push_id }}
       GH_TAIL_REF: ${{ github.event.before }}
       GIT_API_KEY: ${{ secrets.GH_API_KEY }}
@@ -24,21 +24,26 @@ jobs:
       - name: Make repatriate branch
         shell: bash
         run: |
-          set -x 
+          set -x
           git config --global user.email "$GIT_USER_EMAIL"
           git config --global user.name "$GIT_USER_NAME"
           git config --global "url.https://$GIT_API_KEY@github.com.insteadof" https://github.com
-          git checkout -b ci-repatriate-changes-to-master-${JOB_ID} origin/release/v1.14
-          git cherry-pick ${GH_TAIL_REF}..${GITHUB_REF}
-          git push --set-upstream origin ci-repatriate-changes-to-master-${JOB_ID}
+          git checkout -b ci-repatriate-changes-${RUN} origin/release/v1.14
+          git cherry-pick ${GH_TAIL_REF}..${GITHUB_REF} --allow-empty
+          git push --set-upstream origin ci-repatriate-changes-${RUN}
       - name: Repatriate branch PR
         shell: bash
         run: |
           set -x
-          echo "${GITHUB_TOKEN}" | gh auth login --with-token
-          gh pr create --reviewer emissary-ingress/emissary-maintainers \
-                       --title '[CI] repatriate changes from push ${PUSH_ID}' \
-                       --body 'This PR contains chhanges from push to master ${PUSH_ID}'
+          echo "${GITHUB_TOKEN}" > temp_credential
+          # GH does NOT want this in the env
+          export GITHUB_TOKEN=
+          cat temp_credential | gh auth login --with-token
+          rm temp_credential
+          gh pr create --title "[CI] repatriate changes job ${RUN}" \
+                       --body "This PR contains changes from push to master ${REF}" \
+                       --base release/v1.14 \
+                       --reviewer "kflynn,aidanhahn,lukeshu,anodelman"
       - name: Slack notification
         if: always()
         uses: edge/simple-slack-notify@master

--- a/.github/workflows/repatriate.yml
+++ b/.github/workflows/repatriate.yml
@@ -29,7 +29,7 @@ jobs:
           git config --global user.name "$GIT_USER_NAME"
           git config --global "url.https://$GIT_API_KEY@github.com.insteadof" https://github.com
           git checkout -b ci-repatriate-changes-to-master-${JOB_ID} origin/release/v1.14
-          git cherry-pick ${GITHUB_REF}..${GH_TAIL_REF}
+          git cherry-pick ${GH_TAIL_REF}..${GITHUB_REF}
           git push --set-upstream origin ci-repatriate-changes-to-master-${JOB_ID}
       - name: Repatriate branch PR
         shell: bash

--- a/.github/workflows/repatriate.yml
+++ b/.github/workflows/repatriate.yml
@@ -46,8 +46,8 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:
           status: ${{ job.status }}
-          success_text: 'Created repatriation PR for push to master: ${PUSH_ID}'
-          failure_text: 'Couldn't cleanly repatriate changes for push to master: ${PUSH_ID}'
+          success_text: 'Created repatriation PR for push to master: ${{ github.event.push_id }}'
+          failure_text: 'Couldn\'t cleanly repatriate changes for push to master: ${{ github.event.push_id }}'
           fields: |
             [{ "title": "Repository", "value": "${env.GITHUB_REPOSITORY}", "short": true },
              { "title": "Branch", "value": "${env.GITHUB_REF}", "short": true}]

--- a/.github/workflows/repatriate.yml
+++ b/.github/workflows/repatriate.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Make repatriate branch
         shell: bash
         run: |
-          set -x
+          set -x 
           git config --global user.email "$GIT_USER_EMAIL"
           git config --global user.name "$GIT_USER_NAME"
           git config --global "url.https://$GIT_API_KEY@github.com.insteadof" https://github.com
@@ -46,8 +46,8 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:
           status: ${{ job.status }}
-          success_text: 'Created repatriation PR for push to master: ${{ github.event.push_id }}'
-          failure_text: 'Couldn\'t cleanly repatriate changes for push to master: ${{ github.event.push_id }}'
+          success_text: "Created repatriation PR for push to master"
+          failure_text: "Couldn\'t cleanly repatriate changes for push to master"
           fields: |
             [{ "title": "Repository", "value": "${env.GITHUB_REPOSITORY}", "short": true },
              { "title": "Branch", "value": "${env.GITHUB_REF}", "short": true}]


### PR DESCRIPTION
## Description
This PR contains a new GitHub Workflow that is triggered on any push to master. 
This workflow will fork a new, unique branch off of release/v1.14 and cherry-pick all commits pushed to master onto the new branch. If that completes cleanly a PR is then opened between the new branch and release/v1.14. Finally, a notification is sent to our Slack channel containing whether the PR was opened or not.

## Testing
Workflow was tested by being added to a fork of release/v1.14. Iterative improvements to the workflow triggered the CI job and in correct conditions resulted in a PR like [this one](https://github.com/emissary-ingress/emissary/pull/3776)
