### PR TITLE
Stop sending upstreams encoded data when using gzip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,9 +93,9 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
   does), an error would always be logged about the Secret not being present, even though it was
   present, and everything was working correctly. This error is no longer logged.
 
-- Bugfix: When using gzip compression upstream services will no longer recieve encoded data. This
-  bug was introduced in 1.14.0. The fix restores the default behavior of  not sending encoded data
-  to upstream services. ([3945])
+- Bugfix: When using gzip compression, upstream services will no longer receive compressed data.
+  This bug was introduced in 1.14.0. The fix restores the default behavior of  not sending
+  compressed data to upstream services. ([3818])
 
 - Security: Update to busybox 1.34.1 to resolve CVE-2021-28831, CVE-2021-42378, CVE-2021-42379,
   CVE-2021-42380, CVE-2021-42381, CVE-2021-42382, CVE-2021-42383, CVE-2021-42384, CVE-2021-42385,
@@ -108,7 +108,7 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
   been removed, resolving CVE-2020-29651.
 
 [3945]: https://github.com/emissary-ingress/emissary/issues/3945
-[3945]: https://github.com/emissary-ingress/emissary/issues/3818
+[3818]: https://github.com/emissary-ingress/emissary/issues/3818
 
 ## [2.0.5] November 08, 2021
 [2.0.5]: https://github.com/emissary-ingress/emissary/compare/v2.0.4...v2.0.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,10 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
   does), an error would always be logged about the Secret not being present, even though it was
   present, and everything was working correctly. This error is no longer logged.
 
+- Bugfix: When using gzip compression upstream services will no longer recieve encoded data. This
+  bug was introduced in 1.14.0. The fix restores the default behavior of  not sending encoded data
+  to upstream services. ([3945])
+
 - Security: Update to busybox 1.34.1 to resolve CVE-2021-28831, CVE-2021-42378, CVE-2021-42379,
   CVE-2021-42380, CVE-2021-42381, CVE-2021-42382, CVE-2021-42383, CVE-2021-42384, CVE-2021-42385,
   and CVE-2021-42386.
@@ -104,6 +108,7 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
   been removed, resolving CVE-2020-29651.
 
 [3945]: https://github.com/emissary-ingress/emissary/issues/3945
+[3945]: https://github.com/emissary-ingress/emissary/issues/3818
 
 ## [2.0.5] November 08, 2021
 [2.0.5]: https://github.com/emissary-ingress/emissary/compare/v2.0.4...v2.0.5

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -54,7 +54,7 @@ items:
           present, even though it was present, and everything was working correctly.
           This error is no longer logged.
       
-      - title: When using gzip, upstreams will no longer recieve encoded data
+      - title: When using gzip, upstreams will no longer receive encoded data
         type: bugfix
         body: >-
           When using gzip compression, upstream services will no longer receive compressed

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -54,6 +54,17 @@ items:
           present, even though it was present, and everything was working correctly.
           This error is no longer logged.
       
+      - title: When using gzip, upstreams will no longer recieve encoded data
+        type: bugfix
+        body: >-
+          When using gzip compression upstream services will no longer recieve encoded
+          data. This bug was introduced in 1.14.0. The fix restores the default behavior of 
+          not sending encoded data to upstream services.
+        github:
+        - title: 3945
+          link: https://github.com/emissary-ingress/emissary/issues/3818
+        docs: https://github.com/emissary-ingress/emissary/issues/3818
+
       - title: Update to busybox 1.34.1
         type: security
         body: >-

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -57,11 +57,11 @@ items:
       - title: When using gzip, upstreams will no longer recieve encoded data
         type: bugfix
         body: >-
-          When using gzip compression upstream services will no longer recieve encoded
+          When using gzip compression, upstream services will no longer receive compressed
           data. This bug was introduced in 1.14.0. The fix restores the default behavior of 
-          not sending encoded data to upstream services.
+          not sending compressed data to upstream services.
         github:
-        - title: 3945
+        - title: 3818
           link: https://github.com/emissary-ingress/emissary/issues/3818
         docs: https://github.com/emissary-ingress/emissary/issues/3818
 

--- a/python/ambassador/envoy/v3/v3httpfilter.py
+++ b/python/ambassador/envoy/v3/v3httpfilter.py
@@ -131,9 +131,6 @@ def V3HTTPFilter_gzip(gzip: IRGzip, v3config: 'V3Config'):
                     'window_bits': gzip.window_bits,
                 }
             },
-            'request_direction_config': {
-                'common_config': common_config,
-            },
             'response_direction_config': {
                 'disable_on_etag_header': gzip.disable_on_etag_header,
                 'remove_accept_encoding_header': gzip.remove_accept_encoding_header,

--- a/python/tests/gold/gzipminimumconfigtest/snapshots/econf.json
+++ b/python/tests/gold/gzipminimumconfigtest/snapshots/econf.json
@@ -117,12 +117,6 @@
                             "window_bits": null
                           }
                         },
-                        "request_direction_config": {
-                          "common_config": {
-                            "content_type": [],
-                            "min_content_length": null
-                          }
-                        },
                         "response_direction_config": {
                           "common_config": {
                             "content_type": [],
@@ -374,12 +368,6 @@
                             "compression_strategy": null,
                             "memory_level": null,
                             "window_bits": null
-                          }
-                        },
-                        "request_direction_config": {
-                          "common_config": {
-                            "content_type": [],
-                            "min_content_length": null
                           }
                         },
                         "response_direction_config": {
@@ -655,12 +643,6 @@
                             "window_bits": null
                           }
                         },
-                        "request_direction_config": {
-                          "common_config": {
-                            "content_type": [],
-                            "min_content_length": null
-                          }
-                        },
                         "response_direction_config": {
                           "common_config": {
                             "content_type": [],
@@ -912,12 +894,6 @@
                             "compression_strategy": null,
                             "memory_level": null,
                             "window_bits": null
-                          }
-                        },
-                        "request_direction_config": {
-                          "common_config": {
-                            "content_type": [],
-                            "min_content_length": null
                           }
                         },
                         "response_direction_config": {

--- a/python/tests/gold/gzipnotsupportedcontenttypetest/snapshots/econf.json
+++ b/python/tests/gold/gzipnotsupportedcontenttypetest/snapshots/econf.json
@@ -117,14 +117,6 @@
                             "window_bits": null
                           }
                         },
-                        "request_direction_config": {
-                          "common_config": {
-                            "content_type": [
-                              "application/json"
-                            ],
-                            "min_content_length": 32
-                          }
-                        },
                         "response_direction_config": {
                           "common_config": {
                             "content_type": [
@@ -378,14 +370,6 @@
                             "compression_strategy": null,
                             "memory_level": null,
                             "window_bits": null
-                          }
-                        },
-                        "request_direction_config": {
-                          "common_config": {
-                            "content_type": [
-                              "application/json"
-                            ],
-                            "min_content_length": 32
                           }
                         },
                         "response_direction_config": {
@@ -663,14 +647,6 @@
                             "window_bits": null
                           }
                         },
-                        "request_direction_config": {
-                          "common_config": {
-                            "content_type": [
-                              "application/json"
-                            ],
-                            "min_content_length": 32
-                          }
-                        },
                         "response_direction_config": {
                           "common_config": {
                             "content_type": [
@@ -924,14 +900,6 @@
                             "compression_strategy": null,
                             "memory_level": null,
                             "window_bits": null
-                          }
-                        },
-                        "request_direction_config": {
-                          "common_config": {
-                            "content_type": [
-                              "application/json"
-                            ],
-                            "min_content_length": 32
                           }
                         },
                         "response_direction_config": {

--- a/python/tests/gold/gziptest/snapshots/econf.json
+++ b/python/tests/gold/gziptest/snapshots/econf.json
@@ -117,14 +117,6 @@
                             "window_bits": 15
                           }
                         },
-                        "request_direction_config": {
-                          "common_config": {
-                            "content_type": [
-                              "text/plain"
-                            ],
-                            "min_content_length": 32
-                          }
-                        },
                         "response_direction_config": {
                           "common_config": {
                             "content_type": [
@@ -378,14 +370,6 @@
                             "compression_strategy": null,
                             "memory_level": null,
                             "window_bits": 15
-                          }
-                        },
-                        "request_direction_config": {
-                          "common_config": {
-                            "content_type": [
-                              "text/plain"
-                            ],
-                            "min_content_length": 32
                           }
                         },
                         "response_direction_config": {
@@ -663,14 +647,6 @@
                             "window_bits": 15
                           }
                         },
-                        "request_direction_config": {
-                          "common_config": {
-                            "content_type": [
-                              "text/plain"
-                            ],
-                            "min_content_length": 32
-                          }
-                        },
                         "response_direction_config": {
                           "common_config": {
                             "content_type": [
@@ -924,14 +900,6 @@
                             "compression_strategy": null,
                             "memory_level": null,
                             "window_bits": 15
-                          }
-                        },
-                        "request_direction_config": {
-                          "common_config": {
-                            "content_type": [
-                              "text/plain"
-                            ],
-                            "min_content_length": 32
                           }
                         },
                         "response_direction_config": {


### PR DESCRIPTION
Signed-off-by: AliceProxy <aliceproxy@protonmail.com>

## Description
Fixes a bug introduced in `1.14.0` where upstream services would receive gzip encoded data when using gzip compression in the `Module`.

Thanks to @kflynn for finding the fix

## Related Issues
https://github.com/emissary-ingress/emissary/issues/3818

## Notes:
A future version of edgissary may expose the ability to enable sending encoded data to upstream, but the default should be to not do that.