### PR TITLE
README and CHANGELOG stuff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 ## RELEASE NOTES
 
-## [2.0.4-ea] (TBD)
+## [2.0.4-ea] TBD
 [2.0.4-ea]: https://github.com/emissary-ingress/emissary/releases/v2.0.4-ea
 
 We're pleased to introduce Emissary-ingress 2.0.3 as a _developer preview_. The 2.X family
@@ -89,7 +89,7 @@ installations, reduce memory footprint, and improve performance. We welcome feed
 - Bugfix: The release now shows its actual released version number, rather than the internal development
   version number.
 
-## [2.0.3-ea] (2021-09-16)
+## [2.0.3-ea] 2021-09-16
 [2.0.3-ea]: https://github.com/emissary-ingress/emissary/releases/v2.0.3-ea
 
 We're pleased to introduce Emissary-ingress 2.0.3 as a _developer preview_. The 2.X family
@@ -112,7 +112,7 @@ installations, reduce memory footprint, and improve performance. We welcome feed
 [#3666]: https://github.com/emissary-ingress/emissary/issues/3666
 [#3707]: https://github.com/emissary-ingress/emissary/issues/3707
 
-## [2.0.2-ea] (2021-08-24)
+## [2.0.2-ea] 2021-08-24
 [2.0.2-ea]: https://github.com/emissary-ingress/emissary/releases/v2.0.2-ea
 
 We're pleased to introduce Emissary-ingress 2.0.2 as a _developer preview_. The 2.X family
@@ -133,7 +133,7 @@ installations, reduce memory footprint, and improve performance. We welcome feed
   of snapshots is controlled by the `AMBASSADOR_AMBEX_SNAPSHOT_COUNT` environment variable; set it
   to 0 to disable. The default is 30.
 
-## [2.0.1-ea] (2021-08-12)
+## [2.0.1-ea] 2021-08-12
 [2.0.1-ea]: https://github.com/emissary-ingress/emissary/releases/v2.0.1-ea
 
 We're pleased to introduce Emissary-ingress 2.0.1 as a _developer preview_. The 2.X family
@@ -164,7 +164,7 @@ installations, reduce memory footprint, and improve performance. We welcome feed
   resolvers, but could make OOMkills more likely with large configurations. The default is `false`,
   meaning that the rate limiter is active.
 
-## [2.0.0-ea] (2021-06-24)
+## [2.0.0-ea] 2021-06-24
 [2.0.0-ea]: https://github.com/emissary-ingress/emissary/releases/v2.0.0-ea
 
 We're pleased to introduce Emissary-ingress 2.0.0 as a _developer preview_. The 2.X family
@@ -241,63 +241,60 @@ installations, reduce memory footprint, and improve performance. We welcome feed
 
 [#2888]: https://github.com/datawire/ambassador/issues/2888
 
-## [1.14.1] (2021-08-24)
-[1.14.1]: https://github.com/emissary-ingress/emissary/releases/v1.14.1
 
-## Emissary-ingress
+## [1.14.1] August 24, 2021
+[1.14.1]: https://github.com/emissary-ingress/emissary/compare/v1.14.0...v1.14.1
 
-- Bugfix: Upgraded Envoy to 1.17.4 to address security vulnerabilities CVE-2021-32777, CVE-2021-32778,
-  CVE-2021-32779, and CVE-2021-32781
+### Emissary Ingress and Ambassador Edge Stack
 
-## [1.14.0] (2021-08-19)
-[1.14.0]: https://github.com/emissary-ingress/emissary/releases/v1.14.0
+- Change: Update Envoy with security patches to fix the following CVEs
+  - CVE-2021-32777
+  - CVE-2021-32779
+  - CVE-2021-32781
+  - CVE-2021-32778
 
-## Emissary-ingress
-
-- Change: Upgraded Envoy from 1.15 to 1.17.3, see the <a
-  href="https://www.envoyproxy.io/docs/envoy/latest/version_history/version_history">Envoy
-  changelog</a> for more information
-
-- Feature: You can now set `allow_chunked_length` in the Ambassador Module to configure the same value in
-  Envoy
-
-- Change: The default Envoy API version has changed from V2 to V3, as V2 has fallen out of support, and has
-  been removed as of Envoy 1.18.0.
-
-- Change: Logs now include subsecond time resolutions, rather than just seconds.
-
-## [1.13.10] (2021-07-27)
-[1.13.10]: https://github.com/emissary-ingress/emissary/releases/v1.13.10
-
-## Emissary-ingress
-
-- Bugfix: Fixed a regression when specifying a comma separated string for `cors.origins` on the ` Mapping`
-  resource
-
-- Change: Envoy-configuration snapshots get saved (as `ambex-#.json`) in `/ambassador/snapshots`. The number
-  of snapshots is controlled by the `AMBASSADOR_AMBEX_SNAPSHOT_COUNT` environment variable; set it
-  to 0 to disable. The default is 30."
-
-- Change: Set `AMBASSADOR_AMBEX_NO_RATELIMIT` to `true` to completely disable ratelimiting Envoy
-  reconfiguration under memory pressure. This can help performance with the endpoint or Consul
-  resolvers, but could make OOMkills more likely with large configurations.
-
-## [1.13.9] (2021-06-30)
-[1.13.9]: https://github.com/emissary-ingress/emissary/releases/v1.13.9
-
-## Emissary-ingress
-
-- Bugfix: Fixed a bug which caused Emissary-ingress to generate invalid Envoy configuration when two
-  TCPMappings were deployed with the same port, but different host."
-
-
-
-## [1.13.11] (TBD)
-[1.13.11]: https://github.com/emissary-ingress/emissary/compare/v1.13.10...v1.13.11
+## [1.14.0] August 19, 2021
+[1.14.0]: https://github.com/emissary-ingress/emissary/compare/v1.13.10...v1.14.0
 
 ### Emissary Ingress and Ambassador Edge Stack
 
 - Change: Logs now include subsecond time resolutions, rather than just seconds.
+- Change: Update from Envoy 1.15 to 1.17.3
+- Change: `AMBASSADOR_ENVOY_API_VERSION` now defaults to `V3`
+- Feature: You can now set `allow_chunked_length` in the Ambassador Module to configure the same value in Envoy.
+
+## [1.13.10] July 28, 2021
+[1.13.10]: https://github.com/emissary-ingress/emissary/compare/v1.13.9...v1.13.10
+
+### Emissary Ingress and Ambassador Edge Stack
+
+- Bugfix: Fixed a regression when specifying a comma separated string for `cors.origins` on the
+  `Mapping` resource. ([#3609])
+- Change: Envoy-configuration snapshots get saved (as `ambex-#.json`) in `/ambassador/snapshots`.
+  The number of snapshots is controlled by the `AMBASSADOR_AMBEX_SNAPSHOT_COUNT` environment
+  variable; set it to 0 to disable. The default is 30.
+- Change: Set `AMBASSADOR_AMBEX_NO_RATELIMIT` to `true` to completely disable ratelimiting Envoy
+  reconfiguration under memory pressure. This can help performance with the endpoint or Consul
+  resolvers, but could make OOMkills more likely with large configurations. The default is `false`,
+  meaning that the rate limiter is active.
+
+### Ambassador Edge Stack only
+
+- Bugfix: The `Mapping` resource can now specify `docs.timeout_ms` to set the timeout when the
+  Dev Portal is fetching API specifications.
+- Bugfix: The Dev Portal will now strip HTML tags when displaying search results, showing just
+  the actual content of the search result.
+- Change: Consul certificate-rotation logging now includes the fingerprints and validity
+  timestamps of certificates being rotated.
+
+[#3609]: https://github.com/emissary-ingress/emissary/issues/3609
+
+## [1.13.9] June 30, 2021
+[1.13.9]: https://github.com/emissary-ingress/emissary/compare/v1.13.8...v1.13.9
+
+### Emissary Ingress and Ambassador Edge Stack
+
+- Bugfix: Configuring multiple TCPMappings with the same ports (but different hosts) no longer generates invalid Envoy configuration.
 
 ## [1.13.8] June 08, 2021
 [1.13.8]: https://github.com/emissary-ingress/emissary/compare/v1.13.7...v1.13.8

--- a/README.md
+++ b/README.md
@@ -1,16 +1,24 @@
-Emissary-Ingress (fka Ambassador API Gateway) [![Build Status][build-status]][build-pages] [![CII Best Practices][cii-badge]][cii-status]
- [![Docker Repository][docker-latest]][docker-repo] ![Docker Pulls][docker-pulls] [![Join Slack][slack-join]][slack-url]
+Emissary-ingress
 ==========
 
-[build-pages]:   https://travis-ci.org/datawire/ambassador
-[build-status]:  https://travis-ci.org/datawire/ambassador.png?branch=master
-[cii-badge]:     https://bestpractices.coreinfrastructure.org/projects/1852/badge
-[cii-status]:    https://bestpractices.coreinfrastructure.org/projects/1852
-[docker-repo]:   https://hub.docker.com/repository/docker/datawire/ambassador
-[docker-latest]: https://img.shields.io/docker/v/datawire/ambassador?sort=semver
-[docker-pulls]:  https://img.shields.io/docker/pulls/datawire/ambassador
-[slack-url]:     https://a8r.io/slack
-[slack-join]:    https://img.shields.io/badge/slack-join-orange.svg
+<!-- [![Build Status][build-status]][build-pages] -->
+[![Docker Repository][version-endpoint]][docker-repo] 
+![Docker Pulls][docker-pulls]
+[![Join Slack][slack-join]][slack-url] <br/>
+[![CII Best Practices][cii-badge]][cii-status]
+
+<!--
+  ![example branch parameter](https://github.com/github/docs/actions/workflows/main.yml/badge.svg?branch=feature-1)
+  [build-pages]:   https://travis-ci.org/datawire/ambassador
+  [build-status]:  https://github.com/emissary-ingress/emissary/actions/workflows/promote-ga.yml/badge.svg?branch=release/v2.0
+-->
+[cii-badge]:        https://bestpractices.coreinfrastructure.org/projects/1852/badge
+[cii-status]:       https://bestpractices.coreinfrastructure.org/projects/1852
+[docker-repo]:      https://hub.docker.com/repository/docker/datawire/emissary
+[version-endpoint]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/kflynn/emissary/flynn/dev/readme/docs/shield.json
+[docker-pulls]:     https://img.shields.io/docker/pulls/datawire/emissary
+[slack-url]:        https://a8r.io/slack
+[slack-join]:       https://img.shields.io/badge/slack-join-orange.svg
 
 Emissary-Ingress (formerly known as the [Ambassador API Gateway](https://www.getambassador.io)) is an open-source Kubernetes-native API Gateway + Layer 7 load balancer + Kubernetes Ingress built on [Envoy Proxy](https://www.envoyproxy.io). Emissary Ingress is an CNCF incubation project.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Emissary-ingress
 
 <!--
   ![example branch parameter](https://github.com/github/docs/actions/workflows/main.yml/badge.svg?branch=feature-1)
-  [build-pages]:   https://travis-ci.org/datawire/ambassador
+  [build-pages]:   https://travis-ci.org/emissary-ingress/emissary
   [build-status]:  https://github.com/emissary-ingress/emissary/actions/workflows/promote-ga.yml/badge.svg?branch=release/v2.0
 -->
 [cii-badge]:        https://bestpractices.coreinfrastructure.org/projects/1852/badge
@@ -20,55 +20,75 @@ Emissary-ingress
 [slack-url]:        https://a8r.io/slack
 [slack-join]:       https://img.shields.io/badge/slack-join-orange.svg
 
-Emissary-Ingress (formerly known as the [Ambassador API Gateway](https://www.getambassador.io)) is an open-source Kubernetes-native API Gateway + Layer 7 load balancer + Kubernetes Ingress built on [Envoy Proxy](https://www.envoyproxy.io). Emissary Ingress is an CNCF incubation project.
+[Emissary-Ingress](https://www.getambassador.io) is an open-source Kubernetes-native API Gateway +
+Layer 7 load balancer + Kubernetes Ingress built on [Envoy Proxy](https://www.envoyproxy.io). 
+Emissary-ingress is an CNCF incubation project (and was formerly known as Ambassador API Gateway.)
 
-The Ambassador Edge Stack is a complete superset of the OSS Emissary Ingress project that offers additional functionality. Edge Stack is designed to easily expose, secure, and manage traffic to your Kubernetes microservices of any type. Edge Stack was built around the ideas of self-service (enabling GitOps-style management) and comprehensiveness (so it works with your situations and technology solutions).
+Emissary-ingress enables its users to:
+* Manage ingress traffic with [load balancing], support for multiple protocols ([gRPC and HTTP/2], [TCP], and [web sockets]), and Kubernetes integration
+* Manage changes to routing with an easy to use declarative policy engine and [self-service configuration], via Kubernetes [CRDs] or annotations
+* Secure microservices with [authentication], [rate limiting], and [TLS]
+* Ensure high availability with [sticky sessions], [rate limiting], and [circuit breaking]
+* Leverage observability with integrations with [Grafana], [Prometheus], and [Datadog], and comprehensive [metrics] support
+* Enable progressive delivery with [canary releases]
+* Connect service meshes including [Consul], [Linkerd], and [Istio]
+* [Knative serverless integration]
 
-Emissary Ingress enables its users to:
+[load balancing]: https://www.getambassador.io/docs/emissary/latest/topics/running/load-balancer/
+[gRPC and HTTP/2]: https://www.getambassador.io/docs/emissary/latest/howtos/grpc/
+[TCP]: https://www.getambassador.io/docs/emissary/latest/topics/using/tcpmappings/
+[web sockets]: https://www.getambassador.io/docs/emissary/latest/topics/using/tcpmappings/
+[self-service configuration]: https://www.getambassador.io/docs/emissary/latest/topics/using/mappings/
+[CRDs]: https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/
+[authentication]: https://www.getambassador.io/docs/emissary/latest/topics/running/services/auth-service/
+[TLS]: https://www.getambassador.io/docs/emissary/latest/howtos/tls-termination/
+[sticky sessions]: https://www.getambassador.io/docs/emissary/latest/topics/running/load-balancer/#sticky-sessions--session-affinity
+[rate limiting]: https://www.getambassador.io/docs/emissary/latest/topics/running/services/rate-limit-service/
+[circuit breaking]: https://www.getambassador.io/docs/emissary/latest/topics/using/circuit-breakers/
+[Grafana]: https://www.getambassador.io/docs/emissary/latest/topics/running/statistics/#grafana
+[Prometheus]: https://www.getambassador.io/docs/emissary/latest/topics/running/statistics/#prometheus
+[Datadog]: https://www.getambassador.io/docs/emissary/latest/topics/running/statistics/#datadog
+[metrics]: https://www.getambassador.io/docs/emissary/latest/topics/running/statistics/
+[canary releases]: https://www.getambassador.io/docs/emissary/latest/topics/using/canary/
+[Consul]: https://www.getambassador.io/docs/emissary/latest/howtos/consul/
+[Linkerd]: https://www.getambassador.io/docs/emissary/latest/howtos/linkerd2/
+[Istio]: https://www.getambassador.io/docs/emissary/latest/howtos/istio/
+[Knative serverless integration]: https://www.getambassador.io/docs/emissary/latest/howtos/knative/
 
-* Manage ingress traffic with [load balancing](https://www.getambassador.io/docs/emissary/latest/topics/running/load-balancer/), protocol support([gRPC and HTTP/2](https://www.getambassador.io/docs/emissary/latest/howtos/grpc/), [TCP](https://www.getambassador.io/docs/emissary/latest/topics/using/tcpmappings/), and [web sockets](https://www.getambassador.io/docs/emissary/latest/topics/using/tcpmappings/)), and Kubernetes integration
-* Manage changes to routing with an easy to use declarative policy engine and [self-service configuration](https://www.getambassador.io/docs/emissary/latest/topics/using/mappings/), via Kubernetes [CRDs](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) or annotations
-* Secure microservices with [authentication](https://www.getambassador.io/docs/emissary/latest/topics/running/services/auth-service/), rate limiting, [TLS](https://www.getambassador.io/docs/emissary/latest/howtos/tls-termination/), and [automatic HTTPS](https://www.getambassador.io/docs/emissary/latest/topics/running/host-crd/)
-* Ensure high availability with [sticky sessions](https://www.getambassador.io/docs/emissary/latest/topics/running/load-balancer/#sticky-sessions--session-affinity), [rate limiting](https://www.getambassador.io/docs/emissary/latest/topics/running/services/rate-limit-service/), and [circuit breaking](https://www.getambassador.io/docs/emissary/latest/topics/using/circuit-breakers/)
-* Leverage observability with integrations with [Grafana](https://www.getambassador.io/docs/emissary/latest/topics/running/statistics/#grafana), [Prometheus](https://www.getambassador.io/docs/emissary/latest/topics/running/statistics/#prometheus), and [Datadog](https://www.getambassador.io/docs/emissary/latest/topics/running/statistics/#datadog), and comprehensive [metrics](https://www.getambassador.io/docs/emissary/latest/topics/running/statistics/) support
-* Enable progressive delivery with [canary releases](https://www.getambassador.io/docs/emissary/latest/topics/using/canary/)
-* Connect service meshes including [Consul](https://www.getambassador.io/docs/emissary/latest/howtos/consul/), [Linkerd](https://www.getambassador.io/docs/emissary/latest/howtos/linkerd2/), and [Istio](https://www.getambassador.io/docs/emissary/latest/howtos/istio/)
-* [Knative serverless integration](https://www.getambassador.io/docs/emissary/latest/howtos/knative/)
-
-See the full list of [features](https://www.getambassador.io/features/) here. Learn [Why the Ambassador Edge Stack?](https://www.getambassador.io/docs/emissary/latest/about/why-ambassador/#why-the-ambassador-edge-stack)
-
+See the full list of [features](https://www.getambassador.io/features/) here.
 
 Architecture
 ============
 
-Ambassador deploys the Envoy Proxy for L7 traffic management. Configuration of Ambassador is via Kubernetes annotations. Ambassador relies on Kubernetes for scaling and resilience. For more on Ambassador's architecture and motivation, read [this blog post](https://blog.getambassador.io/building-ambassador-an-open-source-api-gateway-on-kubernetes-and-envoy-ed01ed520844).
+Emissary is configured via Kubernetes CRDs, or via annotations on Kubernetes `Service`s. Internally,
+it uses the [Envoy Proxy] to actually handle routing data; externally, it relies on Kubernetes for
+scaling and resiliency. For more on Emissary's architecture and motivation, read [this blog post](https://blog.getambassador.io/building-ambassador-an-open-source-api-gateway-on-kubernetes-and-envoy-ed01ed520844).
 
 Getting Started
 ===============
 
-You can get Ambassador up and running in just three steps. Follow the instructions here: https://www.getambassador.io/docs/emissary/latest/tutorials/getting-started/
+You can get Emissary up and running in just three steps. Follow the instructions here: https://www.getambassador.io/docs/emissary/latest/tutorials/getting-started/
 
-
-If you are looking for a Kubernetes ingress controller, Ambassador provides a superset of the functionality of a typical ingress controller. (It does the traditional routing, and layers on a raft of configuration options.) This blog post covers [Kubernetes ingress](https://blog.getambassador.io/kubernetes-ingress-nodeport-load-balancers-and-ingress-controllers-6e29f1c44f2d).
+If you are looking for a Kubernetes ingress controller, Emissary provides a superset of the functionality of a typical ingress controller. (It does the traditional routing, and layers on a raft of configuration options.) This blog post covers [Kubernetes ingress](https://blog.getambassador.io/kubernetes-ingress-nodeport-load-balancers-and-ingress-controllers-6e29f1c44f2d).
 
 For other common questions, view this [FAQ page](https://www.getambassador.io/docs/emissary/latest/about/faq/).
 
-You can also use Helm to install Ambassador. For more information, see the instructions in the [Helm installation documentation](https://www.getambassador.io/docs/emissary/latest/topics/install/helm/)
+You can also use Helm to install Emissary. For more information, see the instructions in the [Helm installation documentation](https://www.getambassador.io/docs/emissary/latest/topics/install/helm/)
 
 Community
 =========
 
-Ambassador is an open-source project, and welcomes any and all contributors. To get started:
+Emissary-ingress is a CNCF Incubating project, and welcomes any and all contributors. To get started:
 
-* Join our [Slack channel](https://d6e.co/slack)
-* Check out the [Ambassador documentation](https://www.getambassador.io/docs/emissary/)
-* Read the [Contributor's Guide](https://github.com/datawire/ambassador/blob/master/DEVELOPING.md).
+* Join our [Slack channel](https://a8r.io/slack)
+* Check out the [Emissary documentation](https://www.getambassador.io/docs/emissary/)
+* Read the [Contributor's Guide](https://github.com/emissary-ingress/emissary/blob/master/DEVELOPING.md).
 
 If you're interested in contributing, here are some ways:
 
 * Write a blog post for [our blog](https://blog.getambassador.io)
-* Investigate an [open issue](https://github.com/datawire/ambassador/issues)
-* Add [more tests](https://github.com/datawire/ambassador/tree/master/ambassador/tests)
+* Investigate an [open issue](https://github.com/emissary-ingress/emissary/issues)
+* Add [more tests](https://github.com/emissary-ingress/emissary/tree/master/ambassador/tests)
 
-The Ambassador Edge Stack is a superset of the Ambassador API Gateway that provides additional functionality including OAuth/OpenID Connect, advanced rate limiting, Swagger/OpenAPI support, integrated ACME support for automatic TLS certificate management, and a UI. For more information, visit https://www.getambassador.io/editions/.
+The Ambassador Edge Stack is a superset of Emissary-ingress that provides additional functionality including OAuth/OpenID Connect, advanced rate limiting, Swagger/OpenAPI support, integrated ACME support for automatic TLS certificate management, and a cloud-based UI. For more information, visit https://www.getambassador.io/editions/.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 Emissary-ingress
-==========
+================
+
+<!-- Links are (mostly) at the end of this document, for legibility. -->
 
 <!-- [![Build Status][build-status]][build-pages] -->
 [![Docker Repository][version-endpoint]][docker-repo] 
@@ -7,18 +9,7 @@ Emissary-ingress
 [![Join Slack][slack-join]][slack-url] <br/>
 [![CII Best Practices][cii-badge]][cii-status]
 
-<!--
-  ![example branch parameter](https://github.com/github/docs/actions/workflows/main.yml/badge.svg?branch=feature-1)
-  [build-pages]:   https://travis-ci.org/emissary-ingress/emissary
-  [build-status]:  https://github.com/emissary-ingress/emissary/actions/workflows/promote-ga.yml/badge.svg?branch=release/v2.0
--->
-[cii-badge]:        https://bestpractices.coreinfrastructure.org/projects/1852/badge
-[cii-status]:       https://bestpractices.coreinfrastructure.org/projects/1852
-[docker-repo]:      https://hub.docker.com/repository/docker/datawire/emissary
-[version-endpoint]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/kflynn/emissary/flynn/dev/readme/docs/shield.json
-[docker-pulls]:     https://img.shields.io/docker/pulls/datawire/emissary
-[slack-url]:        https://a8r.io/slack
-[slack-join]:       https://img.shields.io/badge/slack-join-orange.svg
+----
 
 [Emissary-Ingress](https://www.getambassador.io) is an open-source Kubernetes-native API Gateway +
 Layer 7 load balancer + Kubernetes Ingress built on [Envoy Proxy](https://www.envoyproxy.io). 
@@ -33,27 +24,6 @@ Emissary-ingress enables its users to:
 * Enable progressive delivery with [canary releases]
 * Connect service meshes including [Consul], [Linkerd], and [Istio]
 * [Knative serverless integration]
-
-[load balancing]: https://www.getambassador.io/docs/emissary/latest/topics/running/load-balancer/
-[gRPC and HTTP/2]: https://www.getambassador.io/docs/emissary/latest/howtos/grpc/
-[TCP]: https://www.getambassador.io/docs/emissary/latest/topics/using/tcpmappings/
-[web sockets]: https://www.getambassador.io/docs/emissary/latest/topics/using/tcpmappings/
-[self-service configuration]: https://www.getambassador.io/docs/emissary/latest/topics/using/mappings/
-[CRDs]: https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/
-[authentication]: https://www.getambassador.io/docs/emissary/latest/topics/running/services/auth-service/
-[TLS]: https://www.getambassador.io/docs/emissary/latest/howtos/tls-termination/
-[sticky sessions]: https://www.getambassador.io/docs/emissary/latest/topics/running/load-balancer/#sticky-sessions--session-affinity
-[rate limiting]: https://www.getambassador.io/docs/emissary/latest/topics/running/services/rate-limit-service/
-[circuit breaking]: https://www.getambassador.io/docs/emissary/latest/topics/using/circuit-breakers/
-[Grafana]: https://www.getambassador.io/docs/emissary/latest/topics/running/statistics/#grafana
-[Prometheus]: https://www.getambassador.io/docs/emissary/latest/topics/running/statistics/#prometheus
-[Datadog]: https://www.getambassador.io/docs/emissary/latest/topics/running/statistics/#datadog
-[metrics]: https://www.getambassador.io/docs/emissary/latest/topics/running/statistics/
-[canary releases]: https://www.getambassador.io/docs/emissary/latest/topics/using/canary/
-[Consul]: https://www.getambassador.io/docs/emissary/latest/howtos/consul/
-[Linkerd]: https://www.getambassador.io/docs/emissary/latest/howtos/linkerd2/
-[Istio]: https://www.getambassador.io/docs/emissary/latest/howtos/istio/
-[Knative serverless integration]: https://www.getambassador.io/docs/emissary/latest/howtos/knative/
 
 See the full list of [features](https://www.getambassador.io/features/) here.
 
@@ -92,3 +62,37 @@ If you're interested in contributing, here are some ways:
 
 The Ambassador Edge Stack is a superset of Emissary-ingress that provides additional functionality including OAuth/OpenID Connect, advanced rate limiting, Swagger/OpenAPI support, integrated ACME support for automatic TLS certificate management, and a cloud-based UI. For more information, visit https://www.getambassador.io/editions/.
 
+<!--
+  ![example branch parameter](https://github.com/github/docs/actions/workflows/main.yml/badge.svg?branch=feature-1)
+  [build-pages]:   https://travis-ci.org/emissary-ingress/emissary
+  [build-status]:  https://github.com/emissary-ingress/emissary/actions/workflows/promote-ga.yml/badge.svg?branch=release/v2.0
+-->
+[cii-badge]:        https://bestpractices.coreinfrastructure.org/projects/1852/badge
+[cii-status]:       https://bestpractices.coreinfrastructure.org/projects/1852
+[docker-repo]:      https://hub.docker.com/repository/docker/datawire/emissary
+[version-endpoint]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/kflynn/emissary/flynn/dev/readme/docs/shield.json
+[docker-pulls]:     https://img.shields.io/docker/pulls/datawire/emissary
+[slack-url]:        https://a8r.io/slack
+[slack-join]:       https://img.shields.io/badge/slack-join-orange.svg
+
+<!-- Please keep this list sorted. -->
+[authentication]: https://www.getambassador.io/docs/emissary/latest/topics/running/services/auth-service/
+[canary releases]: https://www.getambassador.io/docs/emissary/latest/topics/using/canary/
+[circuit breaking]: https://www.getambassador.io/docs/emissary/latest/topics/using/circuit-breakers/
+[Consul]: https://www.getambassador.io/docs/emissary/latest/howtos/consul/
+[CRDs]: https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/
+[Datadog]: https://www.getambassador.io/docs/emissary/latest/topics/running/statistics/#datadog
+[Grafana]: https://www.getambassador.io/docs/emissary/latest/topics/running/statistics/#grafana
+[gRPC and HTTP/2]: https://www.getambassador.io/docs/emissary/latest/howtos/grpc/
+[Istio]: https://www.getambassador.io/docs/emissary/latest/howtos/istio/
+[Knative serverless integration]: https://www.getambassador.io/docs/emissary/latest/howtos/knative/
+[Linkerd]: https://www.getambassador.io/docs/emissary/latest/howtos/linkerd2/
+[load balancing]: https://www.getambassador.io/docs/emissary/latest/topics/running/load-balancer/
+[metrics]: https://www.getambassador.io/docs/emissary/latest/topics/running/statistics/
+[Prometheus]: https://www.getambassador.io/docs/emissary/latest/topics/running/statistics/#prometheus
+[rate limiting]: https://www.getambassador.io/docs/emissary/latest/topics/running/services/rate-limit-service/
+[self-service configuration]: https://www.getambassador.io/docs/emissary/latest/topics/using/mappings/
+[sticky sessions]: https://www.getambassador.io/docs/emissary/latest/topics/running/load-balancer/#sticky-sessions--session-affinity
+[TCP]: https://www.getambassador.io/docs/emissary/latest/topics/using/tcpmappings/
+[TLS]: https://www.getambassador.io/docs/emissary/latest/howtos/tls-termination/
+[web sockets]: https://www.getambassador.io/docs/emissary/latest/topics/using/tcpmappings/

--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -782,7 +782,7 @@ release/promote-oss/dev-to-rc:
 .PHONY: release/promote-oss/dev-to-rc
 
 release/promote-oss/rc-update-apro:
-	$(OSS_HOME)/releng/01-release-rc-update-apro v$(RELEASE_VERSION) v$(VERSIONS_YAML_VERSION)
+	$(OSS_HOME)/releng/01-release-rc-update-apro v$(RELEASE_VERSION) v$(VERSIONS_YAML_VER)
 .PHONY: release/promote-oss/rc-update-apro
 
 release/print-test-artifacts:

--- a/docs/CHANGELOG.tpl
+++ b/docs/CHANGELOG.tpl
@@ -76,7 +76,7 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 ## RELEASE NOTES
 
 {{ range (datasource "relnotes").items -}}
-## [{{ .version }}] ({{ .date }})
+## [{{ .version }}] {{ .date }}
 [{{ .version }}]: https://github.com/emissary-ingress/emissary/releases/v{{ .version }}
 {{- range .notes }}{{ if index . "isHeadline" }}{{ if .isHeadline }}
 
@@ -90,13 +90,59 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 [{{.title}}]: {{.link}}{{ end -}}{{- end -}}{{- end }}
 {{ if $anyGitLinks }}
 {{ end }}{{ end }}
+## [1.14.1] August 24, 2021
+[1.14.1]: https://github.com/emissary-ingress/emissary/compare/v1.14.0...v1.14.1
 
-## [1.13.11] (TBD)
-[1.13.11]: https://github.com/emissary-ingress/emissary/compare/v1.13.10...v1.13.11
+### Emissary Ingress and Ambassador Edge Stack
+
+- Change: Update Envoy with security patches to fix the following CVEs
+  - CVE-2021-32777
+  - CVE-2021-32779
+  - CVE-2021-32781
+  - CVE-2021-32778
+
+## [1.14.0] August 19, 2021
+[1.14.0]: https://github.com/emissary-ingress/emissary/compare/v1.13.10...v1.14.0
 
 ### Emissary Ingress and Ambassador Edge Stack
 
 - Change: Logs now include subsecond time resolutions, rather than just seconds.
+- Change: Update from Envoy 1.15 to 1.17.3
+- Change: `AMBASSADOR_ENVOY_API_VERSION` now defaults to `V3`
+- Feature: You can now set `allow_chunked_length` in the Ambassador Module to configure the same value in Envoy.
+
+## [1.13.10] July 28, 2021
+[1.13.10]: https://github.com/emissary-ingress/emissary/compare/v1.13.9...v1.13.10
+
+### Emissary Ingress and Ambassador Edge Stack
+
+- Bugfix: Fixed a regression when specifying a comma separated string for `cors.origins` on the
+  `Mapping` resource. ([#3609])
+- Change: Envoy-configuration snapshots get saved (as `ambex-#.json`) in `/ambassador/snapshots`.
+  The number of snapshots is controlled by the `AMBASSADOR_AMBEX_SNAPSHOT_COUNT` environment
+  variable; set it to 0 to disable. The default is 30.
+- Change: Set `AMBASSADOR_AMBEX_NO_RATELIMIT` to `true` to completely disable ratelimiting Envoy
+  reconfiguration under memory pressure. This can help performance with the endpoint or Consul
+  resolvers, but could make OOMkills more likely with large configurations. The default is `false`,
+  meaning that the rate limiter is active.
+
+### Ambassador Edge Stack only
+
+- Bugfix: The `Mapping` resource can now specify `docs.timeout_ms` to set the timeout when the
+  Dev Portal is fetching API specifications.
+- Bugfix: The Dev Portal will now strip HTML tags when displaying search results, showing just
+  the actual content of the search result.
+- Change: Consul certificate-rotation logging now includes the fingerprints and validity
+  timestamps of certificates being rotated.
+
+[#3609]: https://github.com/emissary-ingress/emissary/issues/3609
+
+## [1.13.9] June 30, 2021
+[1.13.9]: https://github.com/emissary-ingress/emissary/compare/v1.13.8...v1.13.9
+
+### Emissary Ingress and Ambassador Edge Stack
+
+- Bugfix: Configuring multiple TCPMappings with the same ports (but different hosts) no longer generates invalid Envoy configuration.
 
 ## [1.13.8] June 08, 2021
 [1.13.8]: https://github.com/emissary-ingress/emissary/compare/v1.13.7...v1.13.8

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -1,4 +1,3 @@
-
 # This file should be placed in the folder for the version of the
 # product that's meant to be documented. A `/release-notes` page will
 # be automatically generated and populated at build time.
@@ -46,7 +45,7 @@ items:
           the internal development version number.
 
   - version: 2.0.3-ea
-    date: "2021-09-16"
+    date: '2021-09-16'
     notes:
       - title: Developer Preview!
         body: We're pleased to introduce $productName$ 2.0.3 as a <b>developer preview</b>. The 2.X family introduces a number of changes to allow $productName$ to more gracefully handle larger installations, reduce global configuration to better handle multitenant or multiorganizational installations, reduce memory footprint, and improve performance. We welcome feedback!! Join us on <a href="https://a8r.io/slack">Slack</a> and let us know what you think.
@@ -242,63 +241,4 @@ items:
         docs: topics/install/helm/
         type: change
 
-  - version: 1.14.1
-    date: '2021-08-24'
-    notes:
-      - title: Envoy security updates
-        type: bugfix
-        body: "Upgraded Envoy to 1.17.4 to address security vulnerabilities CVE-2021-32777, CVE-2021-32778, CVE-2021-32779, and CVE-2021-32781"
-        docs: https://groups.google.com/g/envoy-announce/c/5xBpsEZZDfE
-
-  - version: 1.14.0
-    date: "2021-08-19"
-    notes:
-      - title: Envoy upgraded to 1.17.3!
-        type: change
-        body: "Upgraded Envoy from 1.15 to 1.17.3, see the <a href=\"https://www.envoyproxy.io/docs/envoy/latest/version_history/version_history\">Envoy changelog</a> for more information"
-        docs: https://www.envoyproxy.io/docs/envoy/latest/version_history/version_history
-      - title: Expose Envoy's allow_chunked_length HTTPProtocolOption
-        type: feature
-        body: "You can now set <code>allow_chunked_length</code> in the Ambassador Module to configure the same value in Envoy"
-        docs: topics/running/ambassador/#content-length-headers
-      - title: Default Envoy API version is now V3
-        type: change
-        body: "The default Envoy API version has changed from V2 to V3, as V2 has fallen out of support, and has been removed as of Envoy 1.18.0."
-        docs: https://www.getambassador.io/docs/edge-stack/latest/topics/running/running/#ambassador_envoy_api_version
-      - title: Subsecond time resolution in logs
-        type: change
-        body: Logs now include subsecond time resolutions, rather than just seconds.
-
-  - version: 1.13.10
-    date: '2021-07-27'
-    notes:
-      - title: Fix for CORS origins configuration on the Mapping resource
-        type: bugfix
-        body: "Fixed a regression when specifying a comma separated string for <code>cors.origins</code> on the <code>
-Mapping</code> resource"
-        docs: topics/using/cors
-        image: ../images/emissary-1.13.10-cors-origin.png
-      - title: New Envoy-configuration snapshots for debugging
-        body: >-
-          Envoy-configuration snapshots get saved (as <code>ambex-#.json</code>) in <code>/ambassador/snapshots</code>.
-          The number of snapshots is controlled by the <code>AMBASSADOR_AMBEX_SNAPSHOT_COUNT</code> environment variable;
-          set it to 0 to disable. The default is 30."
-        type: change
-        docs: topics/running/environment/
-      - title: Optionally remove ratelimiting for Envoy reconfiguration
-        body: >-
-          Set <code>AMBASSADOR_AMBEX_NO_RATELIMIT</code> to <code>true</code> to completely disable ratelimiting
-          Envoy reconfiguration under memory pressure. This can help performance with the endpoint or Consul resolvers,
-          but could make OOMkills more likely with large configurations.
-        type: change
-        docs: topics/running/environment/
-
-  - version: 1.13.9
-    date: '2021-06-30'
-    notes:
-      - title: Fix for TCPMappings
-        body: >-
-          Fixed a bug which caused $productName$ to generate invalid Envoy configuration when two TCPMappings were
-          deployed with the same port, but different host."
-        type: bugfix
-        docs: topics/using/tcpmappings/
+# This file should contain only 2.0.0 and higher.

--- a/docs/shield.json
+++ b/docs/shield.json
@@ -1,0 +1,6 @@
+{
+    "schemaVersion": 1,
+    "label": "version",
+    "message": "2.0.3-ea",
+    "color": "blue"
+}

--- a/releng/00-release-start
+++ b/releng/00-release-start
@@ -101,6 +101,11 @@ def main(next_ver: str, commit: bool = True) -> int:
         print('not committing')
         return 0
 
+    out = run_capture(["git", "status", "--porcelain"])
+    if not out:
+        print("No changes needed, all good.")
+        return 0
+    
     with check(f"Committing changes..."):
         gitdir = run_capture(['git', 'rev-parse', '--git-dir'])
         with open(os.path.join(gitdir, 'GITGUI_MSG'), 'w') as msgfile:

--- a/releng/00-release-start
+++ b/releng/00-release-start
@@ -70,10 +70,13 @@ def main(next_ver: str, commit: bool = True) -> int:
 
     workbranch = current_release_branch
     base_branch = release_branch
-    if branch_exists('origin/' + current_release_branch):
-        with check(f"Checking out {current_release_branch} and making it up to date with {release_branch}"):
+    if branch_exists(current_release_branch):
+        with check(f"Checking out {current_release_branch}"):
             run(["git", "checkout", current_release_branch])
-            run(["git", "pull", "origin", current_release_branch])
+
+        if branch_exists("origin/" + current_release_branch):
+            with check(f"Bringing our branch it up to date with origin/{release_branch}"):
+                run(["git", "pull", "origin", current_release_branch])
     else:
         with check(f"Creating {current_release_branch}"):
             run(["git", "checkout", "-b", current_release_branch])

--- a/releng/00-release-start
+++ b/releng/00-release-start
@@ -83,7 +83,7 @@ def main(next_ver: str, commit: bool = True) -> int:
     if not checker.ok:
         return 1
     run(["git", "merge", f"origin/{release_branch}"])
-    with check(f"Checking if there are conflicts in merge"):
+    with check(f"Checking for clean branch with no conflicts..."):
         out = run_capture(["git", "status", "--porcelain"])
         if out:
             raise AssertionError(f"Merge conflicts on {current_release_branch}. Resolve these, then rerun this scrip")

--- a/releng/release-go-changelog-update
+++ b/releng/release-go-changelog-update
@@ -104,7 +104,7 @@ def main(next_ver: str, today: datetime.date, quiet: bool=False, commit: bool = 
         found = False
         for line in fileinput.FileInput("CHANGELOG.md", inplace=True):
             if not found and line.startswith(f"## [{next_ver}]"):
-                line = f"## [{next_ver}] {today.strftime('%B %d, %Y')}\n"
+                line = f"## [{next_ver}] {today.strftime('%Y-%m-%d')}\n"
                 found = True
 
             sys.stdout.write(line)
@@ -113,6 +113,36 @@ def main(next_ver: str, today: datetime.date, quiet: bool=False, commit: bool = 
             raise Exception(f"Changelog entry for {next_ver} not found. Was releng/start-update-version run?")
 
         git_add("CHANGELOG.md")
+
+    with check(f"Updating releaseNotes.yml with date for {next_ver}..."):
+        state = 0
+
+        for line in fileinput.FileInput("docs/releaseNotes.yml", inplace=True):
+            if state == 0:
+                if line.strip() == f"- version: {next_ver}":
+                    state = 1
+            elif state == 1:
+                m = re.match(r"(\s+date:)\s+.*$", line)
+
+                if m:
+                    line = f"{m.group(1)} '{today.strftime('%Y-%m-%d')}'\n"
+                    state = 2
+            
+            sys.stdout.write(line)
+
+        if state != 2:
+            # Something didn't go right.
+            sadness = f"""
+ ==> ERROR: could not find the date for version '{next_ver}' in 
+     docs/releaseNotes.yml. Make sure that the block for that release
+     starts with
+
+     - version: {next_ver}
+       date: ....
+
+     as the start of the block."""
+
+            raise Exception(sadness)
 
     if checker.ok and commit:
         with check(f"Committing changes..."):


### PR DESCRIPTION
- Clean up the README some.
   - This includes dropping the build-status shield which was reading from Travis; it'll go back in once we hook it properly into GitHub Actions.
   - This also includes tweaking the version shield to pull from a little JSON file which will need updating pretty much the moment we merge this.
- Drop everything prior to 2.0 from `releaseNotes.yml`.
- Make sure that everything prior to 2.0 is in `CHANGELOG.tpl`.
- Make sure that we fix the date in `releaseNotes.yml` when we fix it in `CHANGELOG.md`, so that the next `make generate` doesn't shred things.
- Allow `make release/start` to work if it doesn't really need to do anything (since the start of the release checklist invokes it).
- Finally, hopefully fix the `apro` updater.