### PR TITLE
Fix matching a Mapping with host_redirect a Host

### DIFF
--- a/python/ambassador/ir/irhost.py
+++ b/python/ambassador/ir/irhost.py
@@ -383,7 +383,7 @@ class IRHost(IRResource):
         else:
             # It is NOT A TYPO that we use group.get("host") here -- whether the Mapping supplies
             # "hostname" or "host", the Mapping code normalizes to "host" internally.
-            group_glob = group.get('host') or None  # NOT A TYPO: see above.
+            group_glob = group.get('host') or group.get('host_redirect', {}).get('host') or None  # NOT A TYPO: see above.
 
             if group_glob:
                 host_match = hostglob_matches(self.hostname, group_glob)


### PR DESCRIPTION
## Description

While preparing the upgrade from 1.x to 2.x, we noticed that any `Mapping` with `host_redirect` set would lead to a 404, which is the issue described #3709. It turns out that the issue lies in the `matches_httpgroup` function of `irhost.py`.

I'd first like to get some feedback before I proceed with adding a regression test or do anything else with this PR.

## Related Issues
- #3709

## Testing

Manual testing (image rebuild + running the example) proved that this patch works.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `CHANGELOG.md`.
   
   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations
 
 - [x] This is unlikely to impact how Ambassador performs at scale.
 
   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability
 
 - [ ] My change is adequately tested.
 
   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points
 
Resolves #3709 and #4005