### PR TITLE
[v1.14] Backport Envoy changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,6 +108,16 @@ commands:
     - amb-config-registry
     - # main
       run: make lint
+  "job-check-envoy-version":
+    steps:
+    # setup
+    - amb-checkout
+    - amb-config-registry
+    - # main
+      run:
+        name: "Check Envoy version"
+        command: |
+          make check-envoy-version
   "job-promote-passed-ci-build":
     steps:
     - amb-linux-install
@@ -802,6 +812,10 @@ jobs:
     executor: oss-linux
     steps:
     - job-lint
+  oss-check-envoy-version:
+    executor: oss-linux
+    steps:
+    - job-check-envoy-version
   oss-images:
     parameters:
       release:

--- a/.circleci/config.yml.d/amb_jobs.yml
+++ b/.circleci/config.yml.d/amb_jobs.yml
@@ -119,6 +119,17 @@ commands:
       # main
       - run: make lint
 
+  "job-check-envoy-version":
+    steps:
+      # setup
+      - amb-checkout
+      - amb-config-registry
+      # main
+      - run:
+          name: "Check Envoy version"
+          command: |
+            make check-envoy-version
+
   "job-promote-passed-ci-build":
     steps:
       - amb-linux-install

--- a/.circleci/config.yml.d/amb_oss.yml
+++ b/.circleci/config.yml.d/amb_oss.yml
@@ -12,6 +12,11 @@ jobs:
     steps:
       - job-lint
 
+  "oss-check-envoy-version":
+    executor: oss-linux
+    steps:
+      - job-check-envoy-version
+
   "oss-images":
     parameters:
       "release":
@@ -464,4 +469,3 @@ workflows:
               - test: pytest-envoy-v2
                 fast-reconfigure: true
                 legacy-mode: true
-

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,8 @@ dist
 *.log
 *.tmp
 *.bak
+*.orig
+*.rej
 log.txt
 
 # From `make update-aws`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,14 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 ## RELEASE NOTES
 
+## [1.14.3] February 24, 2022
+[1.14.3]: https://github.com/emissary-ingress/emissary/compare/v1.14.2...v1.14.3
+
+### Emissary Ingress and Ambassador Edge Stack
+
+- Security: Upgraded Envoy to address security vulnerabilities CVE-2021-43824, CVE-2021-43825,
+  CVE-2021-43826, CVE-2022-21654, and CVE-2022-21655.
+
 ## [1.14.2] September 29, 2021
 [1.14.2]: https://github.com/emissary-ingress/emissary/compare/v1.14.1...v1.14.2
 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -613,13 +613,15 @@ I'd put this in in the pull request template, but so few PRs change Envoy...
 
  - [ ] The image has been pushed to...
    * [ ] `docker.io/datawire/ambassador-base`
-   * [ ] `quay.io/datawire/ambassador-base`
    * [ ] `gcr.io/datawire/ambassador-base`
  - [ ] The envoy.git commit has been tagged as `datawire-$(git
    describe --tags --match='v*')` (the `--match` is to prevent
    `datawire-*` tags from stacking on each other).
  - [ ] It's been tested with...
    * [ ] `make check-envoy`
+
+The `check-envoy-version` CI job should check all of those things,
+except for `make check-envoy`.
 
 How do I test Ambassador when using a private Docker repository?
 ----------------------------------------------------------------

--- a/_cxx/envoy.mk
+++ b/_cxx/envoy.mk
@@ -21,6 +21,17 @@ ENVOY_TEST_LABEL ?= //test/...
 # for builder.mk...
 export ENVOY_DOCKER_TAG
 
+# Set ENVOY_DOCKER_REPO to the list of mirrors that we should
+# sanity-check that things get pushed to.
+ifneq ($(IS_PRIVATE),)
+  # If $(IS_PRIVATE), then just the private repo...
+  ENVOY_DOCKER_REPOS = $(ENVOY_DOCKER_REPO)
+else
+  # ...otherwise, this list of repos:
+  ENVOY_DOCKER_REPOS  = docker.io/datawire/ambassador-base
+  ENVOY_DOCKER_REPOS += gcr.io/datawire/ambassador-base
+endif
+
 #
 # Envoy build
 
@@ -181,6 +192,24 @@ check-envoy: $(ENVOY_BASH.deps)
 	     $(ENVOY_DOCKER_EXEC) bazel test --config=clang --test_output=errors --verbose_failures -c dbg --test_env=ENVOY_IP_TEST_VERSIONS=v4only $(ENVOY_TEST_LABEL); \
 	 )
 .PHONY: check-envoy
+
+.PHONY: check-envoy-version
+check-envoy-version: ## Check that Envoy version has been pushed to the right places
+check-envoy-version: $(OSS_HOME)/_cxx/envoy
+	# First, we're going to check whether the envoy commit is tagged, which
+	# is one of the things that has to happen before landing a PR that bumps
+	# the ENVOY_COMMIT.
+	cd $< && unset GIT_DIR GIT_WORK_TREE && git describe --tags --exact-match
+	# Now, we're going to check that the Envoy Docker images have been
+	# pushed to all of the mirrors, which is another thing that has to
+	# happen before landing a PR that bumps the ENVOY_COMMIT.
+	#
+	# We "could" use `docker manifest inspect` instead of `docker
+	# pull` to test that these exist without actually pulling
+	# them... except that gcr.io doesn't allow `manifest inspect`.
+	# So just go ahead and do the `pull` :(
+	@PS4=; set -ex; $(foreach ENVOY_DOCKER_REPO,$(ENVOY_DOCKER_REPOS), docker pull $(ENVOY_DOCKER_TAG) >/dev/null; )
+	@PS4=; set -ex; $(foreach ENVOY_DOCKER_REPO,$(ENVOY_DOCKER_REPOS), docker pull $(ENVOY_FULL_DOCKER_TAG) >/dev/null; )
 
 envoy-shell: ## Run a shell in the Envoy build container
 envoy-shell: $(ENVOY_BASH.deps)

--- a/_cxx/envoy.mk
+++ b/_cxx/envoy.mk
@@ -12,7 +12,7 @@ ENVOY_TEST_LABEL ?= //test/...
   # You may reset BASE_ENVOY_RELVER when adjusting ENVOY_COMMIT.
   BASE_ENVOY_RELVER ?= 0
 
-  ENVOY_DOCKER_REPO ?= $(if $(IS_PRIVATE),quay.io/datawire-private/ambassador-base,docker.io/datawire/ambassador-base)
+  ENVOY_DOCKER_REPO ?= $(if $(IS_PRIVATE),quay.io/datawire-private/base-envoy,docker.io/emissaryingress/base-envoy)
   ENVOY_DOCKER_VERSION ?= $(BASE_ENVOY_RELVER).$(ENVOY_COMMIT).$(ENVOY_COMPILATION_MODE)
   ENVOY_DOCKER_TAG ?= $(ENVOY_DOCKER_REPO):envoy-$(ENVOY_DOCKER_VERSION)
   ENVOY_FULL_DOCKER_TAG ?= $(ENVOY_DOCKER_REPO):envoy-full-$(ENVOY_DOCKER_VERSION)
@@ -28,7 +28,7 @@ ifneq ($(IS_PRIVATE),)
   ENVOY_DOCKER_REPOS = $(ENVOY_DOCKER_REPO)
 else
   # ...otherwise, this list of repos:
-  ENVOY_DOCKER_REPOS  = docker.io/datawire/ambassador-base
+  ENVOY_DOCKER_REPOS  = docker.io/emissaryingress/base-envoy
   ENVOY_DOCKER_REPOS += gcr.io/datawire/ambassador-base
 endif
 

--- a/_cxx/envoy.mk
+++ b/_cxx/envoy.mk
@@ -298,6 +298,12 @@ clobber: _clobber-envoy
 
 _clean-envoy: _clean-envoy-old
 _clean-envoy: $(OSS_HOME)/_cxx/envoy-build-container.txt.clean
+	@PS4=; set -e; { \
+		if docker volume inspect envoy-build >/dev/null 2>&1; then \
+			set -x ;\
+			docker volume rm envoy-build >/dev/null ;\
+		fi ;\
+	}
 	rm -f $(OSS_HOME)/_cxx/envoy-build-image.txt
 _clobber-envoy: _clean-envoy
 	rm -f $(OSS_HOME)/docker/base-envoy/envoy-static

--- a/_cxx/envoy.mk
+++ b/_cxx/envoy.mk
@@ -6,7 +6,7 @@ ENVOY_TEST_LABEL ?= //test/...
 
 # IF YOU MESS WITH ANY OF THESE VALUES, YOU MUST RUN `make update-base`.
   ENVOY_REPO ?= $(if $(IS_PRIVATE),git@github.com:datawire/envoy-private.git,https://github.com/datawire/envoy.git)
-  ENVOY_COMMIT ?= 7a33e53fd3d3c4befa53030797f344fcacaa61f4
+  ENVOY_COMMIT ?= 049f125c1c9a6cd7e49bd4a660cdeccd9f6ec383
   ENVOY_COMPILATION_MODE ?= opt
   # Increment BASE_ENVOY_RELVER on changes to `docker/base-envoy/Dockerfile`, or Envoy recipes.
   # You may reset BASE_ENVOY_RELVER when adjusting ENVOY_COMMIT.

--- a/_cxx/envoy.mk
+++ b/_cxx/envoy.mk
@@ -6,7 +6,7 @@ ENVOY_TEST_LABEL ?= //test/...
 
 # IF YOU MESS WITH ANY OF THESE VALUES, YOU MUST RUN `make update-base`.
   ENVOY_REPO ?= $(if $(IS_PRIVATE),git@github.com:datawire/envoy-private.git,https://github.com/datawire/envoy.git)
-  ENVOY_COMMIT ?= 049f125c1c9a6cd7e49bd4a660cdeccd9f6ec383
+  ENVOY_COMMIT ?= 4ce93dc3ace00ae9108b179d0afaceac13f4602a
   ENVOY_COMPILATION_MODE ?= opt
   # Increment BASE_ENVOY_RELVER on changes to `docker/base-envoy/Dockerfile`, or Envoy recipes.
   # You may reset BASE_ENVOY_RELVER when adjusting ENVOY_COMMIT.

--- a/_cxx/envoy.mk
+++ b/_cxx/envoy.mk
@@ -5,7 +5,7 @@ YES_I_AM_OK_WITH_COMPILING_ENVOY ?=
 ENVOY_TEST_LABEL ?= //test/...
 
 # IF YOU MESS WITH ANY OF THESE VALUES, YOU MUST RUN `make update-base`.
-  ENVOY_REPO ?= $(if $(IS_PRIVATE),git@github.com:datawire/envoy-private.git,git://github.com/datawire/envoy.git)
+  ENVOY_REPO ?= $(if $(IS_PRIVATE),git@github.com:datawire/envoy-private.git,https://github.com/datawire/envoy.git)
   ENVOY_COMMIT ?= 7a33e53fd3d3c4befa53030797f344fcacaa61f4
   ENVOY_COMPILATION_MODE ?= opt
   # Increment BASE_ENVOY_RELVER on changes to `docker/base-envoy/Dockerfile`, or Envoy recipes.

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -31,6 +31,16 @@
 
 changelog: https://github.com/emissary-ingress/emissary/blob/$branch$/CHANGELOG.md
 items:
+  - version: 1.14.3
+    date: '2022-02-24'
+    notes:
+      - title: Envoy security updates
+        type: security
+        body: >-
+          Upgraded Envoy to address security vulnerabilities CVE-2021-43824, CVE-2021-43825, CVE-2021-43826,
+          CVE-2022-21654, and CVE-2022-21655.
+        docs: https://groups.google.com/g/envoy-announce/c/bIUgEDKHl4g
+
   - version: 1.14.2
     date: '2021-09-29'
     notes:


### PR DESCRIPTION
## Description
This PR cherry-picks changes to our Envoy from `release/v2.2` to `release/v1.14`.  I determined which commits to cherry-pick by looking at which commits in `origin/release/v2.2 ^origin/release/v1.14` touch `_cxx/envoy.mk`, and ignoring the ones that only have ENVOY_COMMIT changes from prior to the 2.2.1 timeframe.

## Related Issues
The pulls down the until-recently-embargoed Envoy security patches.

## Testing
I built confident that this fully backported all relevant changes by running `git diff origin/{release/v2.2,lukeshu/envoy-sec} -- _cxx/envoy.mk docker/base-envoy/`, which gives
```patch
diff --git a/_cxx/envoy.mk b/_cxx/envoy.mk
index cb32b4a8f..7f8fe6cae 100644
--- a/_cxx/envoy.mk
+++ b/_cxx/envoy.mk
@@ -1,4 +1,4 @@
-# ...
+# yo
 include $(OSS_HOME)/build-aux/prelude.mk
 
 YES_I_AM_OK_WITH_COMPILING_ENVOY ?=
@@ -102,13 +102,13 @@ $(OSS_HOME)/_cxx/go-control-plane: FORCE
 	    git checkout $(ENVOY_GO_CONTROL_PLANE_COMMIT); \
 	}
 
-$(OSS_HOME)/_cxx/envoy-build-image.txt: $(OSS_HOME)/_cxx/envoy $(tools/write-ifchanged) FORCE
+$(OSS_HOME)/_cxx/envoy-build-image.txt: $(OSS_HOME)/_cxx/envoy $(WRITE_IFCHANGED) FORCE
 	@PS4=; set -ex -o pipefail; { \
 	    pushd $</ci; \
 	    echo "$$(pwd)"; \
 	    . envoy_build_sha.sh; \
 	    popd; \
-	    echo docker.io/envoyproxy/envoy-build-ubuntu:$$ENVOY_BUILD_SHA | $(tools/write-ifchanged) $@; \
+	    echo docker.io/envoyproxy/envoy-build-ubuntu:$$ENVOY_BUILD_SHA | $(WRITE_IFCHANGED) $@; \
 	}
 
 $(OSS_HOME)/_cxx/envoy-build-container.txt: $(OSS_HOME)/_cxx/envoy-build-image.txt FORCE
@@ -239,8 +239,8 @@ $(OSS_HOME)/pkg/api/pb $(OSS_HOME)/pkg/api/envoy: $(OSS_HOME)/pkg/api/%: $(OSS_H
 	  find "$$tmpdir" -type f \
 	    -exec chmod 644 {} + \
 	    -exec sed -E -i.bak \
-	      -e 's,github\.com/envoyproxy/go-control-plane/envoy,github.com/datawire/ambassador/v2/pkg/api/envoy,g' \
-	      -e 's,github\.com/envoyproxy/go-control-plane/pb,github.com/datawire/ambassador/v2/pkg/api/pb,g' \
+	      -e 's,github\.com/envoyproxy/go-control-plane/envoy,github.com/datawire/ambassador/pkg/api/envoy,g' \
+	      -e 's,github\.com/envoyproxy/go-control-plane/pb,github.com/datawire/ambassador/pkg/api/pb,g' \
 	      -- {} +; \
 	  find "$$tmpdir" -name '*.bak' -delete; \
 	  mv "$$tmpdir/$*" $@; \
```

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `CHANGELOG.md`. - yes
   
   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations
 
 - [x] This is unlikely to impact how Ambassador performs at scale.
 
   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability
 
 - [x] My change is adequately tested.
 
   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points
 
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently. - no tricks
