### PR TITLE
Test empty rewrites

### DIFF
--- a/python/ambassador/utils.py
+++ b/python/ambassador/utils.py
@@ -169,7 +169,7 @@ def parse_bool(s: Optional[Union[str, bool]]) -> bool:
 
     # OK, we got _something_, so try strtobool.
     try:
-        return strtobool(s)
+        return bool(strtobool(s)) # the linter does not like a Literal[0, 1] being returned here
     except ValueError:
         return False
 

--- a/python/tests/kat/t_grpc.py
+++ b/python/tests/kat/t_grpc.py
@@ -25,7 +25,7 @@ kind: Mapping
 grpc: True
 hostname: "*"
 prefix: /echo.EchoService/
-rewrite: /echo.EchoService/
+rewrite: ""   # This means to leave the prefix unaltered.
 name:  {self.target.path.k8s}
 service: {self.target.path.k8s}
 """)
@@ -84,7 +84,7 @@ kind: Mapping
 grpc: True
 hostname: "*"
 prefix: /echo.EchoService/
-rewrite: /echo.EchoService/
+rewrite: ""   # This means to leave the prefix unaltered.
 name:  {self.target.path.k8s}
 service: {self.target.path.k8s}
 resolver: my-endpoint

--- a/python/tests/kat/t_grpc.py
+++ b/python/tests/kat/t_grpc.py
@@ -74,23 +74,22 @@ metadata:
     name: my-endpoint
 spec:
     ambassador_id: ["endpointgrpctest"]
-''') + super().manifests()
-
-    def config(self) -> Generator[Union[str, Tuple[Node, str]], None, None]:
-        yield self, self.format("""
 ---
 apiVersion: getambassador.io/v3alpha1
 kind: Mapping
-grpc: True
-hostname: "*"
-prefix: /echo.EchoService/
-rewrite: ""   # This means to leave the prefix unaltered.
-name:  {self.target.path.k8s}
-service: {self.target.path.k8s}
-resolver: my-endpoint
-load_balancer:
-  policy: round_robin
-""")
+metadata:
+    name: {self.target.path.k8s}
+spec:
+    ambassador_id: ["endpointgrpctest"]
+    grpc: True
+    hostname: "*"
+    prefix: /echo.EchoService/
+    rewrite: ""   # This means to leave the prefix unaltered.
+    service: {self.target.path.k8s}
+    resolver: my-endpoint
+    load_balancer:
+        policy: round_robin
+''') + super().manifests()
 
     def queries(self):
         # [0]


### PR DESCRIPTION
We had an issue a little while back where empty rewrites (`rewrite: ""` in a `Mapping`) caused a regression, and we realized that we weren't testing that specific case. 

This PR changes two gRPC tests (which actually require a `rewrite`, and which can use an empty rewrite effectively) to test that case, and also switches one of them to use a CRD rather than an annotation so that we cover both annotations and CRDs. I also verified that the `rewrite` is indeed necessary for the gRPC `Mapping`s: if you set it to something other than the `prefix` value or `""`, the gRPC calls fail.

Signed-off-by: Flynn <flynn@datawire.io>

 - [x] I didn't need to update `CHANGELOG.md`.
 - [x] This is unlikely to impact how Ambassador performs at scale.
 - [x] My change is adequately tested.
 - [x] I didn't need to update `DEVELOPING.md`.
