### PR TITLE
Allow Rollout "resume" command to recover from "abort" state

### DIFF
--- a/pkg/agent/rollouts.go
+++ b/pkg/agent/rollouts.go
@@ -89,7 +89,7 @@ func (r *rolloutCommand) patchRollout(ctx context.Context, client argov1alpha1.R
 	return nil
 }
 
-func (r *rolloutCommand) applyPatch(ctx context.Context, client argov1alpha1.RolloutsGetter, patch string, subresources ...string) error {
+func (r *rolloutCommand) applyPatch(ctx context.Context, client argov1alpha1.RolloutsGetter, patch string) error {
 	rollout := client.Rollouts(r.namespace)
 	_, err := rollout.Patch(
 		ctx,
@@ -97,7 +97,6 @@ func (r *rolloutCommand) applyPatch(ctx context.Context, client argov1alpha1.Rol
 		types.MergePatchType,
 		[]byte(patch),
 		metav1.PatchOptions{},
-		subresources...,
 	)
 	return err
 }

--- a/pkg/agent/rollouts.go
+++ b/pkg/agent/rollouts.go
@@ -6,6 +6,7 @@ import (
 
 	argov1alpha1 "github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned/typed/rollouts/v1alpha1"
 	"github.com/datawire/dlib/dlog"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
@@ -47,15 +48,23 @@ func (r *rolloutCommand) RunWithClientFactory(ctx context.Context, rolloutsClien
 	return r.patchRollout(ctx, client)
 }
 
+const unpausePatch = `{"spec":{"paused":false}}`
+const abortPatch = `{"status":{"abort":true}}`
+const retryPatch = `{"status":{"abort":false}}`
+const pausePatch = `{"spec":{"paused":true}}`
+
 func (r *rolloutCommand) patchRollout(ctx context.Context, client argov1alpha1.RolloutsGetter) error {
-	var patch []byte
+	var err error
 	switch r.action {
 	case rolloutActionResume:
-		patch = []byte(`{"spec":{"paused":false}}`)
+		err = r.applyPatch(ctx, client, unpausePatch)
+		if err == nil {
+			err = r.applyRetryPatch(ctx, client)
+		}
 	case rolloutActionAbort:
-		patch = []byte(`{"status":{"abort":true}}`)
+		err = r.applyPatch(ctx, client, abortPatch)
 	case rolloutActionPause:
-		patch = []byte(`{"spec":{"paused":true}}`)
+		err = r.applyPatch(ctx, client, pausePatch)
 	default:
 		err := fmt.Errorf(
 			"tried to perform unknown action '%s' on rollout %s (%s)",
@@ -66,14 +75,6 @@ func (r *rolloutCommand) patchRollout(ctx context.Context, client argov1alpha1.R
 		dlog.Errorln(ctx, err)
 		return err
 	}
-	rollout := client.Rollouts(r.namespace)
-	_, err := rollout.Patch(
-		ctx,
-		r.rolloutName,
-		types.MergePatchType,
-		patch,
-		metav1.PatchOptions{},
-	)
 	if err != nil {
 		errMsg := fmt.Errorf(
 			"failed to %s rollout %s (%s): %w",
@@ -86,6 +87,41 @@ func (r *rolloutCommand) patchRollout(ctx context.Context, client argov1alpha1.R
 		return err
 	}
 	return nil
+}
+
+func (r *rolloutCommand) applyPatch(ctx context.Context, client argov1alpha1.RolloutsGetter, patch string, subresources ...string) error {
+	rollout := client.Rollouts(r.namespace)
+	_, err := rollout.Patch(
+		ctx,
+		r.rolloutName,
+		types.MergePatchType,
+		[]byte(patch),
+		metav1.PatchOptions{},
+		subresources...,
+	)
+	return err
+}
+
+func (r *rolloutCommand) applyRetryPatch(ctx context.Context, client argov1alpha1.RolloutsGetter) error {
+	rollout := client.Rollouts(r.namespace)
+	_, err := rollout.Patch(
+		ctx,
+		r.rolloutName,
+		types.MergePatchType,
+		[]byte(retryPatch),
+		metav1.PatchOptions{},
+		"status",
+	)
+	if err != nil && k8serrors.IsNotFound(err) {
+		_, err = rollout.Patch(
+			ctx,
+			r.rolloutName,
+			types.MergePatchType,
+			[]byte(retryPatch),
+			metav1.PatchOptions{},
+		)
+	}
+	return err
 }
 
 // NewArgoRolloutsGetter creates a RolloutsGetter from Argo's v1alpha1 API.


### PR DESCRIPTION
## Description
When a Rollout is aborted, Argo Rollouts doesn't proceed with any new Rollout until a "retry" is triggered. A retry is done by attempting to applying the patch `{"status":{"abort":false}}` on the "status" subresource, and if it fails the same is attempted without the subresource. 

In this pull request I add the power of recovering from aborted Rollouts to the "resume" command.

## Related Issues
List related issues.

## Testing
Automated tests updated and manual tests.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `CHANGELOG.md`.
   
   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations
 
 - [x] This is unlikely to impact how Ambassador performs at scale.
 
   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability
 
 - [x] My change is adequately tested.
 
   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points
 
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
