### PR TITLE
add support for a new knative ingress annotation

### DIFF
--- a/python/ambassador/fetch/knative.py
+++ b/python/ambassador/fetch/knative.py
@@ -38,7 +38,10 @@ class KnativeIngressProcessor (ManagedKubernetesProcessor):
         # to ignore KnativeIngress iff networking.knative.dev/ingress.class is
         # present in annotation. If it's not there, then we accept all ingress
         # classes.
-        ingress_class = annotations.get('networking.knative.dev/ingress.class', self.INGRESS_CLASS)
+        ingress_class = annotations.get('networking.knative.dev/ingress-class')
+        if ingress_class is None:
+            ingress_class = annotations.get('networking.knative.dev/ingress.class', self.INGRESS_CLASS)
+
         if ingress_class.lower() != self.INGRESS_CLASS:
             self.logger.debug(f'Ignoring Knative {obj.kind} {obj.name}; set networking.knative.dev/ingress.class '
                               f'annotation to {self.INGRESS_CLASS} for ambassador to parse it.')


### PR DESCRIPTION
## Description

Upstream in Knative I'm looking to make our annotations have consistent style & casing. This change introduces the ability for ambassador to recognize the new ingress annotation that'll be introduced a later date. 

## Related Issues
List related issues.

## Testing

Running tests was asking for root so I'm opting to letting the CI do it.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->
 - [X] This is unlikely to impact how Ambassador performs at scale.
 - [X] My change is adequately tested.
