### PR TITLE
Issue 3989

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Emissary-ingress
 <!-- Links are (mostly) at the end of this document, for legibility. -->
 
 <!-- [![Build Status][build-status]][build-pages] -->
-[![Docker Repository][version-endpoint]][docker-repo]
+[![Docker Repository][version-endpoint]][docker-repo] 
 ![Docker Pulls][docker-pulls]
 [![Join Slack][slack-join]][slack-url] <br/>
 [![CII Best Practices][cii-badge]][cii-status]
@@ -19,7 +19,7 @@ Emissary-ingress enables its users to:
 * Manage ingress traffic with [load balancing], support for multiple protocols ([gRPC and HTTP/2], [TCP], and [web sockets]), and Kubernetes integration
 * Manage changes to routing with an easy to use declarative policy engine and [self-service configuration], via Kubernetes [CRDs] or annotations
 * Secure microservices with [authentication], [rate limiting], and [TLS]
-* Ensure high availability with [sticky sessions], [rate limiting], and [circuit breaking]v3httpfilter.py
+* Ensure high availability with [sticky sessions], [rate limiting], and [circuit breaking]
 * Leverage observability with integrations with [Grafana], [Prometheus], and [Datadog], and comprehensive [metrics] support
 * Enable progressive delivery with [canary releases]
 * Connect service meshes including [Consul], [Linkerd], and [Istio]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Emissary-ingress
 <!-- Links are (mostly) at the end of this document, for legibility. -->
 
 <!-- [![Build Status][build-status]][build-pages] -->
-[![Docker Repository][version-endpoint]][docker-repo]
+[![Docker Repository][version-endpoint]][docker-repo] 
 ![Docker Pulls][docker-pulls]
 [![Join Slack][slack-join]][slack-url] <br/>
 [![CII Best Practices][cii-badge]][cii-status]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Emissary-ingress
 <!-- Links are (mostly) at the end of this document, for legibility. -->
 
 <!-- [![Build Status][build-status]][build-pages] -->
-[![Docker Repository][version-endpoint]][docker-repo]
+[![Docker Repository][version-endpoint]][docker-repo] 
 ![Docker Pulls][docker-pulls]
 [![Join Slack][slack-join]][slack-url] <br/>
 [![CII Best Practices][cii-badge]][cii-status]
@@ -12,7 +12,7 @@ Emissary-ingress
 ----
 
 [Emissary-Ingress](https://www.getambassador.io) is an open-source Kubernetes-native API Gateway +
-Layer 7 load balancer + Kubernetes Ingress built on [Envoy Proxy](https://www.envoyproxy.io). 
+Layer 7 load balancer + Kubernetes Ingress built on [Envoy Proxy](https://www.envoyproxy.io).
 Emissary-ingress is an CNCF incubation project (and was formerly known as Ambassador API Gateway.)
 
 Emissary-ingress enables its users to:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Emissary-ingress
 <!-- Links are (mostly) at the end of this document, for legibility. -->
 
 <!-- [![Build Status][build-status]][build-pages] -->
-[![Docker Repository][version-endpoint]][docker-repo] 
+[![Docker Repository][version-endpoint]][docker-repo]
 ![Docker Pulls][docker-pulls]
 [![Join Slack][slack-join]][slack-url] <br/>
 [![CII Best Practices][cii-badge]][cii-status]
@@ -12,7 +12,7 @@ Emissary-ingress
 ----
 
 [Emissary-Ingress](https://www.getambassador.io) is an open-source Kubernetes-native API Gateway +
-Layer 7 load balancer + Kubernetes Ingress built on [Envoy Proxy](https://www.envoyproxy.io).
+Layer 7 load balancer + Kubernetes Ingress built on [Envoy Proxy](https://www.envoyproxy.io). 
 Emissary-ingress is an CNCF incubation project (and was formerly known as Ambassador API Gateway.)
 
 Emissary-ingress enables its users to:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Emissary-ingress
 <!-- Links are (mostly) at the end of this document, for legibility. -->
 
 <!-- [![Build Status][build-status]][build-pages] -->
-[![Docker Repository][version-endpoint]][docker-repo] 
+[![Docker Repository][version-endpoint]][docker-repo]
 ![Docker Pulls][docker-pulls]
 [![Join Slack][slack-join]][slack-url] <br/>
 [![CII Best Practices][cii-badge]][cii-status]
@@ -12,14 +12,14 @@ Emissary-ingress
 ----
 
 [Emissary-Ingress](https://www.getambassador.io) is an open-source Kubernetes-native API Gateway +
-Layer 7 load balancer + Kubernetes Ingress built on [Envoy Proxy](https://www.envoyproxy.io). 
+Layer 7 load balancer + Kubernetes Ingress built on [Envoy Proxy](https://www.envoyproxy.io).
 Emissary-ingress is an CNCF incubation project (and was formerly known as Ambassador API Gateway.)
 
 Emissary-ingress enables its users to:
 * Manage ingress traffic with [load balancing], support for multiple protocols ([gRPC and HTTP/2], [TCP], and [web sockets]), and Kubernetes integration
 * Manage changes to routing with an easy to use declarative policy engine and [self-service configuration], via Kubernetes [CRDs] or annotations
 * Secure microservices with [authentication], [rate limiting], and [TLS]
-* Ensure high availability with [sticky sessions], [rate limiting], and [circuit breaking]
+* Ensure high availability with [sticky sessions], [rate limiting], and [circuit breaking]v3httpfilter.py
 * Leverage observability with integrations with [Grafana], [Prometheus], and [Datadog], and comprehensive [metrics] support
 * Enable progressive delivery with [canary releases]
 * Connect service meshes including [Consul], [Linkerd], and [Istio]

--- a/python/ambassador/envoy/v3/v3httpfilter.py
+++ b/python/ambassador/envoy/v3/v3httpfilter.py
@@ -345,6 +345,7 @@ def V3HTTPFilter_authv1(auth: IRAuth, v3config: 'V3Config'):
                     },
                     'timeout': "%0.3fs" % (float(auth.timeout_ms) / 1000.0)
                 },
+                'include_peer_certificate': True,
                 'transport_api_version': protocol_version.replace("alpha", "").upper(),
             }
         }


### PR DESCRIPTION
## Description
Enable "include_peer_certificate" so that envoy passes the client cert into auth service.

## Testing

Tested locally, verified that auth gRPC server sees the client cert

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `CHANGELOG.md`.
   
   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations
 
 - [ ] This is unlikely to impact how Ambassador performs at scale.
 
   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability
 
 - [x] My change is adequately tested.
 
   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points
 
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
