### PR TITLE
CI and CHANGELOG for #3974

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,15 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 ## RELEASE NOTES
 
+## [2.2.0] TBD
+[2.2.0]: https://github.com/emissary-ingress/emissary/compare/v2.1.0...v2.2.0
+
+### Emissary-ingress and Ambassador Edge Stack
+
+- Feature: Emissary uses its `ambassador_id` and Namespace to construct a nodename for itself to use
+  in diagnostics. This nodename is now passed all the way through to the Envoy configuration
+  (thanks, <a href="https://github.com/psalaberria002">Paul Salaberria</a>!).
+
 ## [2.1.0] December 16, 2021
 [2.1.0]: https://github.com/emissary-ingress/emissary/compare/v2.0.5...v2.1.0
 

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -31,6 +31,16 @@
 
 changelog: https://github.com/emissary-ingress/emissary/blob/$branch$/CHANGELOG.md
 items:
+  - version: 2.2.0
+    date: 'TBD'
+    notes:
+      - title: Pass Emissary nodename through to Envoy config
+        type: feature
+        body: >-
+          Emissary uses its <code>ambassador_id</code> and Namespace to construct a nodename for
+          itself to use in diagnostics. This nodename is now passed all the way through to the
+          Envoy configuration (thanks, <a href="https://github.com/psalaberria002">Paul Salaberria</a>!).
+
   - version: 2.1.0
     date: '2021-12-16'
     notes:

--- a/python/ambassador/envoy/v2/v2bootstrap.py
+++ b/python/ambassador/envoy/v2/v2bootstrap.py
@@ -19,7 +19,7 @@ class V2Bootstrap(dict):
         super().__init__(**{
             "node": {
                 "cluster": config.ir.ambassador_nodename,
-                "id": "test-id"         # MUST BE test-id, see below
+                "id": config.ir.ambassador_nodename,
             },
             "static_resources": {},     # Filled in later
             "dynamic_resources": {

--- a/python/ambassador/envoy/v3/v3bootstrap.py
+++ b/python/ambassador/envoy/v3/v3bootstrap.py
@@ -20,7 +20,7 @@ class V3Bootstrap(dict):
         super().__init__(**{
             "node": {
                 "cluster": config.ir.ambassador_nodename,
-                "id": "test-id"         # MUST BE test-id, see below
+                "id": config.ir.ambassador_nodename
             },
             "static_resources": {},     # Filled in later
             "dynamic_resources": {


### PR DESCRIPTION
This adds a CHANGELOG to @psalaberria002's #3974, and will let full CI run.

I was initially concerned that this would break the link between Emissary and Envoy (because `ambex` and Envoy have to agree on a particular name internally) but the nodename here is not that name. I tested that by hand before adding the CHANGELOG.

 - [x] I made sure to update `CHANGELOG.md`.
 - [x] This is unlikely to impact how Ambassador performs at scale.
 - [x] My change is adequately tested.
 - [x] I didn't need to update `DEVELOPING.md`.
