### PR TITLE
Fix rollout abort action

### DIFF
--- a/pkg/agent/rollouts_test.go
+++ b/pkg/agent/rollouts_test.go
@@ -116,8 +116,9 @@ func TestRolloutCommand_RunWithClient(t *testing.T) {
 				rolloutName: "my-rollout",
 				action:      rolloutActionResume,
 			},
-			wantPatches: []string{`{"spec":{"paused":false}}`, `{"status":{"abort":false}}`},
-			wantErr:     nil,
+			wantPatches:      []string{`{"spec":{"paused":false}}`, `{"status":{"abort":false}}`},
+			wantSubresources: []string{"status"},
+			wantErr:          nil,
 		},
 	}
 
@@ -143,6 +144,7 @@ func TestRolloutCommand_RunWithClient(t *testing.T) {
 			assert.Equal(t, tt.fields.rolloutName, mockRolloutInterface.latestName)
 			assert.Equal(t, types.MergePatchType, mockRolloutInterface.latestPatchType)
 			assert.Equal(t, tt.wantPatches, mockRolloutInterface.patches)
+			assert.Equal(t, tt.wantSubresources, mockRolloutInterface.subresources)
 			assert.Equal(t, metav1.PatchOptions{}, mockRolloutInterface.latestOptions)
 		})
 	}


### PR DESCRIPTION
Signed-off-by: Douglas Camata <dcamata@datawire.io>

## Description
Unfortunately the tests weren't doing what they were supposed to and this bug has passed: all rollout patches on the `status` key have to be done on the `status` subresource. 

The PR fixes the tests to ensure that the bug doesn't appear again.

## Related Issues
List related issues.

## Testing
Manual tests and automated tests.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `CHANGELOG.md`.
   
   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations
 
 - [x] This is unlikely to impact how Ambassador performs at scale.
 
   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability
 
 - [x] My change is adequately tested.
 
   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points
 
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
