### PR TITLE
Klambert/agent metrics close stream

### DIFF
--- a/pkg/agent/comm.go
+++ b/pkg/agent/comm.go
@@ -216,11 +216,7 @@ func (c *RPCComm) StreamMetrics(ctx context.Context, metrics *agent.StreamMetric
 		return err
 	}
 
-	if err := streamClient.CloseSend(); err != nil {
-		return err
-	}
-
-	return nil
+	return streamClient.CloseSend()
 }
 
 func (c *RPCComm) Directives() <-chan *agent.Directive {

--- a/pkg/agent/comm.go
+++ b/pkg/agent/comm.go
@@ -211,7 +211,16 @@ func (c *RPCComm) StreamMetrics(ctx context.Context, metrics *agent.StreamMetric
 	if err != nil {
 		return err
 	}
-	return streamClient.Send(metrics)
+
+	if err := streamClient.Send(metrics); err != nil {
+		return err
+	}
+
+	if err := streamClient.CloseSend(); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (c *RPCComm) Directives() <-chan *agent.Directive {


### PR DESCRIPTION
## Description
It looks like the StreamMetrics recently added does not close properly the stream. 

Example : 

One stream is opened each time, making the integration on the server side more difficult. If I want to rely on a for loop (since it's a stream), the code will stay stucked at : 

```go
msg, err := stream.Recv()
```

```go
	for {
                //it never leaves this loop
		log.Infof("Wait for new message, process %s", uid)
		msg, err := stream.Recv()

		if err != nil {
			if err == io.EOF {
				break
			} else {
				log.Error(err)
				return err
			}
		}

		messages = append(messages, msg)
	}
```
## Testing
I tested with a sample script the logic, and closing this stream each time it is opened and forgot is definitively fixing my issues. Although, in the future, that stream should stay opened. This is a quick fix to make the code cleaner.

Currently, I need to only pull the first message to make it work, and to ignore all the following. I would like my server code to be future proof. 

## Checklist

 - [X] I made sure to update `CHANGELOG.md` **(There is already a line regarding the metrics)**
 - [X] This is unlikely to impact how Ambassador performs at scale.
 - [X] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
