### PR TITLE
[2.2] No unserved v1 for Hosts or Listeners

### DIFF
--- a/manifests/emissary/emissary-crds.yaml.in
+++ b/manifests/emissary/emissary-crds.yaml.in
@@ -1322,14 +1322,6 @@ spec:
     storage: false
     subresources:
       status: {}
-  - name: v1
-    schema:
-      openAPIV3Schema:
-        description: Host is the Schema for the hosts API
-        type: object
-        x-kubernetes-preserve-unknown-fields: true
-    served: false
-    storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/tools/src/fix-crds/business.go
+++ b/tools/src/fix-crds/business.go
@@ -53,8 +53,10 @@ func FixCRD(args Args, crd *CRD) error {
 	// Really, Golang? You couldn't just have a "set" type?
 	// TODO(Flynn): Look into having kubebuilder generate our unserved v1.
 	CRDsWithNoUnservedV1 := map[string]interface{}{
-		"filterpolicies.getambassador.io": struct{}{},
 		"filters.getambassador.io":        struct{}{},
+		"filterpolicies.getambassador.io": struct{}{},
+		"hosts.getambassador.io":          struct{}{},
+		"listeners.getambassador.io":      struct{}{},
 		"ratelimits.getambassador.io":     struct{}{},
 	}
 


### PR DESCRIPTION
Don't do an unserved v1 for `Host`s or `Listener`s, because they never
actually had a v1 in the first place.

(Listeners actually weren't getting one anyway, since they'd only the one version. But we add it to the exclusion list anyway for the future.)

Signed-off-by: Flynn <flynn@datawire.io>
