### PR TITLE
Better tests (and another fix!) for mapping weights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,9 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 - Bugfix: Changes to the `weight` of `Mapping` in a canary group will now always be correctly
   managed during reconfiguration; such changes could have been missed in earlier releases.
 
+- Bugfix: A `Mapping` that is not part of a canary group, but that has a `weight` less than 100,
+  will be correctly configured to receive all traffic as if the `weight` were 100.
+
 - Bugfix: Using `rewrite: ""` in a `Mapping` is correctly handled to mean "do not rewrite the path
   at all".
 

--- a/cmd/entrypoint/testutil_fake_findutils_test.go
+++ b/cmd/entrypoint/testutil_fake_findutils_test.go
@@ -41,10 +41,10 @@ func mustFindListenerByName(t *testing.T, envoyConfig *bootstrap.Bootstrap, name
 	return listener
 }
 
-func findVirtualHostRoute(listener *v3listener.Listener, predicate func(*route.Route) bool) []*route.Route {
+func findRoutes(listener *v3listener.Listener, predicate func(*route.Route) bool) []*route.Route {
 	routes := make([]*route.Route, 0)
 
-	// fmt.Printf("---- findVirtualHostRoute\n")
+	// fmt.Printf("---- findRoutes\n")
 
 	for _, chain := range listener.FilterChains {
 		for _, filter := range chain.Filters {
@@ -77,8 +77,8 @@ func findVirtualHostRoute(listener *v3listener.Listener, predicate func(*route.R
 	return routes
 }
 
-func findVirtualHostRouteAction(listener *v3listener.Listener, predicate func(*route.RouteAction) bool) *route.RouteAction {
-	routes := findVirtualHostRoute(listener, func(r *route.Route) bool {
+func findRouteAction(listener *v3listener.Listener, predicate func(*route.RouteAction) bool) *route.RouteAction {
+	routes := findRoutes(listener, func(r *route.Route) bool {
 		routeAction, ok := r.Action.(*route.Route_Route)
 
 		if ok {

--- a/cmd/entrypoint/testutil_fake_findutils_test.go
+++ b/cmd/entrypoint/testutil_fake_findutils_test.go
@@ -1,13 +1,45 @@
 package entrypoint_test
 
 import (
+	"testing"
+
 	bootstrap "github.com/datawire/ambassador/v2/pkg/api/envoy/config/bootstrap/v3"
 	v3listener "github.com/datawire/ambassador/v2/pkg/api/envoy/config/listener/v3"
 	route "github.com/datawire/ambassador/v2/pkg/api/envoy/config/route/v3"
 	http "github.com/datawire/ambassador/v2/pkg/api/envoy/extensions/filters/network/http_connection_manager/v3"
 	"github.com/datawire/ambassador/v2/pkg/envoy-control-plane/resource/v3"
 	"github.com/datawire/ambassador/v2/pkg/envoy-control-plane/wellknown"
+	"github.com/stretchr/testify/assert"
 )
+
+// findListener finds the first listener in a given Envoy configuration that matches a
+// given predicate. If no listener is found, nil is returned.
+//
+// Obviously, in a perfect world, the given predicate would be constructed to match only
+// a single listener...
+func findListener(envoyConfig *bootstrap.Bootstrap, predicate func(*v3listener.Listener) bool) *v3listener.Listener {
+	for _, listener := range envoyConfig.StaticResources.Listeners {
+		if predicate(listener) {
+			return listener
+		}
+	}
+	return nil
+}
+
+// findListenerByName finds uses findListener to find a listener with a given name.
+func findListenerByName(envoyConfig *bootstrap.Bootstrap, name string) *v3listener.Listener {
+	return findListener(envoyConfig, func(listener *v3listener.Listener) bool {
+		return listener.Name == name
+	})
+}
+
+// mustFindListenerByName looks for a listener with a given name, and asserts that it
+// must be present.
+func mustFindListenerByName(t *testing.T, envoyConfig *bootstrap.Bootstrap, name string) *v3listener.Listener {
+	listener := findListenerByName(envoyConfig, name)
+	assert.NotNil(t, listener)
+	return listener
+}
 
 func findVirtualHostRoute(listener *v3listener.Listener, predicate func(*route.Route) bool) []*route.Route {
 	routes := make([]*route.Route, 0)
@@ -61,13 +93,4 @@ func findVirtualHostRouteAction(listener *v3listener.Listener, predicate func(*r
 	}
 
 	return routes[0].Action.(*route.Route_Route).Route
-}
-
-func findListener(envoyConfig *bootstrap.Bootstrap, predicate func(*v3listener.Listener) bool) *v3listener.Listener {
-	for _, listener := range envoyConfig.StaticResources.Listeners {
-		if predicate(listener) {
-			return listener
-		}
-	}
-	return nil
 }

--- a/cmd/entrypoint/testutil_fake_findutils_test.go
+++ b/cmd/entrypoint/testutil_fake_findutils_test.go
@@ -1,0 +1,73 @@
+package entrypoint_test
+
+import (
+	bootstrap "github.com/datawire/ambassador/v2/pkg/api/envoy/config/bootstrap/v3"
+	v3listener "github.com/datawire/ambassador/v2/pkg/api/envoy/config/listener/v3"
+	route "github.com/datawire/ambassador/v2/pkg/api/envoy/config/route/v3"
+	http "github.com/datawire/ambassador/v2/pkg/api/envoy/extensions/filters/network/http_connection_manager/v3"
+	"github.com/datawire/ambassador/v2/pkg/envoy-control-plane/resource/v3"
+	"github.com/datawire/ambassador/v2/pkg/envoy-control-plane/wellknown"
+)
+
+func findVirtualHostRoute(listener *v3listener.Listener, predicate func(*route.Route) bool) []*route.Route {
+	routes := make([]*route.Route, 0)
+
+	// fmt.Printf("---- findVirtualHostRoute\n")
+
+	for _, chain := range listener.FilterChains {
+		for _, filter := range chain.Filters {
+			if filter.Name != wellknown.HTTPConnectionManager {
+				continue
+			}
+
+			hcm := resource.GetHTTPConnectionManager(filter)
+
+			if hcm != nil {
+				rs, ok := hcm.RouteSpecifier.(*http.HttpConnectionManager_RouteConfig)
+
+				if ok {
+					for _, vh := range rs.RouteConfig.VirtualHosts {
+						for _, vhr := range vh.Routes {
+							// if !(strings.HasPrefix(vhr.Match.GetPrefix(), "/ambassador/")) {
+							// 	fmt.Printf("ROUTE: #%v\n", vhr)
+							// }
+
+							if predicate(vhr) {
+								routes = append(routes, vhr)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return routes
+}
+
+func findVirtualHostRouteAction(listener *v3listener.Listener, predicate func(*route.RouteAction) bool) *route.RouteAction {
+	routes := findVirtualHostRoute(listener, func(r *route.Route) bool {
+		routeAction, ok := r.Action.(*route.Route_Route)
+
+		if ok {
+			return predicate(routeAction.Route)
+		}
+
+		return false
+	})
+
+	if len(routes) == 0 {
+		return nil
+	}
+
+	return routes[0].Action.(*route.Route_Route).Route
+}
+
+func findListener(envoyConfig *bootstrap.Bootstrap, predicate func(*v3listener.Listener) bool) *v3listener.Listener {
+	for _, listener := range envoyConfig.StaticResources.Listeners {
+		if predicate(listener) {
+			return listener
+		}
+	}
+	return nil
+}

--- a/cmd/entrypoint/testutil_fake_mapping_cors_test.go
+++ b/cmd/entrypoint/testutil_fake_mapping_cors_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/datawire/ambassador/v2/cmd/entrypoint"
 	bootstrap "github.com/datawire/ambassador/v2/pkg/api/envoy/config/bootstrap/v3"
-	v3listener "github.com/datawire/ambassador/v2/pkg/api/envoy/config/listener/v3"
 	route "github.com/datawire/ambassador/v2/pkg/api/envoy/config/route/v3"
 
 	"github.com/stretchr/testify/assert"
@@ -69,11 +68,7 @@ spec:
 
 	assert.NoError(t, err)
 
-	listener := findListener(config, func(l *v3listener.Listener) bool {
-		return l.Name == "ambassador-listener-8080"
-	})
-
-	assert.NotNil(t, listener)
+	listener := mustFindListenerByName(t, config, "ambassador-listener-8080")
 
 	// Here we're looking for a route whose _action_ is to route to the cluster we want.
 	routeAction := findVirtualHostRouteAction(listener, func(r *route.RouteAction) bool {

--- a/cmd/entrypoint/testutil_fake_mapping_cors_test.go
+++ b/cmd/entrypoint/testutil_fake_mapping_cors_test.go
@@ -71,7 +71,7 @@ spec:
 	listener := mustFindListenerByName(t, config, "ambassador-listener-8080")
 
 	// Here we're looking for a route whose _action_ is to route to the cluster we want.
-	routeAction := findVirtualHostRouteAction(listener, func(r *route.RouteAction) bool {
+	routeAction := findRouteAction(listener, func(r *route.RouteAction) bool {
 		return r.GetCluster() == "cluster_foo_default_default"
 	})
 	assert.NotNil(t, routeAction)

--- a/cmd/entrypoint/testutil_fake_mapping_cors_test.go
+++ b/cmd/entrypoint/testutil_fake_mapping_cors_test.go
@@ -7,9 +7,6 @@ import (
 	bootstrap "github.com/datawire/ambassador/v2/pkg/api/envoy/config/bootstrap/v3"
 	v3listener "github.com/datawire/ambassador/v2/pkg/api/envoy/config/listener/v3"
 	route "github.com/datawire/ambassador/v2/pkg/api/envoy/config/route/v3"
-	http "github.com/datawire/ambassador/v2/pkg/api/envoy/extensions/filters/network/http_connection_manager/v3"
-	"github.com/datawire/ambassador/v2/pkg/envoy-control-plane/resource/v3"
-	"github.com/datawire/ambassador/v2/pkg/envoy-control-plane/wellknown"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -78,7 +75,8 @@ spec:
 
 	assert.NotNil(t, listener)
 
-	routeAction := findVirtualHostRoute(listener, func(r *route.RouteAction) bool {
+	// Here we're looking for a route whose _action_ is to route to the cluster we want.
+	routeAction := findVirtualHostRouteAction(listener, func(r *route.RouteAction) bool {
 		return r.GetCluster() == "cluster_foo_default_default"
 	})
 	assert.NotNil(t, routeAction)
@@ -88,42 +86,4 @@ spec:
 		assert.Contains(t, []string{"bar.example.com", "foo.example.com"}, m.GetExact())
 
 	}
-}
-
-func findVirtualHostRoute(listener *v3listener.Listener, predicate func(*route.RouteAction) bool) *route.RouteAction {
-	for _, fc := range listener.FilterChains {
-		for _, filter := range fc.Filters {
-			if filter.Name != wellknown.HTTPConnectionManager {
-				continue
-			}
-			hcm := resource.GetHTTPConnectionManager(filter)
-			if hcm != nil {
-				rs, ok := hcm.RouteSpecifier.(*http.HttpConnectionManager_RouteConfig)
-				if ok {
-					for _, vh := range rs.RouteConfig.VirtualHosts {
-						for _, vhr := range vh.Routes {
-							routeAction, ok := vhr.Action.(*route.Route_Route)
-							if ok {
-								if predicate(routeAction.Route) {
-									return routeAction.Route
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-
-	}
-	return nil
-
-}
-
-func findListener(envoyConfig *bootstrap.Bootstrap, predicate func(*v3listener.Listener) bool) *v3listener.Listener {
-	for _, listener := range envoyConfig.StaticResources.Listeners {
-		if predicate(listener) {
-			return listener
-		}
-	}
-	return nil
 }

--- a/cmd/entrypoint/testutil_fake_mapping_cors_test.go
+++ b/cmd/entrypoint/testutil_fake_mapping_cors_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/datawire/ambassador/v2/cmd/entrypoint"
 	bootstrap "github.com/datawire/ambassador/v2/pkg/api/envoy/config/bootstrap/v3"
-	route "github.com/datawire/ambassador/v2/pkg/api/envoy/config/route/v3"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -71,10 +70,7 @@ spec:
 	listener := mustFindListenerByName(t, config, "ambassador-listener-8080")
 
 	// Here we're looking for a route whose _action_ is to route to the cluster we want.
-	routeAction := findRouteAction(listener, func(r *route.RouteAction) bool {
-		return r.GetCluster() == "cluster_foo_default_default"
-	})
-	assert.NotNil(t, routeAction)
+	routeAction := mustFindRouteActionToCluster(t, listener, "cluster_foo_default_default")
 	assert.NotNil(t, routeAction.Cors)
 	assert.Equal(t, len(routeAction.Cors.AllowOriginStringMatch), 2)
 	for _, m := range routeAction.Cors.AllowOriginStringMatch {

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -51,6 +51,14 @@ items:
           have been missed in earlier releases.
         docs: topics/using/canary/#the-weight-attribute
 
+      - title: Correctly handle solitary Mappings with explicit weights
+        type: bugfix
+        body: >-
+          A <code>Mapping</code> that is not part of a canary group, but that has a
+          <code>weight</code> less than 100, will be correctly configured to receive all
+          traffic as if the <code>weight</code> were 100.
+        docs: topics/using/canary/#the-weight-attribute
+
       - title: Correctly handle empty rewrite in a Mapping
         type: bugfix
         body: >-


### PR DESCRIPTION
Best to review commit-by-commit: everything except the last commit is updating tests to actually test `Mapping` weights when reconfiguring `Mapping` weights.

 - [x] I made sure to update `CHANGELOG.md`.
 - [x] This is unlikely to impact how Ambassador performs at scale.
 - [x] My change is... pretty much all about testing.
 - [x] I didn't need to update `DEVELOPING.md`.
