### PR TITLE
Fix issue #3975 - Added configurable IngressClass resource to helm chart

### DIFF
--- a/charts/emissary-ingress/CHANGELOG.md
+++ b/charts/emissary-ingress/CHANGELOG.md
@@ -7,6 +7,8 @@ numbering uses [semantic versioning](http://semver.org).
 
 - Add "lifecycle" option to main container. This can be used, for example, to add a lifecycle.preStop hook. Thanks to [Eric Totten](https://github.com/etotten) for the contribution!
 
+- Feature: Added configurable IngressClass resource to be compliant with Kubernetes 1.22+ ingress specification.
+
 ## v7.2.2
 
 - Update Emissary chart image to version v2.1.2: [CHANGELOG](https://github.com/emissary-ingress/emissary/blob/master/CHANGELOG.md)

--- a/charts/emissary-ingress/templates/controller-ingressclass.yaml
+++ b/charts/emissary-ingress/templates/controller-ingressclass.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.controller.ingressClassResource.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: {{ .Values.ingressClassResource.name }}
+{{- if .Values.ingressClassResource.default }}
+  annotations:
+    ingressclass.kubernetes.io/is-default-class: "true"
+{{- end }}
+spec:
+  controller: {{ .Values.ingressClassResource.controllerValue }}
+{{- end }}

--- a/charts/emissary-ingress/templates/controller-ingressclass.yaml
+++ b/charts/emissary-ingress/templates/controller-ingressclass.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.controller.ingressClassResource.enabled -}}
+{{- if .Values.ingressClassResource.enabled -}}
 {{- if or (.Capabilities.APIVersions.Has "networking.k8s.io/v1/IngressClass") (.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/IngressClass") }}
 {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/IngressClass" }}
 apiVersion: networking.k8s.io/v1

--- a/charts/emissary-ingress/templates/controller-ingressclass.yaml
+++ b/charts/emissary-ingress/templates/controller-ingressclass.yaml
@@ -1,5 +1,10 @@
 {{- if .Values.controller.ingressClassResource.enabled -}}
+{{- if or (.Capabilities.APIVersions.Has "networking.k8s.io/v1/IngressClass") (.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/IngressClass") }}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/IngressClass" }}
 apiVersion: networking.k8s.io/v1
+{{- else }}
+apiVersion: networking.k8s.io/v1beta1
+{{- end }}
 kind: IngressClass
 metadata:
   name: {{ .Values.ingressClassResource.name }}
@@ -9,4 +14,5 @@ metadata:
 {{- end }}
 spec:
   controller: {{ .Values.ingressClassResource.controllerValue }}
+{{- end }}
 {{- end }}

--- a/charts/emissary-ingress/values.yaml.in
+++ b/charts/emissary-ingress/values.yaml.in
@@ -36,6 +36,13 @@ canary:
   # Environment variables to be used for the canary deployment, see `envRaw` for usage example
   envRaw: {}
 
+# Install IngressClass resource
+ingressClassResource:
+  enabled: true
+  name: ambassador
+  default: false
+  controllerValue: getambassador.io/ingress-controller
+
 # Enable autoscaling using HorizontalPodAutoscaler
 # daemonSet: true, autoscaling will be disabled
 autoscaling: # +doc-gen:break


### PR DESCRIPTION
## Description
Added ingress class.

## Related Issues
Fixes issue #3975

## Testing
Installed emissary, verified with another helm chart with this template, installed with `--set myip=<node-public-ip>`:
```yaml
---

apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: hello
  name: hello
spec:
  replicas: 1
  selector:
    matchLabels:
      app: hello
  template:
    metadata:
      labels:
        app: hello
    spec:
      containers:
      - image: nginx
        name: nginx

---

apiVersion: v1
kind: Service
metadata:
  labels:
    app: hello
  name: hello
spec:
  type: ClusterIP
  selector:
    app: hello
  ports:
  - name: http
    port: 80
    protocol: TCP
    targetPort: 80

---

apiVersion: getambassador.io/v3alpha1
kind: Host
metadata:
  name: hello
spec:
  hostname: hello.{{ regexReplaceAll "\\." .Values.myip "-" }}.nip.io
  requestPolicy:
    insecure:
      action: Route

---

apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: hello
spec:
  ingressClassName: ambassador
  rules:
  - host: hello.{{ regexReplaceAll "\\." .Values.myip "-" }}.nip.io
    http:
      paths:
      - backend:
          service:
            name: hello
            port:
              number: 80
        path: /
        pathType: Prefix

```

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

Note! 
No changes to actual emissary ingress, only helm chart

 - [ ] I made sure to update `CHANGELOG.md`.
 - [X] This is unlikely to impact how Ambassador performs at scale.
 - [X] My change is adequately tested.
 - [X] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
   (No tricks needed)