### PR TITLE
[2.1.0] Don't log resource contents when debugging is enabled

### DIFF
--- a/python/ambassador/fetch/resource.py
+++ b/python/ambassador/fetch/resource.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
-from typing import Any, Dict, List, Optional
+from typing import Any, ClassVar, Dict, List, Optional
 
 import dataclasses
-import json
 import logging
+import os
 
 from ..config import ACResource, Config
-from ..utils import dump_yaml, parse_yaml, dump_json
+from ..utils import dump_yaml, parse_yaml, parse_bool, dump_json
 
 from .dependency import DependencyManager
 from .k8sobject import KubernetesObjectScope, KubernetesObject
@@ -21,6 +21,7 @@ class NormalizedResource:
 
     object: dict
     rkey: Optional[str] = None
+    log_resources: ClassVar[bool] = parse_bool(os.environ.get('AMBASSADOR_LOG_RESOURCES'))
 
     @classmethod
     def from_data(cls, kind: str, name: str, namespace: Optional[str] = None,
@@ -173,7 +174,8 @@ class ResourceManager:
         except Exception as e:
             self.aconf.post_error(e.args[0])
 
-        self.logger.debug("%s PROCESS %s save %s: %s" % (self.location, obj['kind'], rkey, serialization))
+        if NormalizedResource.log_resources:
+            self.logger.debug("%s PROCESS %s save %s: %s", self.location, obj['kind'], rkey, serialization)
 
         return True
 


### PR DESCRIPTION
Don't log the contents of resources when debugging is enabled (unless
`AMBASSADOR_LOG_RESOURCES` is set to true).

Signed-off-by: Flynn <flynn@datawire.io>

 - [x] I didn't need to update `CHANGELOG.md`; this is only when debugging is on.
 - [x] This is unlikely to impact how Ambassador performs at scale.
 - [x] My change is adequately tested.
 - [x] I didn't need to update `DEVELOPING.md`.
