### PR TITLE
Add filters and FilterPolicies to snapshot

### DIFF
--- a/cmd/entrypoint/interesting_types.go
+++ b/cmd/entrypoint/interesting_types.go
@@ -115,6 +115,10 @@ func GetInterestingTypes(ctx context.Context, serverTypeList []kates.APIResource
 		"KNativeClusterIngresses": {{typename: "clusteringresses.v1alpha1.networking.internal.knative.dev", ignoreIf: !IsKnativeEnabled()}}, // New in Knative Serving 0.3.0 (2019-01-09)
 		"KNativeIngresses":        {{typename: "ingresses.v1alpha1.networking.internal.knative.dev", ignoreIf: !IsKnativeEnabled()}},        // New in Knative Serving 0.7.0 (2019-06-25)
 
+		// Unstructured from Edge Stack
+		"FilterPolicies": {{typename: "filterpolicies.v3alpha1.getambassador.io"}},
+		"Filters":        {{typename: "filters.v3alpha1.getambassador.io"}},
+
 		// Native Emissary types
 		"AuthServices":                {{typename: "authservices.v3alpha1.getambassador.io"}},
 		"ConsulResolvers":             {{typename: "consulresolvers.v3alpha1.getambassador.io"}},

--- a/cmd/entrypoint/testutil_fake_k8s_store_test.go
+++ b/cmd/entrypoint/testutil_fake_k8s_store_test.go
@@ -261,6 +261,10 @@ func canonGVK(rawString string) (canonKind string, canonGroupVersion string, err
 		return "TLSContext", "getambassador.io/v3alpha1", nil
 	case "tracingservice", "tracingservices":
 		return "TracingService", "getambassador.io/v3alpha1", nil
+	case "filter", "filters":
+		return "Filter", "getambassador.io/v3alpha1", nil
+	case "filterpolicy", "filterpolicies":
+		return "Filterpolicy", "getambassador.io/v3alpha1", nil
 	default:
 		return "", "", fmt.Errorf("I don't know how to canonicalize kind: %q", rawString)
 	}

--- a/pkg/snapshot/v1/types.go
+++ b/pkg/snapshot/v1/types.go
@@ -92,6 +92,9 @@ type KubernetesSnapshot struct {
 	KNativeClusterIngresses []*kates.Unstructured `json:"clusteringresses.networking.internal.knative.dev,omitempty"`
 	KNativeIngresses        []*kates.Unstructured `json:"ingresses.networking.internal.knative.dev,omitempty"`
 
+	FilterPolicies []*kates.Unstructured `json:"filterpolicies.v3alpha1.getambassador.io,omitempty"`
+	Filters        []*kates.Unstructured `json:"filters.v3alpha1.getambassador.io,omitempty"`
+
 	K8sSecrets []*kates.Secret             `json:"-"`      // Secrets from Kubernetes
 	FSSecrets  map[SecretRef]*kates.Secret `json:"-"`      // Secrets from the filesystem
 	Secrets    []*kates.Secret             `json:"secret"` // Secrets we'll feed to Ambassador


### PR DESCRIPTION
Signed-off-by: AliceProxy <alicewasko@datawire.io>

## Description
This is a small PR that adds Filters and Filterpolicies to interesting types so that they will be picked up and stored in the snapshot. This has little/no impact on emissary, but will allow for edge-stack to simply read the filters and filterpolicies from the snapshot instead of setting up separate watch queries. 

## Related Issues
https://github.com/emissary-ingress/emissary/pull/4127 is indirectly (through edge-stack) dependent upon the changes in this PR. 

## Testing
N/A

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] ~~I made sure to update `CHANGELOG.md`.~~
   
   ~~Remember, the CHANGELOG needs to mention:~~
    + ~~Any new features~~
    + ~~Any changes to our included version of Envoy~~
    + ~~Any non-backward-compatible changes~~
    + ~~Any deprecations~~

This is not added to the changelog since it does not impact end-users, but will allow for other user-impacting changes that will provide their own documentation.
 
 - [x] This is unlikely to impact how Ambassador performs at scale.
 
   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability
 


 - [ ] ~~My change is adequately tested.~~
 
   ~~Remember when considering testing:~~
    + ~~Your change needs to be specifically covered by tests.~~
       + ~~Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.~~
    + ~~You also need to make sure that the _entire area being changed_ has adequate test coverage.~~
       + ~~If existing tests don't actually cover the entire area being changed, add tests.~~
       + ~~This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!~~
    + ~~We should lean on the bulk of code being covered by unit tests, but...~~
    + ~~... an end-to-end test should cover the integration points~~
 
No testing is necessary/applicable on the emissary side as this change should ultimately only impact edge-stack. The machinery on the edge-stack side already contains tests for Filters/Filterpolicies which will not succeed if there are any issues with reading the configuration for those resources from the snapshot instead of via separate queries.

 - [ ] ~~I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.~~
 No special black magic was used in the making of these changes.
