### PR TITLE
Port example envoy metrics sink to the v3 bootstrap

### DIFF
--- a/cmd/busyambassador/main.go
+++ b/cmd/busyambassador/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/datawire/ambassador/v2/cmd/ambex"
 	"github.com/datawire/ambassador/v2/cmd/apiext"
 	"github.com/datawire/ambassador/v2/cmd/entrypoint"
+	metricssink "github.com/datawire/ambassador/v2/cmd/example-envoy-metrics-sink"
 	"github.com/datawire/ambassador/v2/cmd/kubestatus"
 	"github.com/datawire/ambassador/v2/cmd/reproducer"
 )
@@ -105,12 +106,13 @@ func main() {
 	}()
 
 	busy.Main("busyambassador", "Ambassador", Version, map[string]busy.Command{
-		"ambex":      {Setup: environment.EnvironmentSetupEntrypoint, Run: ambex.Main},
-		"kubestatus": {Setup: environment.EnvironmentSetupEntrypoint, Run: kubestatus.Main},
-		"entrypoint": {Setup: noop, Run: entrypoint.Main},
-		"reproducer": {Setup: noop, Run: reproducer.Main},
-		"agent":      {Setup: environment.EnvironmentSetupEntrypoint, Run: amb_agent.Main},
-		"version":    {Setup: noop, Run: showVersion},
-		"apiext":     {Setup: noop, Run: apiext.Main},
+		"ambex":       {Setup: environment.EnvironmentSetupEntrypoint, Run: ambex.Main},
+		"kubestatus":  {Setup: environment.EnvironmentSetupEntrypoint, Run: kubestatus.Main},
+		"entrypoint":  {Setup: noop, Run: entrypoint.Main},
+		"reproducer":  {Setup: noop, Run: reproducer.Main},
+		"agent":       {Setup: environment.EnvironmentSetupEntrypoint, Run: amb_agent.Main},
+		"metricssink": {Setup: environment.EnvironmentSetupEntrypoint, Run: metricssink.Main},
+		"version":     {Setup: noop, Run: showVersion},
+		"apiext":      {Setup: noop, Run: apiext.Main},
 	})
 }

--- a/cmd/example-envoy-metrics-sink/main.go
+++ b/cmd/example-envoy-metrics-sink/main.go
@@ -1,14 +1,12 @@
-package main
+package example_envoy_metrics_sink
 
 import (
 	"context"
-	"io"
-	"os"
-
 	"github.com/datawire/dlib/dhttp"
 	"github.com/datawire/dlib/dlog"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/encoding/protojson"
+	"io"
 
 	v2_metrics "github.com/datawire/ambassador/v2/pkg/api/envoy/service/metrics/v2"
 )
@@ -17,9 +15,7 @@ type server struct{}
 
 var _ v2_metrics.MetricsServiceServer = &server{}
 
-func main() {
-	ctx := context.Background()
-
+func Main(ctx context.Context, version string, args ...string) error {
 	grpcMux := grpc.NewServer()
 	v2_metrics.RegisterMetricsServiceServer(grpcMux, &server{})
 
@@ -31,10 +27,11 @@ func main() {
 
 	if err := sc.ListenAndServe(ctx, ":8123"); err != nil {
 		dlog.Errorf(ctx, "shut down with error: %v", err)
-		os.Exit(1)
+		return err
 	}
 
 	dlog.Print(ctx, "shut down without error")
+	return nil
 }
 
 func (s *server) StreamMetrics(stream v2_metrics.MetricsService_StreamMetricsServer) error {

--- a/python/ambassador/envoy/v3/v3bootstrap.py
+++ b/python/ambassador/envoy/v3/v3bootstrap.py
@@ -107,6 +107,57 @@ class V3Bootstrap(dict):
         #     assert ratelimit.cluster
         #     clusters.append(V3Cluster(config, ratelimit.cluster))
 
+        stats_sinks = []
+
+        grpcSink = os.environ.get("AMBASSADOR_GRPC_METRICS_SINK")
+        if grpcSink:
+            try:
+                host, port = split_host_port(grpcSink)
+                valid = True
+            except ValueError as ex:
+                config.ir.logger.error("AMBASSADOR_GRPC_METRICS_SINK value %s is invalid: %s" % (grpcSink, ex))
+                valid = False
+
+            if valid:
+                stats_sinks.append({
+                    'name': "envoy.metrics_service",
+                    'typed_config': {
+                        '@type': 'type.googleapis.com/envoy.config.metrics.v3.MetricsServiceConfig',
+                        'grpc_service': {
+                            'envoy_grpc': {
+                                'cluster_name': 'envoy_metrics_service'
+                            }
+                        }
+                    }
+                })
+                clusters.append({
+                    "name": "envoy_metrics_service",
+                    "type": "strict_dns",
+                    "connect_timeout": "1s",
+                    "http2_protocol_options": {},
+                    "lb_policy": "ROUND_ROBIN",
+                    "load_assignment": {
+                        "cluster_name": "envoy_metrics_service",
+                        "endpoints": [
+                            {
+                                "lb_endpoints": [
+                                    {
+                                        "endpoint": {
+                                            "address": {
+                                                "socket_address": {
+                                                    "address": host,
+                                                    "port_value": port,
+                                                    "protocol": "TCP"
+                                                }
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                })
+
         if config.ir.statsd['enabled']:
             if config.ir.statsd['dogstatsd']:
                 name = 'envoy.stat_sinks.dog_statsd'
@@ -122,28 +173,39 @@ class V3Bootstrap(dict):
                 name = 'envoy.stats_sinks.statsd'
                 typename = 'type.googleapis.com/envoy.config.metrics.v3.StatsdSink'
 
-            self['stats_sinks'] = [
-                {
-                    'name': name,
-                    'typed_config': {
-                        '@type': typename,
-                        'address': {
-                            'socket_address': {
-                                'protocol': 'UDP',
-                                'address': config.ir.statsd['ip'],
-                                'port_value': 8125
-                            }
+            stats_sinks.append({
+                'name': name,
+                'typed_config': {
+                    '@type': typename,
+                    'address': {
+                        'socket_address': {
+                            'protocol': 'UDP',
+                            'address': config.ir.statsd['ip'],
+                            'port_value': 8125
                         }
                     }
                 }
-            ]
+            })
 
             self['stats_flush_interval'] = {
                 'seconds': config.ir.statsd['interval']
             }
-
+        self['stats_sinks'] = stats_sinks
         self['static_resources']['clusters'] = clusters
 
     @classmethod
     def generate(cls, config: 'V3Config') -> None:
         config.bootstrap = V3Bootstrap(config)
+
+
+def split_host_port(value):
+    parts = value.split(":")
+    if len(parts) == 1:
+        host = parts[0]
+        port = 80
+    elif len(parts) == 2:
+        host = parts[0]
+        port = int(parts[1])
+    else:
+        raise ValueError("too many colons")
+    return host, port


### PR DESCRIPTION
## Description
This pull requests port the example envoy metrics sink to the v3 configuration bootstrap. Additionally: 

* If the environment variable `AMBASSADOR_GRPC_METRICS_SINK` is present, the example sink is automatically started by the Go entrypoint.
* The example Envoy metrics sink is available in the entrypoint binary at `ambassadorbusy metricssink`

## Related Issues
List related issues.

## Testing
I've done manual tests in a cluster I own with a custom image built from the source code.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `CHANGELOG.md`.
   
   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations
 
 - [ ] This is unlikely to impact how Ambassador performs at scale.
 
   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability
 
 - [ ] My change is adequately tested.
 
   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points
 
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
