### PR TITLE
Swap the order of the CORS filter and the ext_authz filter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,9 +97,13 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 - Feature: It is now possible to set `propagation_modes` in the `TracingService` config when using
   lightstep as the driver. (Thanks to <a href="https://github.com/psalaberria002">Paul</a>!) ([#4179])
 
+- Bugfix: When CORS is specified (either in a `Mapping` or in the `Ambassador` `Module`), CORS
+  processing will happen before authentication. This corrects a problem where XHR to authenticated
+  endpoints would fail.
+
 [#4179]: https://github.com/emissary-ingress/emissary/pull/4179
 
-## [2.2.2] TBD
+## [2.2.2] February 25, 2022
 [2.2.2]: https://github.com/emissary-ingress/emissary/compare/v2.2.1...v2.2.2
 
 ### Emissary-ingress and Ambassador Edge Stack

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -48,9 +48,15 @@ items:
         github:
           - title: "#4179"
             link: https://github.com/emissary-ingress/emissary/pull/4179
+      - title: CORS now happens before auth
+        type: bugfix
+        body: >-
+          When CORS is specified (either in a <code>Mapping</code> or in the <code>Ambassador</code>
+          <code>Module</code>), CORS processing will happen before authentication. This corrects a
+          problem where XHR to authenticated endpoints would fail.
 
   - version: 2.2.2
-    date: 'TBD'
+    date: '2022-02-25'
     notes:
       - title: TLS Secret validation is now opt-in
         type: change

--- a/python/ambassador/ir/ir.py
+++ b/python/ambassador/ir/ir.py
@@ -377,14 +377,15 @@ class IR:
         IRLogServiceFactory.load_all(self, aconf)
 
         # After the Ambassador and TLS modules are done, we need to set up the
-        # filter chains. Note that order of the filters matters. Start with auth,
-        # since it needs to be able to override everything...
-        self.save_filter(IRAuth(self, aconf))
+        # filter chains. Note that order of the filters matters. Start with CORS,
+        # so that preflights will work even for things behind auth.
 
-        # ...then deal with the non-configurable cors filter...
         self.save_filter(IRFilter(ir=self, aconf=aconf,
                                   rkey="ir.cors", kind="ir.cors", name="cors",
                                   config={}))
+
+        # Next is auth...
+        self.save_filter(IRAuth(self, aconf))
 
         # ...then the ratelimit filter...
         if self.ratelimit:


### PR DESCRIPTION
Having auth happen before CORS prevents CORS preflights of authenticated resources from ever having a chance at working. Swapping them allows preflights and "real" requests to both work.

Signed-off-by: Flynn <flynn@datawire.io>

 - [x] I made sure to update `CHANGELOG.md`.
 - [x] This is unlikely to impact how Ambassador performs at scale.
 - [x] My change is adequately tested.
 - [x] I didn't need to update `DEVELOPING.md`.
