### PR TITLE
Forcibly remove chardet

### DIFF
--- a/OPENSOURCE.md
+++ b/OPENSOURCE.md
@@ -139,7 +139,6 @@ libraries:
     attrs                19.3.0     MIT license
     cachetools           4.1.1      MIT license
     certifi              2020.6.20  Mozilla Public License 2.0
-    chardet              3.0.4      GNU Lesser General Public License Version 2.1
     charset-normalizer   2.0.8      MIT license
     click                8.0.3      3-clause BSD license
     clize                4.2.1      MIT license

--- a/builder/Dockerfile.base
+++ b/builder/Dockerfile.base
@@ -105,6 +105,10 @@ RUN mkdir /tmp/pyyaml && \
   cd pyyaml-5.4.1.1 && \
   python3 setup.py --with-libyaml install
 
+# Installing `requests` pulls in both `chardet` and `charset_normalizer`. Only one of these is
+# needed, so we'll uninstall `chardet` since it's GPL-licensed.
+RUN pip3 uninstall -y chardet
+
 FROM ${builderbase_stage1} as builderbase-stage2
 
 # orjson is also special. It relies on glibc, so we need to temporarily convince


### PR DESCRIPTION
Installing `requests` in the stage builder base also pulls in both `chardet` and `charset_normalizer`. Only one of these is needed, so we'll uninstall the one with the more restrictive license.

Signed-off-by: Flynn <flynn@datawire.io

 - [x] I didn't need to update `CHANGELOG.md`.
 - [x] This is unlikely to impact how Ambassador performs at scale.
 - [x] My change is adequately tested.
 - [x] I didn't need to update `DEVELOPING.md`.
