### PR TITLE
2.0.3 Release Notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,10 +86,17 @@ installations, reduce memory footprint, and improve performance. We welcome feed
 
 ## Emissary-ingress
 
-- Feature: The environment variable `AES_LOG_LEVEL` now also sets the log level for the `diagd` logger.
+- Feature: The environment variable `AES_LOG_LEVEL` now also sets the log level for the `diagd` logger. [#3686] [#3666]
 
 - Feature: You can now set `dns_type` in the `AmbassadorMapping` to configure how Envoy will use the DNS for
   the service.
+
+- Bugfix: It is no longer necessary to set `DOCKER_BUILDKIT=0` when building Emissary. A future change will
+  fully support BuildKit. [#3707]
+
+[#3686]: https://github.com/emissary-ingress/emissary/issues/3686
+[#3666]: https://github.com/emissary-ingress/emissary/issues/3666
+[#3707]: https://github.com/emissary-ingress/emissary/issues/3707
 
 ## [2.0.2-ea] (2021-08-24)
 [2.0.2-ea]: https://github.com/emissary-ingress/emissary/releases/v2.0.2-ea
@@ -173,7 +180,7 @@ installations, reduce memory footprint, and improve performance. We welcome feed
   should reduce Envoy memory requirements for installations with many `AmbassadorHost`s
 
 - Bugfix: Each `AmbassadorHost` can specify its `requestPolicy.insecure.action` independently of any other
-  `AmbassadorHost`, allowing for HTTP routing as flexible as HTTPS routing.
+  `AmbassadorHost`, allowing for HTTP routing as flexible as HTTPS routing. [#2888]
 
 - Bugfix: Emissary-ingress 2.0.0 fixes a regression in detecting the Ambassador Kubernetes service that
   could cause the wrong IP or hostname to be used in Ingress statuses -- thanks, <a
@@ -217,6 +224,8 @@ installations, reduce memory footprint, and improve performance. We welcome feed
   Telepresence product replaces this functionality.
 
 - Change: The `edgectl` CLI tool has been deprecated; please use the `emissary-ingress` helm chart instead.
+
+[#2888]: https://github.com/datawire/ambassador/issues/2888
 
 ## [1.14.1] (2021-08-24)
 [1.14.1]: https://github.com/emissary-ingress/emissary/releases/v1.14.1

--- a/docs/CHANGELOG.tpl
+++ b/docs/CHANGELOG.tpl
@@ -85,9 +85,11 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 ## Emissary-ingress
 {{ range .notes -}}{{ if not (index . "isHeadline") }}
-- {{ .type | strings.Title }}: {{ .body | strings.ReplaceAll "$productName$" "Emissary-ingress" | strings.ReplaceAll "<b>" "_" | strings.ReplaceAll "</b>" "_" | strings.ReplaceAll "<code>" "`" | strings.ReplaceAll "</code>" "`" | strings.WordWrap 98 "\n  " }}
+- {{ .type | strings.Title }}: {{ .body | strings.ReplaceAll "$productName$" "Emissary-ingress" | strings.ReplaceAll "<b>" "_" | strings.ReplaceAll "</b>" "_" | strings.ReplaceAll "<code>" "`" | strings.ReplaceAll "</code>" "`" | strings.WordWrap 98 "\n  " }}{{ if index . "github" }}{{ range .github }} [{{.title}}]{{ end }}{{ end }}
+{{ end }}{{ end }}{{ $anyGitLinks := false }}{{ range .notes -}}{{- if index . "github" -}}{{- range .github }}{{ $anyGitLinks = true }}
+[{{.title}}]: {{.link}}{{ end -}}{{- end -}}{{- end }}
+{{ if $anyGitLinks }}
 {{ end }}{{ end }}
-{{ end }}
 
 ## [1.13.11] (TBD)
 [1.13.11]: https://github.com/emissary-ingress/emissary/compare/v1.13.10...v1.13.11

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -42,11 +42,24 @@ items:
         body: The environment variable <code>AES_LOG_LEVEL</code> now also sets the log level for the <code>diagd</code> logger.
         type: feature
         docs: topics/running/running/
+        github:
+        - title: "#3686"
+          link: https://github.com/emissary-ingress/emissary/issues/3686
+        - title: "#3666"
+          link: https://github.com/emissary-ingress/emissary/issues/3666
 
       - title: AmbassadorMapping supports setting the DNS type
         body: You can now set <code>dns_type</code> in the <code>AmbassadorMapping</code> to configure how Envoy will use the DNS for the service.
         type: feature
         docs: topics/using/intro-mappings/
+
+      - title: Building Emissary no longer requires setting DOCKER_BUILDKIT
+        body: It is no longer necessary to set <code>DOCKER_BUILDKIT=0</code> when building Emissary. A future change will fully support BuildKit.
+        type: bugfix
+        docs: https://github.com/emissary-ingress/emissary/issues/3707
+        github:
+        - title: "#3707"
+          link: https://github.com/emissary-ingress/emissary/issues/3707
 
   - version: 2.0.2-ea
     date: '2021-08-24'
@@ -149,7 +162,7 @@ items:
         body: Each <code>AmbassadorHost</code> can specify its <code>requestPolicy.insecure.action</code> independently of any other <code>AmbassadorHost</code>, allowing for HTTP routing as flexible as HTTPS routing.
         docs: topics/running/host-crd/#secure-and-insecure-requests
         github:
-          title: 2888
+        - title: "#2888"
           link: https://github.com/datawire/ambassador/issues/2888
         image: ./edge-stack-2.0.0-insecure_action_hosts.png
         type: bugfix


### PR DESCRIPTION
Release-note and CHANGELOG tweaks for 2.0.3:

- Update release notes for 2.0.3
   - Add an element we missed
   - Add GitHub links where appropriate.
   - Oh yeah, the titles of GitHub links need to be quoted.
- Update CHANGELOG.tpl to render GitHub links into CHANGELOG.md
- make generate

 - [x] I made sure to update `CHANGELOG.md`.
 - [x] This is unlikely to impact how Ambassador performs at scale.
 - [x] My change is adequately tested.
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
