### PR TITLE
helm chart - Include ambassador_id when default listeners are created

### DIFF
--- a/charts/emissary-ingress/CHANGELOG.md
+++ b/charts/emissary-ingress/CHANGELOG.md
@@ -6,6 +6,7 @@ numbering uses [semantic versioning](http://semver.org).
 ## Next Release
 
 - Add "lifecycle" option to main container. This can be used, for example, to add a lifecycle.preStop hook. Thanks to [Eric Totten](https://github.com/etotten) for the contribution!
+- Add `ambassador_id` to listener manifests rendered when using `createDefaultListeners: true` with `AMBASSADOR_ID` set in environment variables.
 
 ## v7.2.2
 

--- a/charts/emissary-ingress/templates/listener.yaml
+++ b/charts/emissary-ingress/templates/listener.yaml
@@ -12,6 +12,10 @@ spec:
   hostBinding:
     namespace:
       from: ALL
+  {{- if hasKey .Values.env "AMBASSADOR_ID" }}
+  ambassador_id:
+  - {{ .Values.env.AMBASSADOR_ID | quote }}
+  {{- end }}
 ---
 apiVersion: getambassador.io/v3alpha1
 kind: Listener
@@ -25,4 +29,8 @@ spec:
   hostBinding:
     namespace:
       from: ALL
+  {{- if hasKey .Values.env "AMBASSADOR_ID" }}
+  ambassador_id:
+  - {{ .Values.env.AMBASSADOR_ID | quote }}
+  {{- end }}
 {{ end }}


### PR DESCRIPTION
## Description
The helm chart currently does not include the 'ambassador_id' in the default set of listeners when 'createDefaultListeners' is set as 'true' and 'AMBASSADOR_ID' exists in the environment variables. NOTE: the "module" deployed does include 'ambassador_id' as expected. This PR fixes this problem so that the two default listener objects are configured properly to work in multi ambassador installation configurations.

## Related Issues
- [Related issue](https://github.com/emissary-ingress/emissary/issues/4198)

## Testing
- Ran ' make release/push-chart' to build chart
- Installed chart on EKS cluster (adding the following to values.yaml passed in to chart):
```
env:
  AMBASSADOR_ID: "two"
```
- Verified default listeners are configured properly

## Checklist

 - [ ] I made sure to update `CHANGELOG.md`.
   
   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations
 
 - [x] This is unlikely to impact how Ambassador performs at scale.
 
   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability
 
 - [x] My change is adequately tested.
 
   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points
 
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
