### PR TITLE
CI for #3906

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,18 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 ## RELEASE NOTES
 
+## [2.2.0] TBD
+[2.2.0]: https://github.com/emissary-ingress/emissary/compare/v2.1.0...v2.2.0
+
+### Emissary-ingress and Ambassador Edge Stack
+
+- Feature: Emissary now supports the metric `ambassador_log_level.debug` which  will be set to 1 if
+  debug logging is enabled for the running Emissary instance, or 0 if not. This can help to be sure
+  that a running production instance was not actually left doing debugging logging, for example.
+  (Thanks to <a href="https://github.com/jfrabaute">Fabrice</a>!) ([3906])
+
+[3906]: https://github.com/emissary-ingress/emissary/issues/3906
+
 ## [2.1.0] December 16, 2021
 [2.1.0]: https://github.com/emissary-ingress/emissary/compare/v2.0.5...v2.1.0
 

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -31,6 +31,22 @@
 
 changelog: https://github.com/emissary-ingress/emissary/blob/$branch$/CHANGELOG.md
 items:
+  - version: 2.2.0
+    date: 'TBD'
+    notes:
+      - title: Support a log-level metric
+        type: feature
+        body: >-
+          Emissary now supports the metric <code>ambassador_log_level.debug</code> which 
+          will be set to 1 if debug logging is enabled for the running Emissary instance,
+          or 0 if not. This can help to be sure that a running production instance was not
+          actually left doing debugging logging, for example.
+          (Thanks to <a href="https://github.com/jfrabaute">Fabrice</a>!)
+        github:
+        - title: 3906
+          link: https://github.com/emissary-ingress/emissary/issues/3906
+        docs: https://github.com/emissary-ingress/emissary/issues/3906
+ 
   - version: 2.1.0
     date: '2021-12-16'
     notes:


### PR DESCRIPTION
This is a clone of @jfrabaute's #3906 for the full CI run.

A new metric ambassador_log_level{level="debug"} is added to report if
the current log level of the instance is debug or not (warning/error).

THis can be useful to monitor that debug logs are not enabled on
production instances, or correctly disabled after some debugging.

Signed-off-by: Fabrice Rabaute <fabrice@arista.com>
