### PR TITLE
Fix apro build due to incorrect license detection for Emissary-ingress

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/cncf/udpa/go v0.0.0-20210322005330-6414d713912e
 	github.com/datawire/dlib v1.2.5-0.20211116212847-0316f8d7af2b
 	github.com/datawire/dtest v0.0.0-20210927191556-2cccf1a938b0
-	github.com/datawire/go-mkopensource v0.0.0-20220121154707-b0476e7f8255
+	github.com/datawire/go-mkopensource v0.0.0-20220204142854-6f955897e776
 	github.com/envoyproxy/protoc-gen-validate v0.3.0-java.0.20200609174644-bd816e4522c1
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/getkin/kin-openapi v0.66.0

--- a/go.sum
+++ b/go.sum
@@ -271,6 +271,8 @@ github.com/datawire/dtest v0.0.0-20210927191556-2cccf1a938b0 h1:gWkYIZQdHDN1rwxf
 github.com/datawire/dtest v0.0.0-20210927191556-2cccf1a938b0/go.mod h1:D/jb71PHlfUjfNSUVpXQAscXsXy3x+CY+c52lPnW2qU=
 github.com/datawire/go-mkopensource v0.0.0-20220121154707-b0476e7f8255 h1:07Ogp/9ry2XlvXc2dPPUGNqvL4+b7H+yCFJBDLGIH4w=
 github.com/datawire/go-mkopensource v0.0.0-20220121154707-b0476e7f8255/go.mod h1:tGRMdARPVuMV4lG0SRihL2R1+7SEgP0BIiIvrSW2H7E=
+github.com/datawire/go-mkopensource v0.0.0-20220204142854-6f955897e776 h1:DdzLX14gaCY6i7Dtjn4htCI5CseA9Rz707LLxaMmrtY=
+github.com/datawire/go-mkopensource v0.0.0-20220204142854-6f955897e776/go.mod h1:tGRMdARPVuMV4lG0SRihL2R1+7SEgP0BIiIvrSW2H7E=
 github.com/davecgh/go-spew v0.0.0-20161028175848-04cdfd42973b/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/tools/src/py-mkopensource/main.go
+++ b/tools/src/py-mkopensource/main.go
@@ -39,7 +39,7 @@ func parseLicenses(name, version, license string) map[License]struct{} {
 		{"Flask", "1.0.2", "BSD"}:                      {BSD3},
 		{"GitPython", "3.1.11", "UNKNOWN"}:             {BSD3},
 		{"Jinja2", "2.10.1", "BSD"}:                    {BSD3},
-		{"chardet", "3.0.4", "LGPL"}:                   {LGPL21},
+		{"chardet", "3.0.4", "LGPL"}:                   {LGPL21OrLater},
 		{"colorama", "0.4.3", "BSD"}:                   {BSD3},
 		{"colorama", "0.4.4", "BSD"}:                   {BSD3},
 		{"decorator", "4.4.2", "new BSD License"}:      {BSD2},
@@ -70,7 +70,7 @@ func parseLicenses(name, version, license string) map[License]struct{} {
 
 		// These are packages with non-trivial strings to parse, and
 		// it's easier to just hard-code it.
-		{"docutils", "0.17.1", "public domain, Python, 2-Clause BSD, GPL 3 (see COPYING.txt)"}: {PublicDomain, PSF, BSD2, GPL3},
+		{"docutils", "0.17.1", "public domain, Python, 2-Clause BSD, GPL 3 (see COPYING.txt)"}: {PublicDomain, PSF, BSD2, GPL3OrLater},
 		{"orjson", "3.3.1", "Apache-2.0 OR MIT"}:                                               {Apache2, MIT},
 		{"orjson", "3.6.6", "Apache-2.0 OR MIT"}:                                               {Apache2, MIT},
 		{"packaging", "20.4", "BSD-2-Clause or Apache-2.0"}:                                    {BSD2, Apache2},

--- a/tools/src/py-mkopensource/testdata/successful-generation/expected_json.json
+++ b/tools/src/py-mkopensource/testdata/successful-generation/expected_json.json
@@ -26,7 +26,7 @@
       "version": "0.17.1",
       "licenses": [
         "2-clause BSD license",
-        "GNU General Public License Version 3",
+        "GNU General Public License v3.0 or later",
         "Public domain",
         "Python Software Foundation license"
       ]
@@ -36,7 +36,7 @@
     "2-clause BSD license": "https://opensource.org/licenses/BSD-2-Clause",
     "3-clause BSD license": "https://opensource.org/licenses/BSD-3-Clause",
     "Apache License 2.0": "https://opensource.org/licenses/Apache-2.0",
-    "GNU General Public License Version 3": "https://opensource.org/licenses/GPL-3.0",
+    "GNU General Public License v3.0 or later": "",
     "Public domain": "",
     "Python Software Foundation license": "https://spdx.org/licenses/PSF-2.0.html"
   }

--- a/tools/src/py-mkopensource/testdata/successful-generation/expected_markdown.txt
+++ b/tools/src/py-mkopensource/testdata/successful-generation/expected_markdown.txt
@@ -6,4 +6,4 @@ libraries:
     CacheControl  0.12.6   Apache License 2.0
     Flask         2.0.2    3-clause BSD license
     Werkzeug      2.0.2    3-clause BSD license
-    docutils      0.17.1   2-clause BSD license, GNU General Public License Version 3, Public domain, Python Software Foundation license
+    docutils      0.17.1   2-clause BSD license, GNU General Public License v3.0 or later, Public domain, Python Software Foundation license

--- a/vendor/github.com/datawire/go-mkopensource/README.md
+++ b/vendor/github.com/datawire/go-mkopensource/README.md
@@ -65,7 +65,7 @@ There are two modes of operation:
     both the `OPENSOURCE.md` file that `--output-format=txt` generates
     (plus a footer reading "The appropriate license notices and source
     code are in correspondingly named directories."), and a directory
-    for each dependency, containing any nescessary license notices and
+    for each dependency, containing any necessary license notices and
     source code.
 
 Many licenses require the author to be credited, the full license text
@@ -92,17 +92,34 @@ directing the output to).
 
 ### Output type
 
-Parameter --output-type controls for output format.
-When parameter is not provided in the command line or value is incorrect, `--output-type` is set to `markdown`
+Parameter --output-type controls for output format.  
+When parameter is not provided in the command line or value is 
+incorrect, `--output-type` is set to `markdown`.
+
 This parameter only applies when `--ouput-format` is `txt`
 
 #### `--output-type=markdown`
 
-Program outputs dependency information in markdown format
+Program outputs dependency information in Markdown format
 
 #### `--output-type=json`
 
 Program outputs dependency information in json format
+
+### Application type
+
+Parameter `--application-type` controls the types of licenses that are 
+allowed. Logic is documented in [Notion](https://www.notion.so/datawire/1-Automate-License-Scan-and-Information-Files-31f4cd0f58f645f0afb922cfd710df81) 
+
+#### `--application-type=internal`
+
+Use this option with applications that run on customer infrastructure. 
+This is the default.
+
+#### `--application-type=external`
+
+Use this option with applications that run on Ambassador Labs 
+infrastructure.
 
 ## Using as a library
 

--- a/vendor/github.com/datawire/go-mkopensource/dependency.go
+++ b/vendor/github.com/datawire/go-mkopensource/dependency.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"fmt"
+	"github.com/datawire/go-mkopensource/pkg/dependencies"
+	"github.com/datawire/go-mkopensource/pkg/detectlicense"
+	"github.com/datawire/go-mkopensource/pkg/golist"
+	"sort"
+)
+
+func GenerateDependencyList(modNames []string, modLicenses map[string]map[detectlicense.License]struct{},
+	modInfos map[string]*golist.Module, goVersion string, licenseUsage detectlicense.AllowedLicenseUse) (dependencies.DependencyInfo, error) {
+	dependencyList := dependencies.NewDependencyInfo()
+
+	for _, modKey := range modNames {
+		ambassadorProprietary := isAmbassadorProprietary(modLicenses[modKey])
+		if ambassadorProprietary {
+			continue
+		}
+
+		modVal := modInfos[modKey]
+
+		dependencyDetails := dependencies.Dependency{
+			Name:     getDependencyName(modVal),
+			Version:  getDependencyVersion(modVal, goVersion),
+			Licenses: []string{},
+		}
+
+		for license := range modLicenses[modKey] {
+			dependencyDetails.Licenses = append(dependencyDetails.Licenses, license.Name)
+		}
+		sort.Strings(dependencyDetails.Licenses)
+
+		dependencyList.Dependencies = append(dependencyList.Dependencies, dependencyDetails)
+	}
+
+	if err := dependencyList.CheckLicenses(licenseUsage); err != nil {
+		return dependencyList, fmt.Errorf("License validation failed: %v\n", err)
+	}
+
+	if err := dependencyList.UpdateLicenseList(); err != nil {
+		return dependencyList, fmt.Errorf("Could not generate list of license URLs: %v\n", err)
+	}
+
+	return dependencyList, nil
+}
+
+func getDependencyName(modVal *golist.Module) string {
+	if modVal == nil {
+		return "the Go language standard library (\"std\")"
+	}
+
+	if modVal.Replace != nil && modVal.Replace.Version != "" && modVal.Replace.Path != modVal.Path {
+		return fmt.Sprintf("%s (modified from %s)", modVal.Replace.Path, modVal.Path)
+	}
+
+	return modVal.Path
+}
+
+func getDependencyVersion(modVal *golist.Module, goVersion string) string {
+	if modVal == nil {
+		return goVersion
+	}
+
+	if modVal.Replace != nil {
+		if modVal.Replace.Version == "" {
+			return "(modified)"
+		} else {
+			return modVal.Replace.Version
+		}
+	}
+
+	return modVal.Version
+}

--- a/vendor/github.com/datawire/go-mkopensource/pkg/dependencies/dependencyinfo.go
+++ b/vendor/github.com/datawire/go-mkopensource/pkg/dependencies/dependencyinfo.go
@@ -3,25 +3,39 @@ package dependencies
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/datawire/go-mkopensource/pkg/detectlicense"
+	. "github.com/datawire/go-mkopensource/pkg/detectlicense"
 )
 
 //nolint:gochecknoglobals // Can't be a constant
-var knownLicenses = map[string]detectlicense.License{
-	detectlicense.Proprietary.Name:  detectlicense.Proprietary,
-	detectlicense.PublicDomain.Name: detectlicense.PublicDomain,
-	detectlicense.Apache2.Name:      detectlicense.Apache2,
-	detectlicense.BSD1.Name:         detectlicense.BSD1,
-	detectlicense.BSD2.Name:         detectlicense.BSD2,
-	detectlicense.BSD3.Name:         detectlicense.BSD3,
-	detectlicense.CcBySa40.Name:     detectlicense.CcBySa40,
-	detectlicense.GPL3.Name:         detectlicense.GPL3,
-	detectlicense.ISC.Name:          detectlicense.ISC,
-	detectlicense.LGPL21.Name:       detectlicense.LGPL21,
-	detectlicense.MIT.Name:          detectlicense.MIT,
-	detectlicense.MPL2.Name:         detectlicense.MPL2,
-	detectlicense.PSF.Name:          detectlicense.PSF,
-	detectlicense.Unicode2015.Name:  detectlicense.Unicode2015}
+var licensesByName = map[string]License{
+	AmbassadorProprietary.Name: AmbassadorProprietary,
+	Apache2.Name:               Apache2,
+	AGPL1Only.Name:             AGPL1Only,
+	AGPL1OrLater.Name:          AGPL1OrLater,
+	AGPL3Only.Name:             AGPL3Only,
+	AGPL3OrLater.Name:          AGPL3OrLater,
+	BSD1.Name:                  BSD1,
+	BSD2.Name:                  BSD2,
+	BSD3.Name:                  BSD3,
+	CcBySa40.Name:              CcBySa40,
+	GPL1Only.Name:              GPL1Only,
+	GPL1OrLater.Name:           GPL1OrLater,
+	GPL2Only.Name:              GPL2Only,
+	GPL2OrLater.Name:           GPL2OrLater,
+	GPL3Only.Name:              GPL3Only,
+	GPL3OrLater.Name:           GPL3OrLater,
+	ISC.Name:                   ISC,
+	LGPL2Only.Name:             LGPL2Only,
+	LGPL2OrLater.Name:          LGPL2OrLater,
+	LGPL21Only.Name:            LGPL21Only,
+	LGPL21OrLater.Name:         LGPL21OrLater,
+	LGPL3Only.Name:             LGPL3Only,
+	LGPL3OrLater.Name:          LGPL3OrLater,
+	MIT.Name:                   MIT,
+	MPL2.Name:                  MPL2,
+	PSF.Name:                   PSF,
+	PublicDomain.Name:          PublicDomain,
+	Unicode2015.Name:           Unicode2015}
 
 type DependencyInfo struct {
 	Dependencies []Dependency      `json:"dependencies"`
@@ -50,13 +64,13 @@ func (d *DependencyInfo) Unmarshal(data []byte) error {
 }
 
 func (d *DependencyInfo) UpdateLicenseList() error {
-	usedLicenses := map[string]detectlicense.License{}
+	usedLicenses := map[string]License{}
 
 	for _, dependency := range d.Dependencies {
 		for _, licenseName := range dependency.Licenses {
-			license, ok := knownLicenses[licenseName]
-			if !ok {
-				return fmt.Errorf("license details for '%s' are not known", licenseName)
+			license, err := getLicenseFromName(licenseName)
+			if err != nil {
+				return err
 			}
 			usedLicenses[license.Name] = license
 		}
@@ -66,5 +80,40 @@ func (d *DependencyInfo) UpdateLicenseList() error {
 		d.Licenses[k] = v.URL
 	}
 
+	return nil
+}
+
+func getLicenseFromName(licenseName string) (License, error) {
+	license, ok := licensesByName[licenseName]
+	if !ok {
+		return License{}, fmt.Errorf("license details for '%s' are not known", licenseName)
+	}
+	return license, nil
+}
+
+// CheckLicenses checks that the licenses used by the dependencies are known and allowed to be used
+//in an application based on the buiness logic described here: https://www.notion.so/datawire/License-Management-5194ca50c9684ff4b301143806c92157.
+//This function must be called after parsing of the licenses has been done.
+func (d *DependencyInfo) CheckLicenses(allowedLicenses AllowedLicenseUse) error {
+	if allowedLicenses == Forbidden {
+		return fmt.Errorf("forbidden licenses should not be used")
+	}
+
+	for _, dependency := range d.Dependencies {
+		for _, licenseName := range dependency.Licenses {
+			license, err := getLicenseFromName(licenseName)
+			if err != nil {
+				return err
+			}
+
+			if license.AllowedUse == Forbidden {
+				return fmt.Errorf("license '%s' is forbidden", license.Name)
+			}
+
+			if license.AllowedUse < allowedLicenses {
+				return fmt.Errorf("license '%s' should not be used since it should not run on customer servers", license.Name)
+			}
+		}
+	}
 	return nil
 }

--- a/vendor/github.com/datawire/go-mkopensource/pkg/detectlicense/licenses.go
+++ b/vendor/github.com/datawire/go-mkopensource/pkg/detectlicense/licenses.go
@@ -9,37 +9,68 @@ import (
 	"strings"
 )
 
+type AllowedLicenseUse int
+
+const (
+	Forbidden AllowedLicenseUse = iota
+	OnAmbassadorServers
+	Unrestricted
+)
+
 type License struct {
 	Name           string
-	NoticeFile     bool   // are NOTICE files "a thing" for this license?
-	WeakCopyleft   bool   // requires that library to be open-source
-	StrongCopyleft bool   // requires the resulting program to be open-source
-	URL            string // Location of the license description
+	NoticeFile     bool              // are NOTICE files "a thing" for this license?
+	WeakCopyleft   bool              // requires that library to be open-source
+	StrongCopyleft bool              // requires the resulting program to be open-source
+	URL            string            // Location of the license description
+	AllowedUse     AllowedLicenseUse // Where is this license allowed
 }
 
 //nolint:gochecknoglobals // Would be 'const'.
 var (
-	Proprietary = License{Name: "proprietary"}
-
-	PublicDomain = License{Name: "Public domain"}
-
-	Apache2  = License{Name: "Apache License 2.0", NoticeFile: true, URL: "https://opensource.org/licenses/Apache-2.0"}
-	BSD1     = License{Name: "1-clause BSD license", URL: "https://opensource.org/licenses/BSD-1-Clause"}
-	BSD2     = License{Name: "2-clause BSD license", URL: "https://opensource.org/licenses/BSD-2-Clause"}
-	BSD3     = License{Name: "3-clause BSD license", URL: "https://opensource.org/licenses/BSD-3-Clause"}
+	AmbassadorProprietary = License{Name: "proprietary Ambassador software"}
+	Apache2               = License{Name: "Apache License 2.0", NoticeFile: true,
+		URL: "https://opensource.org/licenses/Apache-2.0", AllowedUse: Unrestricted}
+	AGPL1Only    = License{Name: "Affero General Public License v1.0 only", AllowedUse: Forbidden}
+	AGPL1OrLater = License{Name: "Affero General Public License v1.0 or later", AllowedUse: Forbidden}
+	AGPL3Only    = License{Name: "GNU Affero General Public License v3.0 only", AllowedUse: Forbidden}
+	AGPL3OrLater = License{Name: "GNU Affero General Public License v3.0 or later", AllowedUse: Forbidden}
+	BSD1         = License{Name: "1-clause BSD license", URL: "https://opensource.org/licenses/BSD-1-Clause",
+		AllowedUse: Unrestricted}
+	BSD2 = License{Name: "2-clause BSD license", URL: "https://opensource.org/licenses/BSD-2-Clause",
+		AllowedUse: Unrestricted}
+	BSD3 = License{Name: "3-clause BSD license", URL: "https://opensource.org/licenses/BSD-3-Clause",
+		AllowedUse: Unrestricted}
 	CcBySa40 = License{Name: "Creative Commons Attribution Share Alike 4.0 International",
-		StrongCopyleft: true, URL: "https://creativecommons.org/licenses/by-sa/4.0/legalcode"}
-	GPL3 = License{Name: "GNU General Public License Version 3", StrongCopyleft: true,
-		URL: "https://opensource.org/licenses/GPL-3.0"}
-	ISC    = License{Name: "ISC license", URL: "https://opensource.org/licenses/ISC"}
-	LGPL21 = License{Name: "GNU Lesser General Public License Version 2.1", WeakCopyleft: true,
-		URL: "https://spdx.org/licenses/LGPL-2.1-or-later.html"}
-	MIT  = License{Name: "MIT license", URL: "https://opensource.org/licenses/MIT"}
+		StrongCopyleft: true, URL: "https://creativecommons.org/licenses/by-sa/4.0/legalcode", AllowedUse: Unrestricted}
+	GPL1Only    = License{Name: "GNU General Public License v1.0 only", AllowedUse: OnAmbassadorServers}
+	GPL1OrLater = License{Name: "GNU General Public License v1.0 or later", AllowedUse: OnAmbassadorServers}
+	GPL2Only    = License{Name: "GNU General Public License v2.0 only", AllowedUse: OnAmbassadorServers}
+	GPL2OrLater = License{Name: "GNU General Public License v2.0 or later", AllowedUse: OnAmbassadorServers}
+	GPL3Only    = License{Name: "GNU General Public License v3.0 only", StrongCopyleft: true,
+		URL: "https://opensource.org/licenses/GPL-3.0", AllowedUse: OnAmbassadorServers}
+	GPL3OrLater = License{Name: "GNU General Public License v3.0 or later", AllowedUse: OnAmbassadorServers}
+	ISC         = License{Name: "ISC license", URL: "https://opensource.org/licenses/ISC", AllowedUse: Unrestricted}
+	LGPL2Only   = License{Name: "GNU Library General Public License v2 only", WeakCopyleft: true,
+		AllowedUse: Unrestricted}
+	LGPL2OrLater = License{Name: "GNU Library General Public License v2 or later", WeakCopyleft: true,
+		AllowedUse: Unrestricted}
+	LGPL21Only = License{Name: "GNU Lesser General Public License v2.1 only", WeakCopyleft: true,
+		AllowedUse: Unrestricted}
+	LGPL21OrLater = License{Name: "GNU Lesser General Public License v2.1 or later", WeakCopyleft: true,
+		URL: "https://spdx.org/licenses/LGPL-2.1-or-later.html", AllowedUse: Unrestricted}
+	LGPL3Only = License{Name: "GNU Lesser General Public License v3.0 only", WeakCopyleft: true,
+		AllowedUse: Unrestricted}
+	LGPL3OrLater = License{Name: "GNU Lesser General Public License v3.0 or later", WeakCopyleft: true,
+		AllowedUse: Unrestricted}
+	MIT  = License{Name: "MIT license", URL: "https://opensource.org/licenses/MIT", AllowedUse: Unrestricted}
 	MPL2 = License{Name: "Mozilla Public License 2.0", NoticeFile: true,
-		WeakCopyleft: true, URL: "https://opensource.org/licenses/MPL-2.0"}
-	PSF         = License{Name: "Python Software Foundation license", URL: "https://spdx.org/licenses/PSF-2.0.html"}
-	Unicode2015 = License{Name: "Unicode License Agreement for Data Files and Software (2015)",
-		URL: "https://spdx.org/licenses/Unicode-DFS-2015.html"}
+		WeakCopyleft: true, URL: "https://opensource.org/licenses/MPL-2.0", AllowedUse: Unrestricted}
+	PSF = License{Name: "Python Software Foundation license", URL: "https://spdx.org/licenses/PSF-2.0.html",
+		AllowedUse: Unrestricted}
+	PublicDomain = License{Name: "Public domain"}
+	Unicode2015  = License{Name: "Unicode License Agreement for Data Files and Software (2015)",
+		URL: "https://spdx.org/licenses/Unicode-DFS-2015.html", AllowedUse: Unrestricted}
 )
 
 // https://spdx.org/licenses/
@@ -51,13 +82,27 @@ var (
 
 	SpdxIdentifiers = map[string]License{
 		"Apache-2.0":        Apache2,
+		"AGPL-1.0-only":     AGPL1Only,
+		"AGPL-1.0-or-later": AGPL1OrLater,
+		"AGPL-3.0-only":     AGPL3Only,
+		"AGPL-3.0-or-later": AGPL3OrLater,
 		"BSD-1-Clause":      BSD1,
 		"BSD-2-Clause":      BSD2,
 		"BSD-3-Clause":      BSD3,
 		"CC-BY-SA-4.0":      CcBySa40,
-		"GPL-3.0-only":      GPL3,
+		"GPL-1.0-only":      GPL1Only,
+		"GPL-1.0-or-later":  GPL1OrLater,
+		"GPL-2.0-only":      GPL2Only,
+		"GPL-2.0-or-later":  GPL2OrLater,
+		"GPL-3.0-only":      GPL3Only,
+		"GPL-3.0-or-later":  GPL3OrLater,
 		"ISC":               ISC,
-		"LGPL-2.1-or-later": LGPL21,
+		"LGPL-2.0-only":     LGPL2Only,
+		"LGPL-2.0-or-later": LGPL2OrLater,
+		"LGPL-2.1-only":     LGPL21Only,
+		"LGPL-2.1-or-later": LGPL21OrLater,
+		"LGPL-3.0-only":     LGPL3Only,
+		"LGPL-3.0-or-later": LGPL3OrLater,
 		"MIT":               MIT,
 		"MPL-2.0":           MPL2,
 		"PSF-2.0":           PSF,
@@ -74,7 +119,14 @@ func expectsNotice(licenses map[License]struct{}) bool {
 	return false
 }
 
-func DetectLicenses(files map[string][]byte) (map[License]struct{}, error) {
+func DetectLicenses(packageName string, files map[string][]byte) (map[License]struct{}, error) {
+	if strings.HasPrefix(packageName, "github.com/datawire/telepresence2-proprietary/") ||
+		strings.HasPrefix(packageName, "github.com/datawire/ambassador/") {
+		// Ambassador's proprietary software has a proprietary license
+		softwareLicenses := map[License]struct{}{AmbassadorProprietary: {}}
+		return softwareLicenses, nil
+	}
+
 	licenses := make(map[License][]string)
 	hasNotice := false
 	hasLicenseFile := false
@@ -92,6 +144,9 @@ loop:
 		case "sigs.k8s.io/kustomize/kyaml/LICENSE_TEMPLATE":
 			// This is a template file for generated code,
 			// not an actual license file.
+			continue loop
+		case "github.com/telepresenceio/telepresence/v2/LICENSES.md":
+			// Licenses for telepresence are in LICENSE and not in LICENSES.md
 			continue loop
 		}
 
@@ -175,6 +230,7 @@ loop:
 			}
 		}
 	}
+
 	if !hasLicenseFile && hasNonSPDXSource {
 		return nil, errors.New("could not identify a license for all sources (had no global LICENSE file)")
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -76,7 +76,7 @@ github.com/datawire/dlib/internal/sigint
 # github.com/datawire/dtest v0.0.0-20210927191556-2cccf1a938b0
 ## explicit; go 1.16
 github.com/datawire/dtest
-# github.com/datawire/go-mkopensource v0.0.0-20220121154707-b0476e7f8255
+# github.com/datawire/go-mkopensource v0.0.0-20220204142854-6f955897e776
 ## explicit; go 1.17
 github.com/datawire/go-mkopensource
 github.com/datawire/go-mkopensource/pkg/dependencies


### PR DESCRIPTION
## Description
Build for Apro fails because file LICENSES.md is picked-up by Apro, and go-mkopensource can't figure out what's the license for Emissary-ingress.

This PR updates go-mkopensource to a version that knows Emissary-ingress is proprietary software.

## Related Issues
List related issues.

## Testing
Ran generation of OPENSOURCE.md in this repo and in apro and they both work.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `CHANGELOG.md`.
   
   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations
 
 - [x] This is unlikely to impact how Ambassador performs at scale.
 
   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability
 
 - [x] My change is adequately tested.
 
   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points
 
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
