### PR TITLE
Added an environment variable to control the polling frequency of API docs from the Agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,10 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 ### Emissary-ingress and Ambassador Edge Stack
 
+- Feature: The Agent environment variable `API_DOCS_POLLING_PERIOD` lets you control the frequency
+  at which the Agent will fetch API docs update from configured AmbassadorMappings. Default is
+  `60s`. Set to `0` to completely turn off API docs polling from the Agent.
+
 ## [2.2.1] February 22, 2022
 [2.2.1]: https://github.com/emissary-ingress/emissary/compare/v2.2.0...v2.2.1
 

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -34,7 +34,10 @@ changelog: https://github.com/emissary-ingress/emissary/blob/$branch$/CHANGELOG.
 items:
   - version: 2.3.0
     date: 'TBD'
-    notes: []
+    notes:
+      - title: Agent supports API_DOCS_POLLING_PERIOD configuration
+        body: The Agent environment variable `API_DOCS_POLLING_PERIOD` lets you control the frequency at which the Agent will fetch API docs update from configured AmbassadorMappings. Default is `60s`. Set to `0` to completely turn off API docs polling from the Agent.
+        type: feature
 
   - version: 2.2.1
     date: '2022-02-22'

--- a/pkg/agent/api_docs_test.go
+++ b/pkg/agent/api_docs_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -202,7 +203,7 @@ func TestAPIDocsStore(t *testing.T) {
 				},
 			}
 
-			store := agent.NewAPIDocsStore()
+			store := agent.NewAPIDocsStore(1 * time.Minute)
 			store.Client = NewMockAPIDocsHTTPClient(t, c.expectedRequestURL, c.expectedRequestHost, c.expectedRequestHeaders, c.rawJSONDocsContent, c.JSONDocsErr)
 
 			// Processing the test case snapshot should yield the expected state of the world


### PR DESCRIPTION
## Description
Added an environment variable to control the polling frequency of API docs from the Agent. 

From the CHANGELOG:
> The Agent environment variable `API_DOCS_POLLING_PERIOD` lets you control the frequency at which the Agent
  will fetch API docs update from configured AmbassadorMappings. Default is `60s`.
  Set to `0` to completely turn off API docs polling from the Agent.

I found no public documentation on https://www.getambassador.io/docs/ about the configuration options and environment variables for the Agent. I'm willing to update any if someone can point me to it!

## Related Issues
None.

## Testing
Unit tests for regressions and manual validation in Ambassador Cloud staging.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `CHANGELOG.md`.
   
   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations
 
 - [x] This is unlikely to impact how Ambassador performs at scale.
 
   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability
 
 - [x] My change is adequately tested.
 
   Remember when considering testing:
    + LEGACY MODE TESTS DO NOT RUN FOR EVERY PR. If your change is affected by legacy mode, you need
      to run legacy-mode tests manually (set `AMBASSADOR_LEGACY_MODE=true` and run the tests).
      (This will be fixed soon.)
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points
 
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
