### PR TITLE
Reenable more tests; fix a bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,10 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 - Bugfix: Using `rewrite: ""` in a `Mapping` is correctly handled to mean "do not rewrite the path
   at all".
 
+- Bugfix: `Mapping`s with DNS wildcard `hostname` will now be correctly matched with `Host`s.
+  Previously, the case where both the `Host` and the `Mapping` use DNS wildcards for their hostnames
+  could sometimes  not correctly match when they should have.
+
 - Change: Docker BuildKit is enabled for all Emissary builds. Additionally, the Go build cache is
   fully enabled when building images, speeding up repeated builds.
 

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -66,6 +66,15 @@ items:
           to mean "do not rewrite the path at all".
         docs: topics/using/rewrites
 
+      - title: Correctly handle DNS wildcards when associating Hosts and Mappings
+        type: bugfix
+        body: >-
+          <code>Mapping</code>s with DNS wildcard <code>hostname</code> will now be correctly
+          matched with <code>Host</code>s. Previously, the case where both the <code>Host</code>
+          and the <code>Mapping</code> use DNS wildcards for their hostnames could sometimes 
+          not correctly match when they should have.
+        docs: howtos/configure-communications/
+
       - title: Docker BuildKit always used for builds
         type: change
         body: >-

--- a/python/ambassador/ir/irbasemapping.py
+++ b/python/ambassador/ir/irbasemapping.py
@@ -8,7 +8,6 @@ from ..config import Config
 from ..utils import dump_json
 
 from .irresource import IRResource
-from .irutils import hostglob_matches
 
 if TYPE_CHECKING:
     from .ir import IR # pragma: no cover

--- a/python/ambassador/ir/irutils.py
+++ b/python/ambassador/ir/irutils.py
@@ -16,33 +16,148 @@ from typing import Any, Dict
 
 import logging
 
+######
+# Utilities for hostglob_matches
+#
+# hostglob_matches_start has g1 starting with '*' and g2 not ending with '*';
+# it's OK for g2 to start with a wilcard too.
+
+def hostglob_matches_start(g1: str, g2: str, g2start: bool) -> bool:
+    # Leading "*" cannot match an empty string, so unless we have a wildcard
+    # for g2, we have to have g1 longer than g2.
+
+    g1match = g1[1:]
+    g2match = g2[1:] if g2start else g2
+
+    if len(g1) > len(g2match):
+        if not g2start:
+            # logging.debug("  match start: %s is too short => False", g1)
+            return False
+
+        # Wildcards for both, so make sure we do the substring match against
+        # the longer one.
+        g1match = g2[1:]
+        g2match = g1[1:]
+
+    match = g2match.endswith(g1match)
+    # logging.debug("  match start: %s ~ %s => %s", g1match, g2match, match)
+
+    return match
+
+
+# hostglob_matches_end has g1 ending with '*' and g2 not starting with '*';
+# it's OK for g2 to end with a wilcard too.
+
+def hostglob_matches_end(g1: str, g2: str, g2end: bool) -> bool:
+    # Leading "*" cannot match an empty string, so unless we have a wildcard
+    # for g2, we have to have g1 longer than g2.
+    g1match = g1[:-1]
+    g2match = g2[:-1] if g2end else g2
+
+    if len(g1) > len(g2match):
+        if not g2end:
+            # logging.debug("  match end: %s is too short => False", g1)
+            return False
+
+        # Wildcards for both, so make sure we do the substring match against
+        # the longer one.
+        g1match = g2[:-1]
+        g2match = g1[:-1]
+
+    match = g2match.startswith(g1match)
+    # logging.debug("  match end: %s ~ %s => %s", g1match, g2match, match)
+
+    return match
+
+
 ################
-## hostglob_matches is a utility for host globbing.
 
-def hostglob_matches(glob: str, value: str) -> bool:
+def hostglob_matches(g1: str, g2: str) -> bool:
     """
-    Does a host glob match a given value?
+    hostglob_matches determines whether or not two given DNS globs are
+    compatible with each other, i.e. whether or not there can be a hostname
+    that matches both globs.
+
+    Note that it does not actually find such a hostname: a return of True
+    just means that such a hostname could exist.
     """
 
-    rc = False
+    # logging.debug("hostglob_matches: %s ~ %s", g1, g2)
 
-    if ('*' in value) and not ('*' in glob):
-        # Swap.
-        tmp = value
-        value = glob
-        glob = tmp
+    # Short-circuit: if g1 & g2 are equal, we're done here.
+    if g1 == g2:
+        # logging.debug("  equal => True")
+        return True
 
-    if glob == "*": # special wildcard
-        rc=True
-    elif glob.endswith("*"): # prefix match
-        rc=value.startswith(glob[:-1])
-    elif glob.startswith("*"): # suffix match
-        rc=value.endswith(glob[1:])
-    else: # exact match
-        rc=value == glob
+    # Next special case: if either glob is "*", then it matches everything.
+    if (g1 == "*") or (g2 == "*"):
+        # logging.debug("  \"*\" present => True")
+        return True
 
-    # sys.stderr.write(f"hostglob_matches: {value} gl~ {glob} == {rc}\n")
-    return rc
+    # Final special case: if either starts with a bare ".", that's not OK.
+    # (Ending with a bare "." is different because DNS.)
+    if g1[0] == "." or g2[0] == ".":
+        # logging.debug("  exact match starts with bare \".\" => False")
+        return False
+
+    # OK, we don't have the simple-"*" case, so any wildcards must be at
+    # the start or end, and they must be a component alone.
+    g1start = (g1[0]  == "*")
+    g1end =   (g1[-1] == "*")
+    g2start = (g2[0]  == "*")
+    g2end =   (g2[-1] == "*")
+
+    # logging.debug("  g1start=%s g1end=%s g2start=%s g2end=%s", g1start, g1end, g2start, g2end)
+
+    if (g1start and g1end) or (g2start and g2end):
+        # Not a valid DNS glob: you can't have a "*" at both ends. (If you do,
+        # Envoy will decide that the one at the start is the allowed wildcard, and
+        # treat the one at the end as a literal "*", which will match nothing.)
+        return g1 == g2
+
+    if not (g1start or g1end or g2start or g2end):
+        # No valid wildcards. and we already know that they're not equal,
+        # so this is not a match.
+        # logging.debug("  not equal => False")
+        return False
+
+    # OK, if we're here, we have a wildcard to check. There are a few cases
+    # here, so we'll start with the easy one: one value starts with "*" and 
+    # the other ends with "*", because those can always overlap as long as 
+    # the overlap between isn't empty -- and in this method, we only need to
+    # concern ourselves with being sure that there is a possibility of a match
+    # to both.
+    if (g1start and g2end) or (g2start and g1end):
+        # logging.debug("  start/end pair => True")
+        return True
+
+    # OK, now we have to actually do some work. Again, we really only have to
+    # be convinced that it's possible for something to match, so e.g. 
+    #
+    # *example.com, example.com
+    #
+    # is not a valid pair, because that "*" must never match an empty string.
+    # However,
+    #  
+    # *example.com, *.example.com
+    #
+    # is fine, because e.g. "foo.example.com" matches both.
+
+    if g1start:
+        return hostglob_matches_start(g1, g2, g2start)
+
+    if g2start:
+        return hostglob_matches_start(g2, g1, g1start)
+
+    if g1end:
+        return hostglob_matches_end(g1, g2, g2end)
+
+    if g2end:
+        return hostglob_matches_end(g2, g1, g1end)
+
+    # This is "impossible"
+    return False
+
 
 ################
 ## selector_matches is a utility for doing K8s label selector matching.

--- a/python/tests/integration/test_docker.py
+++ b/python/tests/integration/test_docker.py
@@ -113,7 +113,6 @@ def test_grab_snapshots():
     assert check_grab_snapshots(), "grab-snapshots check failed"
 
 def test_demo():
-    pytest.xfail("IHA FIXME")
     test_status = False
 
     # And this tests that the Ambasasdor can run with the `--demo` argument

--- a/python/tests/kat/t_hosts.py
+++ b/python/tests/kat/t_hosts.py
@@ -753,7 +753,6 @@ class HostCRDWildcards(AmbassadorTest):
     target: ServiceType
 
     def init(self):
-        self.xfail = "IHA FIXME (swap glob)"
         self.target = HTTP()
 
     def manifests(self) -> str:

--- a/python/tests/unit/test_hostglob_matches.py
+++ b/python/tests/unit/test_hostglob_matches.py
@@ -1,0 +1,60 @@
+import logging
+import sys
+
+import pytest
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s test %(levelname)s: %(message)s",
+    datefmt='%Y-%m-%d %H:%M:%S'
+)
+
+logger = logging.getLogger("ambassador")
+
+from ambassador.ir.irutils import hostglob_matches
+
+@pytest.mark.compilertest
+def test_hostglob_matches():
+    for v1, v2, wanted_result in [
+        ( "a.example.com",     "a.example.com",    True  ),
+        ( "a.example.com",     "b.example.com",    False ),
+        ( "*",                 "foo.example.com",  True  ),
+        ( "*.example.com",     "a.example.com",    True  ),
+        ( "*example.com",      "b.example.com",    True  ),
+        # This is never OK: the "*" can't match a bare ".".
+        ( "*example.com",      ".example.com",     False ),
+        # This is OK, because DNS allows names to end with a "."
+        ( "foo.example*",      "foo.example.com.", True  ),
+        # This is never OK: the "*" cannot match an empty string.
+        ( "*example.com",      "example.com",      False ),
+        ( "*ple.com",          "b.example.com",    True  ),
+        ( "*.example.com",     "a.example.org",    False ),
+        ( "*example.com",      "a.example.org",    False ),
+        ( "*ple.com",          "a.example.org",    False ),
+        ( "a.example.*",       "a.example.com",    True  ),
+        ( "a.example*",        "a.example.com",    True  ),
+        ( "a.exa*",            "a.example.com",    True  ),
+        ( "a.example.*",       "a.example.org",    True  ),
+        ( "a.example.*",       "b.example.com",    False ),
+        ( "a.example*",        "b.example.com",    False ),
+        ( "a.exa*",            "b.example.com",    False ),
+        # '*' has to appear at the beginning or the end, not in the middle.
+        ( "a.*.com",           "a.example.com",    False ),
+        # Various DNS glob situations disagree about whether "*" can cross subdomain
+        # boundaries. We follow what Envoy does, which is to allow crossing.
+        ( "*.com",             "a.example.com",    True  ),
+        ( "*.com",             "a.example.org",    False ),
+        ( "*.example.com",     "*.example.com",    True  ),
+        # This looks wrong but it's OK: both match e.g. foo.example.com.
+        ( "*example.com",      "*.example.com",    True  ),
+        # These are ugly corner cases, but they should still work!
+        ( "*.example.com",     "a.example.*",      True  ),
+        ( "*.example.com",     "a.b.example.*",    True  ),
+        ( "*.example.baz.com", "a.b.example.*",    True  ),
+        ( "*.foo.bar",         "baz.zing.*",      True  ),
+    ]:
+        assert hostglob_matches(v1, v2) == wanted_result, f"1. {v1} ~ {v2} != {wanted_result}"
+        assert hostglob_matches(v2, v1) == wanted_result, f"2. {v2} ~ {v1} != {wanted_result}"
+
+if __name__ == '__main__':
+    pytest.main(sys.argv)


### PR DESCRIPTION
- Reenable the `HostCRDWildcards` test
- Add a unit test for `hostglob_matches`, which is the internal function that decides whether DNS glob match
- Fix a bug in `hostglob_matches` revealed by said tests
- Also, reenable the `demo` test, which verifies that we can use `docker run` to run the demo

These were XFailed during the 2.0-EA cycle, but should _never_ have been allowed to stay that way.

 - [x] I made sure to update `CHANGELOG.md`.
 - [x] This is unlikely to impact how Ambassador performs at scale.
 - [x] My change is adequately tested.
 - [x] I didn't need to update `DEVELOPING.md`
