### PR TITLE
[2.1.0] Minor tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,8 +93,7 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
   does), an error would always be logged about the Secret not being present, even though it was
   present, and everything was working correctly. This error is no longer logged.
 
-- Security: Update to busybox 1.34.1 to fix multiple CVE-2021-28831, CVE-2021-42381, CVE-2021-42382,
-  CVE-2021-42383, CVE-2021-42384, CVE-2021-42385, CVE-2021-42386, CVE-2021-42378, CVE-2021-42379,
+- Security: Update to busybox 1.34.1 to resolve CVE-2021-28831, CVE-2021-42378, CVE-2021-42379,
   CVE-2021-42380, CVE-2021-42381, CVE-2021-42382, CVE-2021-42383, CVE-2021-42384, CVE-2021-42385,
   and CVE-2021-42386.
 

--- a/demo/config/auth.yaml
+++ b/demo/config/auth.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: getambassador.io/v2
+apiVersion: getambassador.io/v3alpha1
 kind:  Module
 name:  authentication
 config:

--- a/demo/config/listeners-and-host.yaml
+++ b/demo/config/listeners-and-host.yaml
@@ -1,16 +1,6 @@
 ---
 apiVersion: getambassador.io/v3alpha1
 kind: Listener
-name: ambassador-https-listener
-port: 8443
-protocol: HTTPS
-securityModel: XFP
-hostBinding:
-  namespace:
-    from: ALL
----
-apiVersion: getambassador.io/v3alpha1
-kind: Listener
 name: ambassador-http-listener
 port: 8080
 protocol: HTTP
@@ -23,3 +13,6 @@ apiVersion: getambassador.io/v3alpha1
 kind: Host
 name: wildcard-host
 hostname: "*"
+requestPolicy:
+  insecure:
+    action: Route

--- a/demo/config/mapping-cqrs.yaml
+++ b/demo/config/mapping-cqrs.yaml
@@ -1,16 +1,18 @@
 ---
-apiVersion: getambassador.io/v2
+apiVersion: getambassador.io/v3alpha1
 kind: Mapping
 name: cqrs_get_mapping
 prefix: /cqrs/
 method: GET
+hostname: "*"
 rewrite: /quote/
 service: 127.0.0.1:5000
 ---
-apiVersion: getambassador.io/v2
+apiVersion: getambassador.io/v3alpha1
 kind: Mapping
 name: cqrs_put_mapping
 prefix: /cqrs/
 method: PUT
+hostname: "*"
 rewrite: /quote/
 service: 127.0.0.1:5000

--- a/demo/config/mapping-diag.yaml
+++ b/demo/config/mapping-diag.yaml
@@ -1,7 +1,8 @@
 ---
-apiVersion: getambassador.io/v2
+apiVersion: getambassador.io/v3alpha1
 kind:  Mapping
 name:  diag_mapping
 prefix: /ambassador/
+hostname: "*"
 rewrite: /ambassador/
 service: 127.0.0.1:8877

--- a/demo/config/mapping-httpbin.yaml
+++ b/demo/config/mapping-httpbin.yaml
@@ -1,7 +1,8 @@
 ---
-apiVersion: getambassador.io/v2
+apiVersion: getambassador.io/v3alpha1
 kind:  Mapping
 name:  httpbin_mapping
 prefix: /httpbin/
+hostname: "*"
 service: httpbin.org:80
 host_rewrite: httpbin.org

--- a/demo/config/mapping-qotm.yaml
+++ b/demo/config/mapping-qotm.yaml
@@ -1,7 +1,8 @@
 ---
-apiVersion: getambassador.io/v2
+apiVersion: getambassador.io/v3alpha1
 kind:  Mapping
 name:  qotm_mapping
 prefix: /qotm/
+hostname: "*"
 rewrite: /
 service: 127.0.0.1:5000

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -57,10 +57,9 @@ items:
       - title: Update to busybox 1.34.1
         type: security
         body: >-
-          Update to busybox 1.34.1 to fix multiple CVE-2021-28831, CVE-2021-42381,
-          CVE-2021-42382, CVE-2021-42383, CVE-2021-42384, CVE-2021-42385, CVE-2021-42386,
-          CVE-2021-42378, CVE-2021-42379, CVE-2021-42380, CVE-2021-42381, CVE-2021-42382,
-          CVE-2021-42383, CVE-2021-42384, CVE-2021-42385, and CVE-2021-42386.
+          Update to busybox 1.34.1 to resolve CVE-2021-28831, CVE-2021-42378,
+          CVE-2021-42379, CVE-2021-42380, CVE-2021-42381, CVE-2021-42382, CVE-2021-42383,
+          CVE-2021-42384, CVE-2021-42385, and CVE-2021-42386.
 
   - version: 2.0.5
     date: '2021-11-08'

--- a/python/ambassador/cache.py
+++ b/python/ambassador/cache.py
@@ -203,16 +203,17 @@ class Cache():
         Dump the cache to the logger.
         """
 
-        self.logger.info("CACHE DUMP AFTER " + what, *args)
+        if self.logger.isEnabledFor(logging.DEBUG):
+            self.logger.debug("CACHE DUMP AFTER " + what, *args)
 
-        for k in sorted(self.cache.keys()):
-            rsrc, on_delete = self.cache[k]
+            for k in sorted(self.cache.keys()):
+                rsrc, on_delete = self.cache[k]
 
-            self.logger.info(f"CACHE DUMP: {k}, on_delete {self.fn_name(on_delete)}:")
+                self.logger.debug(f"CACHE DUMP: {k}, on_delete {self.fn_name(on_delete)}:")
 
-            if k in self.links:
-                for owned in sorted(self.links[k]):
-                    self.logger.info(f"CACHE DUMP:   -> {owned}")
+                if k in self.links:
+                    for owned in sorted(self.links[k]):
+                        self.logger.debug(f"CACHE DUMP:   -> {owned}")
 
     def dump_stats(self) -> None:
         total = self.hits + self.misses


### PR DESCRIPTION
Minor tweaks that should be in 2.1.0:

- Fix CVE numbers for busybox update, since my earlier busybox PR
  had a lot of duplicates
- Update demo config to v3alpha1
- Don't do cache dumps at INFO.

 - [x] I made sure to update `CHANGELOG.md`.
 - [x] This is unlikely to impact how Ambassador performs at scale.
 - [ ] My change is adequately tested.
 - [x] I didn't need to update `DEVELOPING.md`.
