### PR TITLE
[v2.0.3-ea] Changelog date update

### DIFF
--- a/.github/workflows/job-chart-changelog.yml
+++ b/.github/workflows/job-chart-changelog.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: "check that chart version was updated"
         run: |
           git fetch origin master:master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 ## RELEASE NOTES
 
-## [2.0.3-ea] (TBD)
+## [2.0.3-ea] September 16, 2021
 [2.0.3-ea]: https://github.com/emissary-ingress/emissary/releases/v2.0.3-ea
 
 We're pleased to introduce Emissary-ingress 2.0.3 as a _developer preview_. The 2.X family


### PR DESCRIPTION
Changelog date updates for 2.0.3-ea

Reviewers: The only changes in this PR should be updating the changelog entry for 2.0.3-ea to the date it was released.

If there are any other changes, the PR creator should note the reason.