### PR TITLE
base-python.docker.gen: Fix support for macOS

### DIFF
--- a/docker/base-python.docker.gen
+++ b/docker/base-python.docker.gen
@@ -128,9 +128,17 @@ main() {
 	# add_repo REPO appends a repo to ${repos[@]}; if ${repos[@]}
 	# doesn't already contain REPO.
 	add_repo() {
-		local
+		local needle straw
 		needle="$1"
-		for straw in "${repos[@]}"; do
+		# The `${repos[@]:+…}` non-emptiness check seems
+		# pointless here, but it's important because macOS
+		# still has Bash 3.2, and prior to Bash 4.4 (Sept
+		# 2016), there was a bug where it would consider an
+		# empty array to be unset, triggering `set -u`.  The
+		# other usages of "${repos[@]}" don't need this
+		# because this is the only one where it might still be
+		# empty.
+		for straw in ${repos[@]:+"${repos[@]}"}; do
 			if [[ "$straw" == "$needle" ]]; then
 				return
 			fi


### PR DESCRIPTION
## Description

Bash prior to 4.4 (Sept 2016) had a bug that `base-python.docker.gen` triggers; and macOS still has Bash 3.2.

## Testing
I tested this on a macOS box.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `CHANGELOG.md`. - no applicable changes
   
   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations
 
 - [x] This is unlikely to impact how Ambassador performs at scale. - not a runtime change
 
   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability
 
 - [x] My change is adequately tested. - yes
 
   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points
 
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently. - no tricks
