### PR TITLE
testing this

### DIFF
--- a/cmd/reproducer/extract.go
+++ b/cmd/reproducer/extract.go
@@ -160,13 +160,13 @@ func (ex *Extraction) CaptureLogs(ctx context.Context, pods []*kates.Pod) func()
 	byID := map[string]string{}
 	for _, pod := range pods {
 		byID[string(pod.GetUID())] = QName(pod)
-		err := ex.client.PodLogs(ctx, pod, &kates.PodLogOptions{Previous: true}, previousEvents)
+		err := ex.client.PodLogs(ctx, pod, &kates.PodLogOptions{Previous: true}, true, previousEvents)
 		if err != nil {
 			ex.Warnf(ctx, err, "error listing previous logs for pod %s in namespaces %s", pod.Name, pod.Namespace)
 		} else {
 			wg.Add(1)
 		}
-		err = ex.client.PodLogs(ctx, pod, &kates.PodLogOptions{}, currentEvents)
+		err = ex.client.PodLogs(ctx, pod, &kates.PodLogOptions{}, true, currentEvents)
 		if err != nil {
 			ex.Warnf(ctx, err, "error listing current logs for pod %s in namespaces %s", pod.Name, pod.Namespace)
 		} else {

--- a/pkg/kates/client.go
+++ b/pkg/kates/client.go
@@ -1025,20 +1025,19 @@ func parseLogLine(line string) (timestamp string, output string) {
 // single channel in order to multiplex log output from many pods, e.g.:
 //
 //   events := make(chan LogEvent)
-//   client.PodLogs(ctx, pod1, options, events)
-//   client.PodLogs(ctx, pod2, options, events)
-//   client.PodLogs(ctx, pod3, options, events)
+//   client.PodLogs(ctx, pod1, options, true, events)
+//   client.PodLogs(ctx, pod2, options, true, events)
+//   client.PodLogs(ctx, pod3, options, false, events)
 //
 //   for event := range events {
 //       fmt.Printf("%s: %s: %s", event.PodId, event.Timestamp, event.Output)
 //   }
 //
 // The above code will print log output from all 3 pods.
-func (c *Client) PodLogs(ctx context.Context, pod *Pod, options *PodLogOptions, events chan<- LogEvent) error {
+func (c *Client) PodLogs(ctx context.Context, pod *Pod, options *PodLogOptions, allContainers bool, events chan<- LogEvent) error {
 	// always use timestamps
 	options.Timestamps = true
 	timeout := 10 * time.Second
-	allContainers := true
 
 	requests, err := polymorphichelpers.LogsForObjectFn(c.config, pod, options, timeout,
 		allContainers)


### PR DESCRIPTION
## Description
Make client.PodLogs take allContainers as an argument instead of being hardcoded. This enables you to get logs for just one container, instead of requiring you to get logs for all containers in a pod when you use this function.

## Related Issues
List related issues.

## Testing
A few sentences describing what testing you've done, e.g., manual tests, automated tests, deployed in production, etc.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `CHANGELOG.md`.
   
   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations
 
 - [x] This is unlikely to impact how Ambassador performs at scale.
 
   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability
 
 - [ ] My change is adequately tested.
 
   Remember when considering testing:
    + LEGACY MODE TESTS DO NOT RUN FOR EVERY PR. If your change is affected by legacy mode, you need
      to run legacy-mode tests manually (set `AMBASSADOR_LEGACY_MODE=true` and run the tests).
      (This will be fixed soon.)
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points
 
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
