### PR TITLE
pkg/agent: Add a test for the metrics server

### DIFF
--- a/pkg/agent/envoy_metrics_server.go
+++ b/pkg/agent/envoy_metrics_server.go
@@ -2,22 +2,24 @@ package agent
 
 import (
 	"context"
+	"io"
+
+	"google.golang.org/grpc"
+
 	envoyMetrics "github.com/datawire/ambassador/v2/pkg/api/envoy/service/metrics/v3"
 	"github.com/datawire/dlib/dhttp"
 	"github.com/datawire/dlib/dlog"
-	"google.golang.org/grpc"
-	"io"
 )
 
-type streamHandler func(logCtx context.Context, in *envoyMetrics.StreamMetricsMessage)
+type StreamHandler func(ctx context.Context, in *envoyMetrics.StreamMetricsMessage)
 
 type metricsServer struct {
 	envoyMetrics.MetricsServiceServer
-	handler streamHandler
+	handler StreamHandler
 }
 
 // NewMetricsServer is the main metricsServer constructor.
-func NewMetricsServer(handler streamHandler) *metricsServer {
+func NewMetricsServer(handler StreamHandler) *metricsServer {
 	return &metricsServer{
 		handler: handler,
 	}

--- a/pkg/agent/envoy_metrics_server_test.go
+++ b/pkg/agent/envoy_metrics_server_test.go
@@ -1,0 +1,65 @@
+package agent_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/datawire/ambassador/v2/pkg/agent"
+	envoyMetrics "github.com/datawire/ambassador/v2/pkg/api/envoy/service/metrics/v3"
+	"github.com/datawire/dlib/dgroup"
+	"github.com/datawire/dlib/dlog"
+)
+
+// TestMetricsContext checks that the parent Context correctly gets passed through to the metrics
+// handler function.
+//
+// There was concern that without storing a "logCtx" in the metricsServer{} that .StreamMetrics
+// would end up using the fallback logger.  This concern was based on the google.golang.org/grpc
+// HTTP server not correctly passing Contexts through.  Since we insist on using the
+// github.com/datawire/dlib/dhttp HTTP server instead, this isn't a problem; but let's add a test
+// for it anyway, to put minds at ease.
+func TestMetricsContext(t *testing.T) {
+	grp := dgroup.NewGroup(dlog.NewTestContext(t, true), dgroup.GroupConfig{
+		ShutdownOnNonError: true,
+	})
+	grp.Go("server", func(ctx context.Context) error {
+		type testCtxKey struct{}
+		ctx = context.WithValue(ctx, testCtxKey{}, "sentinel")
+		srv := agent.NewMetricsServer(func(ctx context.Context, _ *envoyMetrics.StreamMetricsMessage) {
+			if val, _ := ctx.Value(testCtxKey{}).(string); val != "sentinel" {
+				t.Error("context did not get passed through")
+			} else {
+				t.Log("SUCCESS!!")
+			}
+		})
+		return srv.StartServer(ctx)
+	})
+	grp.Go("client", func(ctx context.Context) error {
+		grpcClient, err := grpc.DialContext(ctx, "localhost:8006",
+			grpc.WithTransportCredentials(insecure.NewCredentials()))
+		if err != nil {
+			return fmt.Errorf("grpc.DialContext: %w", err)
+		}
+		metricsClient := envoyMetrics.NewMetricsServiceClient(grpcClient)
+		stream, err := metricsClient.StreamMetrics(ctx)
+		if err != nil {
+			return fmt.Errorf("metricsClient.StreamMetrics: %w", err)
+		}
+		if err := stream.Send(&envoyMetrics.StreamMetricsMessage{}); err != nil {
+			return fmt.Errorf("stream.Send: %w", err)
+		}
+		if _, err := stream.CloseAndRecv(); err != nil && !errors.Is(err, io.EOF) {
+			return fmt.Errorf("stream.CloseAndRecv: %w", err)
+		}
+		return nil
+	})
+	if err := grp.Wait(); err != nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
## Description

@douglascamata reached out to me this morning, concerned that 0935b3dc6c7a3793f0cca0ffb15ee8c90e460224 will end up triggering the fallback logger, which is a bug.

I believe that this concern is based on experience with the google.golang.org/grpc HTTP server not passing the Context through correctly; this is one of the reasons why we insist on using the github.com/datawire/dlib/dhttp HTTP server instead.

So, to validate that this concern is obviated by dhttp, I wrote a test for it.

## Testing

This PR is just adding tests.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `CHANGELOG.md`. - no applicable changes
   
   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations
 
 - [x] This is unlikely to impact how Ambassador performs at scale. - not a runtime change
 
   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability
 
 - [x] My change is adequately tested. - that's all this is
 
   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points
 
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently. - no tricks
