### PR TITLE
Fix job-image and promote-to-passed CI jobs

### DIFF
--- a/.github/workflows/execute-tests-and-promote.yml
+++ b/.github/workflows/execute-tests-and-promote.yml
@@ -167,6 +167,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: ./.github/actions/execute-job-image
         name: "execute job-image action"
   promote-to-passed:
@@ -188,6 +189,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: "promote build to passed"
         run: |
           make release/promote-oss/dev-to-passed-ci


### PR DESCRIPTION
## Description
Explicitly checkout head of branch instead of merge commit.

## Testing
Mock RCs were performed on my fork of emissary.
