### PR TITLE
[WIP] Allow configuring Envoy's buffer limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,9 @@ feedback!! Join us on <a href="https://a8r.io/slack">Slack</a> and let us know w
 
 ## Emissary-ingress
 
+- Feature: You can now set `buffer_limit_bytes` in the `ambassador` `Module` to to change the size of the
+  upstream read and write buffers. The default is 1MiB. 
+  
 - Change: The `x.getambassador.io/v3alpha1` API version has become the `getambassador.io/v3alpha1` API
   version. The `Ambassador-` prefixes from `x.getambassador.io/v3alpha1` resources have been removed
   for ease of migration. _Note that `getambassador.io/v3alpha1` is the only supported API version

--- a/python/ambassador/envoy/v2/v2listener.py
+++ b/python/ambassador/envoy/v2/v2listener.py
@@ -135,6 +135,7 @@ class V2Listener(dict):
         self.use_proxy_proto = False
         self.listener_filters: List[dict] = []
         self.traffic_direction: str = "UNSPECIFIED"
+        self.per_connection_buffer_limit_bytes: Optional[int] = None
         self._irlistener = irlistener   # We cache the IRListener to use its match method later
         self._stats_prefix = irlistener.statsPrefix
         self._security_model: str = irlistener.securityModel
@@ -154,6 +155,10 @@ class V2Listener(dict):
 
         # If the IRListener is marked insecure-only, so are we.
         self._insecure_only = irlistener.insecure_only
+
+        buffer_limit_bytes = self.config.ir.ambassador_module.get('buffer_limit_bytes', None)
+        if buffer_limit_bytes:
+            self.per_connection_buffer_limit_bytes = buffer_limit_bytes
 
         # Build out our listener filters, and figure out if we're an HTTP listener
         # in the process.
@@ -945,6 +950,9 @@ class V2Listener(dict):
         if self.listener_filters:
             odict["listener_filters"] = self.listener_filters
 
+        if self.per_connection_buffer_limit_bytes:
+            odict['per_connection_buffer_limit_bytes'] = self.per_connection_buffer_limit_bytes
+            
         return odict          
 
     def pretty(self) -> dict:

--- a/python/ambassador/envoy/v3/v3listener.py
+++ b/python/ambassador/envoy/v3/v3listener.py
@@ -135,6 +135,7 @@ class V3Listener(dict):
         self.use_proxy_proto = False
         self.listener_filters: List[dict] = []
         self.traffic_direction: str = "UNSPECIFIED"
+        self.per_connection_buffer_limit_bytes: Optional[int] = None
         self._irlistener = irlistener   # We cache the IRListener to use its match method later
         self._stats_prefix = irlistener.statsPrefix
         self._security_model: str = irlistener.securityModel
@@ -154,6 +155,10 @@ class V3Listener(dict):
 
         # If the IRListener is marked insecure-only, so are we.
         self._insecure_only = irlistener.insecure_only
+        
+        buffer_limit_bytes = self.config.ir.ambassador_module.get('buffer_limit_bytes', None)
+        if buffer_limit_bytes:
+            self.per_connection_buffer_limit_bytes = buffer_limit_bytes
 
         # Build out our listener filters, and figure out if we're an HTTP listener
         # in the process.
@@ -974,6 +979,10 @@ class V3Listener(dict):
 
         if self.listener_filters:
             odict["listener_filters"] = self.listener_filters
+
+        if self.per_connection_buffer_limit_bytes:
+            odict['per_connection_buffer_limit_bytes'] = self.per_connection_buffer_limit_bytes
+
 
         return odict          
 

--- a/python/ambassador/ir/ir.py
+++ b/python/ambassador/ir/ir.py
@@ -938,6 +938,8 @@ class IR:
 
         od['custom_ambassador_id'] = bool(self.ambassador_id != 'default')
 
+        od['buffer_limit_bytes'] = self.ambassador_module.get('buffer_limit_bytes', None)
+
         default_port = Constants.SERVICE_PORT_HTTPS if tls_termination_count else Constants.SERVICE_PORT_HTTP
 
         od['custom_listener_port'] = bool(self.ambassador_module.service_port != default_port)

--- a/python/ambassador/ir/irambassador.py
+++ b/python/ambassador/ir/irambassador.py
@@ -32,6 +32,7 @@ class IRAmbassador (IRResource):
         'admin_port',
         'auth_enabled',
         'allow_chunked_length',
+        'buffer_limit_bytes',
         'circuit_breakers',
         'cluster_idle_timeout_ms',
         'cluster_max_connection_lifetime_ms',

--- a/python/tests/kat/t_bufferlimitbytes.py
+++ b/python/tests/kat/t_bufferlimitbytes.py
@@ -1,0 +1,39 @@
+from kat.harness import Query
+from abstract_tests import AmbassadorTest, ServiceType, HTTP
+import json
+
+class BufferLimitBytesTest(AmbassadorTest):
+    target: ServiceType
+
+    def init(self):
+        self.target = HTTP(name="target")
+
+    # Test generating config with an increased buffer and that the lua body() funciton runs to buffer the request body
+    def config(self):
+        yield self, self.format("""
+---
+apiVersion: ambassador/v2
+kind:  Module
+name:  ambassador
+config:
+  buffer_limit_bytes: 5242880
+  lua_scripts: |
+    function envoy_on_request(request_handle)
+      request_handle:headers():add("request_body_size", request_handle:body():length())
+    end
+---
+apiVersion: x.getambassador.io/v3alpha1
+kind: AmbassadorMapping
+name:  {self.target.path.k8s}-foo
+hostname: "*"
+prefix: /foo/
+service: {self.target.path.fqdn}
+""")
+
+    def queries(self):
+        yield Query(self.url("foo/"))
+        yield Query(self.url("ambassador/v0/diag/"))   
+
+    def check(self):
+        assert self.results[0].status == 200
+        assert self.results[1].status == 200

--- a/python/tests/kat/test_ambassador.py
+++ b/python/tests/kat/test_ambassador.py
@@ -14,6 +14,7 @@ if letter_range not in ["all", "ah", "ip", "qz"]:
 
 if letter_range in ["all","ah"]:
     import t_basics
+    import t_bufferlimitbytes
     import t_chunked_length
     import t_circuitbreaker
     import t_cluster_tag

--- a/python/tests/unit/test_buffer_limit_bytes.py
+++ b/python/tests/unit/test_buffer_limit_bytes.py
@@ -1,0 +1,208 @@
+import logging
+
+import pytest
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s test %(levelname)s: %(message)s",
+    datefmt='%Y-%m-%d %H:%M:%S'
+)
+
+logger = logging.getLogger("ambassador")
+
+from ambassador import Config, IR, EnvoyConfig
+from ambassador.fetch import ResourceFetcher
+from ambassador.utils import NullSecretHandler
+
+from tests.utils import default_listener_manifests
+
+def _get_envoy_config(yaml, version='V3'):
+    aconf = Config()
+    fetcher = ResourceFetcher(logger, aconf)
+    fetcher.parse_yaml(default_listener_manifests() + yaml, k8s=True)
+    aconf.load_all(fetcher.sorted())
+    secret_handler = NullSecretHandler(logger, None, None, "0")
+    ir = IR(aconf, file_checker=lambda path: True, secret_handler=secret_handler)
+
+    assert ir
+
+    econf = EnvoyConfig.generate(ir, version)
+    assert econf, "could not create an econf"
+
+    return econf
+
+
+@pytest.mark.compilertest
+def test_setting_buffer_limit():
+    yaml = """
+---
+apiVersion: getambassador.io/v2
+kind: Module
+metadata:
+  name: ambassador
+  namespace: default
+spec:
+  config:
+    buffer_limit_bytes: 5242880
+---
+apiVersion: x.getambassador.io/v3alpha1
+kind: AmbassadorMapping
+metadata:
+  name: ambassador
+  namespace: default
+spec:
+  prefix: /test/
+  hostname: "*"
+  service: test:9999
+"""
+    econf = _get_envoy_config(yaml, version='V2')
+    expected = 5242880
+    key_found = False
+
+    conf = econf.as_dict()
+
+    for listener in conf['static_resources']['listeners']:
+        per_connection_buffer_limit_bytes = listener.get('per_connection_buffer_limit_bytes', None)
+        assert per_connection_buffer_limit_bytes is not None, \
+            f"per_connection_buffer_limit_bytes not found on listener: {listener.name}"
+        print(f"Found per_connection_buffer_limit_bytes = {per_connection_buffer_limit_bytes}")
+        key_found = True
+        assert expected == int(per_connection_buffer_limit_bytes), \
+            "per_connection_buffer_limit_bytes must equal the value set on the ambassador Module"
+    assert key_found, 'per_connection_buffer_limit_bytes must be found in the envoy config'
+
+
+@pytest.mark.compilertest
+def test_setting_buffer_limit_V3():
+    yaml = """
+---
+apiVersion: getambassador.io/v2
+kind: Module
+metadata:
+  name: ambassador
+  namespace: default
+spec:
+  config:
+    buffer_limit_bytes: 5242880
+---
+apiVersion: x.getambassador.io/v3alpha1
+kind: AmbassadorMapping
+metadata:
+  name: ambassador
+  namespace: default
+spec:
+  prefix: /test/
+  hostname: "*"
+  service: test:9999
+"""
+    econf = _get_envoy_config(yaml)
+    expected = 5242880
+    key_found = False
+
+    conf = econf.as_dict()
+
+    for listener in conf['static_resources']['listeners']:
+        per_connection_buffer_limit_bytes = listener.get('per_connection_buffer_limit_bytes', None)
+        assert per_connection_buffer_limit_bytes is not None, \
+            f"per_connection_buffer_limit_bytes not found on listener: {listener.name}"
+        print(f"Found per_connection_buffer_limit_bytes = {per_connection_buffer_limit_bytes}")
+        key_found = True
+        assert expected == int(per_connection_buffer_limit_bytes), \
+            "per_connection_buffer_limit_bytes must equal the value set on the ambassador Module"
+    assert key_found, 'per_connection_buffer_limit_bytes must be found in the envoy config'
+
+# Tests that the default value of per_connection_buffer_limit_bytes is disabled when there is not Module config for it.
+@pytest.mark.compilertest
+def test_default_buffer_limit():
+    yaml = """
+---
+apiVersion: x.getambassador.io/v3alpha1
+kind: AmbassadorMapping
+metadata:
+  name: ambassador
+  namespace: default
+spec:
+  prefix: /test/
+  hostname: "*"
+  service: test:9999
+"""
+    econf = _get_envoy_config(yaml, version='V2')
+
+    conf = econf.as_dict()
+
+    for listener in conf['static_resources']['listeners']:
+        per_connection_buffer_limit_bytes = listener.get('per_connection_buffer_limit_bytes', None)
+        assert per_connection_buffer_limit_bytes is None, \
+            f"per_connection_buffer_limit_bytes found on listener (should not exist unless configured in the module): {listener.name}"
+
+
+@pytest.mark.compilertest
+def test_default_buffer_limit_V3():
+    yaml = """
+---
+apiVersion: x.getambassador.io/v3alpha1
+kind: AmbassadorMapping
+metadata:
+  name: ambassador
+  namespace: default
+spec:
+  prefix: /test/
+  hostname: "*"
+  service: test:9999
+"""
+    econf = _get_envoy_config(yaml)
+
+    conf = econf.as_dict()
+
+    for listener in conf['static_resources']['listeners']:
+        per_connection_buffer_limit_bytes = listener.get('per_connection_buffer_limit_bytes', None)
+        assert per_connection_buffer_limit_bytes is None, \
+            f"per_connection_buffer_limit_bytes found on listener (should not exist unless configured in the module): {listener.name}" 
+
+# Tests that the default value of per_connection_buffer_limit_bytes is disabled when there is not Module config for it (and that there are no issues when we dont make a listener).
+@pytest.mark.compilertest
+def test_buffer_limit_no_listener():
+    yaml = """
+---
+apiVersion: x.getambassador.io/v3alpha1
+kind: AmbassadorMapping
+metadata:
+  name: ambassador
+  namespace: default
+spec:
+  prefix: /test/
+  hostname: "*"
+  service: test:9999
+"""
+    econf = _get_envoy_config(yaml, version='V2')
+
+    conf = econf.as_dict()
+
+    for listener in conf['static_resources']['listeners']:
+        per_connection_buffer_limit_bytes = listener.get('per_connection_buffer_limit_bytes', None)
+        assert per_connection_buffer_limit_bytes is None, \
+            f"per_connection_buffer_limit_bytes found on listener (should not exist unless configured in the module): {listener.name}"
+
+
+@pytest.mark.compilertest
+def test_buffer_limit_no_listener_V3():
+    yaml = """
+---
+apiVersion: x.getambassador.io/v3alpha1
+kind: AmbassadorMapping
+metadata:
+  name: ambassador
+  namespace: default
+spec:
+  prefix: /test/
+  hostname: "*"
+  service: test:9999
+"""
+    econf = _get_envoy_config(yaml)
+
+    conf = econf.as_dict()
+
+    for listener in conf['static_resources']['listeners']:
+        per_connection_buffer_limit_bytes = listener.get('per_connection_buffer_limit_bytes', None)
+        assert per_connection_buffer_limit_bytes is None, \
+            f"per_connection_buffer_limit_bytes found on listener (should not exist unless configured in the module): {listener.name}"


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request's commits.

## Related Issues
List related issues.

## Testing
A few sentences describing what testing you've done, e.g., manual tests, automated tests, deployed in production, etc.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `CHANGELOG.md`.
   
   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations
 
 - [x] This is unlikely to impact how Ambassador performs at scale.
 
   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability
 
 - [x] My change is adequately tested.
 
   Remember when considering testing:
    + LEGACY MODE TESTS DO NOT RUN FOR EVERY PR. If your change is affected by legacy mode, you need
      to run legacy-mode tests manually (set `AMBASSADOR_LEGACY_MODE=true` and run the tests).
      (This will be fixed soon.)
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points
 
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
