### PR TITLE
CI: Check that the Envoy version has been pushed to the right places

### DIFF
--- a/.github/workflows/execute-tests-and-promote.yml
+++ b/.github/workflows/execute-tests-and-promote.yml
@@ -39,6 +39,14 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/execute-generate
         name: "execute generate action"
+  check-envoy-version:
+    name: "check-envoy-version"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - run: make check-envoy-version
   go-tests:
     runs-on: ubuntu-latest
     strategy:
@@ -175,6 +183,7 @@ jobs:
       - lint-test
       - job-image
       - generate
+      - check-envoy-version
       - go-tests
       - pytests
       - pytest-unit

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,8 @@ dist
 *.log
 *.tmp
 *.bak
+*.orig
+*.rej
 log.txt
 
 # From `make update-aws`

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -613,13 +613,15 @@ I'd put this in in the pull request template, but so few PRs change Envoy...
 
  - [ ] The image has been pushed to...
    * [ ] `docker.io/datawire/ambassador-base`
-   * [ ] `quay.io/datawire/ambassador-base`
    * [ ] `gcr.io/datawire/ambassador-base`
  - [ ] The envoy.git commit has been tagged as `datawire-$(git
    describe --tags --match='v*')` (the `--match` is to prevent
    `datawire-*` tags from stacking on each other).
  - [ ] It's been tested with...
    * [ ] `make check-envoy`
+
+The `check-envoy-version` CI job should check all of those things,
+except for `make check-envoy`.
 
 How do I test Ambassador when using a private Docker repository?
 ----------------------------------------------------------------

--- a/_cxx/envoy.mk
+++ b/_cxx/envoy.mk
@@ -21,6 +21,17 @@ ENVOY_TEST_LABEL ?= //test/...
 # for builder.mk...
 export ENVOY_DOCKER_TAG
 
+# Set ENVOY_DOCKER_REPO to the list of mirrors that we should
+# sanity-check that things get pushed to.
+ifneq ($(IS_PRIVATE),)
+  # If $(IS_PRIVATE), then just the private repo...
+  ENVOY_DOCKER_REPOS = $(ENVOY_DOCKER_REPO)
+else
+  # ...otherwise, this list of repos:
+  ENVOY_DOCKER_REPOS  = docker.io/datawire/ambassador-base
+  ENVOY_DOCKER_REPOS += gcr.io/datawire/ambassador-base
+endif
+
 #
 # Envoy build
 
@@ -178,6 +189,24 @@ check-envoy: $(ENVOY_BASH.deps)
 	     $(ENVOY_DOCKER_EXEC) bazel test --config=clang --test_output=errors --verbose_failures -c dbg --test_env=ENVOY_IP_TEST_VERSIONS=v4only $(ENVOY_TEST_LABEL); \
 	 )
 .PHONY: check-envoy
+
+.PHONY: check-envoy-version
+check-envoy-version: ## Check that Envoy version has been pushed to the right places
+check-envoy-version: $(OSS_HOME)/_cxx/envoy
+	# First, we're going to check whether the envoy commit is tagged, which
+	# is one of the things that has to happen before landing a PR that bumps
+	# the ENVOY_COMMIT.
+	cd $< && unset GIT_DIR GIT_WORK_TREE && git describe --tags --exact-match
+	# Now, we're going to check that the Envoy Docker images have been
+	# pushed to all of the mirrors, which is another thing that has to
+	# happen before landing a PR that bumps the ENVOY_COMMIT.
+	#
+	# We "could" use `docker manifest inspect` instead of `docker
+	# pull` to test that these exist without actually pulling
+	# them... except that gcr.io doesn't allow `manifest inspect`.
+	# So just go ahead and do the `pull` :(
+	@PS4=; set -ex; $(foreach ENVOY_DOCKER_REPO,$(ENVOY_DOCKER_REPOS), docker pull $(ENVOY_DOCKER_TAG) >/dev/null; )
+	@PS4=; set -ex; $(foreach ENVOY_DOCKER_REPO,$(ENVOY_DOCKER_REPOS), docker pull $(ENVOY_FULL_DOCKER_TAG) >/dev/null; )
 
 envoy-shell: ## Run a shell in the Envoy build container
 envoy-shell: $(ENVOY_BASH.deps)


### PR DESCRIPTION
## Description
This replaces https://github.com/datawire/apro/pull/2546

## Testing
I looked that the CI job looks like it tested the things that it's supposed to.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `CHANGELOG.md`. - no applicable changes
   
   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations
 
 - [x] This is unlikely to impact how Ambassador performs at scale. - not a runtime change
 
   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability
 
 - [x] My change is adequately tested. - I think so
 
   Remember when considering testing:
    + LEGACY MODE TESTS DO NOT RUN FOR EVERY PR. If your change is affected by legacy mode, you need
      to run legacy-mode tests manually (set `AMBASSADOR_LEGACY_MODE=true` and run the tests).
      (This will be fixed soon.)
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points
 
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently. - yes
