### PR TITLE
Fixes for 2.1.2

### DIFF
--- a/.github/workflows/execute-tests-and-promote.yml
+++ b/.github/workflows/execute-tests-and-promote.yml
@@ -69,6 +69,7 @@ jobs:
       DOCKER_USERNAME: ${{ secrets.GH_DOCKER_BUILD_USERNAME }}
       DOCKER_PASSWORD: ${{ secrets.GH_DOCKER_BUILD_TOKEN }}
     strategy:
+      fail-fast: false
       matrix:
         test: [envoy-ah, envoy-v2-ah, envoy-ip, envoy-v2-ip, envoy-qz, envoy-v2-qz, kat, integration]
     name: pytest-${{ matrix.test }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,10 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 ### Emissary-ingress and Ambassador Edge Stack
 
+- Bugfix: Emissary-ingress 2.1.0 generated invalid Envoy configuration for `getambassador.io/v2`
+  `Mappings` that set `spec.cors.origins` to a string rather than a list of strings; this has been
+  fixed, and these `Mappings` should once again function correctly.
+
 - Change: Docker BuildKit is enabled for all Emissary builds. Additionally, the Go build cache is
   fully enabled when building images, speeding up repeated builds.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,9 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
   `Mappings` that set `spec.cors.origins` to a string rather than a list of strings; this has been
   fixed, and these `Mappings` should once again function correctly.
 
+- Bugfix: Using `rewrite: ""` in a `Mapping` is correctly handled to mean "do not rewrite the path
+  at all".
+
 - Change: Docker BuildKit is enabled for all Emissary builds. Additionally, the Go build cache is
   fully enabled when building images, speeding up repeated builds.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,9 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
   `Mappings` that set `spec.cors.origins` to a string rather than a list of strings; this has been
   fixed, and these `Mappings` should once again function correctly.
 
+- Bugfix: Changes to the `weight` of `Mapping` in a canary group will now always be correctly
+  managed during reconfiguration; such changes could have been missed in earlier releases.
+
 - Bugfix: Using `rewrite: ""` in a `Mapping` is correctly handled to mean "do not rewrite the path
   at all".
 

--- a/OPENSOURCE.md
+++ b/OPENSOURCE.md
@@ -111,7 +111,7 @@ following Free and Open Source software:
     k8s.io/component-base                                                     v0.20.2                                     Apache License 2.0
     k8s.io/gengo                                                              v0.0.0-20201214224949-b6c5ce23f027          Apache License 2.0
     k8s.io/klog/v2                                                            v2.10.0                                     Apache License 2.0
-    k8s.io/kube-openapi                                                       v0.0.0-20201113171705-d219536bb9fd          Apache License 2.0
+    k8s.io/kube-openapi                                                       v0.0.0-20210304212320-e467f52fd9db          Apache License 2.0
     k8s.io/kubectl                                                            v0.20.2                                     Apache License 2.0
     k8s.io/kubernetes                                                         v1.20.2                                     Apache License 2.0
     k8s.io/metrics                                                            v0.20.2                                     Apache License 2.0

--- a/cmd/apiext/logutil.go
+++ b/cmd/apiext/logutil.go
@@ -1,0 +1,18 @@
+package apiext
+
+// This is a separate file from anything else so that people don't see
+// logrus being imported and think that it's OK to use logrus instead
+// of dlog.  We're just coopting logrus.ParseLevel and the
+// logrus.Level type, and not using any of the actual logging
+// functionality.  Use dlog!
+
+import (
+	//nolint:depguard // So we can turn off buffering if we're not debug logging
+	"github.com/sirupsen/logrus"
+
+	"github.com/datawire/ambassador/v2/pkg/busy"
+)
+
+func LogLevelIsAtLeastDebug() bool {
+	return busy.GetLogLevel() >= logrus.DebugLevel
+}

--- a/cmd/apiext/main.go
+++ b/cmd/apiext/main.go
@@ -9,7 +9,7 @@ import (
 	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
 	k8sRuntimeUtil "k8s.io/apimachinery/pkg/util/runtime"
 
-	"github.com/datawire/ambassador/v2/pkg/api/getambassador.io/v2"
+	v2 "github.com/datawire/ambassador/v2/pkg/api/getambassador.io/v2"
 	"github.com/datawire/ambassador/v2/pkg/api/getambassador.io/v3alpha1"
 	"github.com/datawire/ambassador/v2/pkg/busy"
 	"github.com/datawire/ambassador/v2/pkg/k8s"

--- a/cmd/apiext/serve.go
+++ b/cmd/apiext/serve.go
@@ -1,17 +1,21 @@
 package apiext
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
+	"net/http/httptest"
 
 	// k8s utils
 	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/conversion"
 
 	"github.com/datawire/dlib/dhttp"
+	"github.com/datawire/dlib/dlog"
 )
 
 const (
@@ -19,6 +23,60 @@ const (
 	pathProbesReady        = "/probes/ready"
 	pathProbesLive         = "/probes/live"
 )
+
+// conversionWithLogging is a wrapper around our real conversion method that logs the JSON
+// input and output for the conversion request. It's used only when we have debug logging
+// enabled.
+func conversionWithLogging(wh *conversion.Webhook, w http.ResponseWriter, r *http.Request) {
+	// This is a little more obnoxious than you'd think because r.Body is a ReadCloser,
+	// not an io.Reader, and because the handler expects to be handed an io.Writer for
+	// response. So we need to buffer both directions (obviously, this works partly
+	// because we know that requests and responses are fairly small... ish).
+	//
+	// So, start by reading the request body into a byte array using iotuil.ReadAll
+	// That's the easy bit.
+	if r.Body == nil {
+		dlog.Errorf(r.Context(), "no conversion request provided?")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	inputBytes, err := ioutil.ReadAll(r.Body)
+
+	// This is mirrored from wh.ServeHttp (cf sigs.k8s.io/controller-runtime/pkg/webhook/conversion.go).
+	if err != nil {
+		dlog.Errorf(r.Context(), "could not read conversion request: %s", err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	// Go ahead and log the input...
+	dlog.Debugf(r.Context(), "INPUT: %s", string(inputBytes))
+
+	// ...then replace the request body with a new io.NopCloser that feeds back
+	// the contents of the input buffer to the actual conversion method...
+	r.Body = io.NopCloser(bytes.NewBuffer(inputBytes))
+
+	// ...then use an httptest.ResponseRecorder to capture the output of the real
+	// conversion method.
+	rec := httptest.NewRecorder()
+	wh.ServeHTTP(rec, r)
+
+	// Log the output...
+	dlog.Debugf(r.Context(), "OUTPUT: %s", rec.Body)
+
+	// ...and then copy the recorded output to the real response.
+	for k, v := range rec.Result().Header {
+		w.Header()[k] = v
+	}
+
+	w.WriteHeader(rec.Code)
+
+	// There's kind of nothing we can do if we can't write the body to w, so, uh... do
+	// nothing? Should we panic instead??
+	//nolint:errcheck
+	rec.Body.WriteTo(w)
+}
 
 func ServeHTTPS(ctx context.Context, port int, ca *CA, scheme *k8sRuntime.Scheme) error {
 	webhook := &conversion.Webhook{}
@@ -30,6 +88,10 @@ func ServeHTTPS(ctx context.Context, port int, ca *CA, scheme *k8sRuntime.Scheme
 
 	mux.Handle(pathWebhooksCrdConvert, webhook)
 
+	dlog.Infof(ctx, "Serving HTTPS on port %d", port)
+
+	// Assume that we'll use the conversion method directly, by using 'mux' for our
+	// Handler...
 	sc := &dhttp.ServerConfig{
 		Handler: mux,
 		TLSConfig: &tls.Config{
@@ -38,6 +100,15 @@ func ServeHTTPS(ctx context.Context, port int, ca *CA, scheme *k8sRuntime.Scheme
 			},
 		},
 	}
+
+	// ...but if we're in debug mode, switch to using our conversionWithLogging handler
+	// instead.
+	if LogLevelIsAtLeastDebug() {
+		sc.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			conversionWithLogging(webhook, w, r)
+		})
+	}
+
 	return sc.ListenAndServeTLS(ctx, fmt.Sprintf(":%d", port), "", "")
 }
 

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -43,6 +43,14 @@ items:
           <code>spec.cors.origins</code> to a string rather than a list of strings; this has been
           fixed, and these <code>Mappings<code> should once again function correctly.
 
+      - title: Correctly handle canary Mapping weights when reconfiguring
+        type: bugfix
+        body: >-
+          Changes to the <code>weight</code> of <code>Mapping</code> in a canary group
+          will now always be correctly managed during reconfiguration; such changes could
+          have been missed in earlier releases.
+        docs: topics/using/canary/#the-weight-attribute
+
       - title: Correctly handle empty rewrite in a Mapping
         type: bugfix
         body: >-

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -35,6 +35,14 @@ items:
     prevVersion: 2.1.0
     date: 'TBD'
     notes:
+      - title: Fix support for for v2 Mappings with CORS
+        type: bugfix
+        body: >-
+          Emissary-ingress 2.1.0 generated invalid Envoy configuration for
+          <code>getambassador.io/v2</code> <code>Mappings</code> that set
+          <code>spec.cors.origins</code> to a string rather than a list of strings; this has been
+          fixed, and these <code>Mappings<code> should once again function correctly.
+
       - title: Docker BuildKit always used for builds
         type: change
         body: >-

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -43,6 +43,13 @@ items:
           <code>spec.cors.origins</code> to a string rather than a list of strings; this has been
           fixed, and these <code>Mappings<code> should once again function correctly.
 
+      - title: Correctly handle empty rewrite in a Mapping
+        type: bugfix
+        body: >-
+          Using <code>rewrite: ""</code> in a <code>Mapping</code> is correctly handled
+          to mean "do not rewrite the path at all".
+        docs: topics/using/rewrites
+
       - title: Docker BuildKit always used for builds
         type: change
         body: >-

--- a/go.mod
+++ b/go.mod
@@ -89,7 +89,7 @@ require (
 	k8s.io/client-go v0.20.2
 	k8s.io/code-generator v0.20.2
 	k8s.io/klog/v2 v2.10.0
-	k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd
+	k8s.io/kube-openapi v0.0.0-20210304212320-e467f52fd9db
 	k8s.io/kubectl v0.20.2
 	k8s.io/kubernetes v1.20.2
 	k8s.io/metrics v0.20.2

--- a/go.sum
+++ b/go.sum
@@ -1115,6 +1115,8 @@ k8s.io/kube-controller-manager v0.20.2/go.mod h1:tEuBoNyKDqoHClDyLePZCs38XuVv5jC
 k8s.io/kube-openapi v0.0.0-20200121204235-bf4fb3bd569c/go.mod h1:GRQhZsXIAJ1xR0C9bd8UpWHZ5plfAS9fzPjJuQ6JL3E=
 k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd h1:sOHNzJIkytDF6qadMNKhhDRpc6ODik8lVC6nOur7B2c=
 k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd/go.mod h1:WOJ3KddDSol4tAGcJo0Tvi+dK12EcqSLqcWsryKMpfM=
+k8s.io/kube-openapi v0.0.0-20210304212320-e467f52fd9db h1:6eSQzsKNEqxmpqbul2YVDt5O4MPA+Q6RljtpWb536bE=
+k8s.io/kube-openapi v0.0.0-20210304212320-e467f52fd9db/go.mod h1:wXW5VT87nVfh/iLV8FpR2uDvrFyomxbtb1KivDbvPTE=
 k8s.io/kube-proxy v0.20.2/go.mod h1:l75PYLoA+hI6WAfT/2cFPUcWy8XWMFGvsyw8UXCNuJc=
 k8s.io/kube-scheduler v0.20.2/go.mod h1:H21kpnQN7U3jRz/MwMxdGPC66UBuTibbq5LEy5AztBg=
 k8s.io/kubectl v0.20.2 h1:mXExF6N4eQUYmlfXJmfWIheCBLF6/n4VnwQKbQki5iE=

--- a/pkg/api/getambassador.io/validation_test.go
+++ b/pkg/api/getambassador.io/validation_test.go
@@ -1,0 +1,45 @@
+package getambassadorio_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	getambassadorio "github.com/datawire/ambassador/v2/pkg/api/getambassador.io"
+	"github.com/datawire/ambassador/v2/pkg/kates"
+	"github.com/datawire/dlib/dlog"
+)
+
+func TestValidation(t *testing.T) {
+	jsonStr := `{
+    "apiVersion":"getambassador.io/v2",
+    "kind":"Mapping",
+    "metadata":{
+        "annotations":{
+            "kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"getambassador.io/v3alpha1\",\"kind\":\"Mapping\",\"metadata\":{\"annotations\":{},\"name\":\"quote-rewrite\",\"namespace\":\"default\"},\"spec\":{\"hostname\":\"*\",\"prefix\":\"/ffs/\",\"rewrite\":\"\",\"service\":\"quote\"}}"
+        },
+        "creationTimestamp":"2022-01-19T00:11:43Z",
+        "generation":1,
+        "name":"quote-rewrite",
+        "namespace":"default",
+        "uid":"01b3ddea-24d7-45c6-a05a-64386f1b9588"
+    },
+    "spec":{
+        "ambassador_id":[
+            "--apiVersion-v3alpha1-only--default"
+        ],
+        "prefix":"/ffs/",
+        "rewrite":"",
+        "service":"quote"
+    }
+}`
+
+	var obj kates.Unstructured
+	require.NoError(t, json.Unmarshal([]byte(jsonStr), &obj.Object))
+
+	validator := getambassadorio.NewValidator()
+	ctx := dlog.NewTestContext(t, true)
+
+	require.NoError(t, validator.Validate(ctx, &obj))
+}

--- a/pkg/kates/validation.go
+++ b/pkg/kates/validation.go
@@ -2,8 +2,9 @@ package kates
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"path"
-	"strings"
 	"sync"
 
 	apiextVInternal "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
@@ -12,7 +13,7 @@ import (
 	"k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
 	"k8s.io/kube-openapi/pkg/validation/validate"
 
-	"github.com/pkg/errors"
+	"github.com/datawire/dlib/derror"
 )
 
 // A Validator may be used in concert with a Client to perform
@@ -41,23 +42,24 @@ func NewValidator(client *Client, staticCRDs []Object) (*Validator, error) {
 		case apiextV1beta1.SchemeGroupVersion.WithKind("CustomResourceDefinition"):
 			var crdV1beta1 apiextV1beta1.CustomResourceDefinition
 			if err := convert(untypedCRD, &crdV1beta1); err != nil {
-				return nil, errors.Wrapf(err, "staticCRDs[%d]", i)
+				return nil, fmt.Errorf("staticCRDs[%d]: %w", i, err)
 			}
 			apiextV1beta1.SetDefaults_CustomResourceDefinition(&crdV1beta1)
 			if err := apiextV1beta1.Convert_v1beta1_CustomResourceDefinition_To_apiextensions_CustomResourceDefinition(&crdV1beta1, &crd, nil); err != nil {
-				return nil, errors.Wrapf(err, "staticCRDs[%d]", i)
+				return nil, fmt.Errorf("staticCRDs[%d]: %w", i, err)
 			}
 		case apiextV1.SchemeGroupVersion.WithKind("CustomResourceDefinition"):
 			var crdV1 apiextV1.CustomResourceDefinition
 			if err := convert(untypedCRD, &crdV1); err != nil {
-				return nil, errors.Wrapf(err, "staticCRDs[%d]", i)
+				return nil, fmt.Errorf("staticCRDs[%d]: %w", i, err)
 			}
 			apiextV1.SetDefaults_CustomResourceDefinition(&crdV1)
 			if err := apiextV1.Convert_v1_CustomResourceDefinition_To_apiextensions_CustomResourceDefinition(&crdV1, &crd, nil); err != nil {
-				return nil, errors.Wrapf(err, "staticCRDs[%d]", i)
+				return nil, fmt.Errorf("staticCRDs[%d]: %w", i, err)
 			}
 		default:
-			return nil, errors.Wrapf(errors.Errorf("unrecognized CRD GroupVersionKind: %v", untypedCRD.GetObjectKind().GroupVersionKind()), "staticCRDs[%d]", i)
+			err := fmt.Errorf("unrecognized CRD GroupVersionKind: %v", untypedCRD.GetObjectKind().GroupVersionKind())
+			return nil, fmt.Errorf("staticCRDs[%d]: %w", i, err)
 		}
 		for _, version := range crd.Spec.Versions {
 			static[TypeMeta{
@@ -178,7 +180,7 @@ func (v *Validator) Validate(ctx context.Context, resource interface{}) error {
 
 	result := validator.Validate(resource)
 
-	var errs []error
+	var errs derror.MultiError
 	for _, e := range result.Errors {
 		errs = append(errs, e)
 	}
@@ -188,11 +190,7 @@ func (v *Validator) Validate(ctx context.Context, resource interface{}) error {
 	}
 
 	if len(errs) > 0 {
-		msg := strings.Builder{}
-		for _, e := range errs {
-			msg.WriteString(e.Error() + "\n")
-		}
-		return errors.New(msg.String())
+		return errs
 	}
 
 	return nil

--- a/pkg/snapshot/v1/annotations_test.go
+++ b/pkg/snapshot/v1/annotations_test.go
@@ -155,7 +155,7 @@ prefix: /blah/`
 						"spec": map[string]interface{}{
 							"prefix": "/blah/",
 						},
-						"errors": "spec.service in body is required\n",
+						"errors": "spec.service in body is required",
 					},
 				},
 			},

--- a/python/ambassador/envoy/v2/v2route.py
+++ b/python/ambassador/envoy/v2/v2route.py
@@ -305,7 +305,7 @@ class V2Route(Cacheable):
 
         runtime_fraction: Dict[str, Union[dict, str]] = {
             'default_value': {
-                'numerator': mapping.get('weight', 100),
+                'numerator': mapping.get('_weight', 100),
                 'denominator': 'HUNDRED'
             }
         }

--- a/python/ambassador/envoy/v3/v3route.py
+++ b/python/ambassador/envoy/v3/v3route.py
@@ -293,7 +293,7 @@ class V3Route(Cacheable):
 
         runtime_fraction: Dict[str, Union[dict, str]] = {
             'default_value': {
-                'numerator': mapping.get('weight', 100),
+                'numerator': mapping.get('_weight', 100),
                 'denominator': 'HUNDRED'
             }
         }

--- a/python/ambassador/envoy/v3/v3route.py
+++ b/python/ambassador/envoy/v3/v3route.py
@@ -616,7 +616,7 @@ class V3Route(Cacheable):
 
             config.cache.add(route)
             config.cache.link(irgroup, route)
-            config.cache.dump("V2Route synth %s: %s", cache_key, v3prettyroute(route))
+            config.cache.dump("V3Route synth %s: %s", cache_key, v3prettyroute(route))
         else:
             # Cache hit. We know a priori that it's a V3Route, but let's assert that
             # before casting.

--- a/python/ambassador/ir/ircors.py
+++ b/python/ambassador/ir/ircors.py
@@ -1,4 +1,4 @@
-from typing import Any, TYPE_CHECKING
+from typing import Any, Dict, TYPE_CHECKING
 
 import copy
 
@@ -20,34 +20,43 @@ class IRCORS (IRResource):
                  **kwargs) -> None:
         # print("IRCORS __init__ (%s %s %s)" % (kind, name, kwargs))
 
-        super().__init__(
-            ir=ir, aconf=aconf, rkey=rkey, kind=kind, name=name,
-            **kwargs
-        )
+        # Convert our incoming kwargs into the things that Envoy actually wants.
+        # Note that we have to treat 'origins' specially here, so that comes after
+        # this renaming loop.
 
-    def setup(self, ir: 'IR', aconf: Config) -> bool:
-        # 'origins' cannot be treated like other keys, because if it's a
-        # list, then it remains as is, but if it's a string, then it's
-        # converted to a list.  It has already been validated by the
-        # JSON schema to either be a string or a list of strings.
-        origins = self.pop('origins', None)
-
-        if origins is not None:
-            if type(origins) is not list:
-                origins = origins.split(',')
-
-            self.allow_origin_string_match = [{'exact': origin} for origin in origins]
+        new_kwargs: Dict[str, Any] = {}
 
         for from_key, to_key in [ ( 'max_age', 'max_age' ),
                                   ( 'credentials', 'allow_credentials' ),
                                   ( 'methods', 'allow_methods' ),
                                   ( 'headers', 'allow_headers' ),
                                   ( 'exposed_headers', 'expose_headers' ) ]:
-            value = self.pop(from_key, None)
+            value = kwargs.get(from_key, None)
 
             if value:
-                self[to_key] = self._cors_normalize(value)
+                new_kwargs[to_key] = self._cors_normalize(value)
 
+        # 'origins' cannot be treated like other keys, because if it's a
+        # list, then it remains as is, but if it's a string, then it's
+        # converted to a list.  It has already been validated by the fetcher
+        # to either be a string or a list of strings.
+        #
+        # (In fact in v3alpha1 it _must_ be a list of strings, but if the
+        # resource was in an annotation, it might be a string.)
+        origins = kwargs.get('origins', None)
+
+        if origins is not None:
+            if type(origins) is not list:
+                origins = origins.split(',')
+
+            new_kwargs['allow_origin_string_match'] = [{'exact': origin} for origin in origins]
+
+        super().__init__(
+            ir=ir, aconf=aconf, rkey=rkey, kind=kind, name=name,
+            **new_kwargs
+        )
+
+    def setup(self, ir: 'IR', aconf: Config) -> bool:
         # This IRCORS has not been finalized with an ID, so leave with an 'unset' ID so far.
         self.set_id('unset')
 

--- a/python/ambassador/ir/irhttpmappinggroup.py
+++ b/python/ambassador/ir/irhttpmappinggroup.py
@@ -233,7 +233,7 @@ class IRHTTPMappingGroup (IRBaseMappingGroup):
                 assert(isinstance(cached_cluster, IRCluster))
                 cluster = cached_cluster
 
-                self.ir.logger.debug(f"IRHTTPMappingGroup: got Cluster from cache for {mapping.cluster_key}")
+                self.ir.logger.debug(f"IRHTTPMappingGroup: got Cluster from cache for {mapping.cluster_key}")
 
         if not cluster:
             # OK, we have to actually do some work.

--- a/python/ambassador/ir/irtcpmappinggroup.py
+++ b/python/ambassador/ir/irtcpmappinggroup.py
@@ -123,7 +123,7 @@ class IRTCPMappingGroup (IRBaseMappingGroup):
                 assert(isinstance(cached_cluster, IRCluster))
                 cluster = cached_cluster
 
-                self.ir.logger.debug(f"IRTCPMappingGroup: got Cluster from cache for {mapping.cluster_key}")
+                self.ir.logger.debug(f"IRTCPMappingGroup: got Cluster from cache for {mapping.cluster_key}")
 
         if not cluster:
             # Find or create the cluster for this Mapping...

--- a/vendor/k8s.io/kube-openapi/pkg/validation/validate/type.go
+++ b/vendor/k8s.io/kube-openapi/pkg/validation/validate/type.go
@@ -132,7 +132,7 @@ func (t *typeValidator) Applies(source interface{}, kind reflect.Kind) bool {
 func (t *typeValidator) Validate(data interface{}) *Result {
 	result := new(Result)
 	result.Inc()
-	if data == nil || reflect.DeepEqual(reflect.Zero(reflect.TypeOf(data)), reflect.ValueOf(data)) {
+	if data == nil {
 		// nil or zero value for the passed structure require Type: null
 		if len(t.Type) > 0 && !t.Type.Contains(nullType) && !t.Nullable { // TODO: if a property is not required it also passes this
 			return errorHelp.sErr(errors.InvalidType(t.Path, t.In, strings.Join(t.Type, ","), nullType))

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -814,7 +814,7 @@ k8s.io/gengo/types
 # k8s.io/klog/v2 v2.10.0
 ## explicit; go 1.13
 k8s.io/klog/v2
-# k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd
+# k8s.io/kube-openapi v0.0.0-20210304212320-e467f52fd9db
 ## explicit; go 1.12
 k8s.io/kube-openapi/pkg/common
 k8s.io/kube-openapi/pkg/util/proto


### PR DESCRIPTION
Fixes for 2.1.2. This used to be #4022, but GitHub didn't read my mind when I rebased onto `flynn/dev/buildkit-2` and closed `flynn/dev/buildkit-test`. D'oh!

Best to review this commit-by-commit:
f34cf759d: Disable fail-fast in the `pytest` matrix -- it causes us more harm than good right now
34a438987: Two places had \u00A0 (non-breaking space) where they should've had \u0020 (space).
719814a14: pkg/kates/validation.go: Use modern error packages
35ebdf24f: Make sure that CORS Envoy-config generation doesn't include fields that aren't correct Envoy configuration
6700c1cf2: Upgrade `k8s.io/kube-openapi` to fix support for `rewrite: ""` in a `Mapping`
47c1c442c: Log conversion-request inputs & outputs in `apiext` if debugging is enabled
dd182079d: Use the correct mapping weight when generating Envoy routes (!! -- how did CI not find this??)

 - [x] I made sure to update `CHANGELOG.md`.
 - [x] This is unlikely to impact how Ambassador performs at scale.
 - [ ] My change is adequately tested.
 - [x] I didn't need to update `DEVELOPING.md`.
