### PR TITLE
Enable Docker BuildKit for CI (v2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,9 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 ### Emissary-ingress and Ambassador Edge Stack
 
+- Change: Docker BuildKit is enabled for all Emissary builds. Additionally, the Go build cache is
+  fully enabled when building images, speeding up repeated builds.
+
 ## 2.1.1 not issued
 
 *Emissary-ingress 2.1.1 was not issued; Ambassador Edge Stack 2.1.1 uses Emissary-ingress 2.1.0.*

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -1,3 +1,5 @@
+# syntax = docker/dockerfile:1.3
+
 ###
 # This dockerfile builds all the source code and docker images for the
 # edge stack.
@@ -77,7 +79,9 @@ ADD pkg pkg
 ADD vendor vendor
 ADD go.mod go.mod
 ADD go.sum go.sum
-RUN mkdir -p /go/bin && \
+
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    mkdir -p /go/bin && \
 	time go build -mod=vendor -o /go/bin/ ./cmd/...
 
 ########################################

--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -146,7 +146,9 @@ INGRESS_TEST_LOCAL_ADMIN_PORT = 8877
 INGRESS_TEST_MANIF_DIR = $(BUILDER_HOME)/../manifests/emissary/
 INGRESS_TEST_MANIFS = emissary-crds.yaml emissary-emissaryns.yaml
 
-# export DOCKER_BUILDKIT := 0
+# DOCKER_BUILDKIT is _required_ by our Dockerfile, since we use Dockerfile extensions for the
+# Go build cache. See https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/syntax.md.
+export DOCKER_BUILDKIT := 1
 
 all: help
 .PHONY: all

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -35,7 +35,12 @@ items:
     prevVersion: 2.1.0
     date: 'TBD'
     notes:
-      # next changelog item here
+      - title: Docker BuildKit always used for builds
+        type: change
+        body: >-
+          Docker BuildKit is enabled for all Emissary builds. Additionally, the Go
+          build cache is fully enabled when building images, speeding up repeated builds.
+        docs: https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/syntax.md
 
   - version: 2.1.1
     date: 'N/A'


### PR DESCRIPTION
Enable Docker BuildKit for CI. This is important because mounting the Go build cache in the Docker build requires BuildKit, and we really, really don't want different Dockerfiles in dev and CI.

My original version (#4024) exported `DOCKER_BUILDKIT` in the inidividual workflows; this one just forces it in `builder.mk` globally. I was originally concerned about some sort of unintended consequence of the global setting, but it seems OK and it's definitely much cleaner, so probably a good thing that @LukeShu called me on it. 😉 

 - [x] I didn't need to update `CHANGELOG.md`.
 - [x] This is CI, so it cannot affect how Ambassador performs at scale.
 - [x] CI is literally the point of this change: it's the only test needed.
 - [x] I didn't need to update `DEVELOPING.md`.
