### PR TITLE
Try ripping out some things getting flagged by security scans: pip, gdbm, sqlite, smtplib, ensurepip, piptools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,8 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 ### Emissary-ingress and Ambassador Edge Stack
 
+- Security: Completely remove gdbm, pip, smtplib, and sqlite packages, as they are unused.
+
 ## [2.2.1] February 22, 2022
 [2.2.1]: https://github.com/emissary-ingress/emissary/compare/v2.2.0...v2.2.1
 

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -153,6 +153,10 @@ RUN setcap cap_net_bind_service=p /opt/ambassador/bin/wrapper
 COPY --from=artifacts /buildroot/ambassador/python /buildroot/ambassador/python
 RUN cd /buildroot/ambassador/python && python setup.py install
 
+# Delete some things that cause problems for security scanners.
+RUN python -m pip uninstall -y pip
+RUN find / \( -iname '*sqlite*' -o -iname '*gdbm*' -o -iname '*smtplib*' -o -iname '*piptools*' -o -iname '*pip_tools*' -o -iname '*ensurepip*' \) -exec rm -rf -- '{}' \+
+
 # Configuration, Docker demo stuff, the AES WebUI. The /ambassador bit changes
 # in post-install so it's always stale. But it's pretty small, so it's not too
 # bad to re-push every time.

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -34,7 +34,11 @@ changelog: https://github.com/emissary-ingress/emissary/blob/$branch$/CHANGELOG.
 items:
   - version: 2.3.0
     date: 'TBD'
-    notes: []
+    notes:
+      - title: Remove unused packages
+        type: security
+        body: >-
+          Completely remove gdbm, pip, smtplib, and sqlite packages, as they are unused.
 
   - version: 2.2.1
     date: '2022-02-22'


### PR DESCRIPTION
Bit of an experiment so far...

Signed-off-by: Flynn <flynn@datawire.io>

 - [x] I made sure to update `CHANGELOG.md`.
 - [x] This is unlikely to impact how Ambassador performs at scale.
 - [x] My change is adequately tested.
 - [x] I didn't need to update `DEVELOPING.md`.
