### PR TITLE
Fix ga-check

### DIFF
--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -938,7 +938,11 @@ release/ga-mirror:
 	@$(OSS_HOME)/releng/release-mirror-images --ga-version $(VERSIONS_YAML_VER) --source-registry $(RELEASE_REGISTRY) --image-name $(LCNAME) --repo-list $(GCR_RELEASE_REGISTRY)
 
 release/ga-check:
-	@$(OSS_HOME)/releng/release-ga-check --ga-version $(VERSIONS_YAML_VER) --source-registry $(RELEASE_REGISTRY) --image-name $(LCNAME)
+	$(OSS_HOME)/releng/release-ga-check \
+		--ga-version $(VERSIONS_YAML_VER) \
+		--chart-version `grep 'version' $(OSS_HOME)/charts/emissary-ingress/Chart.yaml | awk '{ print $$2 }'` \
+		--source-registry $(RELEASE_REGISTRY) \
+		--image-name $(LCNAME)
 
 clean:
 	@$(BUILDER) clean

--- a/releng/lib/check_artifacts.py
+++ b/releng/lib/check_artifacts.py
@@ -109,38 +109,6 @@ def main(ga_ver: str, chart_ver: str, include_docker: bool = True,
                     if b != a:
                         subcheck.ok = False
 
-    # def do_check_binary(checker: Checker, name: str, txt: bool, private: bool) -> None:
-    #     with checker.check(name=f'Executable: {name}', clear_on_success=False) as checker:
-    #         for platform in ['linux/amd64/{}', 'darwin/amd64/{}', 'windows/amd64/{}.exe']:
-    #             rc_body: Optional[bytes] = None
-    #             with do_check_s3(checker, f'{name}/{rc_ver}/{platform.format(name)}',
-    #                              private=private, bucket=s3_bucket) as (subcheck, body):
-    #                 if body is not None:
-    #                     rc_body = body
-    #                     # TODO: Validate the binary somehow
-    #             if ga:
-    #                 with do_check_s3(checker, f'{name}/{ga_ver}/{platform.format(name)}',
-    #                                  private=private, bucket=s3_bucket) as (subcheck, body):
-    #                     if body is not None:
-    #                         assert body == rc_body
-    #         if txt:
-    #             if include_latest:
-    #                 with do_check_s3(checker, f'{name}/latest.txt', private=private, bucket=s3_bucket) as (subcheck, body):
-    #                     if body is not None:
-    #                         subcheck.result = body.decode('UTF-8').strip()
-    #                         if is_private:
-    #                             assert subcheck.result != rc_ver
-    #                         else:
-    #                             assert_eq(subcheck.result, rc_ver)
-    #             if ga or is_private:
-    #                 with do_check_s3(checker, f'{name}/stable.txt', private=private, bucket=s3_bucket) as (subcheck, body):
-    #                     if body is not None:
-    #                         subcheck.result = body.decode('UTF-8').strip()
-    #                         if is_private:
-    #                             assert subcheck.result != ga_ver
-    #                         else:
-    #                             assert_eq(subcheck.result, ga_ver)
-
     s3_login()
 
     checker = Checker()

--- a/releng/lib/check_artifacts.py
+++ b/releng/lib/check_artifacts.py
@@ -164,13 +164,6 @@ def main(ga_ver: str, chart_ver: str, include_docker: bool = True,
                     else:
                         assert_eq(subcheck.result, ga_ver)
 
-    # This is redundant since we now look at the tag for which the GitHub release was
-    # created -- we're trusting GitHub not to allow a release that points to a tag that
-    # doesn't exist.
-    # with checker.check(name='Git tags') as check:
-    #     check.result = 'TODO'
-    #     raise NotImplementedError()
-        
     with checker.check(name='Website YAML') as check:
         yaml_str = http_cat('https://app.getambassador.io/yaml/emissary/latest/emissary-emissaryns.yaml').decode('utf-8')
         images = [
@@ -213,7 +206,11 @@ def main(ga_ver: str, chart_ver: str, include_docker: bool = True,
             check_tag = f"{check_tag}-{release_channel}"
         assert_eq(check.result, check_tag)
 
-    with checker.check(name='ambassador.git GitHub release for chart') as check:
+    # The existence of a GitHub release implies the existence of its tag, and we check to
+    # make sure that the tag matches what we expect. Therefore we don't do a separate check
+    # for the tag. (It's true that you can delete the tag after the release; we're just not
+    # going to worry about that.)
+    with checker.check(name='ambassador.git GitHub release for chart (implies GitHub tag, too)') as check:
         tag = run_txtcapture([
             "gh", "release", "view",
             "--json=tagName",
@@ -222,7 +219,8 @@ def main(ga_ver: str, chart_ver: str, include_docker: bool = True,
             f"chart/v{chart_ver}"])
         assert_eq(tag.strip(), f"chart/v{chart_ver}")
 
-    with checker.check(name='ambassador.git GitHub release for code') as check:
+    # See above re tags.
+    with checker.check(name='ambassador.git GitHub release for code (implies GitHub tag, too)') as check:
         tag = run_txtcapture([
             "gh", "release", "view",
             "--json=tagName",

--- a/releng/lib/check_artifacts.py
+++ b/releng/lib/check_artifacts.py
@@ -188,13 +188,7 @@ def main(ga_ver: str, chart_ver: str, include_docker: bool = True,
         run(['helm', 'repo', 'update'])
 
     with checker.check(name="Check Helm Chart"):
-        # chart_version = ""
-        # for line in fileinput.FileInput("charts/emissary-ingress/Chart.yaml"):
-        #     if line.startswith("version:"):
-        #         chart_version = line.replace('version:', '').strip()
-        chart_version = chart_ver
-
-        yaml_str = run_txtcapture(['helm', 'show', 'chart', '--version', chart_version, 'emissary/emissary-ingress'])
+        yaml_str = run_txtcapture(['helm', 'show', 'chart', '--version', chart_ver, 'emissary/emissary-ingress'])
 
         versions = [
             line[len('appVersion:'):].strip() for line in yaml_str.split("\n") if line.startswith('appVersion:')

--- a/releng/release-ga-check
+++ b/releng/release-ga-check
@@ -12,6 +12,7 @@ if __name__ == '__main__':
     parser.add_argument('--no-docker', dest='docker', default=True, action='store_false')
     parser.add_argument('--promote-path', default="")
     parser.add_argument('--ga-version', required=True)
+    parser.add_argument('--chart-version', required=True)
     parser.add_argument('--source-registry', default='docker.io/datawire')
     parser.add_argument('--image-name', default='emissary')
     parser.add_argument('--image-append', default='')
@@ -19,12 +20,16 @@ if __name__ == '__main__':
 
     include_docker = True
     ga_ver = args.ga_version
-
+    chart_ver = args.chart_version
 
     if not re_ga.match(ga_ver) and not re_ea.match(ga_ver):
         sys.stderr.write(f"{ga_ver} does not match X.Y.Z(-ea)?")
         sys.exit(2)
 
-    sys.exit(check_artifacts.main(ga_ver=ga_ver, ga=True, include_latest=True,
+    if not re_ga.match(chart_ver) and not re_ea.match(chart_ver):
+        sys.stderr.write(f"{chart_ver} does not match X.Y.Z(-ea)?")
+        sys.exit(2)
+
+    sys.exit(check_artifacts.main(ga_ver=ga_ver, chart_ver=chart_ver,
         include_docker=args.docker, release_channel=args.promote_path,
         source_registry=args.source_registry, image_append=args.image_append, image_name=args.image_name))


### PR DESCRIPTION
- Split things up to be more clear about what's breaking exactly.
- Don't get confused about what the chart version is: require it as an argument.
- Clear the remaining TODO items (mostly, GitHub releases).

Note that I dropped the separate GitHub tag check -- I check that the release has the
tag we expect, and I'm trusting GitHub not to allow a release to have a nonexistent tag.

Signed-off-by: Flynn <flynn@datawire.io>
