### PR TITLE
[v1.14.2] Release Branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,13 +68,6 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 ### Emissary Ingress and Ambassador Edge Stack
 
-(no changes yet)
-
-## [1.14.2] TBD
-[1.14.2]: https://github.com/emissary-ingress/emissary/compare/v1.14.1...v1.14.2
-
-### Emissary Ingress and Ambassador Edge Stack
-
 - Feature: You can now set `respect_dns_ttl` in Ambassador Mappings. When true it configures that upstream's refresh rate to be set to resource record’s TTL
 - Feature: You can now set `dns_type` to in Ambassador Mappings to use Envoy's `logical_dns` resolution instead of the default `strict_dns`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,13 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 ## RELEASE NOTES
 
+## [1.14.2] (TBD)
+[1.14.2]: https://github.com/emissary-ingress/emissary/compare/v1.14.1...v1.14.2
+
+### Emissary Ingress and Ambassador Edge Stack
+
+(no changes yet)
+
 ## [1.14.2] TBD
 [1.14.2]: https://github.com/emissary-ingress/emissary/compare/v1.14.1...v1.14.2
 

--- a/docs/yaml/versions.yml
+++ b/docs/yaml/versions.yml
@@ -1,2 +1,2 @@
-version: 1.14.1
+version: 1.14.2
 quoteVersion: 0.4.1

--- a/python/schemas/v2/DevPortal.schema
+++ b/python/schemas/v2/DevPortal.schema
@@ -20,6 +20,7 @@
             ]
         },
         "default": { "type": "boolean" },
+        "preserve_servers": { "type": "boolean" },
         "docs": {
             "type": "array",
             "items": {

--- a/python/schemas/v2/Mapping.schema
+++ b/python/schemas/v2/Mapping.schema
@@ -31,6 +31,8 @@
         "case_sensitive": { "type": "boolean" },
         "enable_ipv4": { "type": "boolean" },
         "enable_ipv6": { "type": "boolean" },
+        "respect_dns_ttl": { "type": "boolean" },
+        "dns_type": { "type": "string" },
         "circuit_breakers": {
             "type": "array",
             "items": {

--- a/python/tests/test_cluster_options.py
+++ b/python/tests/test_cluster_options.py
@@ -61,15 +61,6 @@ def test_logical_dns_type_wrong():
             expected="STRICT_DNS", exists=True, envoy_version=v)
 
 @pytest.mark.compilertest
-def test_logical_dns_type_wrong():
-    # Ensure we use endpoint discovery instead of this value when using the endpoint resolver
-    yaml = module_and_mapping_manifests(None, ["dns_type: logical_dns", "resolver: endpoint"])
-    for v in SUPPORTED_ENVOY_VERSIONS:
-        # The dns type is listed as just "type"
-        _test_cluster_setting(yaml, setting="type", 
-            expected="EDS", exists=True, envoy_version=v)
-
-@pytest.mark.compilertest
 def test_dns_ttl():
     # Test configuring the respect_dns_ttl generates an Envoy config
     yaml = module_and_mapping_manifests(None, ["respect_dns_ttl: true"])


### PR DESCRIPTION

All commits that are going out in 1.14.2 release **must** be on rel/v1.14.2.
This will allow the appropriate CI to run.

To get the hotfix changes onto this branch you can do one of the following:
    * use rel/v1.14.2 as the development branch for the fix
    * land (or have already landed) hotfix changes on release/v1.14 branch, and merge release/v1.14 into rel/v1.14.2
    * cherry-pick hotfix commits from ambassador.git to rel/v1.14.2

It is okay if you've already landed the hotfix changes on release/v1.14 branch,
reviewers just need to validate that the hotfix commits are in the tree for rel/v1.14.2,
and all the appropriate changelog updates exist.

## REVIEWERS MUST CHECK THAT:
* hotfix commits are on rel/v1.14.2
* CHANGELOG updates are on rel/v1.14.2
