### PR TITLE
enhanced DEVELOPING.md to improve first time contributors experience

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,3 @@
+# Emissary-Ingress Architecture
+
+WIP - we are working to get this updated. Check back soon!


### PR DESCRIPTION
## Description

One of the challenges of the current Development.md is that it reads more like an Faq and has some carry over items from when the project was Ambassador. Here are some of the enhancements:

- Introduced Table of Contents to help with navigation
- Re-organized sections to help guide contributors of all levels
- Added new Development Setup section to help get new contributors setup faster
- Switched usages of `Ambassador` to `Emissary-ingress` to reflect the new branding
- Switched usages of `Datawire` to new company branding `Ambassador Labs` where it made sense.

## Related Issues
N/a

## Testing
No code changes, only contributors docs

## Checklist

 - [ ] I made sure to update `CHANGELOG.md`.
 - [x] This is unlikely to impact how Ambassador performs at scale.
 - [ ] My change is adequately tested.
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
