### PR TITLE
fix: updated helm template module's api kind to version v3alpha1

### DIFF
--- a/charts/emissary-ingress/templates/module.yaml
+++ b/charts/emissary-ingress/templates/module.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.module }}
-apiVersion: getambassador.io/v2
+apiVersion: getambassador.io/v3alpha1
 kind: Module
 metadata:
   name: ambassador


### PR DESCRIPTION
## Description
Emissary-ingress helm chart 7.2 installations with module give error regarding the module version
```
Error: UPGRADE FAILED: unable to recognize "": no matches for kind "Module" in version "getambassador.io/v2"
```

Updated the module's apiVersion to match with the one used in the documentation for version emissary 2.1
