### PR TITLE
Fix chart CI

### DIFF
--- a/.github/workflows/execute-chart-test.yml
+++ b/.github/workflows/execute-chart-test.yml
@@ -18,6 +18,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.GH_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.GH_AWS_SECRET_ACCESS_KEY }}
       AWS_EC2_METADATA_DISABLED: true
+      GH_GITHUB_API_KEY: ${{ secrets.GH_GITHUB_API_KEY }}
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/execute-chart-test.yml
+++ b/.github/workflows/execute-chart-test.yml
@@ -18,7 +18,6 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.GH_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.GH_AWS_SECRET_ACCESS_KEY }}
       AWS_EC2_METADATA_DISABLED: true
-      GH_GITHUB_API_KEY: ${{ secrets.GH_GITHUB_API_KEY }}
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/publish-chart.yml
+++ b/.github/workflows/publish-chart.yml
@@ -12,6 +12,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.GH_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.GH_AWS_SECRET_ACCESS_KEY }}
       AWS_EC2_METADATA_DISABLED: true
+      GH_GITHUB_API_KEY: ${{ secrets.GH_GITHUB_API_KEY }}
       PUBLISH_GIT_RELEASE: true
     steps:
       - uses: actions/checkout@v2

--- a/charts/scripts/push_chart.sh
+++ b/charts/scripts/push_chart.sh
@@ -80,15 +80,15 @@ if [[ `basename ${chart_dir}` != emissary-ingress ]] ; then
 fi
 
 if [[ $thisversion =~ ^[0-9]+\.[0-9]+\.[0-9]+(-ea)?$ ]] && [[ -n "${PUBLISH_GIT_RELEASE}" ]]; then
-    if [[ -z "${GH_RELEASE_TOKEN}" ]] ; then
-        echo "GH_RELEASE_TOKEN not set"
+    if [[ -z "${GH_GITHUB_API_KEY}" ]] ; then
+        echo "GH_GITHUB_API_KEY not set"
         exit 1
     fi
     tag="chart-v${thisversion}"
     export CHART_VERSION=${thisversion}
     title=`envsubst < ${chart_dir}/RELEASE_TITLE.tpl`
     repo_full_name="emissary-ingress/emissary"
-    token="${GH_RELEASE_TOKEN}"
+    token="${GH_GITHUB_API_KEY}"
     description=`envsubst < ${chart_dir}/RELEASE.tpl | awk '{printf "%s\\\n", $0}'`
     in_changelog=false
     while IFS= read -r line ; do


### PR DESCRIPTION
## Description
Push_chart.sh did not have the secrets it needed. This PR adds GH_GITHUB_API_KEY.
Charts will be re-tagged on this branch after CI passes.