### PR TITLE
Allow Host and TLSContext to configure a CRL

### DIFF
--- a/cmd/entrypoint/secrets.go
+++ b/cmd/entrypoint/secrets.go
@@ -326,6 +326,10 @@ func findSecretRefs(ctx context.Context, resource kates.Object, secretNamespacin
 		if r.Spec.TLS != nil {
 			// Host.spec.tls.caSecret is the thing to worry about here.
 			secretRef(r.GetNamespace(), r.Spec.TLS.CASecret, secretNamespacing, action)
+
+			if r.Spec.TLS.CRLSecret != "" {
+				secretRef(r.GetNamespace(), r.Spec.TLS.CRLSecret, secretNamespacing, action)
+			}
 		}
 
 		// Host.spec.tlsSecret and Host.spec.acmeProvider.privateKeySecret are native-Kubernetes-style
@@ -357,6 +361,13 @@ func findSecretRefs(ctx context.Context, resource kates.Object, secretNamespacin
 				secretNamespacing = *r.Spec.SecretNamespacing
 			}
 			secretRef(r.GetNamespace(), r.Spec.CASecret, secretNamespacing, action)
+		}
+
+		if r.Spec.CRLSecret != "" {
+			if r.Spec.SecretNamespacing != nil {
+				secretNamespacing = *r.Spec.SecretNamespacing
+			}
+			secretRef(r.GetNamespace(), r.Spec.CRLSecret, secretNamespacing, action)
 		}
 
 	case *amb.Module:

--- a/manifests/emissary/emissary-crds.yaml.in
+++ b/manifests/emissary/emissary-crds.yaml.in
@@ -896,6 +896,8 @@ spec:
                     type: integer
                   sni:
                     type: string
+                  v3CRLSecret:
+                    type: string
                 type: object
               tlsContext:
                 description: "Name of the TLSContext the Host resource is linked with.
@@ -1212,6 +1214,8 @@ spec:
                     items:
                       type: string
                     type: array
+                  crl_secret:
+                    type: string
                   ecdh_curves:
                     items:
                       type: string
@@ -3529,6 +3533,8 @@ spec:
                 type: boolean
               sni:
                 type: string
+              v3CRLSecret:
+                type: string
             type: object
             x-kubernetes-preserve-unknown-fields: true
         type: object
@@ -3577,6 +3583,8 @@ spec:
                 items:
                   type: string
                 type: array
+              crl_secret:
+                type: string
               ecdh_curves:
                 items:
                   type: string

--- a/pkg/api/getambassador.io/crds.yaml
+++ b/pkg/api/getambassador.io/crds.yaml
@@ -902,6 +902,8 @@ spec:
                     type: integer
                   sni:
                     type: string
+                  v3CRLSecret:
+                    type: string
                 type: object
               tlsContext:
                 description: "Name of the TLSContext the Host resource is linked with.
@@ -1217,6 +1219,8 @@ spec:
                     items:
                       type: string
                     type: array
+                  crl_secret:
+                    type: string
                   ecdh_curves:
                     items:
                       type: string
@@ -3592,6 +3596,8 @@ spec:
                 type: boolean
               sni:
                 type: string
+              v3CRLSecret:
+                type: string
             type: object
         type: object
     served: true
@@ -3639,6 +3645,8 @@ spec:
                 items:
                   type: string
                 type: array
+              crl_secret:
+                type: string
               ecdh_curves:
                 items:
                   type: string

--- a/pkg/api/getambassador.io/v2/crd_host.go
+++ b/pkg/api/getambassador.io/v2/crd_host.go
@@ -152,6 +152,9 @@ type TLSConfig struct {
 	ECDHCurves            []string `json:"ecdh_curves,omitempty"`
 	RedirectCleartextFrom *int     `json:"redirect_cleartext_from,omitempty"`
 	SNI                   string   `json:"sni,omitempty"`
+
+	// +k8s:conversion-gen:rename=CRLSecret
+	V3CRLSecret string `json:"v3CRLSecret,omitempty"`
 }
 
 // The first value listed in the Enum marker becomes the "zero" value,

--- a/pkg/api/getambassador.io/v2/crd_tlscontext.go
+++ b/pkg/api/getambassador.io/v2/crd_tlscontext.go
@@ -44,6 +44,9 @@ type TLSContextSpec struct {
 	SecretNamespacing     *bool    `json:"secret_namespacing,omitempty"`
 	RedirectCleartextFrom *int     `json:"redirect_cleartext_from,omitempty"`
 	SNI                   string   `json:"sni,omitempty"`
+
+	// +k8s:conversion-gen:rename=CRLSecret
+	V3CRLSecret string `json:"v3CRLSecret,omitempty"`
 }
 
 // TLSContext is the Schema for the tlscontexts API

--- a/pkg/api/getambassador.io/v2/zz_generated.conversion.go
+++ b/pkg/api/getambassador.io/v2/zz_generated.conversion.go
@@ -5083,7 +5083,58 @@ func autoConvert_v3alpha1_TCPMappingSpec_To_v2_TCPMappingSpec(in *v3alpha1.TCPMa
 }
 
 func autoConvert_v2_TLSConfig_To_v3alpha1_TLSConfig(in *TLSConfig, out *v3alpha1.TLSConfig, s conversion.Scope) error {
-	*out = v3alpha1.TLSConfig(*in)
+	if true {
+		in, out := &in.CertChainFile, &out.CertChainFile
+		*out = *in
+	}
+	if true {
+		in, out := &in.PrivateKeyFile, &out.PrivateKeyFile
+		*out = *in
+	}
+	if true {
+		in, out := &in.CASecret, &out.CASecret
+		*out = *in
+	}
+	if true {
+		in, out := &in.CAcertChainFile, &out.CAcertChainFile
+		*out = *in
+	}
+	if true {
+		in, out := &in.AlpnProtocols, &out.AlpnProtocols
+		*out = *in
+	}
+	if true {
+		in, out := &in.CertRequired, &out.CertRequired
+		*out = *in
+	}
+	if true {
+		in, out := &in.MinTLSVersion, &out.MinTLSVersion
+		*out = *in
+	}
+	if true {
+		in, out := &in.MaxTLSVersion, &out.MaxTLSVersion
+		*out = *in
+	}
+	if true {
+		in, out := &in.CipherSuites, &out.CipherSuites
+		*out = *in
+	}
+	if true {
+		in, out := &in.ECDHCurves, &out.ECDHCurves
+		*out = *in
+	}
+	if true {
+		in, out := &in.RedirectCleartextFrom, &out.RedirectCleartextFrom
+		*out = *in
+	}
+	if true {
+		in, out := &in.SNI, &out.SNI
+		*out = *in
+	}
+	if true {
+		in, out := &in.V3CRLSecret, &out.CRLSecret
+		*out = *in
+	}
 	return nil
 }
 
@@ -5093,7 +5144,58 @@ func Convert_v2_TLSConfig_To_v3alpha1_TLSConfig(in *TLSConfig, out *v3alpha1.TLS
 }
 
 func autoConvert_v3alpha1_TLSConfig_To_v2_TLSConfig(in *v3alpha1.TLSConfig, out *TLSConfig, s conversion.Scope) error {
-	*out = TLSConfig(*in)
+	if true {
+		in, out := &in.CertChainFile, &out.CertChainFile
+		*out = *in
+	}
+	if true {
+		in, out := &in.PrivateKeyFile, &out.PrivateKeyFile
+		*out = *in
+	}
+	if true {
+		in, out := &in.CASecret, &out.CASecret
+		*out = *in
+	}
+	if true {
+		in, out := &in.CAcertChainFile, &out.CAcertChainFile
+		*out = *in
+	}
+	if true {
+		in, out := &in.CRLSecret, &out.V3CRLSecret
+		*out = *in
+	}
+	if true {
+		in, out := &in.AlpnProtocols, &out.AlpnProtocols
+		*out = *in
+	}
+	if true {
+		in, out := &in.CertRequired, &out.CertRequired
+		*out = *in
+	}
+	if true {
+		in, out := &in.MinTLSVersion, &out.MinTLSVersion
+		*out = *in
+	}
+	if true {
+		in, out := &in.MaxTLSVersion, &out.MaxTLSVersion
+		*out = *in
+	}
+	if true {
+		in, out := &in.CipherSuites, &out.CipherSuites
+		*out = *in
+	}
+	if true {
+		in, out := &in.ECDHCurves, &out.ECDHCurves
+		*out = *in
+	}
+	if true {
+		in, out := &in.RedirectCleartextFrom, &out.RedirectCleartextFrom
+		*out = *in
+	}
+	if true {
+		in, out := &in.SNI, &out.SNI
+		*out = *in
+	}
 	return nil
 }
 
@@ -5261,6 +5363,10 @@ func autoConvert_v2_TLSContextSpec_To_v3alpha1_TLSContextSpec(in *TLSContextSpec
 		in, out := &in.SNI, &out.SNI
 		*out = *in
 	}
+	if true {
+		in, out := &in.V3CRLSecret, &out.CRLSecret
+		*out = *in
+	}
 	return nil
 }
 
@@ -5298,6 +5404,10 @@ func autoConvert_v3alpha1_TLSContextSpec_To_v2_TLSContextSpec(in *v3alpha1.TLSCo
 	}
 	if true {
 		in, out := &in.CACertChainFile, &out.CACertChainFile
+		*out = *in
+	}
+	if true {
+		in, out := &in.CRLSecret, &out.V3CRLSecret
 		*out = *in
 	}
 	if true {

--- a/pkg/api/getambassador.io/v3alpha1/crd_host.go
+++ b/pkg/api/getambassador.io/v3alpha1/crd_host.go
@@ -141,6 +141,7 @@ type TLSConfig struct {
 	PrivateKeyFile        string   `json:"private_key_file,omitempty"`
 	CASecret              string   `json:"ca_secret,omitempty"`
 	CAcertChainFile       string   `json:"cacert_chain_file,omitempty"`
+	CRLSecret             string   `json:"crl_secret,omitempty"`
 	AlpnProtocols         string   `json:"alpn_protocols,omitempty"`
 	CertRequired          *bool    `json:"cert_required,omitempty"`
 	MinTLSVersion         string   `json:"min_tls_version,omitempty"`

--- a/pkg/api/getambassador.io/v3alpha1/crd_tlscontext.go
+++ b/pkg/api/getambassador.io/v3alpha1/crd_tlscontext.go
@@ -33,6 +33,7 @@ type TLSContextSpec struct {
 	PrivateKeyFile  string   `json:"private_key_file,omitempty"`
 	CASecret        string   `json:"ca_secret,omitempty"`
 	CACertChainFile string   `json:"cacert_chain_file,omitempty"`
+	CRLSecret       string   `json:"crl_secret,omitempty"`
 	ALPNProtocols   string   `json:"alpn_protocols,omitempty"`
 	CertRequired    *bool    `json:"cert_required,omitempty"`
 	// +kubebuilder:validation:Enum={"v1.0", "v1.1", "v1.2", "v1.3"}

--- a/python/ambassador/envoy/v3/v3tls.py
+++ b/python/ambassador/envoy/v3/v3tls.py
@@ -127,6 +127,7 @@ class V3TLSContext(Dict):
             ( 'cert_chain_file', self.update_cert_zero, 'certificate_chain' ),
             ( 'private_key_file', self.update_cert_zero, 'private_key' ),
             ( 'cacert_chain_file', self.update_validation, 'trusted_ca' ),
+            ( 'crl_file', self.update_validation, 'crl' ),
         ]:
             if secretinfokey in ctx['secret_info']:
                 handler(hkey, ctx['secret_info'][secretinfokey])

--- a/python/ambassador/ir/ir.py
+++ b/python/ambassador/ir/ir.py
@@ -1004,6 +1004,7 @@ class IR:
 
         tls_termination_count = 0   # TLS termination contexts
         tls_origination_count = 0   # TLS origination contexts
+        tls_crl_file_count = 0      # CRL files used
 
         using_tls_module = False
         using_tls_contexts = False
@@ -1021,6 +1022,9 @@ class IR:
                     if secret_info.get('cacert_chain_file', None):
                         tls_origination_count += 1
 
+                    if secret_info.get('crl_file', None):
+                        tls_crl_file_count += 1
+
                 if ctx.get('_legacy', False):
                     using_tls_module = True
 
@@ -1028,6 +1032,7 @@ class IR:
         od['tls_using_contexts'] = using_tls_contexts
         od['tls_termination_count'] = tls_termination_count
         od['tls_origination_count'] = tls_origination_count
+        od['tls_crl_file_count'] = tls_crl_file_count
 
         for key in [ 'diagnostics', 'liveness_probe', 'readiness_probe', 'statsd' ]:
             od[key] = self.ambassador_module.get(key, {}).get('enabled', False)

--- a/python/ambassador/ir/irhost.py
+++ b/python/ambassador/ir/irhost.py
@@ -143,6 +143,8 @@ class IRHost(IRResource):
                             'certChainFile': 'cert_chain_file',
                             'privateKeyFile': 'private_key_file',
                             'cacertChainFile': 'cacert_chain_file',
+                            'crlSecret': 'crl_secret',
+                            'crlFile': 'crl_file',
                             'caSecret': 'ca_secret',
                             # 'sni': 'sni' (this field is not required in snake-camel but adding for completeness)
                         }
@@ -385,7 +387,7 @@ class IRHost(IRResource):
             # "hostname" or "host", the Mapping code normalizes to "host" internally.
 
             # It's possible for group.host_redirect to be None instead of missing, and it's also
-            # conceivably possible for group.host_redirect.host to be "", which we'd rather be 
+            # conceivably possible for group.host_redirect.host to be "", which we'd rather be
             # None. Hence we do this two-line dance to massage the various cases.
             host_redirect = (group.get('host_redirect') or {}).get('host')
             group_glob = group.get('host') or host_redirect  # NOT A TYPO: see above.

--- a/python/ambassador/ir/irtlscontext.py
+++ b/python/ambassador/ir/irtlscontext.py
@@ -20,7 +20,10 @@ class IRTLSContext(IRResource):
         'private_key_file',
 
         'ca_secret',
-        'cacert_chain_file'
+        'cacert_chain_file',
+
+        'crl_secret',
+        'crl_file',
     }
 
     AllowedKeys: ClassVar = {
@@ -218,6 +221,23 @@ class IRTLSContext(IRResource):
 
         self.ir.logger.debug("TLSContext - successfully processed the cert_chain_file, private_key_file, and cacert_chain_file: %s" % self.secret_info)
 
+        # OK. Repeat for the crl_secret.
+        crl_secret = self.secret_info.get('crl_secret')
+        if crl_secret:
+            # They gave a secret name for the certificate revocation list. Try loading it.
+            crls = self.resolve_secret(crl_secret)
+
+            self.ir.logger.debug("resolve_secrets: IR returned secret %s as %s" % (crl_secret, crls))
+
+            if not crls:
+                # This is definitively an error: they mentioned a secret, it can't be loaded,
+                # give up.
+                self.post_error("TLSContext %s found no certificate revocation list in %s" % (self.name, crls.name))
+                secret_valid = False
+            else:
+                self.ir.logger.debug("TLSContext %s saved certificate revocation list secret %s" % (self.name, crls.name))
+                self.secret_info['crl_file'] = crls.user_path
+
         # OK. Repeat for the ca_secret_name.
         ca_secret_name = self.secret_info.get('ca_secret')
 
@@ -272,7 +292,7 @@ class IRTLSContext(IRResource):
         errors = 0
 
         # self.ir.logger.debug("resolve_secrets before path checks: %s" % self.as_json())
-        for key in [ 'cert_chain_file', 'private_key_file', 'cacert_chain_file' ]:
+        for key in [ 'cert_chain_file', 'private_key_file', 'cacert_chain_file', 'crl_file' ]:
             path = self.secret_info.get(key, None)
 
             if path:
@@ -280,7 +300,7 @@ class IRTLSContext(IRResource):
                 if not fc(path):
                     self.post_error("TLSContext %s found no %s '%s'" % (self.name, key, path))
                     errors += 1
-            elif key != 'cacert_chain_file' and self.get('hosts', None):
+            elif (key != 'cacert_chain_file' or key != 'crl_file') and self.get('hosts', None):
                 self.post_error("TLSContext %s is missing %s" % (self.name, key))
                 errors += 1
 

--- a/python/tests/integration/manifests/crds.yaml
+++ b/python/tests/integration/manifests/crds.yaml
@@ -872,6 +872,8 @@ spec:
                     type: integer
                   sni:
                     type: string
+                  v3CRLSecret:
+                    type: string
                 type: object
               tlsContext:
                 description: "Name of the TLSContext the Host resource is linked with.
@@ -1188,6 +1190,8 @@ spec:
                     items:
                       type: string
                     type: array
+                  crl_secret:
+                    type: string
                   ecdh_curves:
                     items:
                       type: string
@@ -3446,6 +3450,8 @@ spec:
                 type: boolean
               sni:
                 type: string
+              v3CRLSecret:
+                type: string
             type: object
             x-kubernetes-preserve-unknown-fields: true
         type: object
@@ -3494,6 +3500,8 @@ spec:
                 items:
                   type: string
                 type: array
+              crl_secret:
+                type: string
               ecdh_curves:
                 items:
                   type: string


### PR DESCRIPTION
Signed-off-by: alex <alex@datawire.io>

## Description
Allow Host and TLSContext to configure a CRL.

## Related Issues
https://github.com/datawire/apro/issues/2619

## Testing
TODO

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `CHANGELOG.md`.

   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations

 - [ ] This is unlikely to impact how Ambassador performs at scale.

   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability

 - [ ] My change is adequately tested.

   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points

 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.

 - [ ] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
