### PR TITLE
Set Ambassador hostname as Envoy's node.id

### DIFF
--- a/python/ambassador/envoy/v2/v2bootstrap.py
+++ b/python/ambassador/envoy/v2/v2bootstrap.py
@@ -10,6 +10,8 @@ from ...ir.irlogservice import IRLogService
 from ...ir.irratelimit import IRRateLimit
 from ...ir.irtracing import IRTracing
 
+from ...utils import SystemInfo
+
 from .v2cluster import V2Cluster
 
 if TYPE_CHECKING:
@@ -21,7 +23,7 @@ class V2Bootstrap(dict):
         super().__init__(**{
             "node": {
                 "cluster": config.ir.ambassador_nodename,
-                "id": "test-id"         # MUST BE test-id, see below
+                "id": SystemInfo.MyHostName,
             },
             "static_resources": {},     # Filled in later
             "dynamic_resources": {

--- a/python/ambassador/envoy/v3/v3bootstrap.py
+++ b/python/ambassador/envoy/v3/v3bootstrap.py
@@ -10,6 +10,8 @@ from ...ir.irlogservice import IRLogService
 from ...ir.irratelimit import IRRateLimit
 from ...ir.irtracing import IRTracing
 
+from ...utils import SystemInfo
+
 from .v3cluster import V3Cluster
 
 if TYPE_CHECKING:
@@ -22,7 +24,7 @@ class V3Bootstrap(dict):
         super().__init__(**{
             "node": {
                 "cluster": config.ir.ambassador_nodename,
-                "id": "test-id"         # MUST BE test-id, see below
+                "id": SystemInfo.MyHostName,
             },
             "static_resources": {},     # Filled in later
             "dynamic_resources": {


### PR DESCRIPTION
(@kflynn: This is actually a cherry pick of @psalaberria's e784d4f6d, as
an experiment. @psalaborria's original comment follows...)

When looking at traces, I noticed there was a node.id tag set to "test-id".

I am not sure what other implications this change may have, but it seems harmless at a first glance.

Signed-off-by: Paul Salaberria <psalaberria002@gmail.com>
(cherry picked from commit e784d4f6d4e7c6a740a0da2d5bebeca0e1450531)

 - [ ] I made sure to update `CHANGELOG.md`.
 - [x] This is unlikely to impact how Ambassador performs at scale.
 - [ ] My change is adequately tested.
 - [x] No changes to `DEVELOPING.md` were necessary.
