### PR TITLE
Fix metriton beta endpoint

### DIFF
--- a/pkg/metriton/reporter.go
+++ b/pkg/metriton/reporter.go
@@ -27,7 +27,7 @@ var (
 	// The endpoint you should use by default
 	DefaultEndpoint = "https://metriton.datawire.io/scout"
 	// Use BetaEndpoint for testing purposes without polluting production data
-	BetaEndpoint = "https://kubernaut.io/beta/scout"
+	BetaEndpoint = "https://metriton.datawire.io/beta/scout"
 	// ScoutPyEndpoint is the default endpoint used by scout.py; it obeys the
 	// SCOUT_HOST and SCOUT_HTTPS environment variables.  I'm not sure when you should
 	// use it instead of DefaultEndpoint, but I'm putting it in Go so that I never

--- a/pkg/metriton/reporter.go
+++ b/pkg/metriton/reporter.go
@@ -44,7 +44,7 @@ func getenvDefault(varname, def string) string {
 }
 
 func endpointFromEnv() string {
-	host := getenvDefault("SCOUT_HOST", "kubernaut.io")
+	host := getenvDefault("SCOUT_HOST", "metriton.datawire.io")
 	useHTTPS, _ := strconv.ParseBool(getenvDefault("SCOUT_HTTPS", "1"))
 	ret := &url.URL{
 		Scheme: "http",

--- a/python/ambassador/scout.py
+++ b/python/ambassador/scout.py
@@ -15,7 +15,7 @@ from uuid import uuid4
 class Scout:
 
     def __init__(self, app, version, install_id=None,
-                 id_plugin=None, id_plugin_args={}, scout_host="kubernaut.io", **kwargs):
+                 id_plugin=None, id_plugin_args={}, scout_host="metriton.datawire.io", **kwargs):
         """
         Create a new Scout instance for later reports.
 


### PR DESCRIPTION

## Description

While doing some testing of our metrics infrastructure, we were told
that the kubernaut.io endpoint is no longer used for metrics.  So this
PR updates to the correct url, which is what we used for our testing so
validated that it does indeed work as expected.

## Related Issues
List related issues.

## Testing
A few sentences describing what testing you've done, e.g., manual tests, automated tests, deployed in production, etc.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `CHANGELOG.md`.
   
   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations
 
 - [ ] This is unlikely to impact how Ambassador performs at scale.
 
   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability
 
 - [ ] My change is adequately tested.
 
   Remember when considering testing:
    + LEGACY MODE TESTS DO NOT RUN FOR EVERY PR. If your change is affected by legacy mode, you need
      to run legacy-mode tests manually (set `AMBASSADOR_LEGACY_MODE=true` and run the tests).
      (This will be fixed soon.)
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points
 
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
