### PR TITLE
Update (some) dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,11 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
   does), an error would always be logged about the Secret not being present, even though it was
   present, and everything was working correctly. This error is no longer logged.
 
+- Security: Update to busybox 1.34.1 to fix multiple CVE-2021-28831, CVE-2021-42381, CVE-2021-42382,
+  CVE-2021-42383, CVE-2021-42384, CVE-2021-42385, CVE-2021-42386, CVE-2021-42378, CVE-2021-42379,
+  CVE-2021-42380, CVE-2021-42381, CVE-2021-42382, CVE-2021-42383, CVE-2021-42384, CVE-2021-42385,
+  and CVE-2021-42386.
+
 [3945]: https://github.com/emissary-ingress/emissary/issues/3945
 
 ## [2.0.5] November 08, 2021

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -178,6 +178,8 @@ WORKDIR /ambassador
 # the like.
 ENV HOME=/tmp/ambassador
 
+COPY --from=artifacts /bin/busybox /bin/busybox
+
 ENTRYPOINT [ "bash", "/buildroot/ambassador/python/entrypoint.sh" ]
 
 ########################################

--- a/builder/Dockerfile.base
+++ b/builder/Dockerfile.base
@@ -58,6 +58,17 @@ RUN apk --no-cache add \
     yaml-dev \
     && ln -s /usr/bin/python3 /usr/bin/python \
     && chmod u+s $(which docker)
+
+RUN mkdir /tmp/busybox \
+    && cd /tmp/busybox \
+    && curl -O https://busybox.net/downloads/busybox-1.34.1.tar.bz2 \
+    && tar -xjf busybox-1.34.1.tar.bz2 \
+    && cd busybox-1.34.1 \
+    && make defconfig \
+    && make busybox \
+    && ls -l /bin \
+    && mv busybox /bin/busybox
+
 # We _must_ pin pip to a version before 20.3 because orjson appears to only have
 # PEP513 compatible wheels, which are supported before 20.3 but (apparently)
 # not in 20.3. We can only upgrade pip to 20.3 after we verify that orjson has

--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -147,7 +147,7 @@ INGRESS_TEST_LOCAL_ADMIN_PORT = 8877
 INGRESS_TEST_MANIF_DIR = $(BUILDER_HOME)/../manifests/emissary/
 INGRESS_TEST_MANIFS = ambassador-crds.yaml ambassador.yaml
 
-export DOCKER_BUILDKIT := 0
+# export DOCKER_BUILDKIT := 0
 
 all: help
 .PHONY: all
@@ -274,8 +274,8 @@ docker/base-envoy.docker.stamp: FORCE
 	    TIMEFORMAT="     (docker pull took %1R seconds)"; \
 	    time docker pull $(ENVOY_DOCKER_TAG); \
 	    unset TIMEFORMAT; \
-	    docker image inspect $(ENVOY_DOCKER_TAG) --format='{{ .Id }}' >$@; \
 	  fi; \
+	  echo $(ENVOY_DOCKER_TAG) >$@; \
 	}
 docker/$(LCNAME).docker.stamp: %/$(LCNAME).docker.stamp: %/base-envoy.docker.tag.local %/builder-base.docker python/ambassador.version $(BUILDER_HOME)/Dockerfile $(tools/dsum) FORCE
 	@printf "${CYN}==> ${GRN}Building image ${BLU}$(LCNAME)${END}\n"

--- a/demo/config/listeners-and-host.yaml
+++ b/demo/config/listeners-and-host.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Listener
+name: ambassador-https-listener
+port: 8443
+protocol: HTTPS
+securityModel: XFP
+hostBinding:
+  namespace:
+    from: ALL
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Listener
+name: ambassador-http-listener
+port: 8080
+protocol: HTTP
+securityModel: XFP
+hostBinding:
+  namespace:
+    from: ALL
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+name: wildcard-host
+hostname: "*"

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -53,6 +53,14 @@ items:
           ACME client does), an error would always be logged about the Secret not being
           present, even though it was present, and everything was working correctly.
           This error is no longer logged.
+      
+      - title: Update to busybox 1.34.1
+        type: security
+        body: >-
+          Update to busybox 1.34.1 to fix multiple CVE-2021-28831, CVE-2021-42381,
+          CVE-2021-42382, CVE-2021-42383, CVE-2021-42384, CVE-2021-42385, CVE-2021-42386,
+          CVE-2021-42378, CVE-2021-42379, CVE-2021-42380, CVE-2021-42381, CVE-2021-42382,
+          CVE-2021-42383, CVE-2021-42384, CVE-2021-42385, and CVE-2021-42386.
 
   - version: 2.0.5
     date: '2021-11-08'


### PR DESCRIPTION
Update to busybox 1.34.1. This is a bit more complex than I would've liked simply
because Alpine 3.12 doesn't already have a package for busybox 1.34.1 -- on the
other hand, it gives us a nice path to ditch a bunch of applets that we don't
need, later.

This was _also_ more complex than I would've liked because it turns out that
our Dockerfile actually ends up getting busybox from the _Envoy_ base, not our
builder base... and the obvious thing of just putting the builder base first
causes Docker to blow up with a circular dependency. So, instead, this does
the hackish thing and just copies the busybox binary late in the Dockerfile.
A later PR will clean this up.

On the upside, this PR allows us to use buildkit.

Signed-off-by: Flynn <flynn@datawire.io>

 - [x] I made sure to update `CHANGELOG.md`.
 - [x] This is unlikely to impact how Ambassador performs at scale.
 - [ ] My change is adequately tested.
 - [x] I didn't need to update `DEVELOPING.md`.
