### PR TITLE
Synthetic v3 AuthService for Edge-Stack

### DIFF
--- a/cmd/entrypoint/syntheticauth.go
+++ b/cmd/entrypoint/syntheticauth.go
@@ -1,0 +1,82 @@
+package entrypoint
+
+import (
+	"context"
+	//"github.com/datawire/dlib/derror"
+	"github.com/datawire/ambassador/v2/pkg/api/getambassador.io/v3alpha1"
+	"github.com/datawire/ambassador/v2/pkg/kates"
+)
+
+// This is a gross hack to remove all AuthServices using protocol_version: v2 only when running Edge-Stack and then inject an
+// AuthService with protocol_version: v3 if needed. The purpose of this hack is to prevent Edge-Stack 2.3 from
+// using any other AuthService than the default one running as part of amb-sidecar and force the protocol version to v3.
+func ReconcileAuthServices(ctx context.Context, sh *SnapshotHolder, deltas *[]*kates.Delta) error {
+	// We only want to remove AuthServices if this is an instance of Edge-Stack
+	isEdgeStack, err := IsEdgeStack()
+	if err != nil {
+		return err
+	} else if !isEdgeStack {
+		return nil
+	}
+
+	syntheticAuth := &v3alpha1.AuthService{
+		TypeMeta: kates.TypeMeta{
+			Kind:       "AuthService",
+			APIVersion: "getambassador.io/v3alpha1",
+		},
+		ObjectMeta: kates.ObjectMeta{
+			Name:      "synthetic-edge-stack-auth",
+			Namespace: "default",
+		},
+		Spec: v3alpha1.AuthServiceSpec{
+			AuthService:     "127.0.0.1:8500",
+			Proto:           "grpc",
+			ProtocolVersion: "v3",
+		},
+	}
+
+	var authServices []*v3alpha1.AuthService
+	syntheticAuthExists := false
+	for _, authService := range sh.k8sSnapshot.AuthServices {
+		// Keep any AuthServices already using protocol_version: v3
+		if authService.ObjectMeta.Name == "synthetic-edge-stack-auth" {
+			syntheticAuthExists = true
+		} else if authService.Spec.ProtocolVersion == "v3" {
+			authServices = append(authServices, authService)
+		}
+	}
+	if len(authServices) == 0 && !syntheticAuthExists {
+		// There are no valid AuthServices with protocol_version: v3. A synthetic one needs to be injected.
+		authServices = append(authServices, syntheticAuth)
+
+		// loop through the deltas and remove any AuthService deltas adding other AuthServices before the Synthetic delta is inserted
+		var newDeltas []*kates.Delta
+		for _, delta := range *deltas {
+			// Keep all the deltas that are not for AuthServices. The AuthService deltas can be kept as long as they are not an add delta.
+			if (delta.Kind != "AuthService") || (delta.Kind == "AuthService" && delta.DeltaType != kates.ObjectAdd) {
+				newDeltas = append(newDeltas, delta)
+			}
+		}
+		newDeltas = append(newDeltas, &kates.Delta{
+			TypeMeta:   syntheticAuth.TypeMeta,
+			ObjectMeta: syntheticAuth.ObjectMeta,
+			DeltaType:  kates.ObjectAdd,
+		})
+
+		*deltas = newDeltas
+		sh.k8sSnapshot.AuthServices = authServices
+	} else if len(authServices) >= 1 && syntheticAuthExists {
+		// One or more Valid AuthServices are present. The synthetic AuthService exists and needs to be removed now.
+		sh.k8sSnapshot.AuthServices = authServices
+		var newDeltas []*kates.Delta
+		*deltas = append(*deltas, &kates.Delta{
+			TypeMeta:   syntheticAuth.TypeMeta,
+			ObjectMeta: syntheticAuth.ObjectMeta,
+			DeltaType:  kates.ObjectDelete,
+		})
+
+		*deltas = newDeltas
+	}
+
+	return nil
+}

--- a/cmd/entrypoint/testutil_fake_syntheticauth_test.go
+++ b/cmd/entrypoint/testutil_fake_syntheticauth_test.go
@@ -1,0 +1,124 @@
+package entrypoint_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/datawire/ambassador/v2/cmd/entrypoint"
+	v3bootstrap "github.com/datawire/ambassador/v2/pkg/api/envoy/config/bootstrap/v3"
+	v3cluster "github.com/datawire/ambassador/v2/pkg/api/envoy/config/cluster/v3"
+	"github.com/datawire/ambassador/v2/pkg/snapshot/v1"
+)
+
+// This predicate is used to check k8s snapshots for an AuthService matching the provided name and namespace
+func HasAuthService(namespace, name string) func(snapshot *snapshot.Snapshot) bool {
+	return func(snapshot *snapshot.Snapshot) bool {
+		for _, m := range snapshot.Kubernetes.AuthServices {
+			if m.Namespace == namespace && m.Name == name {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// Tests the synthetic auth generation when a valid AuthService is created
+// This authservice has protocol_Version: v3 and should not be replaced by the synthetic AuthService
+func TestSyntheticAuthWithValid(t *testing.T) {
+	t.Setenv("EDGE_STACK", "true")
+
+	f := entrypoint.RunFake(t, entrypoint.FakeConfig{EnvoyConfig: true}, nil)
+
+	err := f.UpsertYAML(`
+---
+apiVersion: getambassador.io/v3alpha1
+kind: AuthService
+metadata:
+  name: edge-stack-auth-test
+  namespace: foo
+spec:
+  auth_service: 127.0.0.1:8500
+  protocol_version: "v3"
+  proto: "grpc"
+`)
+	assert.NoError(t, err)
+	f.Flush()
+
+	// Use the predicate above to check that the snapshot contains the AuthService defined above
+	// The AuthService has protocol_Version: v3 so it should not be removed/replaced by the synthetic AuthService
+	// injected by syntheticauth.go
+	snap, err := f.GetSnapshot(HasAuthService("foo", "edge-stack-auth-test"))
+	assert.NoError(t, err)
+	assert.NotNil(t, snap)
+
+	assert.Equal(t, "edge-stack-auth-test", snap.Kubernetes.AuthServices[0].Name)
+
+	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are harder to check since they always have the same name)
+	// the namespace for this extauthz cluster should be foo (since that is the namespace of the valid AuthService above)
+	isAuthCluster := func(c *v3cluster.Cluster) bool {
+		return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_foo")
+	}
+
+	// Grab the next Envoy config that has an Edge Stack auth cluster on 127.0.0.1:8500
+	envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
+		return FindCluster(envoy, isAuthCluster) != nil
+	})
+	require.NoError(t, err)
+
+	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was defined
+	assert.NotNil(t, envoyConfig)
+
+	t.Setenv("EDGE_STACK", "")
+}
+
+// This tests with a provided AuthService that has no protocol_version (which defaults to v2)
+// The synthetic AuthService should be created instead
+func TestSyntheticAuthInvalid(t *testing.T) {
+	t.Setenv("EDGE_STACK", "true")
+
+	f := entrypoint.RunFake(t, entrypoint.FakeConfig{EnvoyConfig: true}, nil)
+
+	err := f.UpsertYAML(`
+---
+apiVersion: getambassador.io/v3alpha1
+kind: AuthService
+metadata:
+  name: edge-stack-auth-test
+  namespace: foo
+spec:
+  auth_service: 127.0.0.1:8500
+  proto: "grpc"
+`)
+	assert.NoError(t, err)
+	f.Flush()
+
+	// Use the predicate above to check that the snapshot contains the AuthService defined above
+	// The AuthService does not have protocol_Version: v3 so it should be removed and replaced by the synthetic AuthService
+	// injected by syntheticauth.go
+	snap, err := f.GetSnapshot(HasAuthService("default", "synthetic-edge-stack-auth"))
+	assert.NoError(t, err)
+	assert.NotNil(t, snap)
+
+	// The snapshot should only have the synthetic AuthService and not the one defined above
+	assert.Equal(t, "synthetic-edge-stack-auth", snap.Kubernetes.AuthServices[0].Name)
+
+	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are harder to check since they always have the same name)
+	// the namespace for this extauthz cluster should be default (since that is the namespace of the synthetic AuthService)
+	isAuthCluster := func(c *v3cluster.Cluster) bool {
+		return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_default")
+	}
+
+	// Grab the next Envoy config that has an Edge Stack auth cluster on 127.0.0.1:8500
+	envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
+		return FindCluster(envoy, isAuthCluster) != nil
+	})
+	require.NoError(t, err)
+
+	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was defined
+	assert.NotNil(t, envoyConfig)
+
+	t.Setenv("EDGE_STACK", "")
+}

--- a/cmd/entrypoint/watcher.go
+++ b/cmd/entrypoint/watcher.go
@@ -371,7 +371,7 @@ func (sh *SnapshotHolder) K8sUpdate(
 	parseAnnotationsTimer := dbg.Timer("parseAnnotations")
 	reconcileSecretsTimer := dbg.Timer("reconcileSecrets")
 	reconcileConsulTimer := dbg.Timer("reconcileConsul")
-	reconcileAuthServicesTimer := dbg.Timer("scrubAuthServices")
+	reconcileAuthServicesTimer := dbg.Timer("reconcileAuthServices")
 
 	endpointsChanged := false
 	dispatcherChanged := false

--- a/cmd/entrypoint/watcher.go
+++ b/cmd/entrypoint/watcher.go
@@ -371,6 +371,7 @@ func (sh *SnapshotHolder) K8sUpdate(
 	parseAnnotationsTimer := dbg.Timer("parseAnnotations")
 	reconcileSecretsTimer := dbg.Timer("reconcileSecrets")
 	reconcileConsulTimer := dbg.Timer("reconcileConsul")
+	reconcileAuthServicesTimer := dbg.Timer("scrubAuthServices")
 
 	endpointsChanged := false
 	dispatcherChanged := false
@@ -436,6 +437,12 @@ func (sh *SnapshotHolder) K8sUpdate(
 		}
 		reconcileConsulTimer.Time(func() {
 			err = ReconcileConsul(ctx, consulWatcher, sh.k8sSnapshot)
+		})
+		if err != nil {
+			return false, err
+		}
+		reconcileAuthServicesTimer.Time(func() {
+			err = ReconcileAuthServices(ctx, sh, &deltas)
 		})
 		if err != nil {
 			return false, err


### PR DESCRIPTION
Signed-off-by: AliceProxy <alicewasko@datawire.io>

## Description
When running Edge-Stack this will remove all AuthServices not using `protocol_version: v3` and then inject a synthetic AuthService pointing at `127.0.0.1:8500` if there are no valid v3 AuthServices. The purpose is to ensure that Edge-Stack always has an available v3 AuthService and that it will not try to use any that are v2 (which is the default).

## Related Issues
List related issues.

## Testing
A few sentences describing what testing you've done, e.g., manual tests, automated tests, deployed in production, etc.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `CHANGELOG.md`.
   
   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations
 
 - [ ] This is unlikely to impact how Ambassador performs at scale.
 
   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability
 
 - [ ] My change is adequately tested.
 
   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points
 
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
