### PR TITLE
Add mapping redirect regression fix into rel2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,11 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 - Change: Docker BuildKit is enabled for all Emissary builds. Additionally, the Go build cache is
   fully enabled when building images, speeding up repeated builds.
 
+- Bugfix: Any `Mapping` that uses the `host_redirect` field is now properly discovered and used.
+  Thanks  to <a href="https://github.com/gferon">Gabriel Féron</a> for contributing this bugfix!  ([3709])
+
+[3709]: https://github.com/emissary-ingress/emissary/issues/3709
+
 ## 2.1.1 not issued
 
 *Emissary-ingress 2.1.1 was not issued; Ambassador Edge Stack 2.1.1 uses Emissary-ingress 2.1.0.*

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -42,6 +42,16 @@ items:
           build cache is fully enabled when building images, speeding up repeated builds.
         docs: https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/syntax.md
 
+      - title: Correctly use Mappings with host redirects
+        type: bugfix
+        body: >-
+          Any <code>Mapping</code> that uses the <code>host_redirect</code> field is now properly discovered and used. Thanks 
+          to <a href="https://github.com/gferon">Gabriel Féron</a> for contributing this bugfix! 
+        github:
+        - title: 3709
+          link: https://github.com/emissary-ingress/emissary/issues/3709
+        docs: https://github.com/emissary-ingress/emissary/issues/3709
+
   - version: 2.1.1
     date: 'N/A'
     notes:

--- a/python/ambassador/ir/irhost.py
+++ b/python/ambassador/ir/irhost.py
@@ -383,7 +383,12 @@ class IRHost(IRResource):
         else:
             # It is NOT A TYPO that we use group.get("host") here -- whether the Mapping supplies
             # "hostname" or "host", the Mapping code normalizes to "host" internally.
-            group_glob = group.get('host') or None  # NOT A TYPO: see above.
+
+            # It's possible for group.host_redirect to be None instead of missing, and it's also
+            # conceivably possible for group.host_redirect.host to be "", which we'd rather be 
+            # None. Hence we do this two-line dance to massage the various cases.
+            host_redirecct = (group.get('host_redirect') or {}).get('host')
+            group_glob = group.get('host') or host_redirecct  # NOT A TYPO: see above.
 
             if group_glob:
                 host_match = hostglob_matches(self.hostname, group_glob)

--- a/python/tests/gold/plain/snapshots/econf.json
+++ b/python/tests/gold/plain/snapshots/econf.json
@@ -2596,6 +2596,68 @@
                                   "name": "x-forwarded-proto"
                                 }
                               ],
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                }
+                              },
+                              "safe_regex": {
+                                "google_re2": {
+                                  "max_program_size": 200
+                                },
+                                "regex": "/HostRedirectMapping-5/assets/([a-f0-9]{12})/images"
+                              }
+                            },
+                            "redirect": {
+                              "host_redirect": "foobar.com",
+                              "regex_rewrite": {
+                                "pattern": {
+                                  "google_re2": {},
+                                  "regex": "/HostRedirectMapping-5/assets/([a-f0-9]{12})/images"
+                                },
+                                "substitution": "/images/\\1"
+                              },
+                              "response_code": 4
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                }
+                              },
+                              "safe_regex": {
+                                "google_re2": {
+                                  "max_program_size": 200
+                                },
+                                "regex": "/HostRedirectMapping-5/assets/([a-f0-9]{12})/images"
+                              }
+                            },
+                            "redirect": {
+                              "host_redirect": "foobar.com",
+                              "regex_rewrite": {
+                                "pattern": {
+                                  "google_re2": {},
+                                  "regex": "/HostRedirectMapping-5/assets/([a-f0-9]{12})/images"
+                                },
+                                "substitution": "/images/\\1"
+                              },
+                              "response_code": 4
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "headers": [
+                                {
+                                  "exact_match": "https",
+                                  "name": "x-forwarded-proto"
+                                }
+                              ],
                               "prefix": "/SimpleMapping-HTTP-AddResponseHeaders-zoo-bar/",
                               "runtime_fraction": {
                                 "default_value": {
@@ -4292,6 +4354,46 @@
                                   "name": "x-forwarded-proto"
                                 }
                               ],
+                              "prefix": "/HostRedirectMapping-4/foo/bar/baz",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                }
+                              }
+                            },
+                            "redirect": {
+                              "host_redirect": "foobar.com",
+                              "prefix_rewrite": "/foobar/baz",
+                              "response_code": 3
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "prefix": "/HostRedirectMapping-4/foo/bar/baz",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                }
+                              }
+                            },
+                            "redirect": {
+                              "host_redirect": "foobar.com",
+                              "prefix_rewrite": "/foobar/baz",
+                              "response_code": 3
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "headers": [
+                                {
+                                  "exact_match": "https",
+                                  "name": "x-forwarded-proto"
+                                }
+                              ],
                               "prefix": "/SimpleMapping-HTTP-UseWebsocket/",
                               "runtime_fraction": {
                                 "default_value": {
@@ -5149,6 +5251,46 @@
                               "prefix_rewrite": "/",
                               "priority": null,
                               "timeout": "3.000s"
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "headers": [
+                                {
+                                  "exact_match": "https",
+                                  "name": "x-forwarded-proto"
+                                }
+                              ],
+                              "prefix": "/HostRedirectMapping-3/foo/",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                }
+                              }
+                            },
+                            "redirect": {
+                              "host_redirect": "foobar.com",
+                              "path_redirect": "/redirect/",
+                              "response_code": 1
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "prefix": "/HostRedirectMapping-3/foo/",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                }
+                              }
+                            },
+                            "redirect": {
+                              "host_redirect": "foobar.com",
+                              "path_redirect": "/redirect/",
+                              "response_code": 1
                             }
                           },
                           {
@@ -7073,6 +7215,42 @@
                           },
                           {
                             "match": {
+                              "case_sensitive": false,
+                              "headers": [
+                                {
+                                  "exact_match": "https",
+                                  "name": "x-forwarded-proto"
+                                }
+                              ],
+                              "prefix": "/HostRedirectMapping-2/",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                }
+                              }
+                            },
+                            "redirect": {
+                              "host_redirect": "foobar.com"
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": false,
+                              "prefix": "/HostRedirectMapping-2/",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                }
+                              }
+                            },
+                            "redirect": {
+                              "host_redirect": "foobar.com"
+                            }
+                          },
+                          {
+                            "match": {
                               "case_sensitive": true,
                               "headers": [
                                 {
@@ -7597,6 +7775,42 @@
                               "prefix_rewrite": "/",
                               "priority": null,
                               "timeout": "3.000s"
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "headers": [
+                                {
+                                  "exact_match": "https",
+                                  "name": "x-forwarded-proto"
+                                }
+                              ],
+                              "prefix": "/HostRedirectMapping/",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                }
+                              }
+                            },
+                            "redirect": {
+                              "host_redirect": "foobar.com"
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "prefix": "/HostRedirectMapping/",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                }
+                              }
+                            },
+                            "redirect": {
+                              "host_redirect": "foobar.com"
                             }
                           },
                           {
@@ -7793,6 +8007,68 @@
                                   "name": "x-forwarded-proto"
                                 }
                               ],
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                }
+                              },
+                              "safe_regex": {
+                                "google_re2": {
+                                  "max_program_size": 200
+                                },
+                                "regex": "/HostRedirectMapping-5/assets/([a-f0-9]{12})/images"
+                              }
+                            },
+                            "redirect": {
+                              "host_redirect": "foobar.com",
+                              "regex_rewrite": {
+                                "pattern": {
+                                  "google_re2": {},
+                                  "regex": "/HostRedirectMapping-5/assets/([a-f0-9]{12})/images"
+                                },
+                                "substitution": "/images/\\1"
+                              },
+                              "response_code": 4
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                }
+                              },
+                              "safe_regex": {
+                                "google_re2": {
+                                  "max_program_size": 200
+                                },
+                                "regex": "/HostRedirectMapping-5/assets/([a-f0-9]{12})/images"
+                              }
+                            },
+                            "redirect": {
+                              "host_redirect": "foobar.com",
+                              "regex_rewrite": {
+                                "pattern": {
+                                  "google_re2": {},
+                                  "regex": "/HostRedirectMapping-5/assets/([a-f0-9]{12})/images"
+                                },
+                                "substitution": "/images/\\1"
+                              },
+                              "response_code": 4
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "headers": [
+                                {
+                                  "exact_match": "https",
+                                  "name": "x-forwarded-proto"
+                                }
+                              ],
                               "prefix": "/SimpleMapping-HTTP-AddResponseHeaders-zoo-bar/",
                               "runtime_fraction": {
                                 "default_value": {
@@ -9489,6 +9765,46 @@
                                   "name": "x-forwarded-proto"
                                 }
                               ],
+                              "prefix": "/HostRedirectMapping-4/foo/bar/baz",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                }
+                              }
+                            },
+                            "redirect": {
+                              "host_redirect": "foobar.com",
+                              "prefix_rewrite": "/foobar/baz",
+                              "response_code": 3
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "prefix": "/HostRedirectMapping-4/foo/bar/baz",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                }
+                              }
+                            },
+                            "redirect": {
+                              "host_redirect": "foobar.com",
+                              "prefix_rewrite": "/foobar/baz",
+                              "response_code": 3
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "headers": [
+                                {
+                                  "exact_match": "https",
+                                  "name": "x-forwarded-proto"
+                                }
+                              ],
                               "prefix": "/SimpleMapping-HTTP-UseWebsocket/",
                               "runtime_fraction": {
                                 "default_value": {
@@ -10346,6 +10662,46 @@
                               "prefix_rewrite": "/",
                               "priority": null,
                               "timeout": "3.000s"
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "headers": [
+                                {
+                                  "exact_match": "https",
+                                  "name": "x-forwarded-proto"
+                                }
+                              ],
+                              "prefix": "/HostRedirectMapping-3/foo/",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                }
+                              }
+                            },
+                            "redirect": {
+                              "host_redirect": "foobar.com",
+                              "path_redirect": "/redirect/",
+                              "response_code": 1
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "prefix": "/HostRedirectMapping-3/foo/",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                }
+                              }
+                            },
+                            "redirect": {
+                              "host_redirect": "foobar.com",
+                              "path_redirect": "/redirect/",
+                              "response_code": 1
                             }
                           },
                           {
@@ -12270,6 +12626,42 @@
                           },
                           {
                             "match": {
+                              "case_sensitive": false,
+                              "headers": [
+                                {
+                                  "exact_match": "https",
+                                  "name": "x-forwarded-proto"
+                                }
+                              ],
+                              "prefix": "/HostRedirectMapping-2/",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                }
+                              }
+                            },
+                            "redirect": {
+                              "host_redirect": "foobar.com"
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": false,
+                              "prefix": "/HostRedirectMapping-2/",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                }
+                              }
+                            },
+                            "redirect": {
+                              "host_redirect": "foobar.com"
+                            }
+                          },
+                          {
+                            "match": {
                               "case_sensitive": true,
                               "headers": [
                                 {
@@ -12794,6 +13186,42 @@
                               "prefix_rewrite": "/",
                               "priority": null,
                               "timeout": "3.000s"
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "headers": [
+                                {
+                                  "exact_match": "https",
+                                  "name": "x-forwarded-proto"
+                                }
+                              ],
+                              "prefix": "/HostRedirectMapping/",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                }
+                              }
+                            },
+                            "redirect": {
+                              "host_redirect": "foobar.com"
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "prefix": "/HostRedirectMapping/",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                }
+                              }
+                            },
+                            "redirect": {
+                              "host_redirect": "foobar.com"
                             }
                           },
                           {
@@ -13010,6 +13438,68 @@
                                   "name": "x-forwarded-proto"
                                 }
                               ],
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                }
+                              },
+                              "safe_regex": {
+                                "google_re2": {
+                                  "max_program_size": 200
+                                },
+                                "regex": "/HostRedirectMapping-5/assets/([a-f0-9]{12})/images"
+                              }
+                            },
+                            "redirect": {
+                              "host_redirect": "foobar.com",
+                              "regex_rewrite": {
+                                "pattern": {
+                                  "google_re2": {},
+                                  "regex": "/HostRedirectMapping-5/assets/([a-f0-9]{12})/images"
+                                },
+                                "substitution": "/images/\\1"
+                              },
+                              "response_code": 4
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                }
+                              },
+                              "safe_regex": {
+                                "google_re2": {
+                                  "max_program_size": 200
+                                },
+                                "regex": "/HostRedirectMapping-5/assets/([a-f0-9]{12})/images"
+                              }
+                            },
+                            "redirect": {
+                              "host_redirect": "foobar.com",
+                              "regex_rewrite": {
+                                "pattern": {
+                                  "google_re2": {},
+                                  "regex": "/HostRedirectMapping-5/assets/([a-f0-9]{12})/images"
+                                },
+                                "substitution": "/images/\\1"
+                              },
+                              "response_code": 4
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "headers": [
+                                {
+                                  "exact_match": "https",
+                                  "name": "x-forwarded-proto"
+                                }
+                              ],
                               "prefix": "/SimpleMapping-HTTP-AddResponseHeaders-zoo-bar/",
                               "runtime_fraction": {
                                 "default_value": {
@@ -14706,6 +15196,46 @@
                                   "name": "x-forwarded-proto"
                                 }
                               ],
+                              "prefix": "/HostRedirectMapping-4/foo/bar/baz",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                }
+                              }
+                            },
+                            "redirect": {
+                              "host_redirect": "foobar.com",
+                              "prefix_rewrite": "/foobar/baz",
+                              "response_code": 3
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "prefix": "/HostRedirectMapping-4/foo/bar/baz",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                }
+                              }
+                            },
+                            "redirect": {
+                              "host_redirect": "foobar.com",
+                              "prefix_rewrite": "/foobar/baz",
+                              "response_code": 3
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "headers": [
+                                {
+                                  "exact_match": "https",
+                                  "name": "x-forwarded-proto"
+                                }
+                              ],
                               "prefix": "/SimpleMapping-HTTP-UseWebsocket/",
                               "runtime_fraction": {
                                 "default_value": {
@@ -15563,6 +16093,46 @@
                               "prefix_rewrite": "/",
                               "priority": null,
                               "timeout": "3.000s"
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "headers": [
+                                {
+                                  "exact_match": "https",
+                                  "name": "x-forwarded-proto"
+                                }
+                              ],
+                              "prefix": "/HostRedirectMapping-3/foo/",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                }
+                              }
+                            },
+                            "redirect": {
+                              "host_redirect": "foobar.com",
+                              "path_redirect": "/redirect/",
+                              "response_code": 1
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "prefix": "/HostRedirectMapping-3/foo/",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                }
+                              }
+                            },
+                            "redirect": {
+                              "host_redirect": "foobar.com",
+                              "path_redirect": "/redirect/",
+                              "response_code": 1
                             }
                           },
                           {
@@ -17487,6 +18057,42 @@
                           },
                           {
                             "match": {
+                              "case_sensitive": false,
+                              "headers": [
+                                {
+                                  "exact_match": "https",
+                                  "name": "x-forwarded-proto"
+                                }
+                              ],
+                              "prefix": "/HostRedirectMapping-2/",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                }
+                              }
+                            },
+                            "redirect": {
+                              "host_redirect": "foobar.com"
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": false,
+                              "prefix": "/HostRedirectMapping-2/",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                }
+                              }
+                            },
+                            "redirect": {
+                              "host_redirect": "foobar.com"
+                            }
+                          },
+                          {
+                            "match": {
                               "case_sensitive": true,
                               "headers": [
                                 {
@@ -18011,6 +18617,42 @@
                               "prefix_rewrite": "/",
                               "priority": null,
                               "timeout": "3.000s"
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "headers": [
+                                {
+                                  "exact_match": "https",
+                                  "name": "x-forwarded-proto"
+                                }
+                              ],
+                              "prefix": "/HostRedirectMapping/",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                }
+                              }
+                            },
+                            "redirect": {
+                              "host_redirect": "foobar.com"
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "prefix": "/HostRedirectMapping/",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                }
+                              }
+                            },
+                            "redirect": {
+                              "host_redirect": "foobar.com"
                             }
                           },
                           {
@@ -18207,6 +18849,68 @@
                                   "name": "x-forwarded-proto"
                                 }
                               ],
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                }
+                              },
+                              "safe_regex": {
+                                "google_re2": {
+                                  "max_program_size": 200
+                                },
+                                "regex": "/HostRedirectMapping-5/assets/([a-f0-9]{12})/images"
+                              }
+                            },
+                            "redirect": {
+                              "host_redirect": "foobar.com",
+                              "regex_rewrite": {
+                                "pattern": {
+                                  "google_re2": {},
+                                  "regex": "/HostRedirectMapping-5/assets/([a-f0-9]{12})/images"
+                                },
+                                "substitution": "/images/\\1"
+                              },
+                              "response_code": 4
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                }
+                              },
+                              "safe_regex": {
+                                "google_re2": {
+                                  "max_program_size": 200
+                                },
+                                "regex": "/HostRedirectMapping-5/assets/([a-f0-9]{12})/images"
+                              }
+                            },
+                            "redirect": {
+                              "host_redirect": "foobar.com",
+                              "regex_rewrite": {
+                                "pattern": {
+                                  "google_re2": {},
+                                  "regex": "/HostRedirectMapping-5/assets/([a-f0-9]{12})/images"
+                                },
+                                "substitution": "/images/\\1"
+                              },
+                              "response_code": 4
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "headers": [
+                                {
+                                  "exact_match": "https",
+                                  "name": "x-forwarded-proto"
+                                }
+                              ],
                               "prefix": "/SimpleMapping-HTTP-AddResponseHeaders-zoo-bar/",
                               "runtime_fraction": {
                                 "default_value": {
@@ -19903,6 +20607,46 @@
                                   "name": "x-forwarded-proto"
                                 }
                               ],
+                              "prefix": "/HostRedirectMapping-4/foo/bar/baz",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                }
+                              }
+                            },
+                            "redirect": {
+                              "host_redirect": "foobar.com",
+                              "prefix_rewrite": "/foobar/baz",
+                              "response_code": 3
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "prefix": "/HostRedirectMapping-4/foo/bar/baz",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                }
+                              }
+                            },
+                            "redirect": {
+                              "host_redirect": "foobar.com",
+                              "prefix_rewrite": "/foobar/baz",
+                              "response_code": 3
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "headers": [
+                                {
+                                  "exact_match": "https",
+                                  "name": "x-forwarded-proto"
+                                }
+                              ],
                               "prefix": "/SimpleMapping-HTTP-UseWebsocket/",
                               "runtime_fraction": {
                                 "default_value": {
@@ -20760,6 +21504,46 @@
                               "prefix_rewrite": "/",
                               "priority": null,
                               "timeout": "3.000s"
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "headers": [
+                                {
+                                  "exact_match": "https",
+                                  "name": "x-forwarded-proto"
+                                }
+                              ],
+                              "prefix": "/HostRedirectMapping-3/foo/",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                }
+                              }
+                            },
+                            "redirect": {
+                              "host_redirect": "foobar.com",
+                              "path_redirect": "/redirect/",
+                              "response_code": 1
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "prefix": "/HostRedirectMapping-3/foo/",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                }
+                              }
+                            },
+                            "redirect": {
+                              "host_redirect": "foobar.com",
+                              "path_redirect": "/redirect/",
+                              "response_code": 1
                             }
                           },
                           {
@@ -22684,6 +23468,42 @@
                           },
                           {
                             "match": {
+                              "case_sensitive": false,
+                              "headers": [
+                                {
+                                  "exact_match": "https",
+                                  "name": "x-forwarded-proto"
+                                }
+                              ],
+                              "prefix": "/HostRedirectMapping-2/",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                }
+                              }
+                            },
+                            "redirect": {
+                              "host_redirect": "foobar.com"
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": false,
+                              "prefix": "/HostRedirectMapping-2/",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                }
+                              }
+                            },
+                            "redirect": {
+                              "host_redirect": "foobar.com"
+                            }
+                          },
+                          {
+                            "match": {
                               "case_sensitive": true,
                               "headers": [
                                 {
@@ -23208,6 +24028,42 @@
                               "prefix_rewrite": "/",
                               "priority": null,
                               "timeout": "3.000s"
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "headers": [
+                                {
+                                  "exact_match": "https",
+                                  "name": "x-forwarded-proto"
+                                }
+                              ],
+                              "prefix": "/HostRedirectMapping/",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                }
+                              }
+                            },
+                            "redirect": {
+                              "host_redirect": "foobar.com"
+                            }
+                          },
+                          {
+                            "match": {
+                              "case_sensitive": true,
+                              "prefix": "/HostRedirectMapping/",
+                              "runtime_fraction": {
+                                "default_value": {
+                                  "denominator": "HUNDRED",
+                                  "numerator": 100
+                                }
+                              }
+                            },
+                            "redirect": {
+                              "host_redirect": "foobar.com"
                             }
                           },
                           {

--- a/python/tests/kat/t_mappingtests_plain.py
+++ b/python/tests/kat/t_mappingtests_plain.py
@@ -373,9 +373,6 @@ class HostRedirectMapping(MappingTest):
     target: ServiceType
 
     def init(self):
-        # Skip until fixing the hostglob thing.
-        self.skip_node = True
-
         MappingTest.init(self, HTTP())
 
     def config(self) -> Generator[Union[str, Tuple[Node, str]], None, None]:


### PR DESCRIPTION
## Description
Cherry picking a community contribution and making a small change to the tests so they actually run now so we can get this out in the next release.

## Related Issues
Original Contribution: https://github.com/emissary-ingress/emissary/pull/4004
Related issues: 
https://github.com/emissary-ingress/emissary/issues/3709
https://github.com/emissary-ingress/emissary/issues/4005

## Testing
We already had tests that should have discovered that this regression occurred, but those tests were set to not run. I've re-enabled them and updated the gold test config to account for the fact that the redirects are now showing up in the Envoy config.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `CHANGELOG.md`.
   
   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations
 
 - [x] This is unlikely to impact how Ambassador performs at scale.
 
   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability
 
 - [x] My change is adequately tested.
 
   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points
 
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.