### PR TITLE
Make protocol v3 the default

### DIFF
--- a/cmd/kat-server/server.go
+++ b/cmd/kat-server/server.go
@@ -48,8 +48,8 @@ func main() {
 
 	case "grpc_auth":
 		protocolVersion := os.Getenv("GRPC_AUTH_PROTOCOL_VERSION")
-		if protocolVersion == "v3" {
-			s = &srv.GRPCAUTHV3{
+		if protocolVersion == "v2" {
+			s = &srv.GRPCAUTH{
 				Port:            Port,
 				Backend:         os.Getenv("BACKEND"),
 				SecurePort:      SSLPort,
@@ -59,7 +59,7 @@ func main() {
 				ProtocolVersion: protocolVersion,
 			}
 		} else {
-			s = &srv.GRPCAUTH{
+			s = &srv.GRPCAUTHV3{
 				Port:            Port,
 				Backend:         os.Getenv("BACKEND"),
 				SecurePort:      SSLPort,
@@ -74,18 +74,7 @@ func main() {
 
 	case "grpc_rls":
 		protocolVersion := os.Getenv("GRPC_RLS_PROTOCOL_VERSION")
-		if protocolVersion == "v3" {
-			s = &srv.GRPCRLSV3{
-				Port:            Port,
-				Backend:         os.Getenv("BACKEND"),
-				SecurePort:      SSLPort,
-				SecureBackend:   os.Getenv("BACKEND"),
-				Cert:            Crt,
-				Key:             Key,
-				ProtocolVersion: protocolVersion,
-			}
-
-		} else {
+		if protocolVersion == "v2" {
 			s = &srv.GRPCRLS{
 				Port:            Port,
 				Backend:         os.Getenv("BACKEND"),
@@ -95,7 +84,16 @@ func main() {
 				Key:             Key,
 				ProtocolVersion: protocolVersion,
 			}
-
+		} else {
+			s = &srv.GRPCRLSV3{
+				Port:            Port,
+				Backend:         os.Getenv("BACKEND"),
+				SecurePort:      SSLPort,
+				SecureBackend:   os.Getenv("BACKEND"),
+				Cert:            Crt,
+				Key:             Key,
+				ProtocolVersion: protocolVersion,
+			}
 		}
 
 		listeners = append(listeners, s)

--- a/python/ambassador/envoy/v3/v3httpfilter.py
+++ b/python/ambassador/envoy/v3/v3httpfilter.py
@@ -262,7 +262,7 @@ def V3HTTPFilter_authv1(auth: IRAuth, v3config: 'V3Config'):
         }
 
     if auth.proto == "grpc":
-        protocol_version = auth.get('protocol_version', 'v2')
+        protocol_version = auth.get('protocol_version', 'v3')
         auth_info = {
             'name': 'envoy.filters.http.ext_authz',
             'typed_config': {

--- a/python/ambassador/ir/irauth.py
+++ b/python/ambassador/ir/irauth.py
@@ -144,7 +144,7 @@ class IRAuth (IRFilter):
         self["cluster_idle_timeout_ms"] = module.get("cluster_idle_timeout_ms", None)
         self["cluster_max_connection_lifetime_ms"] = module.get("cluster_max_connection_lifetime_ms", None)
         self["add_auth_headers"] = module.get("add_auth_headers", {})
-        self["protocol_version"] = module.get("protocol_version", "v2")
+        self["protocol_version"] = module.get("protocol_version", "v3")
         self.__to_header_list('allowed_headers', module)
         self.__to_header_list('allowed_request_headers', module)
         self.__to_header_list('allowed_authorization_headers', module)

--- a/python/ambassador/ir/irratelimit.py
+++ b/python/ambassador/ir/irratelimit.py
@@ -55,7 +55,7 @@ class IRRateLimit (IRFilter):
         self.name = "rate_limit"    # Force this, just in case.
         self.namespace = config.get("namespace", self.namespace)
         self.domain = config.get('domain', ir.ambassador_module.default_label_domain)
-        self.protocol_version = config.get("protocol_version", "v2")
+        self.protocol_version = config.get("protocol_version", "v3")
 
         # XXX host_rewrite actually isn't in the schema right now.
         self.host_rewrite = config.get('host_rewrite', None)

--- a/python/tests/kat/abstract_tests.py
+++ b/python/tests/kat/abstract_tests.py
@@ -455,7 +455,7 @@ class AHTTP(ServiceType):
 class AGRPC(ServiceType):
     skip_variant: ClassVar[bool] = True
 
-    def __init__(self, protocol_version: str="v2", *args, **kwargs) -> None:
+    def __init__(self, protocol_version: str="v3", *args, **kwargs) -> None:
         self.protocol_version = protocol_version
 
         # Do this unconditionally, because that's the point of this class.
@@ -468,7 +468,7 @@ class AGRPC(ServiceType):
 class RLSGRPC(ServiceType):
     skip_variant: ClassVar[bool] = True
 
-    def __init__(self, protocol_version: str="v2", *args, **kwargs) -> None:
+    def __init__(self, protocol_version: str="v3", *args, **kwargs) -> None:
         self.protocol_version = protocol_version
 
         # Do this unconditionally, because that's the point of this class.


### PR DESCRIPTION
Signed-off-by: AliceProxy <alicewasko@datawire.io>

## Description
Makes protocol v3 the default when not specified for authservice/ratelimitservice

## Related Issues
List related issues.

## Testing
A few sentences describing what testing you've done, e.g., manual tests, automated tests, deployed in production, etc.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `CHANGELOG.md`.
   
   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations
 
 - [ ] This is unlikely to impact how Ambassador performs at scale.
 
   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability
 
 - [ ] My change is adequately tested.
 
   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points
 
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
