### PR TITLE
[WIP] Fix 503s on secret rotation

### DIFF
--- a/.github/actions/collect-logs/action.yml
+++ b/.github/actions/collect-logs/action.yml
@@ -45,6 +45,10 @@ runs:
 
           tools/bin/kubectl get pods --all-namespaces -ocustom-columns="name:.metadata.name,namespace:.metadata.namespace" --no-headers | while read -r name namespace; do
             tools/bin/kubectl --namespace="$namespace" logs "$name" >"/tmp/test-logs/cluster/pod.${namespace}.${name}.log" || true
+            tools/bin/kubectl --namespace="$namespace" cp "$name":snapshots "/tmp/test-logs/cluster/pod.${namespace}.${name}-snapshots" || true
+            tools/bin/kubectl --namespace="$namespace" cp "$name":envoy "/tmp/test-logs/cluster/pod.${namespace}.${name}-envoy" || true
+            tools/bin/kubectl --namespace="$namespace" cp "$name":../tmp/ambassador/snapshots "/tmp/test-logs/cluster/pod.${namespace}.${name}-snapshots" || true
+            tools/bin/kubectl --namespace="$namespace" cp "$name":../tmp/ambassador/envoy "/tmp/test-logs/cluster/pod.${namespace}.${name}-envoy" || true
           done
         fi
     - name: "Upload Logs"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,17 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
 
 ## RELEASE NOTES
 
+## [2.3.2] TBD
+[2.3.2]: https://github.com/emissary-ingress/emissary/compare/v2.3.1...v2.3.2
+
+### Emissary-ingress and Ambassador Edge Stack
+
+- Bugfix: Emissary-ingress would ocasionally start returning 503s on all new requests to the
+  upstream service when a TLS certificate was rotated/renewed while there was active load on the
+  upstream service. These 503s would persist between a few hours to a few days until one of the
+  Emissary-ingress pod was restarted. This bug was encountered most frequently when using Consul and
+  was previously mitigated by the no longer supported legacy mode.
+
 ## [2.3.1] June 09, 2022
 [2.3.1]: https://github.com/emissary-ingress/emissary/compare/v2.3.0...v2.3.1
 

--- a/cmd/entrypoint/entrypoint.go
+++ b/cmd/entrypoint/entrypoint.go
@@ -172,8 +172,7 @@ func Main(ctx context.Context, Version string, args ...string) error {
 
 	fastpathCh := make(chan *ambex.FastpathSnapshot)
 	group.Go("ambex", func(ctx context.Context) error {
-		return ambex.Main(ctx, Version, usage.PercentUsed, fastpathCh, "--ads-listen-address",
-			"127.0.0.1:8003", GetEnvoyDir())
+		return ambex.Main(ctx, Version, usage.PercentUsed, fastpathCh, GetEnvoyDir())
 	})
 
 	group.Go("envoy", func(ctx context.Context) error {

--- a/cmd/entrypoint/secrets.go
+++ b/cmd/entrypoint/secrets.go
@@ -208,7 +208,6 @@ func ReconcileSecrets(ctx context.Context, sh *SnapshotHolder) error {
 			resources = append(resources, h)
 		}
 	}
-	dlog.Warnf(ctx, "Alice, number of Hosts in ReconcileSecrets: %d", len(sh.k8sSnapshot.Hosts))
 
 	// TLSContexts, Modules, and Ingresses are all straightforward.
 	for _, t := range sh.k8sSnapshot.TLSContexts {
@@ -216,7 +215,6 @@ func ReconcileSecrets(ctx context.Context, sh *SnapshotHolder) error {
 			resources = append(resources, t)
 		}
 	}
-	dlog.Warnf(ctx, "Alice, number of TlsContexts in ReconcileSecrets: %d", len(sh.k8sSnapshot.TLSContexts))
 
 	for _, m := range sh.k8sSnapshot.Modules {
 		if include(m.Spec.AmbassadorID) {

--- a/cmd/entrypoint/secrets.go
+++ b/cmd/entrypoint/secrets.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	ambex "github.com/datawire/ambassador/v2/pkg/ambex"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -207,6 +208,7 @@ func ReconcileSecrets(ctx context.Context, sh *SnapshotHolder) error {
 			resources = append(resources, h)
 		}
 	}
+	dlog.Warnf(ctx, "Alice, number of Hosts in ReconcileSecrets: %d", len(sh.k8sSnapshot.Hosts))
 
 	// TLSContexts, Modules, and Ingresses are all straightforward.
 	for _, t := range sh.k8sSnapshot.TLSContexts {
@@ -214,6 +216,8 @@ func ReconcileSecrets(ctx context.Context, sh *SnapshotHolder) error {
 			resources = append(resources, t)
 		}
 	}
+	dlog.Warnf(ctx, "Alice, number of TlsContexts in ReconcileSecrets: %d", len(sh.k8sSnapshot.TLSContexts))
+
 	for _, m := range sh.k8sSnapshot.Modules {
 		if include(m.Spec.AmbassadorID) {
 			resources = append(resources, m)
@@ -507,4 +511,227 @@ type ModuleSecrets struct {
 	Client struct {
 		Secret string `json:"secret"`
 	} `json:"client"`
+}
+
+// MakeSecrets takes all the Secrets in a snapshot and packages them up for
+// consumption by ambex.
+func MakeSecrets(ctx context.Context, k8sSnapshot *snapshotTypes.KubernetesSnapshot) (*ambex.Secrets, [][]string) {
+	tlsSecrets := []*ambex.Secret{}        // Secrets to be used for tls.
+	validationSecrets := []*ambex.Secret{} // Secrets to be used for validation_contexts. We can't just rely on whether the secret is Opaque to detemine this
+
+	validationGroups := [][]string{} // List of groups of secrets to be bundled together into a single validation_context
+
+	validationRefs := []string{} // list of secret names that we should treat as a validation secret rather than a tls certificate
+
+	// Iterate over alll the Hosts and TLSContexts. If they have `ca_secret` and/or `crl_secret`
+	// Then record the name of these secrets so we can add them to the correct group later.
+
+	// Secrets used for validation_contexts will get combined into groups within a single secret later
+	// so we must keep track of which validation_context secrets such as `CASecret` and `CRLSecret` belong
+	// in the same group (because they are from the same resource)
+
+	var resources []kates.Object
+	// First thing is to check all the annotations and the Module to see if we are doing secret namespacing
+	// TODO: @aliceproxy extract this check for secret namespacing to its own function
+	// since it get used in ReconcileSecrets as well.
+	for _, list := range k8sSnapshot.Annotations {
+		for _, a := range list {
+			if _, isInvalid := a.(*kates.Unstructured); isInvalid {
+				continue
+			}
+			if include(GetAmbId(ctx, a)) {
+				resources = append(resources, a)
+			}
+		}
+	}
+	for _, m := range k8sSnapshot.Modules {
+		if include(m.Spec.AmbassadorID) {
+			resources = append(resources, m)
+		}
+	}
+
+	// When this is true (default: true) we interpret the last `.` in a secret name
+	// as the namespace of that secret instead of being part of it's name.
+	// Otherwise we will just take the Namespace of the Host/TLSContext
+	secretNamespacing := true
+	for _, resource := range resources {
+		mod, ok := resource.(*amb.Module)
+		if ok && mod.GetName() == "ambassador" {
+			// XXX ModuleSecrets is a _godawful_ hack. See the comment on
+			// ModuleSecrets itself for more.
+			secs := ModuleSecrets{}
+			err := convert(mod.Spec.Config, &secs)
+			if err != nil {
+				dlog.Errorf(ctx, "error parsing module: %v", err)
+				continue
+			}
+			secretNamespacing = secs.Defaults.TLSSecretNamespacing
+			break
+		}
+	}
+
+	// Iterate over all the Hosts to see if they have validation_context secrets
+	for _, host := range k8sSnapshot.Hosts {
+		// First check if it belongs to this Ambassador
+		var id amb.AmbassadorID
+		if len(host.Spec.AmbassadorID) > 0 {
+			id = host.Spec.AmbassadorID
+		}
+		if !include(id) {
+			continue
+		}
+
+		// Group of secret references to be packaged into a validation context later
+		vGroup := []string{}
+		if hasSecrets := host.Spec.TLS; hasSecrets == nil {
+			continue // skip if this Host doesn't have a tls section
+		}
+		if caSecret := host.Spec.TLS.CASecret; caSecret != "" {
+			// Take the namespace of the resource if secretNamespacing is not disabled
+			var name, namespace string
+			if !secretNamespacing {
+				name = caSecret
+				namespace = host.ObjectMeta.Namespace
+			} else if strings.Contains(caSecret, ".") {
+				last := strings.LastIndex(caSecret, ".")
+				name = caSecret[:last]
+				namespace = caSecret[last+1:]
+			}
+			fullName := fmt.Sprintf("secret/%s.%s", name, namespace)
+			vGroup = append(vGroup, fullName)
+			validationRefs = append(validationRefs, fullName)
+		}
+		if crlSecret := host.Spec.TLS.CRLSecret; crlSecret != "" {
+			var name, namespace string
+			if !secretNamespacing {
+				name = crlSecret
+				namespace = host.ObjectMeta.Namespace
+			} else if strings.Contains(crlSecret, ".") {
+				last := strings.LastIndex(crlSecret, ".")
+				name = crlSecret[:last]
+				namespace = crlSecret[last+1:]
+			}
+			fullName := fmt.Sprintf("secret/%s.%s", name, namespace)
+			vGroup = append(vGroup, fullName)
+			validationRefs = append(validationRefs, fullName)
+		}
+		dlog.Debugf(ctx, "[MakeSecrets] Adding validation_context group for Host: %v: %v\n", host.Name, vGroup)
+		validationGroups = append(validationGroups, vGroup)
+	}
+
+	for _, tlsContext := range k8sSnapshot.TLSContexts {
+		// First check the Ambassador ID...
+		if !include(tlsContext.Spec.AmbassadorID) {
+			continue
+		}
+
+		// Group of secret references to be packaged into a validation context later
+		vGroup := []string{}
+
+		// Unlike Hosts, TLSContexts can set/override secret namespacing
+		secretNs := secretNamespacing
+		if tlsContext.Spec.SecretNamespacing != nil {
+			secretNs = *tlsContext.Spec.SecretNamespacing
+		}
+
+		if caSecret := tlsContext.Spec.CASecret; caSecret != "" {
+			// Take the namespace of the resource if secretNamespacing is not disabled
+
+			var name, namespace string
+			if !secretNs {
+				name = caSecret
+				namespace = tlsContext.ObjectMeta.Namespace
+			} else if strings.Contains(caSecret, ".") {
+				last := strings.LastIndex(caSecret, ".")
+				name = caSecret[:last]
+				namespace = caSecret[last+1:]
+			}
+			fullName := fmt.Sprintf("secret/%s.%s", name, namespace)
+			vGroup = append(vGroup, fullName)
+			validationRefs = append(validationRefs, fullName)
+		}
+		if crlSecret := tlsContext.Spec.CRLSecret; crlSecret != "" {
+			var name, namespace string
+			if !secretNs {
+				name = crlSecret
+				namespace = tlsContext.ObjectMeta.Namespace
+			} else if strings.Contains(crlSecret, ".") {
+				last := strings.LastIndex(crlSecret, ".")
+				name = crlSecret[:last]
+				namespace = crlSecret[last+1:]
+			}
+			fullName := fmt.Sprintf("secret/%s.%s", name, namespace)
+			vGroup = append(vGroup, fullName)
+			validationRefs = append(validationRefs, fullName)
+		}
+		dlog.Debugf(ctx, "[MakeSecrets] Adding validation_context group for TlsContext: %v: %v\n", tlsContext.Name, vGroup)
+		validationGroups = append(validationGroups, vGroup)
+	}
+
+	// Now that we've figured out which secrets are used for validation we can built the list of ambex secrets
+	// If it wasnt marked as being a secret for validation by the above section then it must be a tls secret
+	for _, secret := range k8sSnapshot.Secrets {
+		name := secret.GetName()
+		namespace := secret.GetNamespace()
+
+		if namespace == "" {
+			namespace = "default"
+		}
+
+		fullName := fmt.Sprintf("secret/%s.%s", name, namespace)
+
+		if secret.Type == v1.SecretTypeTLS {
+			dlog.Warnf(ctx, "[MakeSecrets] secret %s: TLS", fullName)
+
+			privateKey := secret.Data["tls.key"]
+			certificate := secret.Data["tls.crt"]
+
+			ambexSecret := &ambex.Secret{
+				Name:             fullName,
+				Type:             secret.Type,
+				PrivateKey:       privateKey,
+				CertificateChain: certificate,
+			}
+			// Check if this secret is for validaiton or for tls
+			if containsElem(validationRefs, fullName) {
+				dlog.Debugf(ctx, "[MakeSecrets] created validation_context Ambex secret: %v\n", fullName)
+				validationSecrets = append(validationSecrets, ambexSecret)
+			} else {
+				dlog.Debugf(ctx, "[MakeSecrets] created TLS Ambex secret: %v\n", fullName)
+				tlsSecrets = append(tlsSecrets, ambexSecret)
+			}
+		} else if secret.Type == v1.SecretTypeOpaque {
+			dlog.Warnf(ctx, "[MakeSecrets] secret %s: Opaque", fullName)
+			if caCertificate := secret.Data["user.key"]; len(caCertificate) != 0 {
+				validationSecrets = append(validationSecrets, &ambex.Secret{
+					Name:        fullName,
+					Type:        secret.Type,
+					CACertChain: caCertificate,
+				})
+			} else if crlCertificate := secret.Data["crl.pem"]; len(crlCertificate) != 0 {
+				validationSecrets = append(validationSecrets, &ambex.Secret{
+					Name: fullName,
+					Type: secret.Type,
+					Crl:  crlCertificate,
+				})
+			}
+			dlog.Debugf(ctx, "[MakeSecrets] created validation_context Ambex secret: %v\n", fullName)
+
+		}
+	}
+	return &ambex.Secrets{
+		TlsSecrets:        tlsSecrets,
+		ValidationSecrets: validationSecrets,
+	}, validationGroups
+}
+
+// Just checks if the list contains the provided string
+// I really wish go just had this builtin....
+func containsElem(s []string, key string) bool {
+	for _, e := range s {
+		if e == key {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/entrypoint/secrets.go
+++ b/cmd/entrypoint/secrets.go
@@ -595,7 +595,7 @@ func MakeSecrets(ctx context.Context, k8sSnapshot *snapshotTypes.KubernetesSnaps
 				name = caSecret[:last]
 				namespace = caSecret[last+1:]
 			}
-			fullName := fmt.Sprintf("secret/%s.%s", name, namespace)
+			fullName := fmt.Sprintf("%s.%s", name, namespace)
 			vGroup = append(vGroup, fullName)
 			validationRefs = append(validationRefs, fullName)
 		}
@@ -609,7 +609,7 @@ func MakeSecrets(ctx context.Context, k8sSnapshot *snapshotTypes.KubernetesSnaps
 				name = crlSecret[:last]
 				namespace = crlSecret[last+1:]
 			}
-			fullName := fmt.Sprintf("secret/%s.%s", name, namespace)
+			fullName := fmt.Sprintf("%s.%s", name, namespace)
 			vGroup = append(vGroup, fullName)
 			validationRefs = append(validationRefs, fullName)
 		}
@@ -644,7 +644,7 @@ func MakeSecrets(ctx context.Context, k8sSnapshot *snapshotTypes.KubernetesSnaps
 				name = caSecret[:last]
 				namespace = caSecret[last+1:]
 			}
-			fullName := fmt.Sprintf("secret/%s.%s", name, namespace)
+			fullName := fmt.Sprintf("%s.%s", name, namespace)
 			vGroup = append(vGroup, fullName)
 			validationRefs = append(validationRefs, fullName)
 		}
@@ -658,7 +658,7 @@ func MakeSecrets(ctx context.Context, k8sSnapshot *snapshotTypes.KubernetesSnaps
 				name = crlSecret[:last]
 				namespace = crlSecret[last+1:]
 			}
-			fullName := fmt.Sprintf("secret/%s.%s", name, namespace)
+			fullName := fmt.Sprintf("%s.%s", name, namespace)
 			vGroup = append(vGroup, fullName)
 			validationRefs = append(validationRefs, fullName)
 		}
@@ -676,7 +676,7 @@ func MakeSecrets(ctx context.Context, k8sSnapshot *snapshotTypes.KubernetesSnaps
 			namespace = "default"
 		}
 
-		fullName := fmt.Sprintf("secret/%s.%s", name, namespace)
+		fullName := fmt.Sprintf("%s.%s", name, namespace)
 
 		if secret.Type == v1.SecretTypeTLS {
 			dlog.Warnf(ctx, "[MakeSecrets] secret %s: TLS", fullName)

--- a/cmd/entrypoint/watcher.go
+++ b/cmd/entrypoint/watcher.go
@@ -373,7 +373,7 @@ func (sh *SnapshotHolder) K8sUpdate(
 	reconcileConsulTimer := dbg.Timer("reconcileConsul")
 	reconcileAuthServicesTimer := dbg.Timer("reconcileAuthServices")
 
-	secretsChanged := false
+	updateSecrets := false
 	endpointsChanged := false
 	dispatcherChanged := false
 	var endpoints *ambex.Endpoints
@@ -471,15 +471,55 @@ func (sh *SnapshotHolder) K8sUpdate(
 		for _, delta := range deltas {
 			sh.unsentDeltas = append(sh.unsentDeltas, delta)
 
-			if delta.Kind == "Endpoints" {
+			switch delta.Kind {
+			case "Endpoints":
 				key := fmt.Sprintf("%s:%s", delta.Namespace, delta.Name)
 				if sh.endpointRoutingInfo.endpointWatches[key] || sh.dispatcher.IsWatched(delta.Namespace, delta.Name) {
 					endpointsChanged = true
 				}
-			} else if delta.Kind == "Secret" {
-				// Might need to do more here!
-				secretsChanged = true
-			} else {
+			case "Secret":
+				updateSecrets = true
+			// If TLSContext or Host delta reference a secret we want to make sure that we're sending the updated
+			// secrets over
+			case "TLSContext":
+				// PERFORMANCE IMPROVEMENT: Linear searches suck and moreover we're doing it multiple times (up to 3)
+				// Mostly likely there won't be that many TLSContexts but would be nice to avoid iterating multiple times 
+				for _, tls := range sh.k8sSnapshot.TLSContexts {
+					if tls.Name == delta.Name {
+						if tls.Spec.Secret != "" || tls.Spec.CASecret != "" || tls.Spec.CRLSecret != "" {
+							updateSecrets = true
+						}
+						break
+					}
+				}
+			case "Host":
+				// PERFORMANCE IMPROVEMENT: Linear searches suck and moreover we're doing it multiple times (up to 3)
+				// Mostly likely there won't be that many Hosts but would be nice to avoid iterating multiple times
+				for _, host := range sh.k8sSnapshot.Hosts {
+					if host.Name == delta.Name {
+						// Host is a little odd. Host.spec.tls, Host.spec.tlsSecret, and
+						// host.spec.acmeProvider.privateKeySecret can all refer to secrets.
+						if host.Spec == nil {
+							break
+						}
+
+						if host.Spec.TLS != nil && (host.Spec.TLS.CRLSecret != "" || host.Spec.TLS.CASecret != "") {
+							updateSecrets = true
+							break
+						}
+
+						if host.Spec.TLSSecret != nil {
+							updateSecrets = true
+							break
+						}
+
+						if host.Spec.AcmeProvider != nil && host.Spec.AcmeProvider.PrivateKeySecret != nil {
+							updateSecrets = true
+							break
+						}
+					}
+				}
+			default:
 				fastpathOnly = false
 			}
 
@@ -499,7 +539,7 @@ func (sh *SnapshotHolder) K8sUpdate(
 			endpoints = makeEndpoints(ctx, sh.k8sSnapshot, sh.consulSnapshot.Endpoints)
 		}
 
-		if secretsChanged {
+		if updateSecrets {
 			secrets = ambex.MakeSecrets(ctx, sh.k8sSnapshot)
 		}
 
@@ -532,7 +572,7 @@ func (sh *SnapshotHolder) K8sUpdate(
 		return changed, err
 	}
 
-	if secretsChanged || endpointsChanged || dispatcherChanged {
+	if updateSecrets || endpointsChanged || dispatcherChanged {
 		fastpath := &ambex.FastpathSnapshot{
 			Endpoints: endpoints,
 			Snapshot:  dispSnapshot,

--- a/cmd/entrypoint/watcher.go
+++ b/cmd/entrypoint/watcher.go
@@ -470,6 +470,7 @@ func (sh *SnapshotHolder) K8sUpdate(
 		fastpathOnly := true
 		for _, delta := range deltas {
 			sh.unsentDeltas = append(sh.unsentDeltas, delta)
+
 			switch delta.Kind {
 			case "Endpoints":
 				key := fmt.Sprintf("%s:%s", delta.Namespace, delta.Name)
@@ -482,7 +483,7 @@ func (sh *SnapshotHolder) K8sUpdate(
 			// secrets over
 			case "TLSContext":
 				// PERFORMANCE IMPROVEMENT: Linear searches suck and moreover we're doing it multiple times (up to 3)
-				// Mostly likely there won't be that many TLSContexts but would be nice to avoid iterating multiple times 
+				// Mostly likely there won't be that many TLSContexts but would be nice to avoid iterating multiple times
 				for _, tls := range sh.k8sSnapshot.TLSContexts {
 					if tls.Name == delta.Name {
 						if tls.Spec.Secret != "" || tls.Spec.CASecret != "" || tls.Spec.CRLSecret != "" {
@@ -534,7 +535,6 @@ func (sh *SnapshotHolder) K8sUpdate(
 
 		if !fastpathOnly {
 			sh.snapshotChangeCount += 1
-			dlog.Infof(ctx, "bumping snapshot changed count to %d", sh.snapshotChangeCount)
 		}
 
 		if endpointsChanged {

--- a/cmd/entrypoint/watcher.go
+++ b/cmd/entrypoint/watcher.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/datawire/ambassador/v2/pkg/acp"
 	"github.com/datawire/ambassador/v2/pkg/ambex"
-	v3tlsconfig "github.com/datawire/ambassador/v2/pkg/api/envoy/extensions/transport_sockets/tls/v3"
 	"github.com/datawire/ambassador/v2/pkg/debug"
 	ecp_v2_cache "github.com/datawire/ambassador/v2/pkg/envoy-control-plane/cache/v2"
 	"github.com/datawire/ambassador/v2/pkg/gateway"
@@ -378,7 +377,7 @@ func (sh *SnapshotHolder) K8sUpdate(
 	endpointsChanged := false
 	dispatcherChanged := false
 	var endpoints *ambex.Endpoints
-	var secrets []*v3tlsconfig.Secret
+	var secrets *ambex.Secrets
 	var dispSnapshot *ecp_v2_cache.Snapshot
 	changed, err := func() (bool, error) {
 		dlog.Debugf(ctx, "[WATCHER]: processing cluster changes detected by the kubernetes watcher")

--- a/cmd/entrypoint/watcher.go
+++ b/cmd/entrypoint/watcher.go
@@ -478,7 +478,6 @@ func (sh *SnapshotHolder) K8sUpdate(
 				}
 			} else if delta.Kind == "Secret" {
 				// Might need to do more here!
-				dlog.Warnf(ctx, "secret changed: %s/%s", delta.Namespace, delta.Name)
 				secretsChanged = true
 			} else {
 				fastpathOnly = false

--- a/cmd/entrypoint/watcher.go
+++ b/cmd/entrypoint/watcher.go
@@ -470,7 +470,6 @@ func (sh *SnapshotHolder) K8sUpdate(
 		fastpathOnly := true
 		for _, delta := range deltas {
 			sh.unsentDeltas = append(sh.unsentDeltas, delta)
-
 			switch delta.Kind {
 			case "Endpoints":
 				key := fmt.Sprintf("%s:%s", delta.Namespace, delta.Name)
@@ -483,7 +482,7 @@ func (sh *SnapshotHolder) K8sUpdate(
 			// secrets over
 			case "TLSContext":
 				// PERFORMANCE IMPROVEMENT: Linear searches suck and moreover we're doing it multiple times (up to 3)
-				// Mostly likely there won't be that many TLSContexts but would be nice to avoid iterating multiple times
+				// Mostly likely there won't be that many TLSContexts but would be nice to avoid iterating multiple times 
 				for _, tls := range sh.k8sSnapshot.TLSContexts {
 					if tls.Name == delta.Name {
 						if tls.Spec.Secret != "" || tls.Spec.CASecret != "" || tls.Spec.CRLSecret != "" {
@@ -492,6 +491,7 @@ func (sh *SnapshotHolder) K8sUpdate(
 						break
 					}
 				}
+				fastpathOnly = false
 			case "Host":
 				// PERFORMANCE IMPROVEMENT: Linear searches suck and moreover we're doing it multiple times (up to 3)
 				// Mostly likely there won't be that many Hosts but would be nice to avoid iterating multiple times
@@ -519,6 +519,7 @@ func (sh *SnapshotHolder) K8sUpdate(
 						}
 					}
 				}
+				fastpathOnly = false
 			default:
 				fastpathOnly = false
 			}
@@ -533,6 +534,7 @@ func (sh *SnapshotHolder) K8sUpdate(
 
 		if !fastpathOnly {
 			sh.snapshotChangeCount += 1
+			dlog.Infof(ctx, "bumping snapshot changed count to %d", sh.snapshotChangeCount)
 		}
 
 		if endpointsChanged {

--- a/cmd/entrypoint/watcher.go
+++ b/cmd/entrypoint/watcher.go
@@ -378,6 +378,7 @@ func (sh *SnapshotHolder) K8sUpdate(
 	dispatcherChanged := false
 	var endpoints *ambex.Endpoints
 	var secrets *ambex.Secrets
+	var validationGroups [][]string
 	var dispSnapshot *ecp_v2_cache.Snapshot
 	changed, err := func() (bool, error) {
 		dlog.Debugf(ctx, "[WATCHER]: processing cluster changes detected by the kubernetes watcher")
@@ -542,7 +543,7 @@ func (sh *SnapshotHolder) K8sUpdate(
 		}
 
 		if updateSecrets {
-			secrets = ambex.MakeSecrets(ctx, sh.k8sSnapshot)
+			secrets, validationGroups = MakeSecrets(ctx, sh.k8sSnapshot)
 		}
 
 		if dispatcherChanged {
@@ -576,9 +577,10 @@ func (sh *SnapshotHolder) K8sUpdate(
 
 	if updateSecrets || endpointsChanged || dispatcherChanged {
 		fastpath := &ambex.FastpathSnapshot{
-			Endpoints: endpoints,
-			Snapshot:  dispSnapshot,
-			Secrets:   secrets,
+			Endpoints:        endpoints,
+			Snapshot:         dispSnapshot,
+			Secrets:          secrets,
+			ValidationGroups: validationGroups,
 		}
 		fastpathProcessor(ctx, fastpath)
 	}

--- a/cmd/entrypoint/watcher.go
+++ b/cmd/entrypoint/watcher.go
@@ -480,44 +480,21 @@ func (sh *SnapshotHolder) K8sUpdate(
 				}
 			case "Secret":
 				updateSecrets = true
-			// If TLSContext or Host delta reference a secret we want to make sure that we're sending the updated
-			// secrets over
-			case "TLSContext":
-				// PERFORMANCE IMPROVEMENT: Linear searches suck and moreover we're doing it multiple times (up to 3)
-				// Mostly likely there won't be that many TLSContexts but would be nice to avoid iterating multiple times
-				for _, tls := range sh.k8sSnapshot.TLSContexts {
-					if tls.Name == delta.Name {
-						if tls.Spec.Secret != "" || tls.Spec.CASecret != "" || tls.Spec.CRLSecret != "" {
-							updateSecrets = true
-						}
-						break
-					}
-				}
+			// If TLSContext or Host delta reference a secret, we want to make sure that we're sending them over.
+			// This is kinda brute force since Hosts and TLSContexts don't have to refer to secrets.
+			// Ideally ReconcileSecrets should handle figuring out whether we need to send over update secrets.
+			// However we don't really expect that many Hosts or TLSContext to be created anyway.
+			case "Host", "TLSContext":
+				updateSecrets = true
 				fastpathOnly = false
-			case "Host":
-				// PERFORMANCE IMPROVEMENT: Linear searches suck and moreover we're doing it multiple times (up to 3)
-				// Mostly likely there won't be that many Hosts but would be nice to avoid iterating multiple times
-				for _, host := range sh.k8sSnapshot.Hosts {
-					if host.Name == delta.Name {
-						// Host is a little odd. Host.spec.tls, Host.spec.tlsSecret, and
-						// host.spec.acmeProvider.privateKeySecret can all refer to secrets.
-						if host.Spec == nil {
-							break
-						}
-
-						if host.Spec.TLS != nil && (host.Spec.TLS.CRLSecret != "" || host.Spec.TLS.CASecret != "") {
+			// Ugh while annotations exist we need to care about those too for secrets update
+			case "Service":
+				resourceName := fmt.Sprintf("%s/%s.%s", delta.Kind, delta.Name, delta.Namespace)
+				if annotations, ok := sh.k8sSnapshot.Annotations[resourceName]; ok {
+					for _, ann := range annotations {
+						kind := ann.GetObjectKind().GroupVersionKind().Kind
+						if kind == "Host" || kind == "TLSContext" {
 							updateSecrets = true
-							break
-						}
-
-						if host.Spec.TLSSecret != nil {
-							updateSecrets = true
-							break
-						}
-
-						if host.Spec.AcmeProvider != nil && host.Spec.AcmeProvider.PrivateKeySecret != nil {
-							updateSecrets = true
-							break
 						}
 					}
 				}

--- a/cmd/entrypoint/watcher.go
+++ b/cmd/entrypoint/watcher.go
@@ -483,7 +483,7 @@ func (sh *SnapshotHolder) K8sUpdate(
 			// secrets over
 			case "TLSContext":
 				// PERFORMANCE IMPROVEMENT: Linear searches suck and moreover we're doing it multiple times (up to 3)
-				// Mostly likely there won't be that many TLSContexts but would be nice to avoid iterating multiple times 
+				// Mostly likely there won't be that many TLSContexts but would be nice to avoid iterating multiple times
 				for _, tls := range sh.k8sSnapshot.TLSContexts {
 					if tls.Name == delta.Name {
 						if tls.Spec.Secret != "" || tls.Spec.CASecret != "" || tls.Spec.CRLSecret != "" {

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -32,6 +32,17 @@
 
 changelog: https://github.com/emissary-ingress/emissary/blob/$branch$/CHANGELOG.md
 items:
+  - version: 2.3.2
+    date: 'TBD'
+    notes:
+      - title: Fix 503s after secret rotation
+        type: bugfix
+        body: >-
+          $productName$ would ocasionally start returning 503s on all new requests to the upstream service when a TLS certificate
+          was rotated/renewed while there was active load on the upstream service. These 503s would persist between a few hours to
+          a few days until one of the $productName$ pod was restarted. This bug was encountered most frequently when using Consul
+          and was previously mitigated by the no longer supported legacy mode.
+
   - version: 2.3.1
     date: '2022-06-09'
     notes:

--- a/pkg/ambex/fastpath.go
+++ b/pkg/ambex/fastpath.go
@@ -1,6 +1,7 @@
 package ambex
 
 import (
+	v3tlsconfig "github.com/datawire/ambassador/v2/pkg/api/envoy/extensions/transport_sockets/tls/v3"
 	ecp_v2_cache "github.com/datawire/ambassador/v2/pkg/envoy-control-plane/cache/v2"
 )
 
@@ -8,4 +9,5 @@ import (
 type FastpathSnapshot struct {
 	Snapshot  *ecp_v2_cache.Snapshot
 	Endpoints *Endpoints
+	Secrets   []*v3tlsconfig.Secret
 }

--- a/pkg/ambex/fastpath.go
+++ b/pkg/ambex/fastpath.go
@@ -10,7 +10,8 @@ import (
 // and, in fact, should probably become proper IR types. They are _not_ yet tied
 // specific Envoy versions here.
 type FastpathSnapshot struct {
-	Snapshot  *ecp_v2_cache.Snapshot
-	Endpoints *Endpoints
-	Secrets   *Secrets
+	Snapshot         *ecp_v2_cache.Snapshot
+	Endpoints        *Endpoints
+	Secrets          *Secrets
+	ValidationGroups [][]string
 }

--- a/pkg/ambex/fastpath.go
+++ b/pkg/ambex/fastpath.go
@@ -1,13 +1,16 @@
 package ambex
 
 import (
-	v3tlsconfig "github.com/datawire/ambassador/v2/pkg/api/envoy/extensions/transport_sockets/tls/v3"
 	ecp_v2_cache "github.com/datawire/ambassador/v2/pkg/envoy-control-plane/cache/v2"
 )
 
 // FastpathSnapshot holds envoy configuration that bypasses python.
+//
+// Note that "Endpoints" and "Secrets" are are the moral equivalent of IR types --
+// and, in fact, should probably become proper IR types. They are _not_ yet tied
+// specific Envoy versions here.
 type FastpathSnapshot struct {
 	Snapshot  *ecp_v2_cache.Snapshot
 	Endpoints *Endpoints
-	Secrets   []*v3tlsconfig.Secret
+	Secrets   *Secrets
 }

--- a/pkg/ambex/main.go
+++ b/pkg/ambex/main.go
@@ -149,8 +149,6 @@ func parseArgs(ctx context.Context, rawArgs ...string) (*Args, error) {
 	flagset.BoolVar(&args.watch, "watch", false, "Watch for file changes")
 
 	// TODO(lukeshu): Consider changing the default here so we don't need to put it in entrypoint.sh
-	// flagset.StringVar(&args.adsNetwork, "ads-listen-network", "tcp", "network for ADS to listen on")
-	// flagset.StringVar(&args.adsAddress, "ads-listen-address", ":18000", "address (on --ads-listen-network) for ADS to listen on")
 	flagset.StringVar(&args.adsNetwork, "ads-listen-network", "unix", "network for ADS to listen on")
 	flagset.StringVar(&args.adsAddress, "ads-listen-address", "/tmp/ambex.sock", "address (on --ads-listen-network) for ADS to listen on")
 
@@ -621,13 +619,11 @@ func (l logAdapterV3) OnStreamRequest(sid int64, req *v3discovery.DiscoveryReque
 // OnStreamResponse implements ecp_v2_server.Callbacks.
 func (l logAdapterV2) OnStreamResponse(sid int64, req *v2.DiscoveryRequest, res *v2.DiscoveryResponse) {
 	dlog.Debugf(context.TODO(), "V2 Stream response[%v] for type %s: returning %d resources", sid, res.TypeUrl, len(res.Resources))
-	// dlog.Debugf(context.TODO(), "V2 Stream dump response[%v]: %v -> %v", sid, req, res)
 }
 
 // OnStreamResponse implements ecp_v3_server.Callbacks.
 func (l logAdapterV3) OnStreamResponse(sid int64, req *v3discovery.DiscoveryRequest, res *v3discovery.DiscoveryResponse) {
 	dlog.Debugf(context.TODO(), "V3 Stream response[%v] for type %s: returning %d resources: %v", sid, res.TypeUrl, len(res.Resources), res.Resources)
-	// dlog.Debugf(context.TODO(), "V3 Stream dump response[%v]: %v -> %v", sid, req, res)
 }
 
 // OnFetchRequest implements ecp_v2_server.Callbacks.

--- a/pkg/ambex/main.go
+++ b/pkg/ambex/main.go
@@ -837,7 +837,7 @@ func Main(
 		for {
 
 			select {
-			case _ = <-sigCh:
+			case <-sigCh:
 				err := update(
 					ctx,
 					args.snapdirPath,

--- a/pkg/ambex/main.go
+++ b/pkg/ambex/main.go
@@ -608,28 +608,26 @@ func (l logAdapterBase) OnStreamClosed(sid int64) {
 
 // OnStreamRequest implements ecp_v2_server.Callbacks.
 func (l logAdapterV2) OnStreamRequest(sid int64, req *v2.DiscoveryRequest) error {
-	dlog.Debugf(context.TODO(), "V2 Stream request[%v] for type %s: requesting %d resources", sid, req.TypeUrl, len(req.ResourceNames))
-	dlog.Debugf(context.TODO(), "V2 Stream request[%v] dump: %v", sid, req)
+	dlog.Debugf(context.TODO(), "V2 Stream request[%v] for type %s: %s", sid, req.TypeUrl, strings.Join(req.ResourceNames, ","))
 	return nil
 }
 
 // OnStreamRequest implements ecp_v3_server.Callbacks.
 func (l logAdapterV3) OnStreamRequest(sid int64, req *v3discovery.DiscoveryRequest) error {
-	dlog.Debugf(context.TODO(), "V3 Stream request[%v] for type %s: requesting %d resources", sid, req.TypeUrl, len(req.ResourceNames))
-	dlog.Debugf(context.TODO(), "V3 Stream request[%v] dump: %v", sid, req)
+	dlog.Debugf(context.TODO(), "V3 Stream request[%v] for type %s: %s", sid, req.TypeUrl, strings.Join(req.ResourceNames, ","))
 	return nil
 }
 
 // OnStreamResponse implements ecp_v2_server.Callbacks.
 func (l logAdapterV2) OnStreamResponse(sid int64, req *v2.DiscoveryRequest, res *v2.DiscoveryResponse) {
 	dlog.Debugf(context.TODO(), "V2 Stream response[%v] for type %s: returning %d resources", sid, res.TypeUrl, len(res.Resources))
-	dlog.Debugf(context.TODO(), "V2 Stream dump response[%v]: %v -> %v", sid, req, res)
+	// dlog.Debugf(context.TODO(), "V2 Stream dump response[%v]: %v -> %v", sid, req, res)
 }
 
 // OnStreamResponse implements ecp_v3_server.Callbacks.
 func (l logAdapterV3) OnStreamResponse(sid int64, req *v3discovery.DiscoveryRequest, res *v3discovery.DiscoveryResponse) {
-	dlog.Debugf(context.TODO(), "V3 Stream response[%v] for type %s: returning %d resources", sid, res.TypeUrl, len(res.Resources))
-	dlog.Debugf(context.TODO(), "V3 Stream dump response[%v]: %v -> %v", sid, req, res)
+	dlog.Debugf(context.TODO(), "V3 Stream response[%v] for type %s: returning %d resources: %v", sid, res.TypeUrl, len(res.Resources), res.Resources)
+	// dlog.Debugf(context.TODO(), "V3 Stream dump response[%v]: %v -> %v", sid, req, res)
 }
 
 // OnFetchRequest implements ecp_v2_server.Callbacks.

--- a/pkg/ambex/main.go
+++ b/pkg/ambex/main.go
@@ -40,6 +40,7 @@ package ambex
 
 import (
 	// standard library
+
 	"context"
 	"encoding/json"
 	"flag"
@@ -303,111 +304,6 @@ func Decode(ctx context.Context, name string) (proto.Message, error) {
 	}
 	dlog.Infof(ctx, "Loaded file %s", name)
 	return v, nil
-}
-
-// Observability:
-//
-// These "expanded" snapshots make the snapshots we log easier to read: basically,
-// instead of just indexing by Golang types, make the JSON marshal with real names.
-type v2ExpandedSnapshot struct {
-	Endpoints ecp_v2_cache.Resources `json:"endpoints"`
-	Clusters  ecp_v2_cache.Resources `json:"clusters"`
-	Routes    ecp_v2_cache.Resources `json:"routes"`
-	Listeners ecp_v2_cache.Resources `json:"listeners"`
-	Runtimes  ecp_v2_cache.Resources `json:"runtimes"`
-}
-
-func NewV2ExpandedSnapshot(v2snap *ecp_v2_cache.Snapshot) v2ExpandedSnapshot {
-	return v2ExpandedSnapshot{
-		Endpoints: v2snap.Resources[ecp_cache_types.Endpoint],
-		Clusters:  v2snap.Resources[ecp_cache_types.Cluster],
-		Routes:    v2snap.Resources[ecp_cache_types.Route],
-		Listeners: v2snap.Resources[ecp_cache_types.Listener],
-		Runtimes:  v2snap.Resources[ecp_cache_types.Runtime],
-	}
-}
-
-type v3ExpandedSnapshot struct {
-	Endpoints ecp_v3_cache.Resources `json:"endpoints"`
-	Clusters  ecp_v3_cache.Resources `json:"clusters"`
-	Routes    ecp_v3_cache.Resources `json:"routes"`
-	Listeners ecp_v3_cache.Resources `json:"listeners"`
-	Runtimes  ecp_v3_cache.Resources `json:"runtimes"`
-}
-
-func NewV3ExpandedSnapshot(v3snap *ecp_v3_cache.Snapshot) v3ExpandedSnapshot {
-	return v3ExpandedSnapshot{
-		Endpoints: v3snap.Resources[ecp_cache_types.Endpoint],
-		Clusters:  v3snap.Resources[ecp_cache_types.Cluster],
-		Routes:    v3snap.Resources[ecp_cache_types.Route],
-		Listeners: v3snap.Resources[ecp_cache_types.Listener],
-		Runtimes:  v3snap.Resources[ecp_cache_types.Runtime],
-	}
-}
-
-// A combinedSnapshot has both a V2 and V3 snapshot, for logging.
-type combinedSnapshot struct {
-	Version string             `json:"version"`
-	V2      v2ExpandedSnapshot `json:"v2"`
-	V3      v3ExpandedSnapshot `json:"v3"`
-}
-
-// csDump creates a combinedSnapshot from a V2 snapshot and a V3 snapshot, then
-// dumps the combinedSnapshot to disk. Only numsnaps snapshots are kept: ambex-1.json
-// is the newest, then ambex-2.json, etc., so ambex-$numsnaps.json is the oldest.
-// Every time we write a new one, we rename all the older ones, ditching the oldest
-// after we've written numsnaps snapshots.
-func csDump(ctx context.Context, snapdirPath string, numsnaps int, generation int, v2snap *ecp_v2_cache.Snapshot, v3snap *ecp_v3_cache.Snapshot) {
-	if numsnaps <= 0 {
-		// Don't do snapshotting at all.
-		return
-	}
-
-	// OK, they want snapshots. Make a proper version string...
-	version := fmt.Sprintf("v%d", generation)
-
-	// ...and a combinedSnapshot.
-	cs := combinedSnapshot{
-		Version: version,
-		V2:      NewV2ExpandedSnapshot(v2snap),
-		V3:      NewV3ExpandedSnapshot(v3snap),
-	}
-
-	// Next up, marshal as JSON and write to ambex-0.json. Note that we
-	// didn't say anything about a -0 file; that's because it's about to
-	// be renamed.
-
-	bs, err := json.MarshalIndent(cs, "", "  ")
-
-	if err != nil {
-		dlog.Errorf(ctx, "CSNAP: marshal failure: %s", err)
-		return
-	}
-
-	csPath := path.Join(snapdirPath, "ambex-0.json")
-
-	err = ioutil.WriteFile(csPath, bs, 0644)
-
-	if err != nil {
-		dlog.Errorf(ctx, "CSNAP: write failure: %s", err)
-	} else {
-		dlog.Infof(ctx, "Saved snapshot %s", version)
-	}
-
-	// Rotate everything one file down. This includes renaming the just-written
-	// ambex-0 to ambex-1.
-	for i := numsnaps; i > 0; i-- {
-		previous := i - 1
-
-		fromPath := path.Join(snapdirPath, fmt.Sprintf("ambex-%d.json", previous))
-		toPath := path.Join(snapdirPath, fmt.Sprintf("ambex-%d.json", i))
-
-		err := os.Rename(fromPath, toPath)
-
-		if (err != nil) && !os.IsNotExist(err) {
-			dlog.Infof(ctx, "CSNAP: could not rename %s -> %s: %#v", fromPath, toPath, err)
-		}
-	}
 }
 
 // Get an updated snapshot going.

--- a/pkg/ambex/main.go
+++ b/pkg/ambex/main.go
@@ -146,8 +146,10 @@ func parseArgs(ctx context.Context, rawArgs ...string) (*Args, error) {
 	flagset.BoolVar(&args.watch, "watch", false, "Watch for file changes")
 
 	// TODO(lukeshu): Consider changing the default here so we don't need to put it in entrypoint.sh
-	flagset.StringVar(&args.adsNetwork, "ads-listen-network", "tcp", "network for ADS to listen on")
-	flagset.StringVar(&args.adsAddress, "ads-listen-address", ":18000", "address (on --ads-listen-network) for ADS to listen on")
+	// flagset.StringVar(&args.adsNetwork, "ads-listen-network", "tcp", "network for ADS to listen on")
+	// flagset.StringVar(&args.adsAddress, "ads-listen-address", ":18000", "address (on --ads-listen-network) for ADS to listen on")
+	flagset.StringVar(&args.adsNetwork, "ads-listen-network", "unix", "network for ADS to listen on")
+	flagset.StringVar(&args.adsAddress, "ads-listen-address", "/tmp/ambex.sock", "address (on --ads-listen-network) for ADS to listen on")
 
 	var legacyAdsPort uint
 	flagset.UintVar(&legacyAdsPort, "ads", 0, "port number for ADS to listen on--deprecated, use --ads-listen-address=:1234 instead")

--- a/pkg/ambex/main.go
+++ b/pkg/ambex/main.go
@@ -778,8 +778,8 @@ func Main(
 					edsEndpointsV3 = fpSnap.Endpoints.ToMap_v3()
 				}
 				if fpSnap.Secrets != nil {
-					sdsSecretsV2 = fpSnap.Secrets.ToV2List(ctx)
-					sdsSecretsV3 = fpSnap.Secrets.ToV3List(ctx)
+					sdsSecretsV2 = fpSnap.Secrets.ToV2List(ctx, fpSnap.ValidationGroups)
+					sdsSecretsV3 = fpSnap.Secrets.ToV3List(ctx, fpSnap.ValidationGroups)
 				}
 				fastpathSnapshot = fpSnap
 				err := update(

--- a/pkg/ambex/main.go
+++ b/pkg/ambex/main.go
@@ -512,7 +512,7 @@ func update(
 	// the ratelimiting logic decides.
 
 	dlog.Debugf(ctx, "Created snapshot %s", version)
-	csDump(ctx, snapdirPath, numsnaps, curgen, &snapshot, &snapshotv3)
+	dumpSnapshot(ctx, snapdirPath, numsnaps, curgen, &snapshot, &snapshotv3)
 
 	update := Update{version, func() error {
 		dlog.Debugf(ctx, "Accepting snapshot %s", version)

--- a/pkg/ambex/main.go
+++ b/pkg/ambex/main.go
@@ -244,11 +244,11 @@ func runManagementServer(ctx context.Context, server ecp_v2_server.Server, serve
 	v2.RegisterListenerDiscoveryServiceServer(grpcServer, server)
 
 	v3discovery.RegisterAggregatedDiscoveryServiceServer(grpcServer, serverv3)
+	v3secret.RegisterSecretDiscoveryServiceServer(grpcServer, serverv3)
 	v3endpoint.RegisterEndpointDiscoveryServiceServer(grpcServer, serverv3)
 	v3cluster.RegisterClusterDiscoveryServiceServer(grpcServer, serverv3)
 	v3route.RegisterRouteDiscoveryServiceServer(grpcServer, serverv3)
 	v3listener.RegisterListenerDiscoveryServiceServer(grpcServer, serverv3)
-	v3secret.RegisterSecretDiscoveryServiceServer(grpcServer, serverv3)
 
 	dlog.Infof(ctx, "Listening on %s:%s", adsNetwork, adsAddress)
 

--- a/pkg/ambex/secret.go
+++ b/pkg/ambex/secret.go
@@ -1,0 +1,84 @@
+package ambex
+
+import (
+	"context"
+	"fmt"
+
+	v3core "github.com/datawire/ambassador/v2/pkg/api/envoy/config/core/v3"
+	v3tlsconfig "github.com/datawire/ambassador/v2/pkg/api/envoy/extensions/transport_sockets/tls/v3"
+	snapshotTypes "github.com/datawire/ambassador/v2/pkg/snapshot/v1"
+	"github.com/datawire/dlib/dlog"
+	v1 "k8s.io/api/core/v1"
+)
+
+type Secret struct {
+	Name             string
+	PrivateKey       []byte
+	CertificateChain []byte
+	CACertChain      []byte
+}
+
+type Secrets struct {
+	Secrets []*v3tlsconfig.Secret
+}
+
+// MakeSecrets takes all the Secrets in a snapshot and packages them up for
+// consumption by ambex.
+func MakeSecrets(ctx context.Context, k8sSnapshot *snapshotTypes.KubernetesSnapshot) []*v3tlsconfig.Secret {
+	secrets := []*v3tlsconfig.Secret{}
+
+	for _, secret := range k8sSnapshot.Secrets {
+		name := secret.GetName()
+		namespace := secret.GetNamespace()
+
+		if namespace == "" {
+			namespace = "default"
+		}
+
+		fullName := fmt.Sprintf("secret/%s/%s", namespace, name)
+
+		var v3secret v3tlsconfig.Secret
+
+		if secret.Type == v1.SecretTypeTLS {
+			dlog.Warnf(ctx, "%s: TLS", fullName)
+
+			privateKey := secret.Data["tls.key"]
+			certificate := secret.Data["tls.crt"]
+
+			v3secret = v3tlsconfig.Secret{
+				Name: fullName,
+				Type: &v3tlsconfig.Secret_TlsCertificate{
+					TlsCertificate: &v3tlsconfig.TlsCertificate{
+						PrivateKey: &v3core.DataSource{
+							Specifier: &v3core.DataSource_InlineBytes{InlineBytes: privateKey},
+						},
+						CertificateChain: &v3core.DataSource{
+							Specifier: &v3core.DataSource_InlineBytes{InlineBytes: certificate},
+						},
+					},
+				},
+			}
+		} else if secret.Type == v1.SecretTypeOpaque {
+			dlog.Warnf(ctx, "%s: Opaque", fullName)
+			caCertificate := secret.Data["user.key"]
+
+			v3secret = v3tlsconfig.Secret{
+				Name: fullName,
+				Type: &v3tlsconfig.Secret_ValidationContext{
+					ValidationContext: &v3tlsconfig.CertificateValidationContext{
+						TrustedCa: &v3core.DataSource{
+							Specifier: &v3core.DataSource_InlineBytes{InlineBytes: caCertificate},
+						},
+					},
+				},
+			}
+		} else {
+			dlog.Errorf(ctx, "%s: unknown %s", fullName, secret.Type)
+			continue
+		}
+
+		secrets = append(secrets, &v3secret)
+	}
+
+	return secrets
+}

--- a/pkg/ambex/secret.go
+++ b/pkg/ambex/secret.go
@@ -8,7 +8,6 @@ import (
 	v2core "github.com/datawire/ambassador/v2/pkg/api/envoy/api/v2/core"
 	v3core "github.com/datawire/ambassador/v2/pkg/api/envoy/config/core/v3"
 	v3tlsconfig "github.com/datawire/ambassador/v2/pkg/api/envoy/extensions/transport_sockets/tls/v3"
-	snapshotTypes "github.com/datawire/ambassador/v2/pkg/snapshot/v1"
 	"github.com/datawire/dlib/dlog"
 	v1 "k8s.io/api/core/v1"
 )
@@ -19,64 +18,86 @@ type Secret struct {
 	PrivateKey       []byte
 	CertificateChain []byte
 	CACertChain      []byte
+	Crl              []byte
 }
 
 type Secrets struct {
-	Secrets []*Secret
+	TlsSecrets        []*Secret
+	ValidationSecrets []*Secret
 }
 
-// MakeSecrets takes all the Secrets in a snapshot and packages them up for
-// consumption by ambex.
-func MakeSecrets(ctx context.Context, k8sSnapshot *snapshotTypes.KubernetesSnapshot) *Secrets {
-	secrets := []*Secret{}
+func (secrets *Secrets) ToV2List(ctx context.Context, validationGroups [][]string) []*v2auth.Secret {
+	v2secrets := make([]*v2auth.Secret, 0, (len(secrets.TlsSecrets) + len(secrets.ValidationSecrets)))
 
-	for _, secret := range k8sSnapshot.Secrets {
-		name := secret.GetName()
-		namespace := secret.GetNamespace()
+	// Iterate over the validation groups and create a validation context for each
+	// There is room for performance improvements here
+	for _, vGroup := range validationGroups {
+		vContext := &v2auth.CertificateValidationContext{}
+		crlName, caName := "", "" // names of the CA and CRL secrets that are needed later to combine into the final shared name
 
-		if namespace == "" {
-			namespace = "default"
+		dlog.Debugf(ctx, "[V2Secrets] building validation_context for secret group: %v\n", vGroup)
+
+		for _, secret := range secrets.ValidationSecrets {
+			if containsElem(vGroup, secret.Name) {
+				if secret.Type == v1.SecretTypeTLS {
+					// If it is a Tls secret for validation_context then it has to be a CACert
+					vContext.TrustedCa = &v2core.DataSource{
+						Specifier: &v2core.DataSource_InlineBytes{
+							InlineBytes: secret.CertificateChain,
+						},
+					}
+					caName = secret.Name
+				} else if secret.Type == v1.SecretTypeOpaque {
+					// If it is Opaque then its either a CACert or a Crl
+					if caCert := secret.CACertChain; len(caCert) != 0 {
+						vContext.TrustedCa = &v2core.DataSource{
+							Specifier: &v2core.DataSource_InlineBytes{
+								InlineBytes: secret.CACertChain,
+							},
+						}
+						caName = secret.Name
+					}
+					if crl := secret.Crl; len(crl) != 0 {
+						vContext.Crl = &v2core.DataSource{
+							Specifier: &v2core.DataSource_InlineBytes{
+								InlineBytes: secret.Crl,
+							},
+						}
+						crlName = secret.Name
+					}
+				} else {
+					dlog.Errorf(ctx, "[V2Secrets] %s: unknown secret type: %s", secret.Name, secret.Type)
+					continue
+				}
+			}
 		}
 
-		fullName := fmt.Sprintf("secret/%s.%s", name, namespace)
-
-		if secret.Type == v1.SecretTypeTLS {
-			dlog.Warnf(ctx, "%s: TLS", fullName)
-
-			privateKey := secret.Data["tls.key"]
-			certificate := secret.Data["tls.crt"]
-
-			secrets = append(secrets, &Secret{
-				Name:             fullName,
-				Type:             secret.Type,
-				PrivateKey:       privateKey,
-				CertificateChain: certificate,
-			})
-		} else if secret.Type == v1.SecretTypeOpaque {
-			dlog.Warnf(ctx, "%s: Opaque", fullName)
-
-			caCertificate := secret.Data["user.key"]
-
-			secrets = append(secrets, &Secret{
-				Name:        fullName,
-				Type:        secret.Type,
-				CACertChain: caCertificate,
-			})
+		// Make a name for the new validation_context built from one or more secrets
+		// Default to joining their names. The name of the CA secret will always be first
+		groupName := ""
+		if caName != "" && crlName != "" {
+			groupName = fmt.Sprintf("%s-%s", caName, crlName)
+		} else if caName != "" && crlName == "" {
+			groupName = caName
+		} else {
+			groupName = crlName
 		}
+
+		dlog.Debugf(ctx, "[V2Secrets] built validation_context Group: %v", groupName)
+		v2secrets = append(v2secrets, &v2auth.Secret{
+			Name: groupName,
+			Type: &v2auth.Secret_ValidationContext{
+				ValidationContext: vContext,
+			},
+		})
+
 	}
 
-	return &Secrets{Secrets: secrets}
-}
-
-func (secrets *Secrets) ToV2List(ctx context.Context) []*v2auth.Secret {
-	v2secrets := make([]*v2auth.Secret, 0, len(secrets.Secrets))
-
-	for _, secret := range secrets.Secrets {
+	// Do the same for tls secrets
+	for _, secret := range secrets.TlsSecrets {
 		var v2secret v2auth.Secret
 
 		if secret.Type == v1.SecretTypeTLS {
-			dlog.Warnf(ctx, "%s: TLS", secret.Name)
-
 			v2secret = v2auth.Secret{
 				Name: secret.Name,
 				Type: &v2auth.Secret_TlsCertificate{
@@ -95,22 +116,9 @@ func (secrets *Secrets) ToV2List(ctx context.Context) []*v2auth.Secret {
 				},
 			}
 		} else if secret.Type == v1.SecretTypeOpaque {
-			dlog.Warnf(ctx, "%s: Opaque", secret.Name)
-
-			v2secret = v2auth.Secret{
-				Name: secret.Name,
-				Type: &v2auth.Secret_ValidationContext{
-					ValidationContext: &v2auth.CertificateValidationContext{
-						TrustedCa: &v2core.DataSource{
-							Specifier: &v2core.DataSource_InlineBytes{
-								InlineBytes: secret.CACertChain,
-							},
-						},
-					},
-				},
-			}
+			dlog.Errorf(ctx, "[V2Secrets] %s: Opaque TLS secret cannot be used", secret.Name)
 		} else {
-			dlog.Errorf(ctx, "%s: unknown %s", secret.Name, secret.Type)
+			dlog.Errorf(ctx, "[V2Secrets] %s: unknown secret type: %s", secret.Name, secret.Type)
 			continue
 		}
 
@@ -120,15 +128,80 @@ func (secrets *Secrets) ToV2List(ctx context.Context) []*v2auth.Secret {
 	return v2secrets
 }
 
-func (secrets *Secrets) ToV3List(ctx context.Context) []*v3tlsconfig.Secret {
-	v3secrets := make([]*v3tlsconfig.Secret, 0, len(secrets.Secrets))
+func (secrets *Secrets) ToV3List(ctx context.Context, validationGroups [][]string) []*v3tlsconfig.Secret {
 
-	for _, secret := range secrets.Secrets {
+	v3secrets := make([]*v3tlsconfig.Secret, 0, (len(secrets.TlsSecrets) + len(secrets.ValidationSecrets)))
+
+	// Iterate over the validation groups and create a validation context for each
+	// There is room for performance improvements here
+	for _, vGroup := range validationGroups {
+		vContext := &v3tlsconfig.CertificateValidationContext{}
+		crlName, caName := "", "" // names of the CA and CRL secrets that are needed later to combine into the final shared name
+
+		dlog.Debugf(ctx, "[V3Secrets] building validation_context for secret group: %v\n", vGroup)
+
+		for _, secret := range secrets.ValidationSecrets {
+			if containsElem(vGroup, secret.Name) {
+				if secret.Type == v1.SecretTypeTLS {
+					// If it is a Tls secret for validation_context then it has to be a CACert
+					vContext.TrustedCa = &v3core.DataSource{
+						Specifier: &v3core.DataSource_InlineBytes{
+							InlineBytes: secret.CertificateChain,
+						},
+					}
+					caName = secret.Name
+				} else if secret.Type == v1.SecretTypeOpaque {
+					// If it is Opaque then its either a CACert or a Crl
+					if caCert := secret.CACertChain; len(caCert) != 0 {
+						vContext.TrustedCa = &v3core.DataSource{
+							Specifier: &v3core.DataSource_InlineBytes{
+								InlineBytes: secret.CACertChain,
+							},
+						}
+						caName = secret.Name
+					}
+					if crl := secret.Crl; len(crl) != 0 {
+						vContext.Crl = &v3core.DataSource{
+							Specifier: &v3core.DataSource_InlineBytes{
+								InlineBytes: secret.Crl,
+							},
+						}
+						crlName = secret.Name
+					}
+				} else {
+					dlog.Errorf(ctx, "[V3Secrets] %s: unknown secret type: %s", secret.Name, secret.Type)
+					continue
+				}
+			}
+		}
+
+		// Make a name for the new validation_context built from one or more secrets
+		// Default to joining their names. The name of the CA secret will always be first
+		groupName := ""
+		if caName != "" && crlName != "" {
+			groupName = fmt.Sprintf("%s-%s", caName, crlName)
+		} else if caName != "" && crlName == "" {
+			groupName = caName
+		} else {
+			groupName = crlName
+		}
+
+		dlog.Debugf(ctx, "[V3Secrets] built validation_context Group: %v", groupName)
+
+		v3secrets = append(v3secrets, &v3tlsconfig.Secret{
+			Name: groupName,
+			Type: &v3tlsconfig.Secret_ValidationContext{
+				ValidationContext: vContext,
+			},
+		})
+
+	}
+
+	// Do the same for tls secrets
+	for _, secret := range secrets.TlsSecrets {
 		var v3secret v3tlsconfig.Secret
 
 		if secret.Type == v1.SecretTypeTLS {
-			dlog.Warnf(ctx, "%s: TLS", secret.Name)
-
 			v3secret = v3tlsconfig.Secret{
 				Name: secret.Name,
 				Type: &v3tlsconfig.Secret_TlsCertificate{
@@ -147,22 +220,9 @@ func (secrets *Secrets) ToV3List(ctx context.Context) []*v3tlsconfig.Secret {
 				},
 			}
 		} else if secret.Type == v1.SecretTypeOpaque {
-			dlog.Warnf(ctx, "%s: Opaque", secret.Name)
-
-			v3secret = v3tlsconfig.Secret{
-				Name: secret.Name,
-				Type: &v3tlsconfig.Secret_ValidationContext{
-					ValidationContext: &v3tlsconfig.CertificateValidationContext{
-						TrustedCa: &v3core.DataSource{
-							Specifier: &v3core.DataSource_InlineBytes{
-								InlineBytes: secret.CACertChain,
-							},
-						},
-					},
-				},
-			}
+			dlog.Errorf(ctx, "[V3Secrets] %s: Opaque TLS secret cannot be used", secret.Name)
 		} else {
-			dlog.Errorf(ctx, "%s: unknown %s", secret.Name, secret.Type)
+			dlog.Errorf(ctx, "[V3Secrets] %s: unknown secret type: %s", secret.Name, secret.Type)
 			continue
 		}
 
@@ -170,4 +230,16 @@ func (secrets *Secrets) ToV3List(ctx context.Context) []*v3tlsconfig.Secret {
 	}
 
 	return v3secrets
+
+}
+
+// Just checks if the list contains the provided string
+// I really wish go just had this builtin....
+func containsElem(s []string, key string) bool {
+	for _, e := range s {
+		if e == key {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/ambex/secret.go
+++ b/pkg/ambex/secret.go
@@ -38,7 +38,7 @@ func MakeSecrets(ctx context.Context, k8sSnapshot *snapshotTypes.KubernetesSnaps
 			namespace = "default"
 		}
 
-		fullName := fmt.Sprintf("secret/%s/%s", namespace, name)
+		fullName := fmt.Sprintf("secret/%s.%s", name, namespace)
 
 		if secret.Type == v1.SecretTypeTLS {
 			dlog.Warnf(ctx, "%s: TLS", fullName)

--- a/pkg/ambex/snapshots.go
+++ b/pkg/ambex/snapshots.go
@@ -116,6 +116,7 @@ func NewMarshaledSnapshot(version string, v2snap *ecp_v2_cache.Snapshot, v3snap 
 	ms.marshalV3Resources("Routes", v3snap.Resources[ecp_cache_types.Route])
 	ms.marshalV3Resources("Listeners", v3snap.Resources[ecp_cache_types.Listener])
 	ms.marshalV3Resources("Runtimes", v3snap.Resources[ecp_cache_types.Runtime])
+	ms.marshalV3Resources("Secrets", v3snap.Resources[ecp_cache_types.Secret])
 
 	return ms
 }

--- a/pkg/ambex/snapshots.go
+++ b/pkg/ambex/snapshots.go
@@ -110,6 +110,7 @@ func NewMarshaledSnapshot(version string, v2snap *ecp_v2_cache.Snapshot, v3snap 
 	ms.marshalV2Resources("Routes", v2snap.Resources[ecp_cache_types.Route])
 	ms.marshalV2Resources("Listeners", v2snap.Resources[ecp_cache_types.Listener])
 	ms.marshalV2Resources("Runtimes", v2snap.Resources[ecp_cache_types.Runtime])
+	ms.marshalV3Resources("Secrets", v3snap.Resources[ecp_cache_types.Secret])
 
 	ms.marshalV3Resources("Endpoints", v3snap.Resources[ecp_cache_types.Endpoint])
 	ms.marshalV3Resources("Clusters", v3snap.Resources[ecp_cache_types.Cluster])

--- a/pkg/ambex/snapshots.go
+++ b/pkg/ambex/snapshots.go
@@ -1,0 +1,174 @@
+package ambex
+
+import (
+	// standard library
+
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+
+	// third-party libraries
+
+	// envoy control plane
+	ecp_cache_types "github.com/datawire/ambassador/v2/pkg/envoy-control-plane/cache/types"
+	ecp_v2_cache "github.com/datawire/ambassador/v2/pkg/envoy-control-plane/cache/v2"
+	ecp_v3_cache "github.com/datawire/ambassador/v2/pkg/envoy-control-plane/cache/v3"
+
+	// Envoy API v2
+	// Be sure to import the package of any types that're referenced with "@type" in our
+	// generated Envoy config, even if that package is otherwise not used by ambex.
+
+	_ "github.com/datawire/ambassador/v2/pkg/api/envoy/api/v2/auth"
+	_ "github.com/datawire/ambassador/v2/pkg/api/envoy/config/accesslog/v2"
+	_ "github.com/datawire/ambassador/v2/pkg/api/envoy/config/filter/http/buffer/v2"
+	_ "github.com/datawire/ambassador/v2/pkg/api/envoy/config/filter/http/ext_authz/v2"
+	_ "github.com/datawire/ambassador/v2/pkg/api/envoy/config/filter/http/gzip/v2"
+	_ "github.com/datawire/ambassador/v2/pkg/api/envoy/config/filter/http/lua/v2"
+	_ "github.com/datawire/ambassador/v2/pkg/api/envoy/config/filter/http/rate_limit/v2"
+	_ "github.com/datawire/ambassador/v2/pkg/api/envoy/config/filter/http/rbac/v2"
+	_ "github.com/datawire/ambassador/v2/pkg/api/envoy/config/filter/http/router/v2"
+	_ "github.com/datawire/ambassador/v2/pkg/api/envoy/config/filter/network/http_connection_manager/v2"
+	_ "github.com/datawire/ambassador/v2/pkg/api/envoy/config/filter/network/tcp_proxy/v2"
+
+	// Envoy API v3
+	// Be sure to import the package of any types that're referenced with "@type" in our
+	// generated Envoy config, even if that package is otherwise not used by ambex.
+	_ "github.com/datawire/ambassador/v2/pkg/api/envoy/config/accesslog/v3"
+	_ "github.com/datawire/ambassador/v2/pkg/api/envoy/extensions/access_loggers/file/v3"
+	_ "github.com/datawire/ambassador/v2/pkg/api/envoy/extensions/access_loggers/grpc/v3"
+	_ "github.com/datawire/ambassador/v2/pkg/api/envoy/extensions/compression/gzip/compressor/v3"
+	_ "github.com/datawire/ambassador/v2/pkg/api/envoy/extensions/filters/http/buffer/v3"
+	_ "github.com/datawire/ambassador/v2/pkg/api/envoy/extensions/filters/http/compressor/v3"
+	_ "github.com/datawire/ambassador/v2/pkg/api/envoy/extensions/filters/http/ext_authz/v3"
+	_ "github.com/datawire/ambassador/v2/pkg/api/envoy/extensions/filters/http/grpc_stats/v3"
+	_ "github.com/datawire/ambassador/v2/pkg/api/envoy/extensions/filters/http/gzip/v3"
+	_ "github.com/datawire/ambassador/v2/pkg/api/envoy/extensions/filters/http/lua/v3"
+	_ "github.com/datawire/ambassador/v2/pkg/api/envoy/extensions/filters/http/ratelimit/v3"
+	_ "github.com/datawire/ambassador/v2/pkg/api/envoy/extensions/filters/http/rbac/v3"
+	_ "github.com/datawire/ambassador/v2/pkg/api/envoy/extensions/filters/http/response_map/v3"
+	_ "github.com/datawire/ambassador/v2/pkg/api/envoy/extensions/filters/http/router/v3"
+	_ "github.com/datawire/ambassador/v2/pkg/api/envoy/extensions/filters/network/http_connection_manager/v3"
+	_ "github.com/datawire/ambassador/v2/pkg/api/envoy/extensions/filters/network/tcp_proxy/v3"
+
+	// first-party libraries
+
+	"github.com/datawire/dlib/dlog"
+)
+
+// Snapshot handling.
+//
+// The Envoy configurations that we work with are called "snapshots", since they're
+// an internally-consistent representation of a single point in time. As a debugging
+// aid, we log the snapshots to disk before sending them on to Envoy. The logs go into
+// /ambassador/snapshots/ambex-<version>.json.
+//
+// Actually making these snapshots is harder than you might think, because the core of
+// the Envoy configuration is protobuf messages rather than Go structs. So we need to
+// do a certain amount of work to make sure we can marshal to JSON using jsonpb.Marshaler
+// rather than just json.Marshal, so that the typed fields in the Envoy configuration are
+// properly serialized.
+//
+// These "expanded" snapshots make the snapshots we log easier to read: basically,
+// instead of just indexing by Golang types, make the JSON marshal with real names.
+type v2ExpandedSnapshot struct {
+	Endpoints ecp_v2_cache.Resources `json:"endpoints"`
+	Clusters  ecp_v2_cache.Resources `json:"clusters"`
+	Routes    ecp_v2_cache.Resources `json:"routes"`
+	Listeners ecp_v2_cache.Resources `json:"listeners"`
+	Runtimes  ecp_v2_cache.Resources `json:"runtimes"`
+}
+
+func NewV2ExpandedSnapshot(v2snap *ecp_v2_cache.Snapshot) v2ExpandedSnapshot {
+	return v2ExpandedSnapshot{
+		Endpoints: v2snap.Resources[ecp_cache_types.Endpoint],
+		Clusters:  v2snap.Resources[ecp_cache_types.Cluster],
+		Routes:    v2snap.Resources[ecp_cache_types.Route],
+		Listeners: v2snap.Resources[ecp_cache_types.Listener],
+		Runtimes:  v2snap.Resources[ecp_cache_types.Runtime],
+	}
+}
+
+type v3ExpandedSnapshot struct {
+	Endpoints ecp_v3_cache.Resources `json:"endpoints"`
+	Clusters  ecp_v3_cache.Resources `json:"clusters"`
+	Routes    ecp_v3_cache.Resources `json:"routes"`
+	Listeners ecp_v3_cache.Resources `json:"listeners"`
+	Runtimes  ecp_v3_cache.Resources `json:"runtimes"`
+}
+
+func NewV3ExpandedSnapshot(v3snap *ecp_v3_cache.Snapshot) v3ExpandedSnapshot {
+	return v3ExpandedSnapshot{
+		Endpoints: v3snap.Resources[ecp_cache_types.Endpoint],
+		Clusters:  v3snap.Resources[ecp_cache_types.Cluster],
+		Routes:    v3snap.Resources[ecp_cache_types.Route],
+		Listeners: v3snap.Resources[ecp_cache_types.Listener],
+		Runtimes:  v3snap.Resources[ecp_cache_types.Runtime],
+	}
+}
+
+// A combinedSnapshot has both a V2 and V3 snapshot, for logging.
+type combinedSnapshot struct {
+	Version string             `json:"version"`
+	V2      v2ExpandedSnapshot `json:"v2"`
+	V3      v3ExpandedSnapshot `json:"v3"`
+}
+
+// csDump creates a combinedSnapshot from a V2 snapshot and a V3 snapshot, then
+// dumps the combinedSnapshot to disk. Only numsnaps snapshots are kept: ambex-1.json
+// is the newest, then ambex-2.json, etc., so ambex-$numsnaps.json is the oldest.
+// Every time we write a new one, we rename all the older ones, ditching the oldest
+// after we've written numsnaps snapshots.
+func csDump(ctx context.Context, snapdirPath string, numsnaps int, generation int, v2snap *ecp_v2_cache.Snapshot, v3snap *ecp_v3_cache.Snapshot) {
+	if numsnaps <= 0 {
+		// Don't do snapshotting at all.
+		return
+	}
+
+	// OK, they want snapshots. Make a proper version string...
+	version := fmt.Sprintf("v%d", generation)
+
+	// ...and a combinedSnapshot.
+	cs := combinedSnapshot{
+		Version: version,
+		V2:      NewV2ExpandedSnapshot(v2snap),
+		V3:      NewV3ExpandedSnapshot(v3snap),
+	}
+
+	// Next up, marshal as JSON and write to ambex-0.json. Note that we
+	// didn't say anything about a -0 file; that's because it's about to
+	// be renamed.
+	bs, err := json.Marshal(cs)
+
+	if err != nil {
+		dlog.Errorf(ctx, "CSNAP: marshal failure: %s", err)
+		return
+	}
+
+	csPath := path.Join(snapdirPath, "ambex-0.json")
+
+	err = ioutil.WriteFile(csPath, bs, 0644)
+
+	if err != nil {
+		dlog.Errorf(ctx, "CSNAP: write failure: %s", err)
+	} else {
+		dlog.Infof(ctx, "Saved snapshot %s", version)
+	}
+
+	// Rotate everything one file down. This includes renaming the just-written
+	// ambex-0 to ambex-1.
+	for i := numsnaps; i > 0; i-- {
+		previous := i - 1
+
+		fromPath := path.Join(snapdirPath, fmt.Sprintf("ambex-%d.json", previous))
+		toPath := path.Join(snapdirPath, fmt.Sprintf("ambex-%d.json", i))
+
+		err := os.Rename(fromPath, toPath)
+
+		if (err != nil) && !os.IsNotExist(err) {
+			dlog.Infof(ctx, "CSNAP: could not rename %s -> %s: %#v", fromPath, toPath, err)
+		}
+	}
+}

--- a/pkg/ambex/snapshots.go
+++ b/pkg/ambex/snapshots.go
@@ -188,12 +188,12 @@ func marshaledV3Elements(resources ecp_v3_cache.Resources) (*marshaledElements, 
 	return &mel, nil
 }
 
-// csDump creates a combinedSnapshot from a V2 snapshot and a V3 snapshot, then
-// dumps the combinedSnapshot to disk. Only numsnaps snapshots are kept: ambex-1.json
+// dumpSnapshot creates a marshaledSnapshot from a V2 snapshot and a V3 snapshot, then
+// dumps the marshaledSnapshot to disk. Only numsnaps snapshots are kept: ambex-1.json
 // is the newest, then ambex-2.json, etc., so ambex-$numsnaps.json is the oldest.
 // Every time we write a new one, we rename all the older ones, ditching the oldest
 // after we've written numsnaps snapshots.
-func csDump(ctx context.Context, snapdirPath string, numsnaps int, generation int, v2snap *ecp_v2_cache.Snapshot, v3snap *ecp_v3_cache.Snapshot) {
+func dumpSnapshot(ctx context.Context, snapdirPath string, numsnaps int, generation int, v2snap *ecp_v2_cache.Snapshot, v3snap *ecp_v3_cache.Snapshot) {
 	if numsnaps <= 0 {
 		// Don't do snapshotting at all.
 		return
@@ -211,16 +211,16 @@ func csDump(ctx context.Context, snapdirPath string, numsnaps int, generation in
 	bs, err := json.Marshal(ms)
 
 	if err != nil {
-		dlog.Errorf(ctx, "CSNAP: marshal failure: %s", err)
+		dlog.Errorf(ctx, "csDump: marshal failure: %s", err)
 		return
 	}
 
-	csPath := path.Join(snapdirPath, "ambex-0.json")
+	snapPath := path.Join(snapdirPath, "ambex-0.json")
 
-	err = ioutil.WriteFile(csPath, bs, 0644)
+	err = ioutil.WriteFile(snapPath, bs, 0644)
 
 	if err != nil {
-		dlog.Errorf(ctx, "CSNAP: write failure: %s", err)
+		dlog.Errorf(ctx, "csDump: write failure: %s", err)
 	} else {
 		dlog.Infof(ctx, "Saved snapshot %s", version)
 	}
@@ -236,7 +236,7 @@ func csDump(ctx context.Context, snapdirPath string, numsnaps int, generation in
 		err := os.Rename(fromPath, toPath)
 
 		if (err != nil) && !os.IsNotExist(err) {
-			dlog.Infof(ctx, "CSNAP: could not rename %s -> %s: %#v", fromPath, toPath, err)
+			dlog.Infof(ctx, "csDump: could not rename %s -> %s: %#v", fromPath, toPath, err)
 		}
 	}
 }

--- a/python/ambassador/envoy/v2/v2bootstrap.py
+++ b/python/ambassador/envoy/v2/v2bootstrap.py
@@ -72,18 +72,15 @@ class V2Bootstrap(dict):
             "http2_protocol_options": {},
             "lb_policy": "ROUND_ROBIN",
             "load_assignment": {
-                "cluster_name": "cluster_127_0_0_1_8003",
+                "cluster_name": "cluster_xds_cluster",
                 "endpoints": [
                     {
                         "lb_endpoints": [
                             {
                                 "endpoint": {
                                     "address": {
-                                        "socket_address": {
-                                            # this should be kept in-sync with entrypoint.sh `ambex --ads-listen-address=...`
-                                            "address": "127.0.0.1",
-                                            "port_value": 8003,
-                                            "protocol": "TCP"
+                                        "pipe": {
+                                            "path": "/tmp/ambex.sock"
                                         }
                                     }
                                 }

--- a/python/ambassador/envoy/v2/v2cluster.py
+++ b/python/ambassador/envoy/v2/v2cluster.py
@@ -157,7 +157,7 @@ class V2Cluster(Cacheable):
                     'common_tls_context': {}
                 }
             else:
-                envoy_ctx = V2TLSContext(ctx=ctx, host_rewrite=cluster.get('host_rewrite', None), isUpstreamContext=True)
+                envoy_ctx = V2TLSContext(ctx=ctx, host_rewrite=cluster.get('host_rewrite', None))
 
             if envoy_ctx:
                 fields['transport_socket'] = {

--- a/python/ambassador/envoy/v2/v2cluster.py
+++ b/python/ambassador/envoy/v2/v2cluster.py
@@ -157,7 +157,7 @@ class V2Cluster(Cacheable):
                     'common_tls_context': {}
                 }
             else:
-                envoy_ctx = V2TLSContext(ctx=ctx, host_rewrite=cluster.get('host_rewrite', None))
+                envoy_ctx = V2TLSContext(ctx=ctx, host_rewrite=cluster.get('host_rewrite', None), isUpstreamContext=True)
 
             if envoy_ctx:
                 fields['transport_socket'] = {

--- a/python/ambassador/envoy/v2/v2config.py
+++ b/python/ambassador/envoy/v2/v2config.py
@@ -87,8 +87,8 @@ class V2Config (EnvoyConfig):
             '@type': '/envoy.config.bootstrap.v2.Bootstrap',
             'static_resources': self.static_resources,
             'node': {
-                "cluster": "ambassador-default",
-                "id": "test-id"
+                "cluster": self.ir.ambassador_nodename,
+                "id": 'test-id'
             },
             'layered_runtime': {
                 'layers': [

--- a/python/ambassador/envoy/v2/v2config.py
+++ b/python/ambassador/envoy/v2/v2config.py
@@ -86,6 +86,10 @@ class V2Config (EnvoyConfig):
         ads_config = {
             '@type': '/envoy.config.bootstrap.v2.Bootstrap',
             'static_resources': self.static_resources,
+            'node': {
+                "cluster": "ambassador-default",
+                "id": "test-id"
+            },
             'layered_runtime': {
                 'layers': [
                     {

--- a/python/ambassador/envoy/v2/v2tls.py
+++ b/python/ambassador/envoy/v2/v2tls.py
@@ -163,7 +163,6 @@ class V2TLSContext(Dict):
 
                 cert_list.append(src)
 
-            # Alice TODO perhaps here is a good place to concatenate the cacert_chain_file and crl_file
             validation_secret = ctx['secret_info'].get('cacert_chain_file') or None
 
             if validation_secret:

--- a/python/ambassador/envoy/v2/v2tls.py
+++ b/python/ambassador/envoy/v2/v2tls.py
@@ -70,24 +70,6 @@ class V2TLSContext(Dict):
 
         return params
 
-    # def get_certs(self) -> ListOfCerts:
-    #    common = self.get_common()
-
-    #    # We have to explicitly cast this empty list to a list of strings.
-    #    empty_cert_list: List[str] = []
-    #    cert_list = common.setdefault('tls_certificates', empty_cert_list)
-
-    #    # cert_list is of type EnvoyCommonTLSElements right now, so we need to cast it.
-    #    return typecast(ListOfCerts, cert_list)
-
-    # def update_cert_zero(self, key: str, value: str) -> None:
-    #     certs = self.get_certs()
-
-    #     if not certs:
-    #         certs.append({})
-
-    #     src: EnvoyCoreSource = { 'filename': value }
-    #     certs[0][key] = src
 
     def update_alpn(self, key: str, value: str) -> None:
         common = self.get_common()
@@ -104,16 +86,6 @@ class V2TLSContext(Dict):
 
         params[key] = value
 
-    # def update_validation(self, key: str, value: str) -> None:
-    #    empty_context: EnvoyValidationContext = {}
-
-    #    # This looks weirder than you might expect, because self.get_common().setdefault() is a truly
-    #    # crazy Union type, so we need to cast it to an EnvoyValidationContext to be able to work
-    #    # with it.
-    #    validation = typecast(EnvoyValidationContext, self.get_common().setdefault('validation_context', empty_context))
-
-    #    src: EnvoyCoreSource = { 'filename': value }
-    #    validation[key] = src
 
     def add_context(self, ctx: IRTLSContext) -> None:
         if TYPE_CHECKING:

--- a/python/ambassador/envoy/v2/v2tls.py
+++ b/python/ambassador/envoy/v2/v2tls.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 
-from typing import Callable, Dict, List, Optional, Union, TYPE_CHECKING
+from typing import Any, Callable, Dict, List, Optional, Union, TYPE_CHECKING
 from typing import cast as typecast
 
 import os
@@ -24,7 +24,7 @@ from ...ir.irtlscontext import IRTLSContext
 # XXX It's also a sure sign that this crap needs to be a proper class
 # structure instead of nested dicts of dicts of unions of dicts of .... :P
 
-EnvoyCoreSource = Dict[str, str]
+EnvoyCoreSource = Dict[str, Union[str, Dict[str, Any]]]
 
 EnvoyTLSCert = Dict[str, EnvoyCoreSource]
 ListOfCerts = List[EnvoyTLSCert]
@@ -34,7 +34,7 @@ EnvoyValidationContext = Dict[str, EnvoyValidationElements]
 
 EnvoyTLSParams = Dict[str, Union[str, List[str]]]
 
-EnvoyCommonTLSElements = Union[List[str], ListOfCerts, EnvoyValidationContext, EnvoyTLSParams]
+EnvoyCommonTLSElements = Union[List[str], List[EnvoyCoreSource], ListOfCerts, EnvoyValidationContext, EnvoyTLSParams]
 EnvoyCommonTLSContext = Dict[str, EnvoyCommonTLSElements]
 
 ElementHandler = Callable[[str, str], None]
@@ -48,7 +48,7 @@ class V2TLSContext(Dict):
         "v1.3": "TLSv1_3",
     }
 
-    def __init__(self, ctx: Optional[IRTLSContext]=None, host_rewrite: Optional[str]=None) -> None:
+    def __init__(self, ctx: Optional[IRTLSContext]=None, host_rewrite: Optional[str]=None, isUpstreamContext: Optional[bool]=False) -> None:
         del host_rewrite    # quiesce warning
 
         super().__init__()
@@ -56,7 +56,7 @@ class V2TLSContext(Dict):
         self.is_fallback = False
 
         if ctx:
-            self.add_context(ctx)
+            self.add_context(ctx, isUpstreamContext)
 
     def get_common(self) -> EnvoyCommonTLSContext:
         return self.setdefault('common_tls_context', {})
@@ -70,15 +70,15 @@ class V2TLSContext(Dict):
 
         return params
 
-    def get_certs(self) -> ListOfCerts:
-        common = self.get_common()
+    # def get_certs(self) -> ListOfCerts:
+    #    common = self.get_common()
 
-        # We have to explicitly cast this empty list to a list of strings.
-        empty_cert_list: List[str] = []
-        cert_list = common.setdefault('tls_certificates', empty_cert_list)
+    #    # We have to explicitly cast this empty list to a list of strings.
+    #    empty_cert_list: List[str] = []
+    #    cert_list = common.setdefault('tls_certificates', empty_cert_list)
 
-        # cert_list is of type EnvoyCommonTLSElements right now, so we need to cast it.
-        return typecast(ListOfCerts, cert_list)
+    #    # cert_list is of type EnvoyCommonTLSElements right now, so we need to cast it.
+    #    return typecast(ListOfCerts, cert_list)
 
     def update_cert_zero(self, key: str, value: str) -> None:
         certs = self.get_certs()
@@ -104,18 +104,18 @@ class V2TLSContext(Dict):
 
         params[key] = value
 
-    def update_validation(self, key: str, value: str) -> None:
-        empty_context: EnvoyValidationContext = {}
+    # def update_validation(self, key: str, value: str) -> None:
+    #    empty_context: EnvoyValidationContext = {}
 
-        # This looks weirder than you might expect, because self.get_common().setdefault() is a truly
-        # crazy Union type, so we need to cast it to an EnvoyValidationContext to be able to work
-        # with it.
-        validation = typecast(EnvoyValidationContext, self.get_common().setdefault('validation_context', empty_context))
+    #    # This looks weirder than you might expect, because self.get_common().setdefault() is a truly
+    #    # crazy Union type, so we need to cast it to an EnvoyValidationContext to be able to work
+    #    # with it.
+    #    validation = typecast(EnvoyValidationContext, self.get_common().setdefault('validation_context', empty_context))
 
-        src: EnvoyCoreSource = { 'filename': value }
-        validation[key] = src
+    #    src: EnvoyCoreSource = { 'filename': value }
+    #    validation[key] = src
 
-    def add_context(self, ctx: IRTLSContext) -> None:
+    def add_context(self, ctx: IRTLSContext, isUpstreamContext: bool) -> None:
         if TYPE_CHECKING:
             # This is needed because otherwise self.__setitem__ confuses things.
             handler: Callable[[str, str], None] # pragma: no cover
@@ -123,13 +123,86 @@ class V2TLSContext(Dict):
         if ctx.is_fallback:
             self.is_fallback = True
 
-        for secretinfokey, handler, hkey in [
-            ( 'cert_chain_file', self.update_cert_zero, 'certificate_chain' ),
-            ( 'private_key_file', self.update_cert_zero, 'private_key' ),
-            ( 'cacert_chain_file', self.update_validation, 'trusted_ca' ),
-        ]:
-            if secretinfokey in ctx['secret_info']:
-                handler(hkey, ctx['secret_info'][secretinfokey])
+        if ctx['secret_info']:
+            common = self.get_common()
+
+            termination_secret = ctx['secret_info'].get('private_key_file') or None
+
+            if termination_secret:
+                # We have to explicitly cast both this empty list and the empty_cert_list
+                # to a list of EnvoyCoreSource, so that mypy knows which of the massive union
+                # that is EnvoyCommonTLSElements to use.
+                empty_cert_list: List[EnvoyCoreSource] = []
+                cert_list_1 = common.setdefault('tls_certificate_sds_secret_configs', empty_cert_list)
+                cert_list = typecast(List[EnvoyCoreSource], cert_list_1)
+
+                src = {
+                    'name': termination_secret,
+                    'sds_config': {
+                        'resource_api_version': 'V2',
+                        'api_config_source': {
+                            'api_type': 'GRPC',
+                            'transport_api_version': 'V3',
+                            'grpc_services': [
+                                {
+                                    'google_grpc': {
+                                        'target_uri': 'unix:/tmp/ambex.sock',
+                                        'stat_prefix': 'sdscluster'
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                } if isUpstreamContext else {
+                    'name': termination_secret,
+                    'sds_config': {
+                        'resource_api_version': 'V2',
+                        'ads': {}
+                    }
+                }
+
+                cert_list.append(src)
+
+            # Alice TODO perhaps here is a good place to concatenate the cacert_chain_file and crl_file
+            validation_secret = ctx['secret_info'].get('cacert_chain_file') or None
+
+            if validation_secret:
+                src = {
+                    'name': termination_secret,
+                    'sds_config': {
+                        'resource_api_version': 'V2',
+                        'api_config_source': {
+                            'api_type': 'GRPC',
+                            'transport_api_version': 'V3',
+                            'grpc_services': [
+                                {
+                                    'google_grpc': {
+                                        'target_uri': 'unix:/tmp/ambex.sock',
+                                        'stat_prefix': 'sdscluster'
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                } if isUpstreamContext else {
+                    'name': termination_secret,
+                    'sds_config': {
+                        'resource_api_version': 'V2',
+                        'ads': {}
+                    }
+                }
+
+                common['validation_context_sds_secret_config'] = src
+
+        # for secretinfokey, handler, hkey in [
+        #     ( 'cert_chain_file', self.update_cert_zero, 'certificate_chain' ),
+        #     ( 'private_key_file', self.update_cert_zero, 'private_key' ),
+        #     ( 'cacert_chain_file', self.update_validation, 'trusted_ca' ),
+        # ]:
+        #     if secretinfokey in ctx['secret_info']:
+        #         handler(hkey, ctx['secret_info'][secretinfokey])
+
+
 
         for ctxkey, handler, hkey in [
             ( 'alpn_protocols', self.update_alpn, 'alpn_protocols' ),

--- a/python/ambassador/envoy/v2/v2tls.py
+++ b/python/ambassador/envoy/v2/v2tls.py
@@ -56,7 +56,7 @@ class V2TLSContext(Dict):
         self.is_fallback = False
 
         if ctx:
-            self.add_context(ctx, isUpstreamContext)
+            self.add_context(ctx, bool(isUpstreamContext))
 
     def get_common(self) -> EnvoyCommonTLSContext:
         return self.setdefault('common_tls_context', {})
@@ -80,14 +80,14 @@ class V2TLSContext(Dict):
     #    # cert_list is of type EnvoyCommonTLSElements right now, so we need to cast it.
     #    return typecast(ListOfCerts, cert_list)
 
-    def update_cert_zero(self, key: str, value: str) -> None:
-        certs = self.get_certs()
+    # def update_cert_zero(self, key: str, value: str) -> None:
+    #     certs = self.get_certs()
 
-        if not certs:
-            certs.append({})
+    #     if not certs:
+    #         certs.append({})
 
-        src: EnvoyCoreSource = { 'filename': value }
-        certs[0][key] = src
+    #     src: EnvoyCoreSource = { 'filename': value }
+    #     certs[0][key] = src
 
     def update_alpn(self, key: str, value: str) -> None:
         common = self.get_common()

--- a/python/ambassador/envoy/v3/v3bootstrap.py
+++ b/python/ambassador/envoy/v3/v3bootstrap.py
@@ -66,18 +66,15 @@ class V3Bootstrap(dict):
             "http2_protocol_options": {},
             "lb_policy": "ROUND_ROBIN",
             "load_assignment": {
-                "cluster_name": "cluster_127_0_0_1_8003",
+                "cluster_name": "cluster_xds_cluster",
                 "endpoints": [
                     {
                         "lb_endpoints": [
                             {
                                 "endpoint": {
                                     "address": {
-                                        "socket_address": {
-                                            # this should be kept in-sync with entrypoint.sh `ambex --ads-listen-address=...`
-                                            "address": "127.0.0.1",
-                                            "port_value": 8003,
-                                            "protocol": "TCP"
+                                        "pipe": {
+                                            "path": "/tmp/ambex.sock"
                                         }
                                     }
                                 }

--- a/python/ambassador/envoy/v3/v3cluster.py
+++ b/python/ambassador/envoy/v3/v3cluster.py
@@ -159,7 +159,7 @@ class V3Cluster(Cacheable):
                     'common_tls_context': {}
                 }
             else:
-                envoy_ctx = V3TLSContext(ctx=ctx, host_rewrite=cluster.get('host_rewrite', None))
+                envoy_ctx = V3TLSContext(ctx=ctx, host_rewrite=cluster.get('host_rewrite', None), isUpstreamContext=True)
 
             if envoy_ctx:
                 fields['transport_socket'] = {

--- a/python/ambassador/envoy/v3/v3cluster.py
+++ b/python/ambassador/envoy/v3/v3cluster.py
@@ -159,7 +159,7 @@ class V3Cluster(Cacheable):
                     'common_tls_context': {}
                 }
             else:
-                envoy_ctx = V3TLSContext(ctx=ctx, host_rewrite=cluster.get('host_rewrite', None), isUpstreamContext=True)
+                envoy_ctx = V3TLSContext(ctx=ctx, host_rewrite=cluster.get('host_rewrite', None))
 
             if envoy_ctx:
                 fields['transport_socket'] = {

--- a/python/ambassador/envoy/v3/v3config.py
+++ b/python/ambassador/envoy/v3/v3config.py
@@ -87,8 +87,8 @@ class V3Config (EnvoyConfig):
             '@type': '/envoy.config.bootstrap.v3.Bootstrap',
             'static_resources': self.static_resources,
             'node': {
-                "cluster": "ambassador-default",
-                "id": "test-id"
+                "cluster": self.ir.ambassador_nodename,
+                "id": 'test-id'
             },
             'layered_runtime': {
                 'layers': [

--- a/python/ambassador/envoy/v3/v3config.py
+++ b/python/ambassador/envoy/v3/v3config.py
@@ -86,6 +86,10 @@ class V3Config (EnvoyConfig):
         ads_config = {
             '@type': '/envoy.config.bootstrap.v3.Bootstrap',
             'static_resources': self.static_resources,
+            'node': {
+                "cluster": "ambassador-default",
+                "id": "test-id"
+            },
             'layered_runtime': {
                 'layers': [
                     {

--- a/python/ambassador/envoy/v3/v3tls.py
+++ b/python/ambassador/envoy/v3/v3tls.py
@@ -193,6 +193,7 @@ class V3TLSContext(Dict):
 
                 cert_list.append(src)
 
+            # Alice TODO perhaps here is a good place to concatenate the cacert_chain_file and crl_file
             validation_secret = ctx['secret_info'].get('cacert_chain_file') or None
 
             if validation_secret:
@@ -223,18 +224,18 @@ class V3TLSContext(Dict):
 
                 common['validation_context_sds_secret_config'] = src
 
-            crl_secret = ctx['secret_info'].get('crl_file') or None
+            # crl_secret = ctx['secret_info'].get('crl_file') or None
 
-            if crl_secret:
-                src = {
-                    'name': crl_secret,
-                    'sds_config': {
-                        'resource_api_version': 'V3',
-                        'ads': {}
-                    }
-                }
+            # if crl_secret:
+            #    src = {
+            #        'name': crl_secret,
+            #        'sds_config': {
+            #            'resource_api_version': 'V3',
+            #            'ads': {}
+            #        }
+            #    }
 
-                cert_list.append(src)
+            #    cert_list.append(src)
 
         # for secretinfokey, handler, hkey in [
         #     ( 'cert_chain_file', self.update_cert_zero, 'certificate_chain' ),

--- a/python/ambassador/envoy/v3/v3tls.py
+++ b/python/ambassador/envoy/v3/v3tls.py
@@ -48,7 +48,7 @@ class V3TLSContext(Dict):
         "v1.3": "TLSv1_3",
     }
 
-    def __init__(self, ctx: Optional[IRTLSContext]=None, host_rewrite: Optional[str]=None) -> None:
+    def __init__(self, ctx: Optional[IRTLSContext]=None, host_rewrite: Optional[str]=None, isUpstreamContext: Optional[bool]=False) -> None:
         del host_rewrite    # quiesce warning
 
         super().__init__()
@@ -56,7 +56,7 @@ class V3TLSContext(Dict):
         self.is_fallback = False
 
         if ctx:
-            self.add_context(ctx)
+            self.add_context(ctx, isUpstreamContext)
 
     def get_common(self) -> EnvoyCommonTLSContext:
         return self.setdefault('common_tls_context', {})
@@ -145,7 +145,7 @@ class V3TLSContext(Dict):
 
         cert_list.append(src)
 
-    def add_context(self, ctx: IRTLSContext) -> None:
+    def add_context(self, ctx: IRTLSContext, isUpstreamContext: bool) -> None:
         if TYPE_CHECKING:
             # This is needed because otherwise self.__setitem__ confuses things.
             handler: Callable[[str, str], None] # pragma: no cover
@@ -170,6 +170,23 @@ class V3TLSContext(Dict):
                     'name': termination_secret,
                     'sds_config': {
                         'resource_api_version': 'V3',
+                        'api_config_source': {
+                            'api_type': 'GRPC',
+                            'transport_api_version': 'V3',
+                            'grpc_services': [
+                                {
+                                    'google_grpc': {
+                                        'target_uri': 'unix:/tmp/ambex.sock',
+                                        'stat_prefix': 'sdscluster'
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                } if isUpstreamContext else {
+                    'name': termination_secret,
+                    'sds_config': {
+                        'resource_api_version': 'V3',
                         'ads': {}
                     }
                 }
@@ -180,7 +197,24 @@ class V3TLSContext(Dict):
 
             if validation_secret:
                 src = {
-                    'name': validation_secret,
+                    'name': termination_secret,
+                    'sds_config': {
+                        'resource_api_version': 'V3',
+                        'api_config_source': {
+                            'api_type': 'GRPC',
+                            'transport_api_version': 'V3',
+                            'grpc_services': [
+                                {
+                                    'google_grpc': {
+                                        'target_uri': 'unix:/tmp/ambex.sock',
+                                        'stat_prefix': 'sdscluster'
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                } if isUpstreamContext else {
+                    'name': termination_secret,
                     'sds_config': {
                         'resource_api_version': 'V3',
                         'ads': {}

--- a/python/ambassador/envoy/v3/v3tls.py
+++ b/python/ambassador/envoy/v3/v3tls.py
@@ -56,7 +56,7 @@ class V3TLSContext(Dict):
         self.is_fallback = False
 
         if ctx:
-            self.add_context(ctx, isUpstreamContext)
+            self.add_context(ctx, bool(isUpstreamContext))
 
     def get_common(self) -> EnvoyCommonTLSContext:
         return self.setdefault('common_tls_context', {})

--- a/python/ambassador/envoy/v3/v3tls.py
+++ b/python/ambassador/envoy/v3/v3tls.py
@@ -70,30 +70,6 @@ class V3TLSContext(Dict):
 
         return params
 
-    # def get_certs(self) -> ListOfCerts:
-    #     common = self.get_common()
-
-    #     # We have to explicitly cast this empty list to a list of strings.
-    #     empty_cert_list: List[str] = []
-    #     cert_list = common.setdefault('tls_certificates_sds_secret_configs', empty_cert_list)
-
-    #     # cert_list is of type EnvoyCommonTLSElements right now, so we need to cast it.
-    #     return typecast(ListOfCerts, cert_list)
-
-    # def update_cert_zero(self, key: str, value: str) -> None:
-    #     certs = self.get_certs()
-
-    #     if not certs:
-    #         certs.append({})
-
-    #     src: EnvoyCoreSource = {
-    #         'name': value,
-    #         'sds_config': {
-    #             'ads': {}
-    #         }
-    #     }
-
-    #     certs[0][key] = src
 
     def update_alpn(self, key: str, value: str) -> None:
         common = self.get_common()
@@ -110,21 +86,6 @@ class V3TLSContext(Dict):
 
         params[key] = value
 
-    # def update_validation(self, key: str, value: str) -> None:
-    #     empty_context: EnvoyValidationContext = {}
-
-    #     # This looks weirder than you might expect, because self.get_common().setdefault() is a truly
-    #     # crazy Union type, so we need to cast it to an EnvoyValidationContext to be able to work
-    #     # with it.
-    #     validation = typecast(EnvoyValidationContext, self.get_common().setdefault('validation_context_sds_secret_config', empty_context))
-
-    #     src: EnvoyCoreSource = {
-    #         'name': value,
-    #         'sds_config': {
-    #             'ads': {}
-    #         }
-    #     }
-    #     validation[key] = src
 
     def use_cert(self, kind: str, cert_name: str) -> None:
         common = self.get_common()
@@ -222,26 +183,6 @@ class V3TLSContext(Dict):
                 }
                 common['validation_context_sds_secret_config'] = src
 
-            # crl_secret = ctx['secret_info'].get('crl_file') or None
-
-            # if crl_secret:
-            #    src = {
-            #        'name': crl_secret,
-            #        'sds_config': {
-            #            'resource_api_version': 'V3',
-            #            'ads': {}
-            #        }
-            #    }
-
-            #    cert_list.append(src)
-
-        # for secretinfokey, handler, hkey in [
-        #     ( 'cert_chain_file', self.update_cert_zero, 'certificate_chain' ),
-        #     ( 'private_key_file', self.update_cert_zero, 'private_key' ),
-        #     ( 'cacert_chain_file', self.update_validation, 'trusted_ca' ),
-        # ]:
-        #     if secretinfokey in ctx['secret_info']:
-        #         handler(hkey, ctx['secret_info'][secretinfokey])
 
         for ctxkey, handler, hkey in [
             ( 'alpn_protocols', self.update_alpn, 'alpn_protocols' ),

--- a/python/ambassador/envoy/v3/v3tls.py
+++ b/python/ambassador/envoy/v3/v3tls.py
@@ -187,9 +187,21 @@ class V3TLSContext(Dict):
 
                 cert_list.append(src)
 
-            validation_secret = ctx['secret_info'].get('cacert_chain_file') or None
+            validation_secret = None
+            ca_secret = ctx['secret_info'].get('cacert_chain_file') or None
+            crl_secret = ctx['secret_info'].get('crl_file') or None
 
-            if validation_secret:
+            # We have a combined validation context for the crl and the ca
+            if ca_secret is not None and crl_secret is not None:
+                validation_secret = ca_secret+"-"+crl_secret
+            # We have a ca but no crl
+            elif ca_secret is not None and crl_secret is None:
+                validation_secret = ca_secret
+            # we have a crl but no ca
+            elif ca_secret is None and crl_secret is not None:
+                validation_secret = crl_secret
+
+            if validation_secret is not None:
                 src = {
                     'name': validation_secret,
                     'sds_config': {

--- a/python/ambassador/envoy/v3/v3tls.py
+++ b/python/ambassador/envoy/v3/v3tls.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 
-from typing import Callable, Dict, List, Optional, Union, TYPE_CHECKING
+from typing import Any, Callable, Dict, List, Optional, Union, TYPE_CHECKING
 from typing import cast as typecast
 
 import os
@@ -24,7 +24,7 @@ from ...ir.irtlscontext import IRTLSContext
 # XXX It's also a sure sign that this crap needs to be a proper class
 # structure instead of nested dicts of dicts of unions of dicts of .... :P
 
-EnvoyCoreSource = Dict[str, str]
+EnvoyCoreSource = Dict[str, Union[str, Dict[str, Any]]]
 
 EnvoyTLSCert = Dict[str, EnvoyCoreSource]
 ListOfCerts = List[EnvoyTLSCert]
@@ -34,7 +34,7 @@ EnvoyValidationContext = Dict[str, EnvoyValidationElements]
 
 EnvoyTLSParams = Dict[str, Union[str, List[str]]]
 
-EnvoyCommonTLSElements = Union[List[str], ListOfCerts, EnvoyValidationContext, EnvoyTLSParams]
+EnvoyCommonTLSElements = Union[List[str], List[EnvoyCoreSource], ListOfCerts, EnvoyValidationContext, EnvoyTLSParams]
 EnvoyCommonTLSContext = Dict[str, EnvoyCommonTLSElements]
 
 ElementHandler = Callable[[str, str], None]
@@ -70,24 +70,30 @@ class V3TLSContext(Dict):
 
         return params
 
-    def get_certs(self) -> ListOfCerts:
-        common = self.get_common()
+    # def get_certs(self) -> ListOfCerts:
+    #     common = self.get_common()
 
-        # We have to explicitly cast this empty list to a list of strings.
-        empty_cert_list: List[str] = []
-        cert_list = common.setdefault('tls_certificates', empty_cert_list)
+    #     # We have to explicitly cast this empty list to a list of strings.
+    #     empty_cert_list: List[str] = []
+    #     cert_list = common.setdefault('tls_certificates_sds_secret_configs', empty_cert_list)
 
-        # cert_list is of type EnvoyCommonTLSElements right now, so we need to cast it.
-        return typecast(ListOfCerts, cert_list)
+    #     # cert_list is of type EnvoyCommonTLSElements right now, so we need to cast it.
+    #     return typecast(ListOfCerts, cert_list)
 
-    def update_cert_zero(self, key: str, value: str) -> None:
-        certs = self.get_certs()
+    # def update_cert_zero(self, key: str, value: str) -> None:
+    #     certs = self.get_certs()
 
-        if not certs:
-            certs.append({})
+    #     if not certs:
+    #         certs.append({})
 
-        src: EnvoyCoreSource = { 'filename': value }
-        certs[0][key] = src
+    #     src: EnvoyCoreSource = {
+    #         'name': value,
+    #         'sds_config': {
+    #             'ads': {}
+    #         }
+    #     }
+
+    #     certs[0][key] = src
 
     def update_alpn(self, key: str, value: str) -> None:
         common = self.get_common()
@@ -104,16 +110,40 @@ class V3TLSContext(Dict):
 
         params[key] = value
 
-    def update_validation(self, key: str, value: str) -> None:
-        empty_context: EnvoyValidationContext = {}
+    # def update_validation(self, key: str, value: str) -> None:
+    #     empty_context: EnvoyValidationContext = {}
 
-        # This looks weirder than you might expect, because self.get_common().setdefault() is a truly
-        # crazy Union type, so we need to cast it to an EnvoyValidationContext to be able to work
-        # with it.
-        validation = typecast(EnvoyValidationContext, self.get_common().setdefault('validation_context', empty_context))
+    #     # This looks weirder than you might expect, because self.get_common().setdefault() is a truly
+    #     # crazy Union type, so we need to cast it to an EnvoyValidationContext to be able to work
+    #     # with it.
+    #     validation = typecast(EnvoyValidationContext, self.get_common().setdefault('validation_context_sds_secret_config', empty_context))
 
-        src: EnvoyCoreSource = { 'filename': value }
-        validation[key] = src
+    #     src: EnvoyCoreSource = {
+    #         'name': value,
+    #         'sds_config': {
+    #             'ads': {}
+    #         }
+    #     }
+    #     validation[key] = src
+
+    def use_cert(self, kind: str, cert_name: str) -> None:
+        common = self.get_common()
+
+        # We have to explicitly cast both this empty list and the empty_cert_list
+        # to a list of EnvoyCoreSource, so that mypy knows which of the massive union
+        # that is EnvoyCommonTLSElements to use.
+        empty_cert_list: List[EnvoyCoreSource] = []
+        cert_list_1 = common.setdefault('tls_certificate_sds_secret_configs', empty_cert_list)
+        cert_list = typecast(List[EnvoyCoreSource], cert_list_1)
+
+        src: EnvoyCoreSource = {
+            'name': cert_name,
+            'sds_config': {
+                'ads': {}
+            }
+        }
+
+        cert_list.append(src)
 
     def add_context(self, ctx: IRTLSContext) -> None:
         if TYPE_CHECKING:
@@ -123,14 +153,62 @@ class V3TLSContext(Dict):
         if ctx.is_fallback:
             self.is_fallback = True
 
-        for secretinfokey, handler, hkey in [
-            ( 'cert_chain_file', self.update_cert_zero, 'certificate_chain' ),
-            ( 'private_key_file', self.update_cert_zero, 'private_key' ),
-            ( 'cacert_chain_file', self.update_validation, 'trusted_ca' ),
-            ( 'crl_file', self.update_validation, 'crl' ),
-        ]:
-            if secretinfokey in ctx['secret_info']:
-                handler(hkey, ctx['secret_info'][secretinfokey])
+        if ctx['secret_info']:
+            common = self.get_common()
+
+            termination_secret = ctx['secret_info'].get('private_key_file') or None
+
+            if termination_secret:
+                # We have to explicitly cast both this empty list and the empty_cert_list
+                # to a list of EnvoyCoreSource, so that mypy knows which of the massive union
+                # that is EnvoyCommonTLSElements to use.
+                empty_cert_list: List[EnvoyCoreSource] = []
+                cert_list_1 = common.setdefault('tls_certificate_sds_secret_configs', empty_cert_list)
+                cert_list = typecast(List[EnvoyCoreSource], cert_list_1)
+
+                src = {
+                    'name': termination_secret,
+                    'sds_config': {
+                        'resource_api_version': 'V3',
+                        'ads': {}
+                    }
+                }
+
+                cert_list.append(src)
+
+            validation_secret = ctx['secret_info'].get('cacert_chain_file') or None
+
+            if validation_secret:
+                src = {
+                    'name': validation_secret,
+                    'sds_config': {
+                        'resource_api_version': 'V3',
+                        'ads': {}
+                    }
+                }
+
+                common['validation_context_sds_secret_config'] = src
+
+            crl_secret = ctx['secret_info'].get('crl_file') or None
+
+            if crl_secret:
+                src = {
+                    'name': crl_secret,
+                    'sds_config': {
+                        'resource_api_version': 'V3',
+                        'ads': {}
+                    }
+                }
+
+                cert_list.append(src)
+
+        # for secretinfokey, handler, hkey in [
+        #     ( 'cert_chain_file', self.update_cert_zero, 'certificate_chain' ),
+        #     ( 'private_key_file', self.update_cert_zero, 'private_key' ),
+        #     ( 'cacert_chain_file', self.update_validation, 'trusted_ca' ),
+        # ]:
+        #     if secretinfokey in ctx['secret_info']:
+        #         handler(hkey, ctx['secret_info'][secretinfokey])
 
         for ctxkey, handler, hkey in [
             ( 'alpn_protocols', self.update_alpn, 'alpn_protocols' ),

--- a/python/ambassador/ir/ir.py
+++ b/python/ambassador/ir/ir.py
@@ -736,7 +736,7 @@ class IR:
                 secret_name = secret_info.name
                 secret_namespace = secret_info.namespace
 
-                full_name = f"secret/{secret_namespace}/{secret_name}"
+                full_name = f"secret/{secret_name}.{secret_namespace}"
                 self.logger.debug('saving "%s" (from %s) in secret_info', full_name, secret_key)
                 self.secret_info[full_name] = secret_info
             else:
@@ -780,7 +780,7 @@ class IR:
 
     def resolve_secret(self, resource: IRResource, secret_name: str, namespace: str):
         # OK. Do we already have a SavedSecret for this?
-        ss_key = f'secret/{namespace}/{secret_name}'
+        ss_key = f'secret/{secret_name}.{namespace}'
 
         ss = self.saved_secrets.get(ss_key, None)
 

--- a/python/ambassador/ir/ir.py
+++ b/python/ambassador/ir/ir.py
@@ -736,9 +736,8 @@ class IR:
                 secret_name = secret_info.name
                 secret_namespace = secret_info.namespace
 
-                full_name = f"secret/{secret_name}.{secret_namespace}"
-                self.logger.debug('saving "%s" (from %s) in secret_info', full_name, secret_key)
-                self.secret_info[full_name] = secret_info
+                self.logger.debug('saving "%s.%s" (from %s) in secret_info', secret_name, secret_namespace, secret_key)
+                self.secret_info[f'{secret_name}.{secret_namespace}'] = secret_info
             else:
                 self.logger.debug('not saving secret_info from %s because there is no public half', secret_key)
 
@@ -780,7 +779,7 @@ class IR:
 
     def resolve_secret(self, resource: IRResource, secret_name: str, namespace: str):
         # OK. Do we already have a SavedSecret for this?
-        ss_key = f'secret/{secret_name}.{namespace}'
+        ss_key = f'{secret_name}.{namespace}'
 
         ss = self.saved_secrets.get(ss_key, None)
 

--- a/python/ambassador/ir/ir.py
+++ b/python/ambassador/ir/ir.py
@@ -736,10 +736,13 @@ class IR:
                 secret_name = secret_info.name
                 secret_namespace = secret_info.namespace
 
-                self.logger.debug('saving "%s.%s" (from %s) in secret_info', secret_name, secret_namespace, secret_key)
-                self.secret_info[f'{secret_name}.{secret_namespace}'] = secret_info
+                full_name = f"secret/{secret_namespace}/{secret_name}"
+                self.logger.debug('saving "%s" (from %s) in secret_info', full_name, secret_key)
+                self.secret_info[full_name] = secret_info
             else:
                 self.logger.debug('not saving secret_info from %s because there is no public half', secret_key)
+
+        self.logger.debug(f"IR: secret_info secrets:\n%s", "\n  ".join(self.secret_info.keys()))
 
     def save_tls_context(self, ctx: IRTLSContext) -> None:
         extant_ctx = self.tls_contexts.get(ctx.name, None)
@@ -777,7 +780,7 @@ class IR:
 
     def resolve_secret(self, resource: IRResource, secret_name: str, namespace: str):
         # OK. Do we already have a SavedSecret for this?
-        ss_key = f'{secret_name}.{namespace}'
+        ss_key = f'secret/{namespace}/{secret_name}'
 
         ss = self.saved_secrets.get(ss_key, None)
 
@@ -812,6 +815,7 @@ class IR:
 
             # Save this for next time.
             self.saved_secrets[secret_name] = ss
+
         return ss
 
     def resolve_resolver(self, cluster: IRCluster, resolver_name: Optional[str]) -> IRServiceResolver:

--- a/python/ambassador/ir/irtlscontext.py
+++ b/python/ambassador/ir/irtlscontext.py
@@ -301,15 +301,6 @@ class IRTLSContext(IRResource):
                     self.post_error("TLSContext %s is missing %s" % (self.name, key))
                     errors += 1
 
-            # if path:
-            #     fc = getattr(self.ir, 'file_checker')
-            #     if not fc(path):
-            #         self.post_error("TLSContext %s found no %s '%s'" % (self.name, key, path))
-            #         errors += 1
-            # elif key != 'cacert_chain_file' and self.get('hosts', None):
-            #     self.post_error("TLSContext %s is missing %s" % (self.name, key))
-            #     errors += 1
-
         if errors > 0:
             return False
 

--- a/python/ambassador/ir/irtlscontext.py
+++ b/python/ambassador/ir/irtlscontext.py
@@ -252,7 +252,7 @@ class IRTLSContext(IRResource):
             # They gave a secret name for the validation cert. Try loading it.
             ss = self.resolve_secret(ca_secret_name)
 
-            self.ir.logger.debug("resolve_secrets: IR returned secret %s as %s" % (ca_secret_name, ss))
+            self.ir.logger.debug("resolve_secrets: IR returned CA secret %s as %s" % (ca_secret_name, ss))
 
             if not ss:
                 # This is definitively an error: they mentioned a secret, it can't be loaded,
@@ -295,14 +295,20 @@ class IRTLSContext(IRResource):
         for key in [ 'cert_chain_file', 'private_key_file', 'cacert_chain_file', 'crl_file' ]:
             path = self.secret_info.get(key, None)
 
-            if path:
-                fc = getattr(self.ir, 'file_checker')
-                if not fc(path):
-                    self.post_error("TLSContext %s found no %s '%s'" % (self.name, key, path))
+            if not path:
+                # Whut.
+                if (not(key == 'cacert_chain_file' or key == 'crl_file')) and self.get('hosts', None):
+                    self.post_error("TLSContext %s is missing %s" % (self.name, key))
                     errors += 1
-            elif (not(key == 'cacert_chain_file' or key == 'crl_file')) and self.get('hosts', None):
-                self.post_error("TLSContext %s is missing %s" % (self.name, key))
-                errors += 1
+
+            # if path:
+            #     fc = getattr(self.ir, 'file_checker')
+            #     if not fc(path):
+            #         self.post_error("TLSContext %s found no %s '%s'" % (self.name, key, path))
+            #         errors += 1
+            # elif key != 'cacert_chain_file' and self.get('hosts', None):
+            #     self.post_error("TLSContext %s is missing %s" % (self.name, key))
+            #     errors += 1
 
         if errors > 0:
             return False

--- a/python/ambassador/utils.py
+++ b/python/ambassador/utils.py
@@ -832,7 +832,7 @@ class SecretHandler:
         h = hashlib.new('sha1')
 
         # XXX SDS
-        full_name = f'secret/{name}.{namespace}'
+        full_name = f'{name}.{namespace}'
         return SavedSecret(name, namespace, full_name, full_name, full_name, full_name, { "full_name": full_name })
 
 

--- a/python/ambassador/utils.py
+++ b/python/ambassador/utils.py
@@ -831,57 +831,10 @@ class SecretHandler:
                        user_key: Optional[str], root_crt: Optional[str]) -> SavedSecret:
         h = hashlib.new('sha1')
 
-        # tls_crt_path = None
-        # tls_key_path = None
-        # user_key_path = None
-        # root_crt_path = None
-        # cert_data = None
-
         # XXX SDS
         full_name = f'secret/{name}.{namespace}'
         return SavedSecret(name, namespace, full_name, full_name, full_name, full_name, { "full_name": full_name })
 
-        # # Don't save if it has neither a tls_crt or a user_key or the root_crt
-        # if tls_crt or user_key or root_crt:
-        #     for el in [tls_crt, tls_key, user_key]:
-        #         if el:
-        #             h.update(el.encode('utf-8'))
-
-        #     hd = h.hexdigest().upper()
-
-        #     secret_dir = os.path.join(self.cache_dir, namespace, "secrets-decoded", name)
-
-        #     try:
-        #         os.makedirs(secret_dir)
-        #     except FileExistsError:
-        #         pass
-
-        #     if tls_crt:
-        #         tls_crt_path = os.path.join(secret_dir, f'{hd}.crt')
-        #         open(tls_crt_path, "w").write(tls_crt)
-
-        #     if tls_key:
-        #         tls_key_path = os.path.join(secret_dir, f'{hd}.key')
-        #         open(tls_key_path, "w").write(tls_key)
-
-        #     if user_key:
-        #         user_key_path = os.path.join(secret_dir, f'{hd}.user')
-        #         open(user_key_path, "w").write(user_key)
-
-        #     if root_crt:
-        #         root_crt_path = os.path.join(secret_dir, f'{hd}.root.crt')
-        #         open(root_crt_path, "w").write(root_crt)
-
-        #     cert_data = {
-        #         'tls_crt': tls_crt,
-        #         'tls_key': tls_key,
-        #         'user_key': user_key,
-        #         'root_crt': root_crt,
-        #     }
-
-        #     self.logger.debug(f"saved secret {name}.{namespace}: {tls_crt_path}, {tls_key_path}, {root_crt_path}")
-
-        # return SavedSecret(name, namespace, tls_crt_path, tls_key_path, user_key_path, root_crt_path, cert_data)
 
     def secret_info_from_k8s(self, resource: 'IRResource',
                              secret_name: str, namespace: str, source: str,

--- a/python/ambassador/utils.py
+++ b/python/ambassador/utils.py
@@ -831,53 +831,57 @@ class SecretHandler:
                        user_key: Optional[str], root_crt: Optional[str]) -> SavedSecret:
         h = hashlib.new('sha1')
 
-        tls_crt_path = None
-        tls_key_path = None
-        user_key_path = None
-        root_crt_path = None
-        cert_data = None
+        # tls_crt_path = None
+        # tls_key_path = None
+        # user_key_path = None
+        # root_crt_path = None
+        # cert_data = None
 
-        # Don't save if it has neither a tls_crt or a user_key or the root_crt
-        if tls_crt or user_key or root_crt:
-            for el in [tls_crt, tls_key, user_key]:
-                if el:
-                    h.update(el.encode('utf-8'))
+        # XXX SDS
+        full_name = f'secret/{namespace}/{name}'
+        return SavedSecret(name, namespace, full_name, full_name, full_name, full_name, { "full_name": full_name })
 
-            hd = h.hexdigest().upper()
+        # # Don't save if it has neither a tls_crt or a user_key or the root_crt
+        # if tls_crt or user_key or root_crt:
+        #     for el in [tls_crt, tls_key, user_key]:
+        #         if el:
+        #             h.update(el.encode('utf-8'))
 
-            secret_dir = os.path.join(self.cache_dir, namespace, "secrets-decoded", name)
+        #     hd = h.hexdigest().upper()
 
-            try:
-                os.makedirs(secret_dir)
-            except FileExistsError:
-                pass
+        #     secret_dir = os.path.join(self.cache_dir, namespace, "secrets-decoded", name)
 
-            if tls_crt:
-                tls_crt_path = os.path.join(secret_dir, f'{hd}.crt')
-                open(tls_crt_path, "w").write(tls_crt)
+        #     try:
+        #         os.makedirs(secret_dir)
+        #     except FileExistsError:
+        #         pass
 
-            if tls_key:
-                tls_key_path = os.path.join(secret_dir, f'{hd}.key')
-                open(tls_key_path, "w").write(tls_key)
+        #     if tls_crt:
+        #         tls_crt_path = os.path.join(secret_dir, f'{hd}.crt')
+        #         open(tls_crt_path, "w").write(tls_crt)
 
-            if user_key:
-                user_key_path = os.path.join(secret_dir, f'{hd}.user')
-                open(user_key_path, "w").write(user_key)
+        #     if tls_key:
+        #         tls_key_path = os.path.join(secret_dir, f'{hd}.key')
+        #         open(tls_key_path, "w").write(tls_key)
 
-            if root_crt:
-                root_crt_path = os.path.join(secret_dir, f'{hd}.root.crt')
-                open(root_crt_path, "w").write(root_crt)
+        #     if user_key:
+        #         user_key_path = os.path.join(secret_dir, f'{hd}.user')
+        #         open(user_key_path, "w").write(user_key)
 
-            cert_data = {
-                'tls_crt': tls_crt,
-                'tls_key': tls_key,
-                'user_key': user_key,
-                'root_crt': root_crt,
-            }
+        #     if root_crt:
+        #         root_crt_path = os.path.join(secret_dir, f'{hd}.root.crt')
+        #         open(root_crt_path, "w").write(root_crt)
 
-            self.logger.debug(f"saved secret {name}.{namespace}: {tls_crt_path}, {tls_key_path}, {root_crt_path}")
+        #     cert_data = {
+        #         'tls_crt': tls_crt,
+        #         'tls_key': tls_key,
+        #         'user_key': user_key,
+        #         'root_crt': root_crt,
+        #     }
 
-        return SavedSecret(name, namespace, tls_crt_path, tls_key_path, user_key_path, root_crt_path, cert_data)
+        #     self.logger.debug(f"saved secret {name}.{namespace}: {tls_crt_path}, {tls_key_path}, {root_crt_path}")
+
+        # return SavedSecret(name, namespace, tls_crt_path, tls_key_path, user_key_path, root_crt_path, cert_data)
 
     def secret_info_from_k8s(self, resource: 'IRResource',
                              secret_name: str, namespace: str, source: str,

--- a/python/ambassador/utils.py
+++ b/python/ambassador/utils.py
@@ -838,7 +838,7 @@ class SecretHandler:
         # cert_data = None
 
         # XXX SDS
-        full_name = f'secret/{namespace}/{name}'
+        full_name = f'secret/{name}.{namespace}'
         return SavedSecret(name, namespace, full_name, full_name, full_name, full_name, { "full_name": full_name })
 
         # # Don't save if it has neither a tls_crt or a user_key or the root_crt

--- a/python/entrypoint.sh
+++ b/python/entrypoint.sh
@@ -19,7 +19,12 @@
 # is currently used only for test_scout.py.  This is a BRUTAL HACK.
 
 if [ "$1" != "--dev-magic" ]; then
-  exec busyambassador entrypoint "$@"   # See comment above.
+  echo "Running entrypoint"
+  if [ -n "$AMBASSADOR_LOGFILE" ]; then
+    exec busyambassador entrypoint "$@" >/tmp/access.log 2>/tmp/entry.log  # See comment above.
+  else
+    exec busyambassador entrypoint "$@"  # See comment above
+  fi
 fi
 
 DEVMAGIC=yes


### PR DESCRIPTION
Fix 503s on secret rotation by switching to SDS, rather than reconfiguring clusters every time. Additionally, clean up the `ambex` snapshot-dumping code so that it properly deals with typed structures in the Envoy configuration.

Things that need tackling before we ship:
- Comments, comments, some more comments, and then finally some comments.
- Restore fingerprinting of secrets, so that we can log "hey, we're now using a secret with this fingerprint" and have it be meaningful.
- Nice-to-have: log ambex snapshots using the actual snapshot version number so that it's trivial to match up a log message with a snapshot on disk.
- Nice-to-have: do that for the watt snapshots too.

I tested this by running ~10RPS through a `Mapping` using TLS origination, and then rotating the secret it's using every five seconds. _Zero_ 503s in a forty-minute test run, which is good, and the ambex logs show the secret being handed over SDS changing. I want to modify the upstream to show the fingerprint of the offered cert, though, for paranoia.

 - [x] I made sure to update `CHANGELOG.md`.
 - [x] This is unlikely to impact how Ambassador performs at scale; in fact, it may well improve performance at scale.
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
