### PR TITLE
Pin to glibc 2.34, and fix make deploy on MacOS

### DIFF
--- a/build-aux/main.mk
+++ b/build-aux/main.mk
@@ -150,7 +150,7 @@ boguschart_dir = build-output/chart-2.0.0-bogus_7.0.0-bogus.d
 boguschart_tgz = $(patsubst %.d,%.tgz,$(boguschart_dir))
 
 # YAML manifests
-build-output/yaml-%: $(shell find $(CURDIR)/manifests/emissary/ -type d -o -name '*.yaml.in') $(var.)DEV_REGISTRY $(var.)RELEASE_REGISTRY
+build-output/yaml-%: $(shell find $(CURDIR)/manifests/emissary -type d -o -name '*.yaml.in') $(var.)DEV_REGISTRY $(var.)RELEASE_REGISTRY
 ifeq ($(CI),)
 	rm -rf $@
 else

--- a/docker/base-python/Dockerfile
+++ b/docker/base-python/Dockerfile
@@ -18,7 +18,7 @@
 # Third-party code
 ########################################
 
-FROM docker.io/frolvlad/alpine-glibc:alpine-3.15
+FROM docker.io/frolvlad/alpine-glibc:alpine-3.15_glibc-2.34
 
 WORKDIR /buildroot
 


### PR DESCRIPTION
We'd been using `frolvlad/alpine-glibc:alpine-3.15` as our base image for things, but that turns out to be a bad idea: that tag gets updated, every so often, with new versions of glibc -- and when it just got updated to glibc 2.35, that broke things for us(*). Instead, pin to `alpine-3.15_glibc-2.34`, which should be more stable.

And, also, ditch the trailing `/` in a `find` that was screwing up `make deploy` on MacOS. C'mon, MacOS – directory names do _not_ have trailing `/` characters really, and you should never output them. 🙄 

(*) Specifically:

"Normal" Alpine uses musl libc, but the `alpine-glibc` images include glibc _in addition to_ musl: the musl libraries are still included. If you dynamically link using musl, you end up with an ELF shared object that uses `/lib/ld-musl-x86_64.so.1` for the runtime link editor; if you dynamically link using glibc, the runtime link editor will be `/lib/ld-linux-x86-64.so.2`. If you try to use `ld-musl-x86_64` for a glibc program, everything falls apart, you find unresolved symbols, and your binary won't run.

Unfortunately, glibc 2.35 symlinks `ld-linux-x86-64` to `ld-musl-x86_64` and bzzt, no dynamic glibc code is gonna work like that. Notably for our purposes, Envoy is a dynamically-linked glibc binary, so... 2.35 is out. (Yes, we could fix the symlink after installing 2.35, but... let's not.)

 - [x] I don't need to update `CHANGELOG.md`; this isn't user-visible.
 - [x] This is unlikely to impact how Ambassador performs at scale.
 - [ ] My change is adequately tested.
 - [x] I didn't need to update `DEVELOPING.md`.
 - [x] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
