### PR TITLE
.github: Fix the repatriation logic to deal with merged/closed PRs

### DIFF
--- a/.github/workflows/repatriate.yml
+++ b/.github/workflows/repatriate.yml
@@ -49,14 +49,15 @@ jobs:
             git push --set-upstream origin "$merge_branch"
           fi
 
-          if url=$(gh pr view --json=url --jq=.url); then
+          url=$(gh pr list --limit=1 --head="$merge_branch" --state=open --json=url --jq='.[0].url')
+          if [[ -n "$url" ]]; then
             echo "::set-output name=verb::Updated"
           else
             gh pr create \
               --title="[${next_ver}] Repatriate from ${this_ver}" \
               --body="This PR merges ${this_branch} in to ${next_branch}." \
               --base="$next_branch"
-            url=$(gh pr view --json=url --jq=.url)
+            url=$(gh pr list --limit=1 --head="$merge_branch" --state=open --json=url --jq='.[0].url')
             echo "::set-output name=verb::Created"
           fi
           echo "::set-output name=pr_url::${url}"


### PR DESCRIPTION
## Description

If there's an old PR that's already been merged, that means we should be creating a new one, rather than assuming that pushing to the branch will update the old one.

As seen on https://github.com/emissary-ingress/emissary/runs/6523998225

## Testing

I used `gh` on the CLI to try out these commands interactively. But I noticed some minor differences in `gh pr view` than what we see in CI, so apparently versions are different; so who knows if this will actually work in CI?

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `CHANGELOG.md`. - no applicable changes

   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations

 - [x] This is unlikely to impact how Ambassador performs at scale.

   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability

 - [ ] My change is adequately tested.

   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points

 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently. - no tricks

 - [ ] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
