### PR TITLE
Fix a bug in kates.Client.patchWatch().

### DIFF
--- a/pkg/kates/client.go
+++ b/pkg/kates/client.go
@@ -989,7 +989,7 @@ func (c *Client) patchWatch(ctx context.Context, field *field) error {
 				// remove it.
 				dlog.Println(ctx, "Patching delete", field.mapping.GroupVersionKind.Kind, key)
 				delete(field.values, key)
-				field.deltas[key] = newDelta(ObjectDelete, can)
+				field.deltas[key] = newDelta(ObjectDelete, item)
 			} else if newer, err := gteq(item.GetResourceVersion(), can.GetResourceVersion()); err != nil {
 				return err
 			} else if newer {

--- a/pkg/kates/client.go
+++ b/pkg/kates/client.go
@@ -595,6 +595,25 @@ func (c *Client) cliForResource(resource *Unstructured) (dynamic.ResourceInterfa
 	return c.cliFor(mapping, ns), nil
 }
 
+func (c *Client) newField(q Query) (*field, error) {
+	mapping, err := c.mappingFor(q.Kind)
+	if err != nil {
+		return nil, err
+	}
+	sel, err := ParseSelector(q.LabelSelector)
+	if err != nil {
+		return nil, err
+	}
+
+	return &field{
+		query:    q,
+		mapping:  mapping,
+		selector: sel,
+		values:   make(map[string]*Unstructured),
+		deltas:   make(map[string]*Delta),
+	}, nil
+}
+
 // mappingFor returns the RESTMapping for the Kind given, or the Kind referenced by the resource.
 // Prefers a fully specified GroupVersionResource match. If one is not found, we match on a fully
 // specified GroupVersionKind, or fallback to a match on GroupKind.

--- a/pkg/kates/client_test.go
+++ b/pkg/kates/client_test.go
@@ -588,26 +588,14 @@ func TestPatchWatch(t *testing.T) {
 	cli, err := NewClient(ClientConfig{})
 	require.NoError(err)
 
-	// Build up a field the same way newAccumulator does. (Could stand to be deduplicated later.)
-	query := Query{Name: "Pods", Kind: "pods"}
-
-	mapping, err := cli.mappingFor(query.Kind)
+	// Make a field the same way newAccumulator does.
+	field, err := cli.newField(Query{Name: "Pods", Kind: "pods"})
 	require.NoError(err)
-	sel, err := ParseSelector(query.LabelSelector)
-	require.NoError(err)
-
-	field := &field{
-		query:    query,
-		mapping:  mapping,
-		selector: sel,
-		values:   make(map[string]*Unstructured),
-		deltas:   make(map[string]*Delta),
-	}
 
 	// Convenience function for making multiple versions of a given pod.
 	makePod := func(namespace, name string, version int) *Unstructured {
 		un := &Unstructured{}
-		un.SetGroupVersionKind(mapping.GroupVersionKind)
+		un.SetGroupVersionKind(field.mapping.GroupVersionKind)
 		un.SetNamespace(namespace)
 		un.SetName(name)
 		un.SetUID(types.UID(fmt.Sprintf("UID:%s.%s", namespace, name)))


### PR DESCRIPTION
## Description

- Add a unit test for kates.Client.patchWatch and fix a panic that can happen when resources are deleted.
- Add a Client.newField in order to dedup field construction.

## Testing

Added a unit test.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `CHANGELOG.md`.
   
   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations
 
 - [x] This is unlikely to impact how Ambassador performs at scale.
 
   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability
 
 - [x] My change is adequately tested.
 
   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points
 
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
