### PR TITLE
Make nodename configureable via env

### DIFF
--- a/python/ambassador/config/config.py
+++ b/python/ambassador/config/config.py
@@ -203,8 +203,8 @@ class Config:
         # Build up the Ambassador node name.
         #
         # XXX This should be overrideable by the Ambassador module.
-        self.ambassador_nodename = "%s-%s" % (os.environ.get('AMBASSADOR_ID', 'ambassador'),
-                                              Config.ambassador_namespace)
+        # Build up the Ambassador node name.
+        self.ambassador_nodename = os.environ.get('AMBASSADOR_NODENAME', "%s-%s" % (os.environ.get('AMBASSADOR_ID', 'ambassador'), Config.ambassador_namespace))
 
     def __str__(self) -> str:
         s = [ "<Config:" ]

--- a/python/ambassador/config/config.py
+++ b/python/ambassador/config/config.py
@@ -201,9 +201,6 @@ class Config:
         self.fast_validation_disagreements = {}
 
         # Build up the Ambassador node name.
-        #
-        # XXX This should be overrideable by the Ambassador module.
-        # Build up the Ambassador node name.
         self.ambassador_nodename = os.environ.get('AMBASSADOR_NODENAME', "%s-%s" % (os.environ.get('AMBASSADOR_ID', 'ambassador'), Config.ambassador_namespace))
 
     def __str__(self) -> str:


### PR DESCRIPTION
## Description
It appears that the zipkin serviceName is taken from ambassador_nodename which is $ambassador_id-$namespace.
I'd like to rename the name to just ambassador.
This pr introduces an optional env variable called AMBASSADOR_NODENAME with which it can be renamed, if the env is not set it would fallback to to $ambassador_id-$namespace

## Related Issues

#3903

## Testing
Not much yet, first I'd like to hear some feedback whether that makes sense.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `CHANGELOG.md`.
   
   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations
 
 - [ ] This is unlikely to impact how Ambassador performs at scale.
 
   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability
 
 - [ ] My change is adequately tested.
 
   Remember when considering testing:
    + LEGACY MODE TESTS DO NOT RUN FOR EVERY PR. If your change is affected by legacy mode, you need
      to run legacy-mode tests manually (set `AMBASSADOR_LEGACY_MODE=true` and run the tests).
      (This will be fixed soon.)
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points
 
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
