### PR TITLE
Enable contributors developing on Apple Silicon (M1 - Arm64)

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -40,6 +40,9 @@ requirements and provide a friendly error message. If you ever find
 that this is not the case please file a PR with a fix. Likewise if you
 ever find anything missing from this list.
 
+> To enable contributors using Apple Silicon we ensure that the artifacts are built for `linux/amd64`
+> rather than the host `linux/arm64` architecture. This can be overriden using the `BUILD_ARCH` environment variable.
+
 ### Requirements:
 
  - git
@@ -727,3 +730,10 @@ upgrade everything else, then
     for those you want to pin.
  2. Delete `python/requirements.in` (if it exists).
  3. Run `make generate`.
+
+How do I develop on an Mac with Apple Silicon?
+----------------------------------------------
+
+To ensure that developers using a Mac with Apple Silicon can contribute, the build system ensures
+the build artifacts are `linux/amd64` rather than the host architecture. This behavior can be overriden
+using the `BUILD_ARCH` environment variable (e.g. `BUILD_ARCH=linux/arm64 make images`).

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ include build-aux/init-configure-make-itself.mk
 include build-aux/prelude.mk # In Haskell, "Prelude" is what they call the stdlib builtins that get get imported by default before anything else
 include build-aux/tools.mk
 
+# To support contributors building project on M1 Macs we will default container builds to run as linux/amd64 rather than
+# the host architecture. Setting the corresponding environment variable allows overriding it if want to work with other architectures.
+BUILD_ARCH ?= linux/amd64
+
 # Bootstrapping the build env
 ifneq ($(MAKECMDGOALS),$(OSS_HOME)/build-aux/go-version.txt)
   $(_prelude.go.ensure)

--- a/build-aux/main.mk
+++ b/build-aux/main.mk
@@ -68,7 +68,7 @@ python/requirements.in: $(tools/py-list-deps) $(tools/write-ifchanged) FORCE
 python/.requirements.txt.stamp: python/requirements.in docker/base-python.docker.tag.local
 # The --interactive is so that stdin gets passed through; otherwise Docker closes stdin.
 	set -ex -o pipefail; { \
-	  docker run --rm --interactive "$$(cat docker/base-python.docker)" sh -c 'tar xf - && find ~/.cache/pip -name "maturin-*.whl" -exec pip install --no-deps {} + >&@ && pip-compile --allow-unsafe --no-build-isolation -q >&2 && cat requirements.txt' \
+	  docker run --platform="$(BUILD_ARCH)" --rm --interactive "$$(cat docker/base-python.docker)" sh -c 'tar xf - && find ~/.cache/pip -name "maturin-*.whl" -exec pip install --no-deps {} + >&@ && pip-compile --allow-unsafe --no-build-isolation -q >&2 && cat requirements.txt' \
 	    < <(bsdtar -cf - -C $(@D) requirements.in requirements.txt) \
 	    > $@; }
 python/requirements.txt: python/%: python/.%.stamp $(tools/copy-ifchanged)
@@ -77,7 +77,7 @@ python/requirements.txt: python/%: python/.%.stamp $(tools/copy-ifchanged)
 docker/base-pip/requirements.txt: python/requirements.txt $(tools/copy-ifchanged)
 	$(tools/copy-ifchanged) $< $@
 docker/.base-pip.docker.stamp: docker/.%.docker.stamp: docker/%/Dockerfile docker/%/requirements.txt docker/base-python.docker.tag.local
-	docker build --build-arg=from="$$(sed -n 2p docker/base-python.docker.tag.local)" --iidfile=$@ $(<D)
+	docker build --platform="$(BUILD_ARCH)" --build-arg=from="$$(sed -n 2p docker/base-python.docker.tag.local)" --iidfile=$@ $(<D)
 
 # The Helm chart
 build-output/charts/emissary-ingress-$(patsubst v%,%,$(CHART_VERSION)).tgz: \

--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -231,6 +231,7 @@ docker/.$(LCNAME).docker.stamp: %/.$(LCNAME).docker.stamp: %/base.docker.tag.loc
 	@printf "    ${BLU}builderbase=$$(sed -n 2p $*/base-pip.docker.tag.local)${END}\n"
 	{ $(tools/dsum) '$(LCNAME) build' 3s \
 	  docker build -f ${BUILDER_HOME}/Dockerfile . \
+			--platform="$(BUILD_ARCH)" \
 	    --build-arg=base="$$(sed -n 2p $*/base.docker.tag.local)" \
 	    --build-arg=envoy="$$(cat $*/base-envoy.docker)" \
 	    --build-arg=builderbase="$$(sed -n 2p $*/base-pip.docker.tag.local)" \


### PR DESCRIPTION
## Description
The Emissary-Ingress build system supports and tests 'linux/amd64' containers which presents a problem when developing locally on newer M1 Macs which have Apple Silicon (arm64). To enable developers to build locally on Apple Silicon we have introduce a new environment variable `BUILD_ARCH` which defaults to `linux/amd64` so that running `make images` will produce the correct artifacts.

**Important** - This does NOT introduce a multi-architecture image but rather to decrease the friction for contributors on Apple Silicon. The multi-architecture support is a separate stream which some of the discussion can be found in #4184.


## Related Issues
N/A

## Testing

- Manually verified that `make images` is able to properly build the containers
- Manually verified that `make deploy` can push containers out to development K8s cluster. 
- Verified that Emissary-Ingress ran successfully within cluster after forcing linux/amd64 architecture
- Tested that Make variable `BUILD_ARCH` defaults `linux/amd64` but can be overridden by setting the Environment Variable with the same name

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `CHANGELOG.md`.
   
I haven't because this doesn't really apply to a specific release...however, it might be good to cherry pick these changes to any release branch that is still supported?
 
 - [x] This is unlikely to impact how Ambassador performs at scale.
 
 - [x] My change is adequately tested.

It might be good if someone without an M1 Mac or another developer on the M1 Mac tries it out as well but so far there doesn't appear to be any issues with using this approach in the short-term.
 
 - [] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
