### PR TITLE
Sync release notes from getambassador.io.git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,7 +151,8 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 - Feature: Emissary-ingress supports `getambassador.io/v2` CRDs, to simplify migration from
   Emissary-ingress 1.X. **Note:** it is important to read the <a
-  href="../topics/install/migration-matrix">migration documentation</a> before starting migration.
+  href="https://www.getambassador.io/docs/emissary/latest/topics/install/migration-matrix">migration
+  documentation</a> before starting migration.
 
 - Bugfix: The incremental reconfiguration cache could miss some updates when multiple `Mapping`s had
   the same `prefix` ("canary"ing multiple `Mapping`s together). This has been corrected, so that all
@@ -329,13 +330,15 @@ href="https://a8r.io/slack">Slack</a> and let us know what you think.
   configuration changes that are not backwards compatible with the 1.X family.  API versions
   `getambassador.io/v0`, `getambassador.io/v1`, and `getambassador.io/v2` are deprecated.  Further
   details are available in the <a
-  href="../about/changes-2.x/#1-configuration-api-version-getambassadoriov3alpha1">Major Changes in
-  2.X</a> document.
+  href="https://www.getambassador.io/docs/emissary/latest/about/changes-2.x/#1-configuration-api-version-getambassadoriov3alpha1">Major
+  Changes in 2.X</a> document.
 
 - Feature: The new `AmbassadorListener` CRD defines where and how to listen for requests from the
   network, and which `AmbassadorHost` definitions should be used to process those requests. Note
   that the `AmbassadorListener` CRD is **mandatory** and consolidates *all* port configuration; see
-  the <a href="../topics/running/listener">`AmbassadorListener` documentation</a> for more details.
+  the <a
+  href="https://www.getambassador.io/docs/emissary/latest/topics/running/listener">`AmbassadorListener`
+  documentation</a> for more details.
 
 - Feature: Where `AmbassadorMapping`'s `host` field is either an exact match or (with `host_regex`
   set) a regex, the new `hostname` element is always a DNS glob. Use `hostname` instead of `host`
@@ -366,17 +369,19 @@ href="https://a8r.io/slack">Slack</a> and let us know what you think.
   `AmbassadorMapping`'s `host` or the `AmbassadorHost`'s `selector` (or both) are explicitly set,
   and match. This change can significantly improve Emissary-ingress's memory footprint when many
   `AmbassadorHost`s are involved. Further details are available in the <a
-  href="../about/changes-2.x/#host-and-mapping-association">Major Changes in 2.X</a> document.
+  href="https://www.getambassador.io/docs/emissary/latest/about/changes-2.x/#host-and-mapping-association">Major
+  Changes in 2.X</a> document.
 
 - Change: An `AmbassadorHost` or `Ingress` resource is now required when terminating TLS -- simply
   creating a `TLSContext` is not sufficient. Further details are available in the <a
-  href="../about/changes-2.x/#host-tlscontext-and-tls-termination">`AmbassadorHost` CRD
-  documentation.</a>
+  href="https://www.getambassador.io/docs/emissary/latest/about/changes-2.x/#host-tlscontext-and-tls-termination">`AmbassadorHost`
+  CRD documentation.</a>
 
 - Change: By default, Emissary-ingress will configure Envoy using the V3 Envoy API. This change is
   mostly transparent to users, but note that Envoy V3 does not support unsafe regular expressions
   or, e.g., Zipkin's V1 collector protocol. Further details are available in the <a
-  href="../about/changes-2.x">Major Changes in 2.X</a> document.
+  href="https://www.getambassador.io/docs/emissary/latest/about/changes-2.x">Major Changes in
+  2.X</a> document.
 
 - Change: The `tls` module and the `tls` field in the Ambassador module are no longer supported.
   Please use `TLSContext` resources instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,14 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 ### Emissary-ingress and Ambassador Edge Stack
 
+- Change: Support for the Envoy V2 API is deprecated in Emissary-ingress v2.1, and will be removed
+  in Emissary-ingress v2.2.0. The `AMBASSADOR_ENVOY_API_VERSION` environment variable will be
+  removed at the same time. Only the Envoy V3 API will be supported (this has been the default since
+  Emissary-ingress v1.14.0).
+
+- Change: Docker BuildKit is enabled for all Emissary builds. Additionally, the Go build cache is
+  fully enabled when building images, speeding up repeated builds.
+
 - Bugfix: Emissary-ingress 2.1.0 generated invalid Envoy configuration for `getambassador.io/v2`
   `Mappings` that set `spec.cors.origins` to a string rather than a list of strings; this has been
   fixed, and these `Mappings` should once again function correctly.
@@ -98,12 +106,12 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 - Bugfix: Using `rewrite: ""` in a `Mapping` is correctly handled to mean "do not rewrite the path
   at all".
 
-- Bugfix: `Mapping`s with DNS wildcard `hostname` will now be correctly matched with `Host`s.
-  Previously, the case where both the `Host` and the `Mapping` use DNS wildcards for their hostnames
-  could sometimes  not correctly match when they should have.
-
 - Bugfix: Any `Mapping` that uses the `host_redirect` field is now properly discovered and used.
   Thanks to <a href="https://github.com/gferon">Gabriel Féron</a> for contributing this bugfix! ([3709])
+
+- Bugfix: `Mapping`s with DNS wildcard `hostname` will now be correctly matched with `Host`s.
+  Previously, the case where both the `Host` and the `Mapping` use DNS wildcards for their hostnames
+  could sometimes not correctly match when they should have.
 
 - Bugfix: If the `ambassador` `Module` sets a global default for `add_request_headers`,
   `add_response_headers`, `remove_request_headers`, or `remove_response_headers`, it is often
@@ -123,9 +131,6 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 - Bugfix: Resource validation errors are now reported more consistently; it was the case that in
   some situations a validation error would not be reported.
 
-- Change: Docker BuildKit is enabled for all Emissary builds. Additionally, the Go build cache is
-  fully enabled when building images, speeding up repeated builds.
-
 [3709]: https://github.com/emissary-ingress/emissary/issues/3709
 
 ## 2.1.1 not issued
@@ -139,16 +144,18 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 ### Emissary-ingress and Ambassador Edge Stack
 
-- Feature: It is now possible to use both the `getambassador.io/v2` and `getambassador.io/v3alpha1`
-  apiVersions.  This is accomplished with the addition of an `emissary-ingress-apiext` Service and
-  Deployment that handles converting between the two versions for the apiserver.  This allows the
-  user to semlessly request and author resources in whichever API version is desired, and
-  facilitates easier migration from Emissary 1.x to 2.x.  Resources authored in v3alpha1 will not be
-  visible to Emissary 1.x; resources authored in v2 will be visible to both Emissary 1.x and 2.x.
+- Change: Support for the Envoy V2 API is deprecated in Emissary-ingress v2.1, and will be removed
+  in Emissary-ingress v2.2.0. The `AMBASSADOR_ENVOY_API_VERSION` environment variable will be
+  removed at the same time. Only the Envoy V3 API will be supported (this has been the default since
+  Emissary-ingress v1.14.0).
+
+- Feature: Emissary-ingress supports `getambassador.io/v2` CRDs, to simplify migration from
+  Emissary-ingress 1.X. **Note:** it is important to read the <a
+  href="../topics/install/migration-matrix">migration documentation</a> before starting migration.
 
 - Bugfix: The incremental reconfiguration cache could miss some updates when multiple `Mapping`s had
   the same `prefix` ("canary"ing multiple `Mapping`s together). This has been corrected, so that all
-  such updates correctly take effect. ([3945])
+  such updates correctly take effect. ([#3945])
 
 - Bugfix: When using Kubernetes Secrets to store ACME private keys (as the Edge Stack ACME client
   does), an error would always be logged about the Secret not being present, even though it was
@@ -156,7 +163,7 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 - Bugfix: When using gzip compression, upstream services will no longer receive compressed data.
   This bug was introduced in 1.14.0. The fix restores the default behavior of not sending compressed
-  data to upstream services. ([3818])
+  data to upstream services. ([#3818])
 
 - Security: Update to busybox 1.34.1 to resolve CVE-2021-28831, CVE-2021-42378, CVE-2021-42379,
   CVE-2021-42380, CVE-2021-42381, CVE-2021-42382, CVE-2021-42383, CVE-2021-42384, CVE-2021-42385,
@@ -168,8 +175,8 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 - Security: Previous built images included some Python packages used only for test. These have now
   been removed, resolving CVE-2020-29651.
 
-[3945]: https://github.com/emissary-ingress/emissary/issues/3945
-[3818]: https://github.com/emissary-ingress/emissary/issues/3818
+[#3945]: https://github.com/emissary-ingress/emissary/issues/3945
+[#3818]: https://github.com/emissary-ingress/emissary/issues/3818
 
 ## [2.0.5] November 08, 2021
 [2.0.5]: https://github.com/emissary-ingress/emissary/compare/v2.0.4...v2.0.5
@@ -186,9 +193,9 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 - Bugfix: The `Host` CRD now correctly supports the `mappingSelector` element, as documented. As a
   transition aid, `selector` is a synonym for `mappingSelector`; a future version of
-  Emissary-ingress will remove the `selector` element. ([3902])
+  Emissary-ingress will remove the `selector` element. ([#3902])
 
-[3902]: https://github.com/emissary-ingress/emissary/issues/3902
+[#3902]: https://github.com/emissary-ingress/emissary/issues/3902
 
 ## [2.0.4] October 19, 2021
 [2.0.4]: https://github.com/emissary-ingress/emissary/compare/v2.0.3-ea...v2.0.4
@@ -322,8 +329,8 @@ href="https://a8r.io/slack">Slack</a> and let us know what you think.
   configuration changes that are not backwards compatible with the 1.X family.  API versions
   `getambassador.io/v0`, `getambassador.io/v1`, and `getambassador.io/v2` are deprecated.  Further
   details are available in the <a
-  href="../about/changes-2.0.0/#1-configuration-api-version-xgetambassadoriov3alpha1">2.0.0
-  Changes</a> document.
+  href="../about/changes-2.x/#1-configuration-api-version-getambassadoriov3alpha1">Major Changes in
+  2.X</a> document.
 
 - Feature: The new `AmbassadorListener` CRD defines where and how to listen for requests from the
   network, and which `AmbassadorHost` definitions should be used to process those requests. Note
@@ -359,17 +366,17 @@ href="https://a8r.io/slack">Slack</a> and let us know what you think.
   `AmbassadorMapping`'s `host` or the `AmbassadorHost`'s `selector` (or both) are explicitly set,
   and match. This change can significantly improve Emissary-ingress's memory footprint when many
   `AmbassadorHost`s are involved. Further details are available in the <a
-  href="../about/changes-2.0.0/#host-and-mapping-association">2.0.0 Changes</a> document.
+  href="../about/changes-2.x/#host-and-mapping-association">Major Changes in 2.X</a> document.
 
 - Change: An `AmbassadorHost` or `Ingress` resource is now required when terminating TLS -- simply
   creating a `TLSContext` is not sufficient. Further details are available in the <a
-  href="../about/changes-2.0.0/#host-tlscontext-and-tls-termination">`AmbassadorHost` CRD
+  href="../about/changes-2.x/#host-tlscontext-and-tls-termination">`AmbassadorHost` CRD
   documentation.</a>
 
 - Change: By default, Emissary-ingress will configure Envoy using the V3 Envoy API. This change is
   mostly transparent to users, but note that Envoy V3 does not support unsafe regular expressions
   or, e.g., Zipkin's V1 collector protocol. Further details are available in the <a
-  href="../about/changes-2.0.0">2.0.0 Changes</a> document.
+  href="../about/changes-2.x">Major Changes in 2.X</a> document.
 
 - Change: The `tls` module and the `tls` field in the Ambassador module are no longer supported.
   Please use `TLSContext` resources instead.

--- a/docs/CHANGELOG.tpl
+++ b/docs/CHANGELOG.tpl
@@ -106,6 +106,7 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
     strings.ReplaceAll "</i>" "*" |
     strings.ReplaceAll "<code>" "`" |
     strings.ReplaceAll "</code>" "`" |
+    strings.ReplaceAll "href=\"../" "href=\"https://www.getambassador.io/docs/emissary/latest/" |
     strings.WordWrap 100 }}
 {{- end }}{{ end }}{{ end }}
 {{ if ne $release.date "N/A" }}
@@ -119,6 +120,7 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
     strings.ReplaceAll "</i>" "*" |
     strings.ReplaceAll "<code>" "`" |
     strings.ReplaceAll "</code>" "`" |
+    strings.ReplaceAll "href=\"../" "href=\"https://www.getambassador.io/docs/emissary/latest/" |
     strings.WordWrap 98 |
     strings.Indent 2 |
     strings.TrimPrefix "  " }}{{ if index . "github" }}{{ range .github }} ([{{.title}}]){{ end }}{{ end }}
@@ -135,6 +137,7 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
     strings.ReplaceAll "</i>" "*" |
     strings.ReplaceAll "<code>" "`" |
     strings.ReplaceAll "</code>" "`" |
+    strings.ReplaceAll "href=\"../" "href=\"https://www.getambassador.io/docs/edge-stack/latest/" |
     strings.WordWrap 98 |
     strings.Indent 2 |
     strings.TrimPrefix "  " }}{{ if index . "github" }}{{ range .github }} ([{{.title}}]){{ end }}{{ end }}

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -28,6 +28,7 @@
 #             `FOO/releaseNotes.yml`, then the image paths are
 #             relative to `FOO/release-notes/`.
 #         - docs: The path to the documentation page where additional information can be found.
+#         - href: A path from the root to a resource on the getambassador website, takes precedence over a docs link.
 
 changelog: https://github.com/emissary-ingress/emissary/blob/$branch$/CHANGELOG.md
 items:
@@ -35,13 +36,29 @@ items:
     prevVersion: 2.1.0
     date: '2022-01-25'
     notes:
+      - title: Envoy V2 API deprecation
+        type: change
+        body: >-
+          Support for the Envoy V2 API is deprecated in $productName$ v2.1, and will be removed in $productName$
+          v2.2.0. The <code>AMBASSADOR_ENVOY_API_VERSION</code> environment variable will be removed at the same
+          time. Only the Envoy V3 API will be supported (this has been the default since $productName$ v1.14.0).
+
+      - title: Docker BuildKit always used for builds
+        type: change
+        body: >-
+          Docker BuildKit is enabled for all Emissary builds. Additionally, the Go
+          build cache is fully enabled when building images, speeding up repeated builds.
+        docs: https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/syntax.md
+
       - title: Fix support for for v2 Mappings with CORS
         type: bugfix
         body: >-
           Emissary-ingress 2.1.0 generated invalid Envoy configuration for
           <code>getambassador.io/v2</code> <code>Mappings</code> that set
           <code>spec.cors.origins</code> to a string rather than a list of strings; this has been
-          fixed, and these <code>Mappings<code> should once again function correctly.
+          fixed, and these <code>Mappings</code> should once again function correctly.
+        docs: topics/using/cors/#the-cors-attribute
+        image: ./v2.1.2-mapping-cors.png
 
       - title: Correctly handle canary Mapping weights when reconfiguring
         type: bugfix
@@ -58,6 +75,7 @@ items:
           <code>weight</code> less than 100, will be correctly configured to receive all
           traffic as if the <code>weight</code> were 100.
         docs: topics/using/canary/#the-weight-attribute
+        image: ./v2.1.2-mapping-less-weighted.png
 
       - title: Correctly handle empty rewrite in a Mapping
         type: bugfix
@@ -65,15 +83,7 @@ items:
           Using <code>rewrite: ""</code> in a <code>Mapping</code> is correctly handled
           to mean "do not rewrite the path at all".
         docs: topics/using/rewrites
-
-      - title: Correctly handle DNS wildcards when associating Hosts and Mappings
-        type: bugfix
-        body: >-
-          <code>Mapping</code>s with DNS wildcard <code>hostname</code> will now be correctly
-          matched with <code>Host</code>s. Previously, the case where both the <code>Host</code>
-          and the <code>Mapping</code> use DNS wildcards for their hostnames could sometimes 
-          not correctly match when they should have.
-        docs: howtos/configure-communications/
+        image: ./v2.1.2-mapping-no-rewrite.png
 
       - title: Correctly use Mappings with host redirects
         type: bugfix
@@ -84,6 +94,16 @@ items:
         - title: 3709
           link: https://github.com/emissary-ingress/emissary/issues/3709
         docs: https://github.com/emissary-ingress/emissary/issues/3709
+
+      - title: Correctly handle DNS wildcards when associating Hosts and Mappings
+        type: bugfix
+        body: >-
+          <code>Mapping</code>s with DNS wildcard <code>hostname</code> will now be correctly
+          matched with <code>Host</code>s. Previously, the case where both the <code>Host</code>
+          and the <code>Mapping</code> use DNS wildcards for their hostnames could sometimes
+          not correctly match when they should have.
+        docs: howtos/configure-communications/
+        image: ./v2.1.2-host-mapping-matching.png
 
       - title: Fix overriding global settings for adding or removing headers
         type: bugfix
@@ -113,19 +133,13 @@ items:
           Resources that exist as <code>getambassador.io/config</code> annotations rather than as
           native Kubernetes resources are now validated and internally converted to v3alpha1 and,
           the same as native Kubernetes resources.
+        image: ./v2.1.2-annotations.png
 
       - title: Validation error reporting
         type: bugfix
         body: >-
           Resource validation errors are now reported more consistently; it was the case that in
           some situations a validation error would not be reported.
-
-      - title: Docker BuildKit always used for builds
-        type: change
-        body: >-
-          Docker BuildKit is enabled for all Emissary builds. Additionally, the Go
-          build cache is fully enabled when building images, speeding up repeated builds.
-        docs: https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/syntax.md
 
   - version: 2.1.1
     date: 'N/A'
@@ -146,16 +160,21 @@ items:
         body: >-
           <i>Emissary-ingress 2.1.0 is not recommended; upgrade to 2.1.2 instead.</i>
 
-      - title: CRD conversions
+      - title: Envoy V2 API deprecation
+        type: change
+        body: >-
+          Support for the Envoy V2 API is deprecated in $productName$ v2.1, and will be removed in $productName$
+          v2.2.0. The <code>AMBASSADOR_ENVOY_API_VERSION</code> environment variable will be removed at the same
+          time. Only the Envoy V3 API will be supported (this has been the default since $productName$ v1.14.0).
+
+      - title: Smoother migrations with support for getambassador.io/v2 CRDs
         type: feature
         body: >-
-          It is now possible to use both the <code>getambassador.io/v2</code> and
-          <code>getambassador.io/v3alpha1</code> apiVersions.  This is accomplished with the
-          addition of an <code>emissary-ingress-apiext</code> Service and Deployment that handles
-          converting between the two versions for the apiserver.  This allows the user to semlessly
-          request and author resources in whichever API version is desired, and facilitates easier
-          migration from Emissary 1.x to 2.x.  Resources authored in v3alpha1 will not be visible to
-          Emissary 1.x; resources authored in v2 will be visible to both Emissary 1.x and 2.x.
+          $productName$ supports <code>getambassador.io/v2</code> CRDs, to simplify migration from $productName$
+          1.X. <b>Note:</b> it is important to read the <a href="../topics/install/migration-matrix">migration
+          documentation</a> before starting migration.
+        docs: topics/install/migration-matrix
+        image: ./v2.1.0-smoother-migration.png
 
       - title: Correctly handle all changing canary configurations
         type: bugfix
@@ -165,9 +184,10 @@ items:
           <code>Mapping</code>s together). This has been corrected, so that all such
           updates correctly take effect.
         github:
-        - title: 3945
+        - title: "#3945"
           link: https://github.com/emissary-ingress/emissary/issues/3945
         docs: https://github.com/emissary-ingress/emissary/issues/3945
+        image: ./v2.1.0-canary.png
 
       - title: Secrets used for ACME private keys will not log errors
         type: bugfix
@@ -184,9 +204,10 @@ items:
           data. This bug was introduced in 1.14.0. The fix restores the default behavior of
           not sending compressed data to upstream services.
         github:
-        - title: 3818
+        - title: "#3818"
           link: https://github.com/emissary-ingress/emissary/issues/3818
         docs: https://github.com/emissary-ingress/emissary/issues/3818
+        image: ./v2.1.0-gzip-enabled.png
 
       - title: Update to busybox 1.34.1
         type: security
@@ -236,7 +257,7 @@ items:
           <code>mappingSelector</code>; a future version of $productName$ will remove the
           <code>selector</code> element.
         github:
-        - title: 3902
+        - title: "#3902"
           link: https://github.com/emissary-ingress/emissary/issues/3902
         docs: https://github.com/emissary-ingress/emissary/issues/3902
         image: ./v2.0.5-mappingselector.png
@@ -254,7 +275,7 @@ items:
           improve performance. We welcome feedback!! Join us on
           <a href="https://a8r.io/slack">Slack</a> and let us know what you think.
         isHeadline: true
-        docs: about/changes-2.0.0
+        docs: about/changes-2.x
         image: ./emissary-ga.png
 
       - title: API version getambassador.io/v3alpha1
@@ -266,7 +287,7 @@ items:
           removed for ease of migration. <b>Note that <code>getambassador.io/v3alpha1</code>
           is the only supported API version for 2.0.4</b> &mdash; full support for
           <code>getambassador.io/v2</code> will arrive soon in a later 2.X version.
-        docs: about/changes-2.0.0
+        docs: about/changes-2.x
         image: ./v2.0.4-v3alpha1.png
 
       - title: Support for Kubernetes 1.22
@@ -276,7 +297,7 @@ items:
           and manifests have been updated to support Kubernetes 1.22. Thanks to
           <a href="https://github.com/imoisharma">Mohit Sharma</a> for contributions to
           this feature!
-        docs: about/changes-2.0.0
+        docs: about/changes-2.x
         image: ./v2.0.4-k8s-1.22.png
 
       - title: Mappings support configuring strict or logical DNS
@@ -340,7 +361,7 @@ items:
         body: We're pleased to introduce $productName$ 2.0.3 as a <b>developer preview</b>. The 2.X family introduces a number of changes to allow $productName$ to more gracefully handle larger installations, reduce global configuration to better handle multitenant or multiorganizational installations, reduce memory footprint, and improve performance. We welcome feedback!! Join us on <a href="https://a8r.io/slack">Slack</a> and let us know what you think.
         type: change
         isHeadline: true
-        docs: about/changes-2.0.0
+        docs: about/changes-2.x
 
       - title: AES_LOG_LEVEL more widely effective
         body: The environment variable <code>AES_LOG_LEVEL</code> now also sets the log level for the <code>diagd</code> logger.
@@ -372,7 +393,7 @@ items:
         body: We're pleased to introduce $productName$ 2.0.2 as a <b>developer preview</b>. The 2.X family introduces a number of changes to allow $productName$ to more gracefully handle larger installations, reduce global configuration to better handle multitenant or multiorganizational installations, reduce memory footprint, and improve performance. We welcome feedback!! Join us on <a href="https://a8r.io/slack">Slack</a> and let us know what you think.
         type: change
         isHeadline: true
-        docs: about/changes-2.0.0
+        docs: about/changes-2.x
 
       - title: Envoy security updates
         type: bugfix
@@ -396,12 +417,12 @@ items:
         body: We're pleased to introduce $productName$ 2.0.1 as a <b>developer preview</b>. The 2.X family introduces a number of changes to allow $productName$ to more gracefully handle larger installations, reduce global configuration to better handle multitenant or multiorganizational installations, reduce memory footprint, and improve performance. We welcome feedback!! Join us on <a href="https://a8r.io/slack">Slack</a> and let us know what you think.
         type: change
         isHeadline: true
-        docs: about/changes-2.0.0
+        docs: about/changes-2.x
 
       - title: Improved Ambassador Cloud visibility
         type: feature
         body: Ambassador Agent reports sidecar process information and <code>AmbassadorMapping</code> OpenAPI documentation to Ambassador Cloud to provide more visibility into services and clusters.
-        docs: ../../cloud/latest/service-catalog/quick-start/
+        docs: /docs/cloud/latest/service-catalog/quick-start/
 
       - title: Configurable per-AmbassadorListener statistics prefix
         body: The optional <code>stats_prefix</code> element of the <code>AmbassadorListener</code> CRD now determines the prefix of HTTP statistics emitted for a specific <code>AmbassadorListener</code>.
@@ -434,7 +455,7 @@ items:
       - title: Developer Preview!
         body: We're pleased to introduce $productName$ 2.0.0 as a <b>developer preview</b>. The 2.X family introduces a number of changes to allow $productName$ to more gracefully handle larger installations, reduce global configuration to better handle multitenant or multiorganizational installations, reduce memory footprint, and improve performance. We welcome feedback!! Join us on <a href="https://a8r.io/slack">Slack</a> and let us know what you think.
         type: change
-        docs: about/changes-2.0.0
+        docs: about/changes-2.x
         isHeadline: true
 
       - title: Configuration API v3alpha1
@@ -443,10 +464,10 @@ items:
           configuration changes that are not backwards compatible with the 1.X family.  API versions
           <code>getambassador.io/v0</code>, <code>getambassador.io/v1</code>, and
           <code>getambassador.io/v2</code> are deprecated.  Further details are available in the <a
-          href="../about/changes-2.0.0/#1-configuration-api-version-xgetambassadoriov3alpha1">2.0.0
-          Changes</a> document.
+          href="../about/changes-2.x/#1-configuration-api-version-getambassadoriov3alpha1">Major Changes
+          in 2.X</a> document.
         type: feature
-        docs: about/changes-2.0.0/#1-configuration-api-version-getambassadoriov3alpha1
+        docs: about/changes-2.x/#1-configuration-api-version-getambassadoriov3alpha1
         image: ./edge-stack-2.0.0-v3alpha1.png
 
       - title: The AmbassadorListener Resource
@@ -459,7 +480,7 @@ items:
         body: >-
           Where <code>AmbassadorMapping</code>'s <code>host</code> field is either an exact match or (with <code>host_regex</code> set) a regex,
           the new <code>hostname</code> element is always a DNS glob. Use <code>hostname</code> instead of <code>host</code> for best results.
-        docs: about/changes-2.0.0/#ambassadorhost-and-ambassadormapping-association
+        docs: about/changes-2.x/#ambassadorhost-and-ambassadormapping-association
         type: feature
 
       - title: Memory usage improvements for installations with many AmbassadorHosts
@@ -490,32 +511,32 @@ items:
       - title: Port configuration outside AmbassadorListener has been moved to AmbassadorListener
         body: The <code>TLSContext</code> <code>redirect_cleartext_from</code> and <code>AmbassadorHost</code> <code>requestPolicy.insecure.additionalPort</code> elements are no longer supported. Use a <code>AmbassadorListener</code> for this functionality instead.
         type: change
-        docs: about/changes-2.0.0/#tlscontext-redirect_cleartext_from-and-host-insecureadditionalport
+        docs: about/changes-2.x/#tlscontext-redirect_cleartext_from-and-host-insecureadditionalport
 
       - title: PROXY protocol configuration has been moved to AmbassadorListener
         body: The <code>use_proxy_protocol</code> element of the Ambassador <code>Module</code> is no longer supported, as it is now part of the <code>AmbassadorListener</code> resource (and can be set per-<code>AmbassadorListener</code> rather than globally).
         type: change
-        docs: about/changes-2.0.0/#proxy-protocol-configuration
+        docs: about/changes-2.x/#proxy-protocol-configuration
 
       - title: Stricter rules for AmbassadorHost/AmbassadorMapping association
-        body: An <code>AmbassadorMapping</code> will only be matched with an <code>AmbassadorHost</code> if the <code>AmbassadorMapping</code>'s <code>host</code> or the <code>AmbassadorHost</code>'s <code>selector</code> (or both) are explicitly set, and match. This change can significantly improve $productName$'s memory footprint when many <code>AmbassadorHost</code>s are involved. Further details are available in the <a href="../about/changes-2.0.0/#host-and-mapping-association">2.0.0 Changes</a> document.
-        docs: about/changes-2.0.0/#host-and-mapping-association
+        body: An <code>AmbassadorMapping</code> will only be matched with an <code>AmbassadorHost</code> if the <code>AmbassadorMapping</code>'s <code>host</code> or the <code>AmbassadorHost</code>'s <code>selector</code> (or both) are explicitly set, and match. This change can significantly improve $productName$'s memory footprint when many <code>AmbassadorHost</code>s are involved. Further details are available in the <a href="../about/changes-2.x/#host-and-mapping-association">Major Changes in 2.X</a> document.
+        docs: about/changes-2.x/#host-and-mapping-association
         type: change
 
       - title: AmbassadorHost or Ingress now required for TLS termination
-        body: An <code>AmbassadorHost</code> or <code>Ingress</code> resource is now required when terminating TLS -- simply creating a <code>TLSContext</code> is not sufficient. Further details are available in the <a href="../about/changes-2.0.0/#host-tlscontext-and-tls-termination"><code>AmbassadorHost</code> CRD documentation.</a>
-        docs: about/changes-2.0.0/#host-tlscontext-and-tls-termination
+        body: An <code>AmbassadorHost</code> or <code>Ingress</code> resource is now required when terminating TLS -- simply creating a <code>TLSContext</code> is not sufficient. Further details are available in the <a href="../about/changes-2.x/#host-tlscontext-and-tls-termination"><code>AmbassadorHost</code> CRD documentation.</a>
+        docs: about/changes-2.x/#host-tlscontext-and-tls-termination
         type: change
         image: ./edge-stack-2.0.0-host_crd.png
 
       - title: Envoy V3 APIs
-        body: By default, $productName$ will configure Envoy using the V3 Envoy API. This change is mostly transparent to users, but note that Envoy V3 does not support unsafe regular expressions or, e.g., Zipkin's V1 collector protocol. Further details are available in the <a href="../about/changes-2.0.0">2.0.0 Changes</a> document.
+        body: By default, $productName$ will configure Envoy using the V3 Envoy API. This change is mostly transparent to users, but note that Envoy V3 does not support unsafe regular expressions or, e.g., Zipkin's V1 collector protocol. Further details are available in the <a href="../about/changes-2.x">Major Changes in 2.X</a> document.
         type: change
-        docs: about/changes-2.0.0/#envoy-v3-api-by-default
+        docs: about/changes-2.x/#envoy-v3-api-by-default
 
       - title: Module-based TLS no longer supported
         body: The <code>tls</code> module and the <code>tls</code> field in the Ambassador module are no longer supported. Please use <code>TLSContext</code> resources instead.
-        docs: about/changes-2.0.0/#tls-the-ambassador-module-and-the-tls-module
+        docs: about/changes-2.x/#tls-the-ambassador-module-and-the-tls-module
         image: ./edge-stack-2.0.0-tlscontext.png
         type: change
 
@@ -562,7 +583,8 @@ items:
         docs: topics/running/ambassador/#modify-default-buffer-size
 
     edgeStackNotes:
-      - type: feature
+      - title: DevPortal supports configuring what server is displayed
+        type: feature
         body: >-
           You can now set <code>preserve_servers</code> in Ambassador Edge Stack's
           <code>DevPortal</code> resource to configure the DevPortal to use server definitions from
@@ -598,7 +620,7 @@ items:
         type: change
         body: >-
           <code>AMBASSADOR_ENVOY_API_VERSION</code> now defaults to <code>V3</code>
-        docs: https://www.getambassador.io/docs/edge-stack/latest/topics/running/running/#ambassador_envoy_api_version
+        docs: topics/running/running/#ambassador_envoy_api_version
 
       - title: Subsecond time resolution in logs
         type: change
@@ -633,18 +655,28 @@ items:
         docs: topics/running/environment/
 
     edgeStackNotes:
-      - type: bugfix
+      - title: Mappings support configuring the DevPortal fetch timeout
+        type: bugfix
         body: >-
           The <code>Mapping</code> resource can now specify <code>docs.timeout_ms</code> to set the
           timeout when the Dev Portal is fetching API specifications.
-      - type: bugfix
+        docs: topics/using/dev-portal
+        image: ../images/edge-stack-1.13.10-docs-timeout.png
+
+      - title: Dev Portal will strip HTML tags when displaying results
+        type: bugfix
         body: >-
           The Dev Portal will now strip HTML tags when displaying search results, showing just the
           actual content of the search result.
-      - type: change
+        docs: topics/using/dev-portal
+
+      - title: Consul certificate rotation logs more information
+        type: change
         body: >-
           Consul certificate-rotation logging now includes the fingerprints and validity timestamps
           of certificates being rotated.
+        docs: howtos/consul/
+        image: ../images/edge-stack-1.13.10-consul-cert-log.png
 
   - version: 1.13.9
     date: '2021-06-30'


### PR DESCRIPTION
We made edits to the release notes over in getambassador.io.git; the changes need to be here, too.

Signed-off-by: Flynn <flynn@datawire.io>
