### PR TITLE
Host selector to mapping_selector

### DIFF
--- a/cmd/entrypoint/testdata/hostsem-basic.yaml
+++ b/cmd/entrypoint/testdata/hostsem-basic.yaml
@@ -34,7 +34,7 @@ spec:
   requestPolicy:
     insecure:
       action: Route
-  selector:
+  mapping_selector:
     matchLabels:
       h1-host: h1
 ---
@@ -49,7 +49,7 @@ spec:
   requestPolicy:
     insecure:
       action: Redirect
-  selector:
+  mapping_selector:
     matchLabels:
       h2-host: h2
 ---

--- a/cmd/entrypoint/testdata/hostsem-disjoint-hosts.yaml
+++ b/cmd/entrypoint/testdata/hostsem-disjoint-hosts.yaml
@@ -43,7 +43,7 @@ spec:
   requestPolicy:
     insecure:
       action: Route
-  selector:
+  mapping_selector:
     matchLabels:
       h1-host: "yes"
 ---
@@ -60,7 +60,7 @@ spec:
   requestPolicy:
     insecure:
       action: Redirect
-  selector:
+  mapping_selector:
     matchLabels:
       h2-host: "yes"
 ---
@@ -75,7 +75,7 @@ spec:
   requestPolicy:
     insecure:
       action: Reject
-  selector:
+  mapping_selector:
     matchLabels:
       h3-host: "yes"
 ---

--- a/cmd/entrypoint/testdata/hostsem-hostsel.yaml
+++ b/cmd/entrypoint/testdata/hostsem-hostsel.yaml
@@ -34,7 +34,7 @@ spec:
   requestPolicy:
     insecure:
       action: Route
-  selector:
+  mapping_selector:
     matchLabels:
       host: h1      
 ---
@@ -49,7 +49,7 @@ spec:
   requestPolicy:
     insecure:
       action: Redirect
-  selector:
+  mapping_selector:
     matchLabels:
       host: h2
 ---

--- a/cmd/entrypoint/testdata/hostsem-minimal.yaml
+++ b/cmd/entrypoint/testdata/hostsem-minimal.yaml
@@ -17,7 +17,7 @@ kind: Host
 metadata:
   name: test-host
 spec:
-  selector:
+  mapping_selector:
     matchLabels:
       host: minimal
     

--- a/cmd/entrypoint/testutil_fake_mapping_cors_test.go
+++ b/cmd/entrypoint/testutil_fake_mapping_cors_test.go
@@ -37,7 +37,7 @@ metadata:
   name: test-host
   namespace: default
 spec:
-  selector:
+  mapping_selector:
     matchLabels:
       host: minimal
 ---

--- a/python/ambassador/ir/irhost.py
+++ b/python/ambassador/ir/irhost.py
@@ -20,7 +20,7 @@ class IRHost(IRResource):
         'hostname',
         'metadata_labels',
         'requestPolicy',
-        'selector',
+        'mapping_selector',
         'tlsSecret',
         'tlsContext',
         'tls',
@@ -166,7 +166,7 @@ class IRHost(IRResource):
                         tls_config_context = IRTLSContext(ir, aconf, **tls_context_init, **host_tls_config)
 
                         # XXX This seems kind of pointless -- nothing looks at the context's labels?
-                        match_labels = self.get('selector', {}).get('matchLabels')
+                        match_labels = self.get('mapping_selector', {}).get('matchLabels')
 
                         if match_labels:
                             tls_config_context['metadata_labels'] = match_labels
@@ -369,7 +369,7 @@ class IRHost(IRResource):
                 host_match = hostglob_matches(self.hostname, group_glob)
                 self.logger.debug("-- hostname %s group glob %s => %s", self.hostname, group_glob, host_match)
 
-        selector = self.get('selector')
+        selector = self.get('mapping_selector')
 
         if selector:
             sel_match = selector_matches(self.logger, selector, group.get('metadata_labels', {}))

--- a/python/tests/kat/t_hosts.py
+++ b/python/tests/kat/t_hosts.py
@@ -59,7 +59,7 @@ spec:
     authority: none
   tlsSecret:
     name: {self.name.k8s}-secret
-  selector:
+  mapping_selector:
     matchLabels:
       hostname: {self.path.fqdn}
 ---
@@ -138,7 +138,7 @@ spec:
     authority: none
   tlsSecret:
     name: {self.name.k8s}-secret
-  selector:
+  mapping_selector:
     matchLabels:
       hostname: {self.path.fqdn}
   requestPolicy:
@@ -202,7 +202,7 @@ spec:
   hostname: {self.path.fqdn}
   acmeProvider:
     authority: none
-  selector:
+  mapping_selector:
     matchLabels:
       hostname: {self.path.k8s}-manual-hostname
   tlsSecret:
@@ -282,7 +282,7 @@ spec:
   hostname: {self.path.fqdn}
   acmeProvider:
     authority: none
-  selector:
+  mapping_selector:
     matchLabels:
       hostname: {self.path.fqdn}
   tlsSecret:
@@ -360,7 +360,7 @@ spec:
   hostname: {self.path.fqdn}
   acmeProvider:
     authority: none
-  selector:
+  mapping_selector:
     matchLabels:
       hostname: {self.path.fqdn}
   tlsSecret:
@@ -425,7 +425,7 @@ spec:
   hostname: {self.path.fqdn}
   acmeProvider:
     authority: none
-  selector:
+  mapping_selector:
     matchLabels:
       hostname: {self.path.k8s}-host-cleartext
   requestPolicy:
@@ -492,7 +492,7 @@ spec:
   hostname: tls-context-host-1
   acmeProvider:
     authority: none
-  selector:
+  mapping_selector:
     matchLabels:
       hostname: tls-context-host-1
   tlsSecret:
@@ -579,7 +579,7 @@ spec:
   hostname: ambassador.example.com
   acmeProvider:
     authority: none
-  selector:
+  mapping_selector:
     matchLabels:
       hostname: ambassador.example.com
   tlsSecret:
@@ -1116,7 +1116,7 @@ spec:
   hostname: tls-context-host-1
   acmeProvider:
     authority: none
-  selector:
+  mapping_selector:
     matchLabels:
       hostname: tls-context-host-1
   tlsSecret:
@@ -1180,7 +1180,7 @@ spec:
   hostname: tls-context-host-1
   acmeProvider:
     authority: none
-  selector:
+  mapping_selector:
     matchLabels:
       hostname: {self.path.fqdn}
   tlsSecret:
@@ -1255,7 +1255,7 @@ spec:
   hostname: tls-context-host-1
   acmeProvider:
     authority: none
-  selector:
+  mapping_selector:
     matchLabels:
       hostname: {self.path.fqdn}
   tlsSecret:
@@ -1347,7 +1347,7 @@ spec:
   hostname: tls-context-host-1
   acmeProvider:
     authority: none
-  selector:
+  mapping_selector:
     matchLabels:
       hostname: {self.path.fqdn}
   tlsSecret:

--- a/python/tests/kat/t_plain.py
+++ b/python/tests/kat/t_plain.py
@@ -44,7 +44,7 @@ metadata:
       name: cleartext-host-{self.path.k8s}
       ambassador_id: [ "plain" ]
       hostname: "*"
-      selector:
+      mapping_selector:
         matchLabels:
           hostname: {self.path.k8s}
       acmeProvider:
@@ -85,7 +85,7 @@ metadata:
       name: cleartext-host-{self.path.k8s}
       ambassador_id: [ "plain" ]
       hostname: "*"
-      selector:
+      mapping_selector:
         matchLabels:
           hostname: {self.path.k8s}
       acmeProvider:


### PR DESCRIPTION
Signed-off-by: AliceProxy <aliceproxy@protonmail.com>

## Description
Our 2.0 documentation says to make use of `mapping_selector` in the `Host` to associate `Hosts` with `Mappings`. As far as I could tell, while `mapping_selector` has been added to the CRDs, `selector` is the only one that is used. I just replaced the usage of `selector` with `mapping_selector` in irhost.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `CHANGELOG.md`.
   
   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations
 
 - [ ] This is unlikely to impact how Ambassador performs at scale.
 
   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability
 
 - [ ] My change is adequately tested.
 
   Remember when considering testing:
    + LEGACY MODE TESTS DO NOT RUN FOR EVERY PR. If your change is affected by legacy mode, you need
      to run legacy-mode tests manually (set `AMBASSADOR_LEGACY_MODE=true` and run the tests).
      (This will be fixed soon.)
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points
 
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
