### PR TITLE
Envoy build fixes

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -47,11 +47,11 @@ ever find anything missing from this list.
  - docker (make sure you can run docker commands as your dev user without sudo)
  - bash
  - rsync (with the --info option)
- - golang 1.13
- - python 3.7+
+ - golang 1.15
+ - python 3.8 or 3.9
  - kubectl
  - a kubernetes cluster
- - a docker registry
+ - a Docker registry
 
 ### Configuration:
 
@@ -110,11 +110,16 @@ NOTE: This will also push the `kat-client` and `kat-server` images.
 How do I deploy an ambassador to a cluster from source?
 -------------------------------------------------------
 
-XXX: This does not work yet, but will be fixed in a future commit!!!
-
 1. `export DEV_REGISTRY=<your-dev-docker-registry>` (you need to be logged in and have permission to push)
 2. `export DEV_KUBECONFIG=<your-dev-kubeconfig>`
 3. `make deploy`
+
+How do I clear everything out to make sure my build runs like it will in CI?
+----------------------------------------------------------------------------
+
+Use `make clobber` to completely remove all derived objects, all cached artifacts, everything, and get back to a clean slate. This is recommended if you change branches within a clone, or if you need to `make generate` when you're not _certain_ that your last `make generate` was using the same Envoy version.
+
+Use `make clean` to remove derived objects, but _not_ clear the caches.
 
 How do I run ambassador tests?
 ------------------------------

--- a/_cxx/envoy.mk
+++ b/_cxx/envoy.mk
@@ -298,6 +298,12 @@ clobber: _clobber-envoy
 
 _clean-envoy: _clean-envoy-old
 _clean-envoy: $(OSS_HOME)/_cxx/envoy-build-container.txt.clean
+	@PS4=; set -e; { \
+		if docker volume inspect envoy-build >/dev/null 2>&1; then \
+			set -x ;\
+			docker volume rm envoy-build >/dev/null ;\
+		fi ;\
+	}
 	rm -f $(OSS_HOME)/_cxx/envoy-build-image.txt
 _clobber-envoy: _clean-envoy
 	rm -f $(OSS_HOME)/docker/base-envoy/envoy-static


### PR DESCRIPTION
Couple of small, but relevant, build fixes around Envoy:

- `make clobber` needs to drop the `envoy-build` Docker volume.
   - `make generate` ends up using Bazel to drive generating Golang code from the Envoy protobuf definitions.
   - Bazel uses a cache to try to speed things up, but if you switch Envoy versions (perhaps by switching between Emissary branches) without dropping the cache, things can get out of sync.
   - If the cache is out of sync, `make generate` can fail in weird ways, like leaving around generated Go files that should've been removed.

- Quieten down the `rsync`s that are part of building Envoy.
   - The `rsync`s are necessary, because we need to run Envoy-build stuff in Docker to make life easier -- however, they were producing (literally) tens of thousands of lines of output in the CI logs. Removing `-v` and `--progress` makes life _much_ better.

 - [x] I didn't need to update `CHANGELOG.md`.
 - [x] This is unlikely to impact how Ambassador performs at scale.
 - [ ] My change is adequately tested.
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
