### PR TITLE
Document that V2 is going away in v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,13 @@ refer both to Emissary-ingress and to the Ambassador Edge Stack.
 
 ## UPCOMING BREAKING CHANGES
 
+#### Envoy V2 API
+
+In *Emissary-ingress v2.2.0*, support for the Envoy V2 API will be removed, and Emissary-ingress
+will support only the Envoy V3 API. The `AMBASSADOR_ENVOY_API_VERSION` environment variable will
+also be removed. Note that Emissary-ingress has been using the Envoy V3 API as its default since
+v1.14.0.
+
 #### TLS Termination and the `Host` CRD
 
 As of Emissary-ingress v2.0.4, you _must_ supply a `Host` CRD to terminate TLS: it is not
@@ -89,6 +96,10 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
   to 1 if debug logging is enabled for the running Emissary instance, or to 0 if not. This can help
   to be sure that a running production instance was not actually left doing debugging logging, for
   example. (Thanks to <a href="https://github.com/jfrabaute">Fabrice</a>!) ([3906])
+
+- Change: Support for the Envoy V2 API and the `AMBASSADOR_ENVOY_API_VERSION` environment variable
+  have been removed. Only the Envoy V3 API is supported (this has been the default since
+  Emissary-ingress v1.14.0).
 
 [3906]: https://github.com/emissary-ingress/emissary/issues/3906
 

--- a/docs/CHANGELOG.tpl
+++ b/docs/CHANGELOG.tpl
@@ -32,6 +32,13 @@ refer both to Emissary-ingress and to the Ambassador Edge Stack.
 
 ## UPCOMING BREAKING CHANGES
 
+#### Envoy V2 API
+
+In *Emissary-ingress v2.2.0*, support for the Envoy V2 API will be removed, and Emissary-ingress
+will support only the Envoy V3 API. The `AMBASSADOR_ENVOY_API_VERSION` environment variable will
+also be removed. Note that Emissary-ingress has been using the Envoy V3 API as its default since
+v1.14.0.
+
 #### TLS Termination and the `Host` CRD
 
 As of Emissary-ingress v2.0.4, you _must_ supply a `Host` CRD to terminate TLS: it is not

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -46,6 +46,13 @@ items:
         - title: 3906
           link: https://github.com/emissary-ingress/emissary/issues/3906
         docs: https://www.getambassador.io/docs/edge-stack/latest/topics/running/statistics/8877-metrics/
+
+      - title: Envoy V2 API no longer supported
+        type: change
+        body: >-
+          Support for the Envoy V2 API and the `AMBASSADOR_ENVOY_API_VERSION` environment
+          variable have been removed. Only the Envoy V3 API is supported (this has been the
+          default since Emissary-ingress v1.14.0).
  
   - version: 2.1.0
     date: '2021-12-16'


### PR DESCRIPTION
We're going to drop support for Envoy V2 config in v2.2.0. Update the CHANGELOG
so we can go ahead and get the word out.

Signed-off-by: Flynn <flynn@datawire.io>
