### PR TITLE
[2.2] Agent & CRD changes for migrations

### DIFF
--- a/build-aux/generate.mk
+++ b/build-aux/generate.mk
@@ -60,6 +60,10 @@ generate-fast/files += $(OSS_HOME)/pkg/api/getambassador.io/v3alpha1/zz_generate
 generate-fast/files += $(OSS_HOME)/manifests/emissary/emissary-crds.yaml.in
 generate-fast/files += $(OSS_HOME)/manifests/emissary/emissary-emissaryns.yaml.in
 generate-fast/files += $(OSS_HOME)/manifests/emissary/emissary-defaultns.yaml.in
+generate-fast/files += $(OSS_HOME)/manifests/emissary/emissary-emissaryns-agent.yaml.in
+generate-fast/files += $(OSS_HOME)/manifests/emissary/emissary-defaultns-agent.yaml.in
+generate-fast/files += $(OSS_HOME)/manifests/emissary/emissary-emissaryns-migration.yaml.in
+generate-fast/files += $(OSS_HOME)/manifests/emissary/emissary-defaultns-migration.yaml.in
 generate-fast/files += $(OSS_HOME)/pkg/api/getambassador.io/crds.yaml
 generate-fast/files += $(OSS_HOME)/python/tests/integration/manifests/ambassador.yaml
 generate-fast/files += $(OSS_HOME)/python/tests/integration/manifests/crds.yaml
@@ -386,27 +390,45 @@ $(OSS_HOME)/python/tests/integration/manifests/crds.yaml: $(OSS_HOME)/_generate.
 $(OSS_HOME)/pkg/api/getambassador.io/crds.yaml: $(OSS_HOME)/_generate.tmp/crds $(tools/fix-crds)
 	$(tools/fix-crds) --target=internal-validator $(sort $(wildcard $</*.yaml)) >$@
 
+# Names for all the helm-expanded.yaml files (and thence output.yaml and *.yaml.in files)
 helm.name.emissary-emissaryns = emissary-ingress
 helm.name.emissary-defaultns = emissary-ingress
 helm.namespace.emissary-emissaryns = emissary
 helm.namespace.emissary-defaultns = default
+helm.name.emissary-emissaryns-agent = emissary-ingress
+helm.namespace.emissary-emissaryns-agent = emissary
+helm.name.emissary-defaultns-agent = emissary-ingress
+helm.namespace.emissary-defaultns-agent = default
+helm.name.emissary-emissaryns-migration = emissary-ingress
+helm.namespace.emissary-emissaryns-migration = emissary
+helm.name.emissary-defaultns-migration = emissary-ingress
+helm.namespace.emissary-defaultns-migration = default
+
+# IF YOU'RE LOOKING FOR *.yaml: recipes, look in version-hack.mk at the
+# build-aux/version-hack.stamp.mk dependencies.
+
 $(OSS_HOME)/k8s-config/%/helm-expanded.yaml: \
   $(OSS_HOME)/k8s-config/%/values.yaml \
   $(OSS_HOME)/charts/emissary-ingress/templates $(wildcard $(OSS_HOME)/charts/emissary-ingress/templates/*.yaml) \
   $(OSS_HOME)/charts/emissary-ingress/values.yaml \
   FORCE
 	helm template --namespace=$(helm.namespace.$*) --values=$(@D)/values.yaml $(or $(helm.name.$*),$*) $(OSS_HOME)/charts/emissary-ingress >$@
+
 $(OSS_HOME)/k8s-config/%/output.yaml: \
   $(OSS_HOME)/k8s-config/%/helm-expanded.yaml \
   $(OSS_HOME)/k8s-config/%/require.yaml \
   $(tools/filter-yaml)
 	$(tools/filter-yaml) $(filter %/helm-expanded.yaml,$^) $(filter %/require.yaml,$^) >$@
+
 $(OSS_HOME)/manifests/emissary/%.yaml.in: $(OSS_HOME)/k8s-config/%/output.yaml
 	cp $< $@
+
 $(OSS_HOME)/python/tests/integration/manifests/%.yaml: $(OSS_HOME)/k8s-config/kat-%/output.yaml
 	sed -e 's/«/{/g' -e 's/»/}/g' -e 's/♯.*//g' -e 's/- ←//g' <$< >$@
+
 $(OSS_HOME)/python/tests/integration/manifests/rbac_cluster_scope.yaml: $(OSS_HOME)/k8s-config/kat-rbac-multinamespace/output.yaml
 	sed -e 's/«/{/g' -e 's/»/}/g' -e 's/♯.*//g' -e 's/- ←//g' <$< >$@
+
 $(OSS_HOME)/python/tests/integration/manifests/rbac_namespace_scope.yaml: $(OSS_HOME)/k8s-config/kat-rbac-singlenamespace/output.yaml
 	sed -e 's/«/{/g' -e 's/»/}/g' -e 's/♯.*//g' -e 's/- ←//g' <$< >$@
 

--- a/build-aux/version-hack.mk
+++ b/build-aux/version-hack.mk
@@ -38,6 +38,10 @@ version-hack.simple-substitutions += docs/yaml/versions.yml
 version-hack.simple-substitutions += manifests/emissary/emissary-crds.yaml
 version-hack.simple-substitutions += manifests/emissary/emissary-defaultns.yaml
 version-hack.simple-substitutions += manifests/emissary/emissary-emissaryns.yaml
+version-hack.simple-substitutions += manifests/emissary/emissary-defaultns-agent.yaml
+version-hack.simple-substitutions += manifests/emissary/emissary-emissaryns-agent.yaml
+version-hack.simple-substitutions += manifests/emissary/emissary-defaultns-migration.yaml
+version-hack.simple-substitutions += manifests/emissary/emissary-emissaryns-migration.yaml
 $(version-hack.simple-substitutions): %: %.in $(tools/write-ifchanged) FORCE
 # Hack: clear $CI, some of the CI jobs intentionally modify these
 # files, as described above.
@@ -60,6 +64,10 @@ build-aux/version-hack.stamp.mk: docs/yaml/versions.yml
 build-aux/version-hack.stamp.mk: manifests/emissary/emissary-crds.yaml
 build-aux/version-hack.stamp.mk: manifests/emissary/emissary-defaultns.yaml
 build-aux/version-hack.stamp.mk: manifests/emissary/emissary-emissaryns.yaml
+build-aux/version-hack.stamp.mk: manifests/emissary/emissary-defaultns-agent.yaml
+build-aux/version-hack.stamp.mk: manifests/emissary/emissary-emissaryns-agent.yaml
+build-aux/version-hack.stamp.mk: manifests/emissary/emissary-defaultns-migration.yaml
+build-aux/version-hack.stamp.mk: manifests/emissary/emissary-emissaryns-migration.yaml
 build-aux/version-hack.stamp.mk: $(tools/write-ifchanged)
 	@ls -l $^ | sed 's/^/#/' | $(tools/write-ifchanged) $@
 # The "-include" directive (compared to plain "include") considers it

--- a/k8s-config/emissary-defaultns-agent/require.yaml
+++ b/k8s-config/emissary-defaultns-agent/require.yaml
@@ -1,0 +1,15 @@
+_anchors:
+  _namespace: &namespace default
+resources:
+  - { kind: ServiceAccount,     name: emissary-ingress-agent,              namespace: *namespace }
+  - { kind: ClusterRoleBinding, name: emissary-ingress-agent                                     }
+  - { kind: ClusterRole,        name: emissary-ingress-agent                                     }
+  - { kind: ClusterRole,        name: emissary-ingress-agent-pods                                }
+  - { kind: ClusterRole,        name: emissary-ingress-agent-rollouts                            }
+  - { kind: ClusterRole,        name: emissary-ingress-agent-applications                        }
+  - { kind: ClusterRole,        name: emissary-ingress-agent-deployments                         }
+  - { kind: ClusterRole,        name: emissary-ingress-agent-endpoints                           }
+  - { kind: ClusterRole,        name: emissary-ingress-agent-configmaps                          }
+  - { kind: Role,               name: emissary-ingress-agent-config,       namespace: *namespace }
+  - { kind: RoleBinding,        name: emissary-ingress-agent-config,       namespace: *namespace }
+  - { kind: Deployment,         name: emissary-ingress-agent,              namespace: *namespace }

--- a/k8s-config/emissary-defaultns-agent/values.yaml
+++ b/k8s-config/emissary-defaultns-agent/values.yaml
@@ -1,0 +1,31 @@
+deploymentTool: getambassador.io
+podAnnotations:
+  consul.hashicorp.com/connect-inject: 'false'
+  sidecar.istio.io/inject: 'false'
+containerNameOverride: ambassador
+restartPolicy: Always
+terminationGracePeriodSeconds: "0"
+service:
+  type: LoadBalancer
+replicaCount: 3
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+    - podAffinityTerm:
+        labelSelector:
+          matchLabels:
+            service: ambassador
+        topologyKey: kubernetes.io/hostname
+      weight: 100
+
+resources:
+  limits:
+    cpu: 1
+    memory: 400Mi
+  requests:
+    memory: 100Mi
+adminService:
+  type: NodePort
+image:
+  repository: "$imageRepo$"
+  tag: "$version$"

--- a/k8s-config/emissary-defaultns-migration/require.yaml
+++ b/k8s-config/emissary-defaultns-migration/require.yaml
@@ -1,0 +1,11 @@
+_anchors:
+  _namespace: &namespace default
+resources:
+  - { kind: Service,            name: emissary-ingress-admin,              namespace: *namespace }
+  - { kind: Service,            name: emissary-ingress,                    namespace: *namespace }
+  - { kind: ClusterRole,        name: emissary-ingress                                           }
+  - { kind: ServiceAccount,     name: emissary-ingress,                    namespace: *namespace }
+  - { kind: ClusterRoleBinding, name: emissary-ingress                                           }
+  - { kind: ClusterRole,        name: emissary-ingress-crd                                       }
+  - { kind: ClusterRole,        name: emissary-ingress-watch                                     }
+  - { kind: Deployment,         name: emissary-ingress,                    namespace: *namespace }

--- a/k8s-config/emissary-defaultns-migration/values.yaml
+++ b/k8s-config/emissary-defaultns-migration/values.yaml
@@ -1,0 +1,31 @@
+deploymentTool: getambassador.io
+podAnnotations:
+  consul.hashicorp.com/connect-inject: 'false'
+  sidecar.istio.io/inject: 'false'
+containerNameOverride: ambassador
+restartPolicy: Always
+terminationGracePeriodSeconds: "0"
+service:
+  type: LoadBalancer
+replicaCount: 3
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+    - podAffinityTerm:
+        labelSelector:
+          matchLabels:
+            service: ambassador
+        topologyKey: kubernetes.io/hostname
+      weight: 100
+
+resources:
+  limits:
+    cpu: 1
+    memory: 400Mi
+  requests:
+    memory: 100Mi
+adminService:
+  type: NodePort
+image:
+  repository: "$imageRepo$"
+  tag: "$version$"

--- a/k8s-config/emissary-emissaryns-agent/require.yaml
+++ b/k8s-config/emissary-emissaryns-agent/require.yaml
@@ -1,0 +1,15 @@
+_anchors:
+  _namespace: &namespace emissary
+resources:
+  - { kind: ServiceAccount,     name: emissary-ingress-agent,              namespace: *namespace }
+  - { kind: ClusterRoleBinding, name: emissary-ingress-agent                                     }
+  - { kind: ClusterRole,        name: emissary-ingress-agent                                     }
+  - { kind: ClusterRole,        name: emissary-ingress-agent-pods                                }
+  - { kind: ClusterRole,        name: emissary-ingress-agent-rollouts                            }
+  - { kind: ClusterRole,        name: emissary-ingress-agent-applications                        }
+  - { kind: ClusterRole,        name: emissary-ingress-agent-deployments                         }
+  - { kind: ClusterRole,        name: emissary-ingress-agent-endpoints                           }
+  - { kind: ClusterRole,        name: emissary-ingress-agent-configmaps                          }
+  - { kind: Role,               name: emissary-ingress-agent-config,       namespace: *namespace }
+  - { kind: RoleBinding,        name: emissary-ingress-agent-config,       namespace: *namespace }
+  - { kind: Deployment,         name: emissary-ingress-agent,              namespace: *namespace }

--- a/k8s-config/emissary-emissaryns-agent/values.yaml
+++ b/k8s-config/emissary-emissaryns-agent/values.yaml
@@ -1,0 +1,31 @@
+deploymentTool: getambassador.io
+podAnnotations:
+  consul.hashicorp.com/connect-inject: 'false'
+  sidecar.istio.io/inject: 'false'
+containerNameOverride: ambassador
+restartPolicy: Always
+terminationGracePeriodSeconds: "0"
+service:
+  type: LoadBalancer
+replicaCount: 3
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+    - podAffinityTerm:
+        labelSelector:
+          matchLabels:
+            service: ambassador
+        topologyKey: kubernetes.io/hostname
+      weight: 100
+
+resources:
+  limits:
+    cpu: 1
+    memory: 400Mi
+  requests:
+    memory: 100Mi
+adminService:
+  type: NodePort
+image:
+  repository: "$imageRepo$"
+  tag: "$version$"

--- a/k8s-config/emissary-emissaryns-migration/require.yaml
+++ b/k8s-config/emissary-emissaryns-migration/require.yaml
@@ -1,0 +1,11 @@
+_anchors:
+  _namespace: &namespace emissary
+resources:
+  - { kind: Service,            name: emissary-ingress-admin,              namespace: *namespace }
+  - { kind: Service,            name: emissary-ingress,                    namespace: *namespace }
+  - { kind: ClusterRole,        name: emissary-ingress                                           }
+  - { kind: ServiceAccount,     name: emissary-ingress,                    namespace: *namespace }
+  - { kind: ClusterRoleBinding, name: emissary-ingress                                           }
+  - { kind: ClusterRole,        name: emissary-ingress-crd                                       }
+  - { kind: ClusterRole,        name: emissary-ingress-watch                                     }
+  - { kind: Deployment,         name: emissary-ingress,                    namespace: *namespace }

--- a/k8s-config/emissary-emissaryns-migration/values.yaml
+++ b/k8s-config/emissary-emissaryns-migration/values.yaml
@@ -1,0 +1,31 @@
+deploymentTool: getambassador.io
+podAnnotations:
+  consul.hashicorp.com/connect-inject: 'false'
+  sidecar.istio.io/inject: 'false'
+containerNameOverride: ambassador
+restartPolicy: Always
+terminationGracePeriodSeconds: "0"
+service:
+  type: LoadBalancer
+replicaCount: 3
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+    - podAffinityTerm:
+        labelSelector:
+          matchLabels:
+            service: ambassador
+        topologyKey: kubernetes.io/hostname
+      weight: 100
+
+resources:
+  limits:
+    cpu: 1
+    memory: 400Mi
+  requests:
+    memory: 100Mi
+adminService:
+  type: NodePort
+image:
+  repository: "$imageRepo$"
+  tag: "$version$"

--- a/manifests/emissary/.gitignore
+++ b/manifests/emissary/.gitignore
@@ -2,3 +2,7 @@
 /emissary-crds.yaml
 /emissary-defaultns.yaml
 /emissary-emissaryns.yaml
+/emissary-defaultns-agent.yaml
+/emissary-emissaryns-agent.yaml
+/emissary-defaultns-migration.yaml
+/emissary-emissaryns-migration.yaml

--- a/manifests/emissary/emissary-crds.yaml.in
+++ b/manifests/emissary/emissary-crds.yaml.in
@@ -245,6 +245,14 @@ spec:
         type: object
     served: true
     storage: false
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: AuthService is the Schema for the authservices API
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: false
+    storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -331,6 +339,14 @@ spec:
             type: object
         type: object
     served: true
+    storage: false
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: ConsulResolver is the Schema for the ConsulResolver API
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: false
     storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -538,6 +554,14 @@ spec:
             type: object
         type: object
     served: true
+    storage: false
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: DevPortal is the Schema for the DevPortals API
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: false
     storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -1024,6 +1048,14 @@ spec:
     storage: false
     subresources:
       status: {}
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: Host is the Schema for the hosts API
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: false
+    storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -1102,6 +1134,14 @@ spec:
         type: object
     served: true
     storage: false
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: KubernetesEndpointResolver is the Schema for the kubernetesendpointresolver API
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: false
+    storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -1179,6 +1219,14 @@ spec:
             type: object
         type: object
     served: true
+    storage: false
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: KubernetesServiceResolver is the Schema for the kubernetesserviceresolver API
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: false
     storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -1481,6 +1529,14 @@ spec:
             type: object
         type: object
     served: true
+    storage: false
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: LogService is the Schema for the logservices API
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: false
     storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -2347,6 +2403,14 @@ spec:
     storage: false
     subresources:
       status: {}
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: Mapping is the Schema for the mappings API
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: false
+    storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -2433,6 +2497,14 @@ spec:
             type: object
         type: object
     served: true
+    storage: false
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: A Module defines system-wide configuration.  The type of module is controlled by the .metadata.name; valid names are "ambassador" or "tls".
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: false
     storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -2562,6 +2634,14 @@ spec:
             type: object
         type: object
     served: true
+    storage: false
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: RateLimitService is the Schema for the ratelimitservices API
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: false
     storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -2751,6 +2831,14 @@ spec:
         type: object
     served: true
     storage: false
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: TCPMapping is the Schema for the tcpmappings API
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: false
+    storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -2921,6 +3009,14 @@ spec:
             type: object
         type: object
     served: true
+    storage: false
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: TLSContext is the Schema for the tlscontexts API
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: false
     storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -3098,6 +3194,14 @@ spec:
             type: object
         type: object
     served: true
+    storage: false
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: TracingService is the Schema for the tracingservices API
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: false
     storage: false
 ---
 ################################################################################

--- a/manifests/emissary/emissary-defaultns-agent.yaml.in
+++ b/manifests/emissary/emissary-defaultns-agent.yaml.in
@@ -1,0 +1,262 @@
+# GENERATED FILE: edits made by hand will not be preserved.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: emissary-ingress
+    app.kubernetes.io/managed-by: getambassador.io
+    app.kubernetes.io/name: emissary-ingress-agent
+    app.kubernetes.io/part-of: emissary-ingress
+    product: aes
+  name: emissary-ingress-agent
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: emissary-ingress
+    app.kubernetes.io/managed-by: getambassador.io
+    app.kubernetes.io/name: emissary-ingress-agent
+    app.kubernetes.io/part-of: emissary-ingress
+    product: aes
+  name: emissary-ingress-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: emissary-ingress-agent
+subjects:
+- kind: ServiceAccount
+  name: emissary-ingress-agent
+  namespace: default
+---
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.getambassador.io/role-group: emissary-ingress-agent
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: emissary-ingress
+    app.kubernetes.io/managed-by: getambassador.io
+    app.kubernetes.io/name: emissary-ingress-agent
+    app.kubernetes.io/part-of: emissary-ingress
+    product: aes
+  name: emissary-ingress-agent
+rules: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: emissary-ingress
+    app.kubernetes.io/managed-by: getambassador.io
+    app.kubernetes.io/name: emissary-ingress-agent
+    app.kubernetes.io/part-of: emissary-ingress
+    product: aes
+    rbac.getambassador.io/role-group: emissary-ingress-agent
+  name: emissary-ingress-agent-pods
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: emissary-ingress
+    app.kubernetes.io/managed-by: getambassador.io
+    app.kubernetes.io/name: emissary-ingress-agent
+    app.kubernetes.io/part-of: emissary-ingress
+    product: aes
+    rbac.getambassador.io/role-group: emissary-ingress-agent
+  name: emissary-ingress-agent-rollouts
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - rollouts
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: emissary-ingress
+    app.kubernetes.io/managed-by: getambassador.io
+    app.kubernetes.io/name: emissary-ingress-agent
+    app.kubernetes.io/part-of: emissary-ingress
+    product: aes
+    rbac.getambassador.io/role-group: emissary-ingress-agent
+  name: emissary-ingress-agent-applications
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - applications
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: emissary-ingress
+    app.kubernetes.io/managed-by: getambassador.io
+    app.kubernetes.io/name: emissary-ingress-agent
+    app.kubernetes.io/part-of: emissary-ingress
+    product: aes
+    rbac.getambassador.io/role-group: emissary-ingress-agent
+  name: emissary-ingress-agent-deployments
+rules:
+- apiGroups:
+  - apps
+  - extensions
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: emissary-ingress
+    app.kubernetes.io/managed-by: getambassador.io
+    app.kubernetes.io/name: emissary-ingress-agent
+    app.kubernetes.io/part-of: emissary-ingress
+    product: aes
+    rbac.getambassador.io/role-group: emissary-ingress-agent
+  name: emissary-ingress-agent-endpoints
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: emissary-ingress
+    app.kubernetes.io/managed-by: getambassador.io
+    app.kubernetes.io/name: emissary-ingress-agent
+    app.kubernetes.io/part-of: emissary-ingress
+    product: aes
+    rbac.getambassador.io/role-group: emissary-ingress-agent
+  name: emissary-ingress-agent-configmaps
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/instance: emissary-ingress
+    app.kubernetes.io/managed-by: getambassador.io
+    app.kubernetes.io/name: emissary-ingress-agent
+    app.kubernetes.io/part-of: emissary-ingress
+    product: aes
+  name: emissary-ingress-agent-config
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: emissary-ingress
+    app.kubernetes.io/managed-by: getambassador.io
+    app.kubernetes.io/name: emissary-ingress-agent
+    app.kubernetes.io/part-of: emissary-ingress
+    product: aes
+  name: emissary-ingress-agent-config
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: emissary-ingress-agent-config
+subjects:
+- kind: ServiceAccount
+  name: emissary-ingress-agent
+  namespace: default
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: emissary-ingress
+    app.kubernetes.io/managed-by: getambassador.io
+    app.kubernetes.io/name: emissary-ingress-agent
+    app.kubernetes.io/part-of: emissary-ingress
+    product: aes
+  name: emissary-ingress-agent
+  namespace: default
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: emissary-ingress
+      app.kubernetes.io/name: emissary-ingress-agent
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: emissary-ingress
+        app.kubernetes.io/managed-by: getambassador.io
+        app.kubernetes.io/name: emissary-ingress-agent
+        app.kubernetes.io/part-of: emissary-ingress
+        product: aes
+    spec:
+      containers:
+      - command:
+        - agent
+        env:
+        - name: AGENT_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: AGENT_CONFIG_RESOURCE_NAME
+          value: emissary-ingress-agent-cloud-token
+        - name: RPC_CONNECTION_ADDRESS
+          value: https://app.getambassador.io/
+        - name: AES_SNAPSHOT_URL
+          value: http://emissary-ingress-admin.default:8005/snapshot-external
+        image: $imageRepo$:$version$
+        imagePullPolicy: IfNotPresent
+        name: agent
+      serviceAccountName: emissary-ingress-agent

--- a/manifests/emissary/emissary-defaultns-migration.yaml.in
+++ b/manifests/emissary/emissary-defaultns-migration.yaml.in
@@ -1,0 +1,330 @@
+# GENERATED FILE: edits made by hand will not be preserved.
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    a8r.io/bugs: https://github.com/datawire/ambassador/issues
+    a8r.io/chat: http://a8r.io/Slack
+    a8r.io/dependencies: None
+    a8r.io/description: The Ambassador Edge Stack admin service for internal use and health checks.
+    a8r.io/documentation: https://www.getambassador.io/docs/edge-stack/latest/
+    a8r.io/owner: Ambassador Labs
+    a8r.io/repository: github.com/datawire/ambassador
+    a8r.io/support: https://www.getambassador.io/about-us/support/
+  labels:
+    app.kubernetes.io/instance: emissary-ingress
+    app.kubernetes.io/managed-by: getambassador.io
+    app.kubernetes.io/name: emissary-ingress
+    app.kubernetes.io/part-of: emissary-ingress
+    product: aes
+    service: ambassador-admin
+  name: emissary-ingress-admin
+  namespace: default
+spec:
+  ports:
+  - name: ambassador-admin
+    port: 8877
+    protocol: TCP
+    targetPort: admin
+  - name: ambassador-snapshot
+    port: 8005
+    protocol: TCP
+    targetPort: 8005
+  selector:
+    app.kubernetes.io/instance: emissary-ingress
+    app.kubernetes.io/name: emissary-ingress
+  type: NodePort
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    a8r.io/bugs: https://github.com/datawire/ambassador/issues
+    a8r.io/chat: http://a8r.io/Slack
+    a8r.io/dependencies: emissary-ingress-redis.default
+    a8r.io/description: The Ambassador Edge Stack goes beyond traditional API Gateways and Ingress Controllers with the advanced edge features needed to support developer self-service and full-cycle development.
+    a8r.io/documentation: https://www.getambassador.io/docs/edge-stack/latest/
+    a8r.io/owner: Ambassador Labs
+    a8r.io/repository: github.com/datawire/ambassador
+    a8r.io/support: https://www.getambassador.io/about-us/support/
+  labels:
+    app.kubernetes.io/component: ambassador-service
+    app.kubernetes.io/instance: emissary-ingress
+    app.kubernetes.io/managed-by: getambassador.io
+    app.kubernetes.io/name: emissary-ingress
+    app.kubernetes.io/part-of: emissary-ingress
+    product: aes
+  name: emissary-ingress
+  namespace: default
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080
+  - name: https
+    port: 443
+    targetPort: 8443
+  selector:
+    app.kubernetes.io/instance: emissary-ingress
+    app.kubernetes.io/name: emissary-ingress
+    profile: main
+  type: LoadBalancer
+---
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.getambassador.io/role-group: emissary-ingress
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: emissary-ingress
+    app.kubernetes.io/managed-by: getambassador.io
+    app.kubernetes.io/name: emissary-ingress
+    app.kubernetes.io/part-of: emissary-ingress
+    product: aes
+  name: emissary-ingress
+rules: []
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: emissary-ingress
+    app.kubernetes.io/managed-by: getambassador.io
+    app.kubernetes.io/name: emissary-ingress
+    app.kubernetes.io/part-of: emissary-ingress
+    product: aes
+  name: emissary-ingress
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: emissary-ingress
+    app.kubernetes.io/managed-by: getambassador.io
+    app.kubernetes.io/name: emissary-ingress
+    app.kubernetes.io/part-of: emissary-ingress
+    product: aes
+  name: emissary-ingress
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: emissary-ingress
+subjects:
+- kind: ServiceAccount
+  name: emissary-ingress
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: emissary-ingress
+    app.kubernetes.io/managed-by: getambassador.io
+    app.kubernetes.io/name: emissary-ingress
+    app.kubernetes.io/part-of: emissary-ingress
+    product: aes
+    rbac.getambassador.io/role-group: emissary-ingress
+  name: emissary-ingress-crd
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: emissary-ingress
+    app.kubernetes.io/managed-by: getambassador.io
+    app.kubernetes.io/name: emissary-ingress
+    app.kubernetes.io/part-of: emissary-ingress
+    product: aes
+    rbac.getambassador.io/role-group: emissary-ingress
+  name: emissary-ingress-watch
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - secrets
+  - configmaps
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - getambassador.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - create
+  - delete
+- apiGroups:
+  - getambassador.io
+  resources:
+  - mappings/status
+  verbs:
+  - update
+- apiGroups:
+  - networking.internal.knative.dev
+  resources:
+  - clusteringresses
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.x-k8s.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.internal.knative.dev
+  resources:
+  - ingresses/status
+  - clusteringresses/status
+  verbs:
+  - update
+- apiGroups:
+  - extensions
+  - networking.k8s.io
+  resources:
+  - ingresses
+  - ingressclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  - networking.k8s.io
+  resources:
+  - ingresses/status
+  verbs:
+  - update
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: emissary-ingress
+    app.kubernetes.io/managed-by: getambassador.io
+    app.kubernetes.io/name: emissary-ingress
+    app.kubernetes.io/part-of: emissary-ingress
+    product: aes
+  name: emissary-ingress
+  namespace: default
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: emissary-ingress
+      app.kubernetes.io/name: emissary-ingress
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        consul.hashicorp.com/connect-inject: "false"
+        sidecar.istio.io/inject: "false"
+      labels:
+        app.kubernetes.io/instance: emissary-ingress
+        app.kubernetes.io/managed-by: getambassador.io
+        app.kubernetes.io/name: emissary-ingress
+        app.kubernetes.io/part-of: emissary-ingress
+        product: aes
+        profile: main
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  service: ambassador
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      containers:
+      - env:
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: AMBASSADOR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: $imageRepo$:$version$
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /ambassador/v0/check_alive
+            port: admin
+          initialDelaySeconds: 30
+          periodSeconds: 3
+        name: ambassador
+        ports:
+        - containerPort: 8080
+          name: http
+        - containerPort: 8443
+          name: https
+        - containerPort: 8877
+          name: admin
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /ambassador/v0/check_ready
+            port: admin
+          initialDelaySeconds: 30
+          periodSeconds: 3
+        resources:
+          limits:
+            cpu: 1
+            memory: 400Mi
+          requests:
+            cpu: 200m
+            memory: 100Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+        volumeMounts:
+        - mountPath: /tmp/ambassador-pod-info
+          name: ambassador-pod-info
+          readOnly: true
+      dnsPolicy: ClusterFirst
+      hostNetwork: false
+      imagePullSecrets: []
+      restartPolicy: Always
+      securityContext:
+        runAsUser: 8888
+      serviceAccountName: emissary-ingress
+      terminationGracePeriodSeconds: 0
+      volumes:
+      - downwardAPI:
+          items:
+          - fieldRef:
+              fieldPath: metadata.labels
+            path: labels
+        name: ambassador-pod-info

--- a/manifests/emissary/emissary-emissaryns-agent.yaml.in
+++ b/manifests/emissary/emissary-emissaryns-agent.yaml.in
@@ -1,0 +1,262 @@
+# GENERATED FILE: edits made by hand will not be preserved.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: emissary-ingress
+    app.kubernetes.io/managed-by: getambassador.io
+    app.kubernetes.io/name: emissary-ingress-agent
+    app.kubernetes.io/part-of: emissary-ingress
+    product: aes
+  name: emissary-ingress-agent
+  namespace: emissary
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: emissary-ingress
+    app.kubernetes.io/managed-by: getambassador.io
+    app.kubernetes.io/name: emissary-ingress-agent
+    app.kubernetes.io/part-of: emissary-ingress
+    product: aes
+  name: emissary-ingress-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: emissary-ingress-agent
+subjects:
+- kind: ServiceAccount
+  name: emissary-ingress-agent
+  namespace: emissary
+---
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.getambassador.io/role-group: emissary-ingress-agent
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: emissary-ingress
+    app.kubernetes.io/managed-by: getambassador.io
+    app.kubernetes.io/name: emissary-ingress-agent
+    app.kubernetes.io/part-of: emissary-ingress
+    product: aes
+  name: emissary-ingress-agent
+rules: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: emissary-ingress
+    app.kubernetes.io/managed-by: getambassador.io
+    app.kubernetes.io/name: emissary-ingress-agent
+    app.kubernetes.io/part-of: emissary-ingress
+    product: aes
+    rbac.getambassador.io/role-group: emissary-ingress-agent
+  name: emissary-ingress-agent-pods
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: emissary-ingress
+    app.kubernetes.io/managed-by: getambassador.io
+    app.kubernetes.io/name: emissary-ingress-agent
+    app.kubernetes.io/part-of: emissary-ingress
+    product: aes
+    rbac.getambassador.io/role-group: emissary-ingress-agent
+  name: emissary-ingress-agent-rollouts
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - rollouts
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: emissary-ingress
+    app.kubernetes.io/managed-by: getambassador.io
+    app.kubernetes.io/name: emissary-ingress-agent
+    app.kubernetes.io/part-of: emissary-ingress
+    product: aes
+    rbac.getambassador.io/role-group: emissary-ingress-agent
+  name: emissary-ingress-agent-applications
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - applications
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: emissary-ingress
+    app.kubernetes.io/managed-by: getambassador.io
+    app.kubernetes.io/name: emissary-ingress-agent
+    app.kubernetes.io/part-of: emissary-ingress
+    product: aes
+    rbac.getambassador.io/role-group: emissary-ingress-agent
+  name: emissary-ingress-agent-deployments
+rules:
+- apiGroups:
+  - apps
+  - extensions
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: emissary-ingress
+    app.kubernetes.io/managed-by: getambassador.io
+    app.kubernetes.io/name: emissary-ingress-agent
+    app.kubernetes.io/part-of: emissary-ingress
+    product: aes
+    rbac.getambassador.io/role-group: emissary-ingress-agent
+  name: emissary-ingress-agent-endpoints
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: emissary-ingress
+    app.kubernetes.io/managed-by: getambassador.io
+    app.kubernetes.io/name: emissary-ingress-agent
+    app.kubernetes.io/part-of: emissary-ingress
+    product: aes
+    rbac.getambassador.io/role-group: emissary-ingress-agent
+  name: emissary-ingress-agent-configmaps
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/instance: emissary-ingress
+    app.kubernetes.io/managed-by: getambassador.io
+    app.kubernetes.io/name: emissary-ingress-agent
+    app.kubernetes.io/part-of: emissary-ingress
+    product: aes
+  name: emissary-ingress-agent-config
+  namespace: emissary
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: emissary-ingress
+    app.kubernetes.io/managed-by: getambassador.io
+    app.kubernetes.io/name: emissary-ingress-agent
+    app.kubernetes.io/part-of: emissary-ingress
+    product: aes
+  name: emissary-ingress-agent-config
+  namespace: emissary
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: emissary-ingress-agent-config
+subjects:
+- kind: ServiceAccount
+  name: emissary-ingress-agent
+  namespace: emissary
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: emissary-ingress
+    app.kubernetes.io/managed-by: getambassador.io
+    app.kubernetes.io/name: emissary-ingress-agent
+    app.kubernetes.io/part-of: emissary-ingress
+    product: aes
+  name: emissary-ingress-agent
+  namespace: emissary
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: emissary-ingress
+      app.kubernetes.io/name: emissary-ingress-agent
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: emissary-ingress
+        app.kubernetes.io/managed-by: getambassador.io
+        app.kubernetes.io/name: emissary-ingress-agent
+        app.kubernetes.io/part-of: emissary-ingress
+        product: aes
+    spec:
+      containers:
+      - command:
+        - agent
+        env:
+        - name: AGENT_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: AGENT_CONFIG_RESOURCE_NAME
+          value: emissary-ingress-agent-cloud-token
+        - name: RPC_CONNECTION_ADDRESS
+          value: https://app.getambassador.io/
+        - name: AES_SNAPSHOT_URL
+          value: http://emissary-ingress-admin.emissary:8005/snapshot-external
+        image: $imageRepo$:$version$
+        imagePullPolicy: IfNotPresent
+        name: agent
+      serviceAccountName: emissary-ingress-agent

--- a/manifests/emissary/emissary-emissaryns-migration.yaml.in
+++ b/manifests/emissary/emissary-emissaryns-migration.yaml.in
@@ -1,0 +1,330 @@
+# GENERATED FILE: edits made by hand will not be preserved.
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    a8r.io/bugs: https://github.com/datawire/ambassador/issues
+    a8r.io/chat: http://a8r.io/Slack
+    a8r.io/dependencies: None
+    a8r.io/description: The Ambassador Edge Stack admin service for internal use and health checks.
+    a8r.io/documentation: https://www.getambassador.io/docs/edge-stack/latest/
+    a8r.io/owner: Ambassador Labs
+    a8r.io/repository: github.com/datawire/ambassador
+    a8r.io/support: https://www.getambassador.io/about-us/support/
+  labels:
+    app.kubernetes.io/instance: emissary-ingress
+    app.kubernetes.io/managed-by: getambassador.io
+    app.kubernetes.io/name: emissary-ingress
+    app.kubernetes.io/part-of: emissary-ingress
+    product: aes
+    service: ambassador-admin
+  name: emissary-ingress-admin
+  namespace: emissary
+spec:
+  ports:
+  - name: ambassador-admin
+    port: 8877
+    protocol: TCP
+    targetPort: admin
+  - name: ambassador-snapshot
+    port: 8005
+    protocol: TCP
+    targetPort: 8005
+  selector:
+    app.kubernetes.io/instance: emissary-ingress
+    app.kubernetes.io/name: emissary-ingress
+  type: NodePort
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    a8r.io/bugs: https://github.com/datawire/ambassador/issues
+    a8r.io/chat: http://a8r.io/Slack
+    a8r.io/dependencies: emissary-ingress-redis.emissary
+    a8r.io/description: The Ambassador Edge Stack goes beyond traditional API Gateways and Ingress Controllers with the advanced edge features needed to support developer self-service and full-cycle development.
+    a8r.io/documentation: https://www.getambassador.io/docs/edge-stack/latest/
+    a8r.io/owner: Ambassador Labs
+    a8r.io/repository: github.com/datawire/ambassador
+    a8r.io/support: https://www.getambassador.io/about-us/support/
+  labels:
+    app.kubernetes.io/component: ambassador-service
+    app.kubernetes.io/instance: emissary-ingress
+    app.kubernetes.io/managed-by: getambassador.io
+    app.kubernetes.io/name: emissary-ingress
+    app.kubernetes.io/part-of: emissary-ingress
+    product: aes
+  name: emissary-ingress
+  namespace: emissary
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080
+  - name: https
+    port: 443
+    targetPort: 8443
+  selector:
+    app.kubernetes.io/instance: emissary-ingress
+    app.kubernetes.io/name: emissary-ingress
+    profile: main
+  type: LoadBalancer
+---
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.getambassador.io/role-group: emissary-ingress
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: emissary-ingress
+    app.kubernetes.io/managed-by: getambassador.io
+    app.kubernetes.io/name: emissary-ingress
+    app.kubernetes.io/part-of: emissary-ingress
+    product: aes
+  name: emissary-ingress
+rules: []
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: emissary-ingress
+    app.kubernetes.io/managed-by: getambassador.io
+    app.kubernetes.io/name: emissary-ingress
+    app.kubernetes.io/part-of: emissary-ingress
+    product: aes
+  name: emissary-ingress
+  namespace: emissary
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: emissary-ingress
+    app.kubernetes.io/managed-by: getambassador.io
+    app.kubernetes.io/name: emissary-ingress
+    app.kubernetes.io/part-of: emissary-ingress
+    product: aes
+  name: emissary-ingress
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: emissary-ingress
+subjects:
+- kind: ServiceAccount
+  name: emissary-ingress
+  namespace: emissary
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: emissary-ingress
+    app.kubernetes.io/managed-by: getambassador.io
+    app.kubernetes.io/name: emissary-ingress
+    app.kubernetes.io/part-of: emissary-ingress
+    product: aes
+    rbac.getambassador.io/role-group: emissary-ingress
+  name: emissary-ingress-crd
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: emissary-ingress
+    app.kubernetes.io/managed-by: getambassador.io
+    app.kubernetes.io/name: emissary-ingress
+    app.kubernetes.io/part-of: emissary-ingress
+    product: aes
+    rbac.getambassador.io/role-group: emissary-ingress
+  name: emissary-ingress-watch
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - services
+  - secrets
+  - configmaps
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - getambassador.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - create
+  - delete
+- apiGroups:
+  - getambassador.io
+  resources:
+  - mappings/status
+  verbs:
+  - update
+- apiGroups:
+  - networking.internal.knative.dev
+  resources:
+  - clusteringresses
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.x-k8s.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.internal.knative.dev
+  resources:
+  - ingresses/status
+  - clusteringresses/status
+  verbs:
+  - update
+- apiGroups:
+  - extensions
+  - networking.k8s.io
+  resources:
+  - ingresses
+  - ingressclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  - networking.k8s.io
+  resources:
+  - ingresses/status
+  verbs:
+  - update
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: emissary-ingress
+    app.kubernetes.io/managed-by: getambassador.io
+    app.kubernetes.io/name: emissary-ingress
+    app.kubernetes.io/part-of: emissary-ingress
+    product: aes
+  name: emissary-ingress
+  namespace: emissary
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: emissary-ingress
+      app.kubernetes.io/name: emissary-ingress
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        consul.hashicorp.com/connect-inject: "false"
+        sidecar.istio.io/inject: "false"
+      labels:
+        app.kubernetes.io/instance: emissary-ingress
+        app.kubernetes.io/managed-by: getambassador.io
+        app.kubernetes.io/name: emissary-ingress
+        app.kubernetes.io/part-of: emissary-ingress
+        product: aes
+        profile: main
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  service: ambassador
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      containers:
+      - env:
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: AMBASSADOR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: $imageRepo$:$version$
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /ambassador/v0/check_alive
+            port: admin
+          initialDelaySeconds: 30
+          periodSeconds: 3
+        name: ambassador
+        ports:
+        - containerPort: 8080
+          name: http
+        - containerPort: 8443
+          name: https
+        - containerPort: 8877
+          name: admin
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /ambassador/v0/check_ready
+            port: admin
+          initialDelaySeconds: 30
+          periodSeconds: 3
+        resources:
+          limits:
+            cpu: 1
+            memory: 400Mi
+          requests:
+            cpu: 200m
+            memory: 100Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+        volumeMounts:
+        - mountPath: /tmp/ambassador-pod-info
+          name: ambassador-pod-info
+          readOnly: true
+      dnsPolicy: ClusterFirst
+      hostNetwork: false
+      imagePullSecrets: []
+      restartPolicy: Always
+      securityContext:
+        runAsUser: 8888
+      serviceAccountName: emissary-ingress
+      terminationGracePeriodSeconds: 0
+      volumes:
+      - downwardAPI:
+          items:
+          - fieldRef:
+              fieldPath: metadata.labels
+            path: labels
+        name: ambassador-pod-info


### PR DESCRIPTION
I plan to use these for cleaning up the migration from 1.X to 2.X:

- apply CRDs
- apply emissary-migration YAML
- test
- scale down 1.14 agent
- apply emissary-agent YAML

I have tested this, so far, only by making sure that emissary-migration + emissary-agent gives you
emissary.yaml. More soon, like actually using it.

Signed-off-by: Flynn <flynn@datawire.io>

 - [x] I didn't need to update `CHANGELOG.md`.
 - [x] This is unlikely to impact how Ambassador performs at scale.
 - [ ] My change is adequately tested.
 - [x] I didn't need to update `DEVELOPING.md`.

