### PR TITLE
fix: set correct protocol stack when using `protocol` HTTPSPROXY

### DIFF
--- a/python/ambassador/ir/irlistener.py
+++ b/python/ambassador/ir/irlistener.py
@@ -53,7 +53,7 @@ class IRListener (IRResource):
         "HTTPPROXY": [ "PROXY", "HTTP", "TCP" ],
 
         # HTTPSPROXY: accepts encrypted HTTP/1.1 or HTTP/2 sessions using the HAProxy PROXY protocol over TLS over TCP.
-        "HTTPSPROXY": [ "TLS", "PROXY", "HTTP", "TCP" ],
+        "HTTPSPROXY": [ "PROXY", "TLS", "HTTP", "TCP" ],
 
         # TCP: accepts raw TCP sessions.
         "TCP": [ "TCP" ],


### PR DESCRIPTION
When using `HTTPSPROXY` the protocol stack needs to be proxy wrapping TLS.

This is a fix for issue #4153 

## Testing

Was done locally by provisioning a HTTPS proxy enabled listener and fronting that with an AWS NLB with proxyProtocol v2 support enabled.
