### PR TITLE
Set Ambassador node name as Envoy's node.id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,15 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 ## RELEASE NOTES
 
+## [2.2.0] TBD
+[2.2.0]: https://github.com/emissary-ingress/emissary/compare/v2.1.0...v2.2.0
+
+### Emissary-ingress and Ambassador Edge Stack
+
+- Feature: Emissary hostname is now passed as `node.id` to the Envoy configuration. The `node.id`
+  tag in trace spans will now contain the hostname instead of the hardcoded `test-id` string
+  (thanks, <a href="https://github.com/psalaberria002">Paul Salaberria</a>!).
+
 ## [2.1.0] December 16, 2021
 [2.1.0]: https://github.com/emissary-ingress/emissary/compare/v2.0.5...v2.1.0
 

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -31,6 +31,16 @@
 
 changelog: https://github.com/emissary-ingress/emissary/blob/$branch$/CHANGELOG.md
 items:
+  - version: 2.2.0
+    date: 'TBD'
+    notes:
+      - title: Pass Emissary hostname through to Envoy config
+        type: feature
+        body: >-
+          Emissary hostname is now passed as `node.id` to the Envoy configuration.
+          The `node.id` tag in trace spans will now contain the hostname instead of the hardcoded
+          `test-id` string (thanks, <a href="https://github.com/psalaberria002">Paul Salaberria</a>!).
+
   - version: 2.1.0
     date: '2021-12-16'
     notes:

--- a/python/ambassador/envoy/v2/v2bootstrap.py
+++ b/python/ambassador/envoy/v2/v2bootstrap.py
@@ -8,6 +8,8 @@ from ...ir.irlogservice import IRLogService
 from ...ir.irratelimit import IRRateLimit
 from ...ir.irtracing import IRTracing
 
+from ...utils import SystemInfo
+
 from .v2cluster import V2Cluster
 
 if TYPE_CHECKING:
@@ -19,7 +21,7 @@ class V2Bootstrap(dict):
         super().__init__(**{
             "node": {
                 "cluster": config.ir.ambassador_nodename,
-                "id": "test-id"         # MUST BE test-id, see below
+                "id": SystemInfo.MyHostName,
             },
             "static_resources": {},     # Filled in later
             "dynamic_resources": {

--- a/python/ambassador/envoy/v3/v3bootstrap.py
+++ b/python/ambassador/envoy/v3/v3bootstrap.py
@@ -8,6 +8,8 @@ from ...ir.irlogservice import IRLogService
 from ...ir.irratelimit import IRRateLimit
 from ...ir.irtracing import IRTracing
 
+from ...utils import SystemInfo
+
 from .v3cluster import V3Cluster
 
 if TYPE_CHECKING:
@@ -20,7 +22,7 @@ class V3Bootstrap(dict):
         super().__init__(**{
             "node": {
                 "cluster": config.ir.ambassador_nodename,
-                "id": "test-id"         # MUST BE test-id, see below
+                "id": SystemInfo.MyHostName,
             },
             "static_resources": {},     # Filled in later
             "dynamic_resources": {


### PR DESCRIPTION
## Description
Set a sensible value for node.id in Envoy's configuration.

When looking at traces, I noticed there was a node.id tag set to "test-id".
It would be very useful to get the ambassador pod name instead in that field.

I am not sure what other implications this change may have, but it seems harmless at a first glance.

## Testing
I have not done any testing so far.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `CHANGELOG.md`.
   
   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations
 
 - [x] This is unlikely to impact how Ambassador performs at scale.
 - [ ] My change is adequately tested.
