### PR TITLE
picking community `ambassador id` helm fix from master to include in release/v2.3

### DIFF
--- a/charts/emissary-ingress/CHANGELOG.md
+++ b/charts/emissary-ingress/CHANGELOG.md
@@ -6,6 +6,7 @@ numbering uses [semantic versioning](http://semver.org).
 ## Next Release
 
 - Add "lifecycle" option to main container. This can be used, for example, to add a lifecycle.preStop hook. Thanks to [Eric Totten](https://github.com/etotten) for the contribution!
+- Add `ambassador_id` to listener manifests rendered when using `createDefaultListeners: true` with `AMBASSADOR_ID` set in environment variables.
 
 - Feature: Added configurable IngressClass resource to be compliant with Kubernetes 1.22+ ingress specification.
 

--- a/charts/emissary-ingress/templates/listener.yaml
+++ b/charts/emissary-ingress/templates/listener.yaml
@@ -12,6 +12,10 @@ spec:
   hostBinding:
     namespace:
       from: ALL
+  {{- if hasKey .Values.env "AMBASSADOR_ID" }}
+  ambassador_id:
+  - {{ .Values.env.AMBASSADOR_ID | quote }}
+  {{- end }}
 ---
 apiVersion: getambassador.io/v3alpha1
 kind: Listener
@@ -25,4 +29,8 @@ spec:
   hostBinding:
     namespace:
       from: ALL
+  {{- if hasKey .Values.env "AMBASSADOR_ID" }}
+  ambassador_id:
+  - {{ .Values.env.AMBASSADOR_ID | quote }}
+  {{- end }}
 {{ end }}


### PR DESCRIPTION
## Description
This cherry-picks the community PR that was already merged into master so that it is included in the release/v2.3 branch.

## Related Issues
see #4199  for more details

## Testing
see #4199  for more details
## Checklist
 - [x] I made sure to update `CHANGELOG.md`. 
_Yes, community member already did this._
 - [x] This is unlikely to impact how Ambassador performs at scale.
 - [x] My change is adequately tested.
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
     _No changes were needed_
 - [x] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
