### PR TITLE
module.yaml will fail on AMBASSADOR_ID

### DIFF
--- a/charts/emissary-ingress/templates/module.yaml
+++ b/charts/emissary-ingress/templates/module.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
   {{- if .Values.env }}
   {{- if hasKey .Values.env "AMBASSADOR_ID" }}
-  ambassador_id: {{ .Values.env.AMBASSADOR_ID | quote }}
+  ambassador_id: [ {{ .Values.env.AMBASSADOR_ID | quote }} ]
   {{- end }}
   {{- end }}
   config:


### PR DESCRIPTION
Change ambassador_id = string ->  ambassador_id = array in template/module.yaml

without this change helm will fail to install when specifying env.AMBASSADOR_ID="string"
