### PR TITLE
Allow suppressing missing-TLS-context error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,11 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 ### Emissary-ingress and Ambassador Edge Stack
 
+- Feature: Emissary-ingress currently logs an error if no `TLSContext`s are found; however, in some
+  situations (for example, when terminating TLS at the load balancer), this is not actually an
+  error. Setting `AMBASSADOR_MISSING_TLS_OK` to `true` in the environment will suppress the error.
+  (Thanks, [Vikas Kumar](https://github.com/vikas027)!)
+
 ## [2.2.1] February 22, 2022
 [2.2.1]: https://github.com/emissary-ingress/emissary/compare/v2.2.0...v2.2.1
 

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -34,7 +34,14 @@ changelog: https://github.com/emissary-ingress/emissary/blob/$branch$/CHANGELOG.
 items:
   - version: 2.3.0
     date: 'TBD'
-    notes: []
+    notes:
+      - title: Allow suppressing error about missing TLSContexts
+        type: feature
+        body: >-
+          $productName$ currently logs an error if no `TLSContext`s are found; however, in some situations
+          (for example, when terminating TLS at the load balancer), this is not actually an error. Setting
+          `AMBASSADOR_MISSING_TLS_OK` to `true` in the environment will suppress the error. (Thanks,
+          [Vikas Kumar](https://github.com/vikas027)!)
 
   - version: 2.2.1
     date: '2022-02-22'

--- a/python/ambassador_diag/diagd.py
+++ b/python/ambassador_diag/diagd.py
@@ -69,6 +69,8 @@ __version__ = Version
 
 boot_time = datetime.datetime.now()
 
+no_tls_errors = parse_bool(os.environ.get('AMBASSADOR_MISSING_TLS_OK', 'false'))
+
 # allows 10 concurrent users, with a request timeout of 60 seconds
 tvars_cache = ExpiringDict(max_len=10, max_age_seconds=60)
 
@@ -1792,7 +1794,8 @@ class AmbassadorEventWatcher(threading.Thread):
 
         if tls_count:
             env_status.OK('TLS', f'{tls_count} TLSContext{" is" if (tls_count == 1) else "s are"} active')
-        else:
+
+        if no_tls_errors:
             chime_failures['no TLS contexts'] = True
             env_status.failure('TLS', "No TLSContexts are active")
 


### PR DESCRIPTION
This was originally #3649 from @vikas027; I've corrected a logic error
so we can take it.

- fix: Remove TLSContext error when absent
- Correct missing-TLS logic

 - [x] I made sure to update `CHANGELOG.md`.
 - [x] This is unlikely to impact how Ambassador performs at scale.
 - [ ] My change is adequately tested.
 - [x] I didn't need to update `DEVELOPING.md`.
 
