### PR TITLE
Fix test "flakes" from `cmd/entrypoint`

### DIFF
--- a/cmd/entrypoint/consul.go
+++ b/cmd/entrypoint/consul.go
@@ -77,20 +77,14 @@ type consulWatcher struct {
 	bootstrapped     bool
 }
 
-func newConsulWatcher(ctx context.Context, watchFunc watchConsulFunc) *consulWatcher {
-	result := &consulWatcher{
+func newConsulWatcher(watchFunc watchConsulFunc) *consulWatcher {
+	return &consulWatcher{
 		watchFunc:      watchFunc,
 		resolvers:      make(map[string]*resolver),
 		coalescedDirty: make(chan struct{}),
 		endpointsCh:    make(chan consulwatch.Endpoints),
 		endpoints:      make(map[string]consulwatch.Endpoints),
 	}
-	go func() {
-		if err := result.run(ctx); err != nil {
-			panic(err) // TODO: Find a better way of reporting errors from goroutines.
-		}
-	}()
-	return result
 }
 
 func (c *consulWatcher) run(ctx context.Context) error {

--- a/cmd/entrypoint/consul_test.go
+++ b/cmd/entrypoint/consul_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/datawire/ambassador/v2/pkg/consulwatch"
 	"github.com/datawire/ambassador/v2/pkg/kates"
 	snapshotTypes "github.com/datawire/ambassador/v2/pkg/snapshot/v1"
+	"github.com/datawire/dlib/dgroup"
 	"github.com/datawire/dlib/dlog"
 )
 
@@ -122,7 +123,13 @@ func TestBootstrap(t *testing.T) {
 }
 
 func setup(t *testing.T) (ctx context.Context, resolvers []*amb.ConsulResolver, mappings []consulMapping, c *consulWatcher, tw *testWatcher) {
-	ctx = dlog.NewTestContext(t, false)
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithCancel(dlog.NewTestContext(t, false))
+	grp := dgroup.NewGroup(ctx, dgroup.GroupConfig{})
+	t.Cleanup(func() {
+		cancel()
+		assert.NoError(t, grp.Wait())
+	})
 
 	parent := &kates.Unstructured{
 		Object: map[string]interface{}{
@@ -157,7 +164,8 @@ func setup(t *testing.T) (ctx context.Context, resolvers []*amb.ConsulResolver, 
 	assert.Equal(t, 4, len(mappings))
 
 	tw = &testWatcher{t: t, events: make(map[string]bool)}
-	c = newConsulWatcher(ctx, tw.Watch)
+	c = newConsulWatcher(tw.Watch)
+	grp.Go("consul", c.run)
 	tw.Assert()
 
 	return

--- a/cmd/entrypoint/consul_test.go
+++ b/cmd/entrypoint/consul_test.go
@@ -121,7 +121,7 @@ func TestBootstrap(t *testing.T) {
 	assert.True(t, c.isBootstrapped())
 }
 
-func setup(t *testing.T) (ctx context.Context, resolvers []*amb.ConsulResolver, mappings []consulMapping, c *consul, tw *testWatcher) {
+func setup(t *testing.T) (ctx context.Context, resolvers []*amb.ConsulResolver, mappings []consulMapping, c *consulWatcher, tw *testWatcher) {
 	ctx = dlog.NewTestContext(t, false)
 
 	parent := &kates.Unstructured{
@@ -157,7 +157,7 @@ func setup(t *testing.T) (ctx context.Context, resolvers []*amb.ConsulResolver, 
 	assert.Equal(t, 4, len(mappings))
 
 	tw = &testWatcher{t: t, events: make(map[string]bool)}
-	c = newConsul(ctx, tw.Watch)
+	c = newConsulWatcher(ctx, tw.Watch)
 	tw.Assert()
 
 	return

--- a/cmd/entrypoint/consul_test.go
+++ b/cmd/entrypoint/consul_test.go
@@ -157,7 +157,7 @@ func setup(t *testing.T) (ctx context.Context, resolvers []*amb.ConsulResolver, 
 	assert.Equal(t, 4, len(mappings))
 
 	tw = &testWatcher{t: t, events: make(map[string]bool)}
-	c = newConsul(ctx, tw)
+	c = newConsul(ctx, tw.Watch)
 	tw.Assert()
 
 	return

--- a/cmd/entrypoint/entrypoint.go
+++ b/cmd/entrypoint/entrypoint.go
@@ -189,7 +189,7 @@ func Main(ctx context.Context, Version string, args ...string) error {
 		group.Go("watcher", func(ctx context.Context) error {
 			// We need to pass the AmbassadorWatcher to this (Kubernetes/Consul) watcher, so
 			// that it can tell the AmbassadorWatcher when snapshots are posted.
-			return watcher(ctx, ambwatch, snapshot, fastpathCh, clusterID, Version)
+			return WatchAllTheThings(ctx, ambwatch, snapshot, fastpathCh, clusterID, Version)
 		})
 	}
 

--- a/cmd/entrypoint/fswatcher.go
+++ b/cmd/entrypoint/fswatcher.go
@@ -118,9 +118,6 @@ func NewFSWatcher(ctx context.Context) (*FSWatcher, error) {
 	// Start with the default error handler...
 	fsw.handleError = fsw.defaultErrorHandler
 
-	// ...and then go watch for events.
-	go fsw.watchForEvents(ctx)
-
 	return fsw, nil
 }
 
@@ -170,7 +167,7 @@ func (fsw *FSWatcher) defaultErrorHandler(ctx context.Context, err error) {
 }
 
 // Watch for events, and handle them.
-func (fsw *FSWatcher) watchForEvents(ctx context.Context) {
+func (fsw *FSWatcher) Run(ctx context.Context) {
 	for {
 		select {
 		case event := <-fsw.FSW.Events:

--- a/cmd/entrypoint/internal/testqueue/queue.go
+++ b/cmd/entrypoint/internal/testqueue/queue.go
@@ -1,4 +1,4 @@
-package entrypoint
+package testqueue
 
 import (
 	"encoding/json"

--- a/cmd/entrypoint/internal/testqueue/queue.go
+++ b/cmd/entrypoint/internal/testqueue/queue.go
@@ -1,6 +1,7 @@
 package testqueue
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/datawire/dlib/dgroup"
 	"github.com/datawire/dlib/dlog"
 )
 
@@ -17,7 +19,6 @@ import (
 // operation (the Get() method) takes a predicate that allows it to skip past queue entries until it
 // finds one that satisfies the specified predicate.
 type Queue struct {
-	T       *testing.T
 	timeout time.Duration
 	cond    *sync.Cond
 	entries []interface{}
@@ -27,29 +28,34 @@ type Queue struct {
 // NewQueue constructs a new queue with the supplied timeout.
 func NewQueue(t *testing.T, timeout time.Duration) *Queue {
 	q := &Queue{
-		T:       t,
 		timeout: timeout,
 		cond:    sync.NewCond(&sync.Mutex{}),
 	}
-	ctx := dlog.NewTestContext(t, false)
+	ctx, cancel := context.WithCancel(dlog.NewTestContext(t, true))
+	grp := dgroup.NewGroup(ctx, dgroup.GroupConfig{})
+	t.Cleanup(func() {
+		cancel()
+		assert.NoError(t, grp.Wait())
+	})
 	// Broadcast on Queue.cond every three seconds so that anyone waiting on the condition has a
 	// chance to timeout. (Go doesn't support timed wait on conditions.)
-	go func() {
+	grp.Go("ticker", func(ctx context.Context) error {
 		ticker := time.NewTicker(3 * time.Second)
 		for {
 			select {
 			case <-ticker.C:
 				q.cond.Broadcast()
 			case <-ctx.Done():
-				return
+				return nil
 			}
 		}
-	}()
+	})
 	return q
 }
 
 // Add an entry to the queue.
-func (q *Queue) Add(obj interface{}) {
+func (q *Queue) Add(t *testing.T, obj interface{}) {
+	t.Helper()
 	q.cond.L.Lock()
 	defer q.cond.L.Unlock()
 	q.entries = append(q.entries, obj)
@@ -57,8 +63,8 @@ func (q *Queue) Add(obj interface{}) {
 }
 
 // Get will return the next entry that satisfies the supplied predicate.
-func (q *Queue) Get(predicate func(interface{}) bool) (interface{}, error) {
-	q.T.Helper()
+func (q *Queue) Get(t *testing.T, predicate func(interface{}) bool) (interface{}, error) {
+	t.Helper()
 	start := time.Now()
 	q.cond.L.Lock()
 	defer q.cond.L.Unlock()
@@ -89,17 +95,17 @@ func (q *Queue) Get(predicate func(interface{}) bool) (interface{}, error) {
 				msg.WriteString(fmt.Sprintf("\n--- Queue Entry[%d] %s---\n%s\n", idx, extra, string(bytes)))
 			}
 
-			q.T.Fatal(fmt.Sprintf("Get timed out!\n%s", msg))
+			t.Fatalf("Get timed out!\n%s", msg)
 		}
 		q.cond.Wait()
 	}
 }
 
 // AssertEmpty will check that the queue remains empty for the supplied duration.
-func (q *Queue) AssertEmpty(timeout time.Duration, msg string) {
-	q.T.Helper()
+func (q *Queue) AssertEmpty(t *testing.T, timeout time.Duration, msg string) {
+	t.Helper()
 	time.Sleep(timeout)
 	q.cond.L.Lock()
 	defer q.cond.L.Unlock()
-	assert.Empty(q.T, q.entries, msg)
+	assert.Empty(t, q.entries, msg)
 }

--- a/cmd/entrypoint/internal/testqueue/queue_test.go
+++ b/cmd/entrypoint/internal/testqueue/queue_test.go
@@ -13,12 +13,12 @@ func TestFakeQueueGet(t *testing.T) {
 
 	go func() {
 		for count := 0; count < 10; count++ {
-			q.Add(count)
+			q.Add(t, count)
 		}
 	}()
 
 	for count := 0; count < 10; count++ {
-		obj, err := q.Get(func(obj interface{}) bool {
+		obj, err := q.Get(t, func(obj interface{}) bool {
 			return true
 		})
 		require.NoError(t, err)
@@ -31,12 +31,12 @@ func TestFakeQueueSkip(t *testing.T) {
 
 	go func() {
 		for count := 0; count < 10; count++ {
-			q.Add(count)
+			q.Add(t, count)
 		}
 	}()
 
 	for count := 0; count < 10; count += 2 {
-		obj, err := q.Get(func(obj interface{}) bool {
+		obj, err := q.Get(t, func(obj interface{}) bool {
 			i := obj.(int)
 			return (i % 2) == 0
 		})

--- a/cmd/entrypoint/internal/testqueue/queue_test.go
+++ b/cmd/entrypoint/internal/testqueue/queue_test.go
@@ -1,15 +1,15 @@
-package entrypoint_test
+package testqueue_test
 
 import (
 	"testing"
 	"time"
 
-	"github.com/datawire/ambassador/v2/cmd/entrypoint"
+	"github.com/datawire/ambassador/v2/cmd/entrypoint/internal/testqueue"
 	"github.com/stretchr/testify/require"
 )
 
 func TestFakeQueueGet(t *testing.T) {
-	q := entrypoint.NewQueue(t, 10*time.Second)
+	q := testqueue.NewQueue(t, 10*time.Second)
 
 	go func() {
 		for count := 0; count < 10; count++ {
@@ -27,7 +27,7 @@ func TestFakeQueueGet(t *testing.T) {
 }
 
 func TestFakeQueueSkip(t *testing.T) {
-	q := entrypoint.NewQueue(t, 10*time.Second)
+	q := testqueue.NewQueue(t, 10*time.Second)
 
 	go func() {
 		for count := 0; count < 10; count++ {

--- a/cmd/entrypoint/istiocert.go
+++ b/cmd/entrypoint/istiocert.go
@@ -60,6 +60,7 @@ func (src *istioCertSource) Watch(ctx context.Context) (IstioCertWatcher, error)
 		if err != nil {
 			return nil, err
 		}
+		go fsw.Run(ctx)
 
 		// ...then tell the FSWatcher to watch the Istio cert directory,
 		// and give it a handler function that'll update the IstioCert

--- a/cmd/entrypoint/testutil_fake_hello_test.go
+++ b/cmd/entrypoint/testutil_fake_hello_test.go
@@ -142,30 +142,53 @@ func FindCluster(envoyConfig *v3bootstrap.Bootstrap, predicate func(*v3cluster.C
 	return nil
 }
 
-func deltaSummary(t *testing.T, snap *snapshot.Snapshot) []string {
+func deltaSummary(t *testing.T, snaps ...*snapshot.Snapshot) []string {
 	summary := []string{}
 
 	var typestr string
 
-	for _, delta := range snap.Deltas {
-		switch delta.DeltaType {
-		case kates.ObjectAdd:
-			typestr = "add"
-		case kates.ObjectUpdate:
-			typestr = "update"
-		case kates.ObjectDelete:
-			typestr = "delete"
-		default:
-			// Bug because the programmer needs to add another case here.
-			t.Fatalf("missing case for DeltaType enum: %#v", delta)
-		}
+	for _, snap := range snaps {
+		for _, delta := range snap.Deltas {
+			switch delta.DeltaType {
+			case kates.ObjectAdd:
+				typestr = "add"
+			case kates.ObjectUpdate:
+				typestr = "update"
+			case kates.ObjectDelete:
+				typestr = "delete"
+			default:
+				// Bug because the programmer needs to add another case here.
+				t.Fatalf("missing case for DeltaType enum: %#v", delta)
+			}
 
-		summary = append(summary, fmt.Sprintf("%s %s %s", typestr, delta.Kind, delta.Name))
+			summary = append(summary, fmt.Sprintf("%s %s %s", typestr, delta.Kind, delta.Name))
+		}
 	}
 
 	sort.Strings(summary)
 
 	return summary
+}
+
+// getSnapshots is like f.GetSnapshot, but returns the list of every snapshot evaluated (rather than
+// discarding the snapshots from before predicate returns true).  This is particularly important if
+// you're looking at deltas; you don't want to discard any deltas just because two snapshots didn't
+// get coalesced.
+func getSnapshots(f *entrypoint.Fake, predicate func(*snapshot.Snapshot) bool) ([]*snapshot.Snapshot, error) {
+	var ret []*snapshot.Snapshot
+	for {
+		snap, err := f.GetSnapshot(func(_ *snapshot.Snapshot) bool {
+			return true
+		})
+		if err != nil {
+			return nil, err
+		}
+		ret = append(ret, snap)
+		if predicate(snap) {
+			break
+		}
+	}
+	return ret, nil
 }
 
 // This test will cover how to exercise the consul portion of the control plane. In principal it is
@@ -337,14 +360,16 @@ spec:
 	f.Flush()
 
 	// Repeat all the checks.
-	snap, err = f.GetSnapshot(func(snap *snapshot.Snapshot) bool {
+	snaps, err := getSnapshots(f, func(snap *snapshot.Snapshot) bool {
 		return (len(snap.Kubernetes.Mappings) > 0) && (len(snap.Kubernetes.TCPMappings) > 0) && (len(snap.Kubernetes.ConsulResolvers) > 0)
 	})
 	require.NoError(t, err)
+	require.Greater(t, len(snaps), 0)
+	snap = snaps[len(snaps)-1]
 
 	// Two deltas here since we've deleted and re-added without a check in between.
 	// (They appear out of order here because of string sorting. Don't panic.)
-	assert.Equal(t, []string{"add ConsulResolver consul-dc1", "delete ConsulResolver consul-dc1"}, deltaSummary(t, snap))
+	assert.Equal(t, []string{"add ConsulResolver consul-dc1", "delete ConsulResolver consul-dc1"}, deltaSummary(t, snaps...))
 
 	// ...one mapping...
 	assert.Equal(t, "hello", snap.Kubernetes.Mappings[0].Name)

--- a/cmd/entrypoint/testutil_fake_hello_test.go
+++ b/cmd/entrypoint/testutil_fake_hello_test.go
@@ -142,7 +142,7 @@ func FindCluster(envoyConfig *v3bootstrap.Bootstrap, predicate func(*v3cluster.C
 	return nil
 }
 
-func deltaSummary(snap *snapshot.Snapshot) []string {
+func deltaSummary(t *testing.T, snap *snapshot.Snapshot) []string {
 	summary := []string{}
 
 	var typestr string
@@ -157,7 +157,7 @@ func deltaSummary(snap *snapshot.Snapshot) []string {
 			typestr = "delete"
 		default:
 			// Bug because the programmer needs to add another case here.
-			panic(fmt.Errorf("missing case for DeltaType enum: %#v", delta))
+			t.Fatalf("missing case for DeltaType enum: %#v", delta)
 		}
 
 		summary = append(summary, fmt.Sprintf("%s %s %s", typestr, delta.Kind, delta.Name))
@@ -242,7 +242,7 @@ func TestFakeHelloConsul(t *testing.T) {
 	assert.Equal(t, "consul-server.default:8500", snap.Kubernetes.ConsulResolvers[0].Spec.Address)
 
 	// Check that our deltas are what we expect.
-	assert.Equal(t, []string{"add ConsulResolver consul-dc1", "add Mapping hello", "add TCPMapping hello-tcp"}, deltaSummary(snap))
+	assert.Equal(t, []string{"add ConsulResolver consul-dc1", "add Mapping hello", "add TCPMapping hello-tcp"}, deltaSummary(t, snap))
 
 	// Create a predicate that will recognize the cluster we care about. The surjection from
 	// Mappings to clusters is a bit opaque, so we just look for a cluster that contains the name
@@ -309,7 +309,7 @@ spec:
 	require.NoError(t, err)
 
 	// ...with one delta, namely the ConsulResolver...
-	assert.Equal(t, []string{"update ConsulResolver consul-dc1"}, deltaSummary(snap))
+	assert.Equal(t, []string{"update ConsulResolver consul-dc1"}, deltaSummary(t, snap))
 
 	// ...where the mapping name hasn't changed...
 	assert.Equal(t, "hello", snap.Kubernetes.Mappings[0].Name)
@@ -344,7 +344,7 @@ spec:
 
 	// Two deltas here since we've deleted and re-added without a check in between.
 	// (They appear out of order here because of string sorting. Don't panic.)
-	assert.Equal(t, []string{"add ConsulResolver consul-dc1", "delete ConsulResolver consul-dc1"}, deltaSummary(snap))
+	assert.Equal(t, []string{"add ConsulResolver consul-dc1", "delete ConsulResolver consul-dc1"}, deltaSummary(t, snap))
 
 	// ...one mapping...
 	assert.Equal(t, "hello", snap.Kubernetes.Mappings[0].Name)

--- a/cmd/entrypoint/testutil_fake_test.go
+++ b/cmd/entrypoint/testutil_fake_test.go
@@ -217,12 +217,12 @@ func (f *Fake) runWatcher(ctx context.Context) error {
 }
 
 func (f *Fake) notifyFastpath(ctx context.Context, fastpath *ambex.FastpathSnapshot) {
-	f.fastpath.Add(fastpath)
+	f.fastpath.Add(f.T, fastpath)
 }
 
 func (f *Fake) GetEndpoints(predicate func(*ambex.Endpoints) bool) (*ambex.Endpoints, error) {
 	f.T.Helper()
-	untyped, err := f.fastpath.Get(func(obj interface{}) bool {
+	untyped, err := f.fastpath.Get(f.T, func(obj interface{}) bool {
 		fastpath := obj.(*ambex.FastpathSnapshot)
 		return predicate(fastpath.Endpoints)
 	})
@@ -234,7 +234,7 @@ func (f *Fake) GetEndpoints(predicate func(*ambex.Endpoints) bool) (*ambex.Endpo
 
 func (f *Fake) AssertEndpointsEmpty(timeout time.Duration) {
 	f.T.Helper()
-	f.fastpath.AssertEmpty(timeout, "endpoints queue not empty")
+	f.fastpath.AssertEmpty(f.T, timeout, "endpoints queue not empty")
 }
 
 type SnapshotEntry struct {
@@ -257,14 +257,14 @@ func (f *Fake) notifySnapshot(ctx context.Context, disp SnapshotDisposition, sna
 		f.T.Fatalf("error decoding snapshot: %+v", err)
 	}
 
-	f.snapshots.Add(SnapshotEntry{disp, snap})
+	f.snapshots.Add(f.T, SnapshotEntry{disp, snap})
 	return nil
 }
 
 // GetSnapshotEntry will return the next SnapshotEntry that satisfies the supplied predicate.
 func (f *Fake) GetSnapshotEntry(predicate func(SnapshotEntry) bool) (SnapshotEntry, error) {
 	f.T.Helper()
-	untyped, err := f.snapshots.Get(func(obj interface{}) bool {
+	untyped, err := f.snapshots.Get(f.T, func(obj interface{}) bool {
 		entry := obj.(SnapshotEntry)
 		return predicate(entry)
 	})
@@ -292,13 +292,13 @@ func (f *Fake) appendEnvoyConfig(ctx context.Context) {
 		f.T.Fatalf("error decoding envoy.json after sending snapshot to python: %+v", err)
 	}
 	bs := msg.(*v3bootstrap.Bootstrap)
-	f.envoyConfigs.Add(bs)
+	f.envoyConfigs.Add(f.T, bs)
 }
 
 // GetEnvoyConfig will return the next envoy config that satisfies the supplied predicate.
 func (f *Fake) GetEnvoyConfig(predicate func(*v3bootstrap.Bootstrap) bool) (*v3bootstrap.Bootstrap, error) {
 	f.T.Helper()
-	untyped, err := f.envoyConfigs.Get(func(obj interface{}) bool {
+	untyped, err := f.envoyConfigs.Get(f.T, func(obj interface{}) bool {
 		return predicate(obj.(*v3bootstrap.Bootstrap))
 	})
 	if err != nil {

--- a/cmd/entrypoint/testutil_fake_test.go
+++ b/cmd/entrypoint/testutil_fake_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/datawire/ambassador/v2/cmd/ambex"
+	"github.com/datawire/ambassador/v2/cmd/entrypoint/internal/testqueue"
 	v3bootstrap "github.com/datawire/ambassador/v2/pkg/api/envoy/config/bootstrap/v3"
 	amb "github.com/datawire/ambassador/v2/pkg/api/getambassador.io/v3alpha1"
 	"github.com/datawire/ambassador/v2/pkg/consulwatch"
@@ -69,9 +70,9 @@ type Fake struct {
 	// This holds the current snapshot.
 	currentSnapshot *atomic.Value
 
-	fastpath     *Queue // All fastpath snapshots that have been produced.
-	snapshots    *Queue // All snapshots that have been produced.
-	envoyConfigs *Queue // All envoyConfigs that have been produced.
+	fastpath     *testqueue.Queue // All fastpath snapshots that have been produced.
+	snapshots    *testqueue.Queue // All snapshots that have been produced.
+	envoyConfigs *testqueue.Queue // All envoyConfigs that have been produced.
 
 	// This is used to make Teardown idempotent.
 	teardownOnce sync.Once
@@ -113,9 +114,9 @@ func NewFake(t *testing.T, config FakeConfig) *Fake {
 
 		currentSnapshot: &atomic.Value{},
 
-		fastpath:     NewQueue(t, config.Timeout),
-		snapshots:    NewQueue(t, config.Timeout),
-		envoyConfigs: NewQueue(t, config.Timeout),
+		fastpath:     testqueue.NewQueue(t, config.Timeout),
+		snapshots:    testqueue.NewQueue(t, config.Timeout),
+		envoyConfigs: testqueue.NewQueue(t, config.Timeout),
 	}
 
 	fake.k8sSource = &fakeK8sSource{fake: fake, store: k8sStore}

--- a/cmd/entrypoint/testutil_fake_test.go
+++ b/cmd/entrypoint/testutil_fake_test.go
@@ -242,6 +242,14 @@ type SnapshotEntry struct {
 	Snapshot    *snapshot.Snapshot
 }
 
+func (entry SnapshotEntry) String() string {
+	snapshot := "nil"
+	if entry.Snapshot != nil {
+		snapshot = fmt.Sprintf("&%#v", *entry.Snapshot)
+	}
+	return fmt.Sprintf("{Disposition: %v, Snapshot: %s}", entry.Disposition, snapshot)
+}
+
 // We pass this into the watcher loop to get notified when a snapshot is produced.
 func (f *Fake) notifySnapshot(ctx context.Context, disp SnapshotDisposition, snapJSON []byte) error {
 	if disp == SnapshotReady && f.config.EnvoyConfig {

--- a/cmd/entrypoint/testutil_fake_test.go
+++ b/cmd/entrypoint/testutil_fake_test.go
@@ -207,7 +207,7 @@ func (f *Fake) runWatcher(ctx context.Context) error {
 		f.currentSnapshot, // encoded
 		f.k8sSource,
 		queries,
-		f.watcher, // consulWatcher
+		f.watcher.Watch, // watchConsulFunc
 		f.istioCertSource,
 		f.notifySnapshot,
 		f.notifyFastpath,

--- a/cmd/entrypoint/testutil_fake_test.go
+++ b/cmd/entrypoint/testutil_fake_test.go
@@ -202,7 +202,7 @@ func (f *Fake) runWatcher(ctx context.Context) error {
 	interestingTypes := GetInterestingTypes(ctx, nil)
 	queries := GetQueries(ctx, interestingTypes)
 
-	return watcherLoop(
+	return watchAllTheThingsInternal(
 		ctx,
 		f.currentSnapshot, // encoded
 		f.k8sSource,

--- a/cmd/entrypoint/watcher.go
+++ b/cmd/entrypoint/watcher.go
@@ -20,7 +20,7 @@ import (
 	"github.com/datawire/dlib/dlog"
 )
 
-func watcher(
+func WatchAllTheThings(
 	ctx context.Context,
 	ambwatch *acp.AmbassadorWatcher,
 	encoded *atomic.Value,
@@ -62,7 +62,7 @@ func watcher(
 	consulSrc := &consulWatcher{}
 	istioCertSrc := newIstioCertSource()
 
-	return watcherLoop(
+	return watchAllTheThingsInternal(
 		ctx,
 		encoded,
 		k8sSrc,
@@ -151,7 +151,7 @@ type FastpathProcessor func(context.Context, *ambex.FastpathSnapshot)
 //
 // 4. If you don't fully understand everything above, _do not touch this function without
 //    guidance_.
-func watcherLoop(
+func watchAllTheThingsInternal(
 	ctx context.Context,
 	encoded *atomic.Value,
 	k8sSrc K8sSource,
@@ -162,20 +162,20 @@ func watcherLoop(
 	fastpathProcessor FastpathProcessor,
 	ambassadorMeta *snapshot.AmbassadorMetaInfo,
 ) error {
-	// Ambassador has three sources of inputs: kubernetes, consul, and the filesystem. The job of
-	// the watcherLoop is to read updates from all three of these sources, assemble them into a
-	// single coherent configuration, and pass them along to other parts of ambassador for
-	// processing.
+	// Ambassador has three sources of inputs: kubernetes, consul, and the filesystem. The job
+	// of the watchAllTheThingsInternal loop is to read updates from all three of these sources,
+	// assemble them into a single coherent configuration, and pass them along to other parts of
+	// ambassador for processing.
 
-	// The watcherLoop must decide what information is relevant to solicit from each source. This is
-	// decided a bit differently for each source.
+	// The watchAllTheThingsInternal loop must decide what information is relevant to solicit
+	// from each source. This is decided a bit differently for each source.
 	//
 	// For kubernetes the set of subscriptions is basically hardcoded to the set of resources
-	// defined in interesting_types.go, this is filtered down at boot based on RBAC limitations. The
-	// filtered list is used to construct the queries that are passed into this function, and that
-	// set of queries remains fixed for the lifetime of the loop, i.e. the lifetime of the
-	// abmassador process (unless we are testing, in which case we may run the watcherLoop more than
-	// once in a single process).
+	// defined in interesting_types.go, this is filtered down at boot based on RBAC
+	// limitations. The filtered list is used to construct the queries that are passed into this
+	// function, and that set of queries remains fixed for the lifetime of the loop, i.e. the
+	// lifetime of the abmassador process (unless we are testing, in which case we may run the
+	// watchAllTheThingsInternal loop more than once in a single process).
 	//
 	// For the consul source we derive the set of resources to watch based on the configuration in
 	// kubernetes, i.e. we watch the services defined in Mappings that are configured to use a

--- a/cmd/entrypoint/watcher.go
+++ b/cmd/entrypoint/watcher.go
@@ -59,7 +59,7 @@ func WatchAllTheThings(
 	}
 
 	k8sSrc := newK8sSource(client)
-	consulSrc := &consulWatcher{}
+	consulSrc := watchConsul
 	istioCertSrc := newIstioCertSource()
 
 	return watchAllTheThingsInternal(
@@ -67,7 +67,7 @@ func WatchAllTheThings(
 		encoded,
 		k8sSrc,
 		queries,
-		consulSrc, // consulWatcher
+		consulSrc, // watchConsulFunc
 		istioCertSrc,
 		notify,         // snapshotProcessor
 		fastpathUpdate, // fastpathProcessor
@@ -156,7 +156,7 @@ func watchAllTheThingsInternal(
 	encoded *atomic.Value,
 	k8sSrc K8sSource,
 	queries []kates.Query,
-	consulWatcher Watcher,
+	watchConsulFunc watchConsulFunc,
 	istioCertSrc IstioCertSource,
 	snapshotProcessor SnapshotProcessor,
 	fastpathProcessor FastpathProcessor,
@@ -196,7 +196,7 @@ func watchAllTheThingsInternal(
 	if err != nil {
 		return err
 	}
-	consul := newConsul(ctx, consulWatcher)
+	consul := newConsul(ctx, watchConsulFunc)
 	istioCertWatcher, err := istioCertSrc.Watch(ctx)
 	if err != nil {
 		return err

--- a/cmd/entrypoint/watcher.go
+++ b/cmd/entrypoint/watcher.go
@@ -199,7 +199,8 @@ func watchAllTheThingsInternal(
 	if err != nil {
 		return err
 	}
-	consulWatcher := newConsulWatcher(ctx, watchConsulFunc)
+	consulWatcher := newConsulWatcher(watchConsulFunc)
+	grp.Go("consul", consulWatcher.run)
 	istioCertWatcher, err := istioCertSrc.Watch(ctx)
 	if err != nil {
 		return err

--- a/cmd/entrypoint/watcher.go
+++ b/cmd/entrypoint/watcher.go
@@ -90,6 +90,7 @@ func getAmbassadorMeta(ambassadorID string, clusterID string, version string, cl
 }
 
 type SnapshotProcessor func(context.Context, SnapshotDisposition, []byte) error
+
 type SnapshotDisposition int
 
 const (
@@ -104,6 +105,19 @@ const (
 	// Indicates that the snapshot is ready to be processed.
 	SnapshotReady
 )
+
+func (disposition SnapshotDisposition) String() string {
+	ret, ok := map[SnapshotDisposition]string{
+		SnapshotIncomplete: "SnapshotIncomplete",
+		SnapshotDefer:      "SnapshotDefer",
+		SnapshotDrop:       "SnapshotDrop",
+		SnapshotReady:      "SnapshotReady",
+	}[disposition]
+	if !ok {
+		return fmt.Sprintf("%[1]T(%[1]d)", disposition)
+	}
+	return ret
+}
 
 type FastpathProcessor func(context.Context, *ambex.FastpathSnapshot)
 


### PR DESCRIPTION
## Description

Since the removal of `gotestsum` (in #4074), we've been seeing pretty frequent failures from the `cmd/entrypoint` tests. There are 3 causes here:
 - test issue: The consul tests being too sensitive about how snapshots are coalesced (fixed)
 - actual issue: Race in shutdown of the consul watch goroutines (fixed)
 - actual issue: Race in the shutdown of the FS watcher goroutines (fixed it in the tests, but not the actual code)

These three are all intermittently-detected issues, so `gotestsum`'s retries were hiding them.  And now that they're unhidden, they are causing problems for other PRs.

This is a good example of why "retries without metrics" are bad.  The race detector can often only intermittently detect races.  If a test "flakes" because of `-race`, the "flake" is that it sometimes passes when it should fail, not that it sometimes fails when it should pass!

Let me be clear here: I 100% believe that there are still races in `cmd/entrypoint`.  However, I am 95% certain that the failure rate of of the `cmd/entrypoint` tests is now below 3%. So this PR slightly improves the state of the code, and significantly reduces development friction.

I wish there were a linter that allowed me to outlaw the `go` keyword, and force everyone to use `dgroup`; this would avoid races with leaking goroutines and goroutine shutdown.

As usual for me, I suggest a commit-by-commit review.

## Related Issues
Look at any of the several PRs that are red because of `cmd/entrypoint` even though they don't touch `cmd/entrypoint`.

## Testing
I ran the tests a whole bunch of times (n=100), with the race detector turned on.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `CHANGELOG.md`. - since I believe there are still many races in this code, I do not believe this merits a changelog entry
   
   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations
 
 - [x] This is unlikely to impact how Ambassador performs at scale.
 
   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability
 
 - [x] My change is adequately tested.
 
   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points
 
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently. - I'm pretty sure GOTEST_ARGS and GOTEST_PKGS are already in there
