### PR TITLE
Expose imagePullSecrets for the redis deployment (helm chart)

### DIFF
--- a/charts/ambassador/templates/aes-redis.yaml
+++ b/charts/ambassador/templates/aes-redis.yaml
@@ -90,6 +90,14 @@ spec:
         imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
         resources:
         {{- toYaml .Values.redis.resources | nindent 10 }}
+        {{- if .Values.redis.containerArgs }}
+        args:
+        {{- toYaml .Values.redis.containerArgs | nindent 10 }}
+        {{- end }}
+      {{- if .Values.redis.imagePullSecrets }}
+      imagePullSecrets:
+      {{- toYaml .Values.redis.imagePullSecrets | nindent 8 }}
+      {{- end }}
       restartPolicy: Always
       {{- with .Values.redis.nodeSelector }}
       nodeSelector:

--- a/charts/ambassador/values.yaml
+++ b/charts/ambassador/values.yaml
@@ -377,6 +377,14 @@ redis:
   nodeSelector: {}
   affinity: {}
   tolerations: {}
+  # Arguments for the redis container
+  containerArgs: {}
+  #  - arg1
+  #  - arg2
+  # Secrets used for pulling the redis image from a private repo
+  imagePullSecrets: {}
+  #  - name: example-secret-1
+  #  - name: example-secret-2
 
 
 # Configures the AuthService that ships with the Ambassador Edge Stack.


### PR DESCRIPTION
Signed-off-by: AliceProxy <aliceproxy@protonmail.com>

Adds helm chart values allowing customization of the redis deployment's imagePullSecrets (used for pulling images from private repositories), and container arguments. 

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `CHANGELOG.md`.
   
   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations
 
 - [ ] This is unlikely to impact how Ambassador performs at scale.
 
   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability
 
 - [ ] My change is adequately tested.
 
   Remember when considering testing:
    + LEGACY MODE TESTS DO NOT RUN FOR EVERY PR. If your change is affected by legacy mode, you need
      to run legacy-mode tests manually (set `AMBASSADOR_LEGACY_MODE=true` and run the tests).
      (This will be fixed soon.)
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points
 
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
