### PR TITLE
fix promote jobs

### DIFF
--- a/.github/workflows/promote-ga.yml
+++ b/.github/workflows/promote-ga.yml
@@ -29,6 +29,8 @@ jobs:
         with:
           username: ${{ secrets.GH_DOCKER_RELEASE_USERNAME }}
           password: ${{ secrets.GH_DOCKER_RELEASE_TOKEN }}
+      - name: "Install Go"
+        uses: ./.github/actions/setup-go
       - name: "make release/promote-oss/to-ga"
         if: steps.check-tag.outputs.match == 'true'
         run: |

--- a/.github/workflows/promote-rc.yml
+++ b/.github/workflows/promote-rc.yml
@@ -18,6 +18,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: "Install Go"
+        uses: ./.github/actions/setup-go
       - name: "Docker Login"
         uses: docker/login-action@v1
         with:


### PR DESCRIPTION
The promote jobs are broken due to a go dependency. They have been modified in this PR to use the same "Install Go" action that the testing workflow uses.