### PR TITLE
[v3.0] add downstream support for HTTP/3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,10 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
   `grpc_stats.services` or `grpc_stats.all_methods` would result in crashing. Now it behaves as if
   `grpc_stats.all_methods=false`.
 
+- Feature: With the ugprade to Envoy 1.22, Emissary-ingress can now be configured to listen for
+  HTTP/3 connections using QUIC and the UDP network protocol. It currently only supports for
+  connections between downstream clients and Emissary-ingress.
+
 ## [2.3.1] June 09, 2022
 [2.3.1]: https://github.com/emissary-ingress/emissary/compare/v2.3.0...v2.3.1
 

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -119,6 +119,12 @@ items:
           Previously setting <code>grpc_stats</code> in the <code>ambassador</code> <code>Module</code>
           without setting either <code>grpc_stats.services</code> or <code>grpc_stats.all_methods</code>
           would result in crashing. Now it behaves as if <code>grpc_stats.all_methods=false</code>.
+      - title: Downstream HTTP/3 support
+        type: feature
+        body: >-
+          With the ugprade to Envoy 1.22, $productName$ can now be configured to listen for HTTP/3
+          connections using QUIC and the UDP network protocol. It currently only supports for connections
+          between downstream clients and $productName$.
   - version: 2.3.1
     date: '2022-06-09'
     notes:

--- a/pkg/ambex/main.go
+++ b/pkg/ambex/main.go
@@ -96,6 +96,7 @@ import (
 	_ "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/extensions/filters/http/router/v3"
 	_ "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/extensions/filters/network/http_connection_manager/v3"
 	_ "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/extensions/filters/network/tcp_proxy/v3"
+	_ "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/extensions/transport_sockets/quic/v3"
 	v3cluster "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/service/cluster/v3"
 	v3discovery "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/service/discovery/v3"
 	v3endpoint "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/service/endpoint/v3"

--- a/python/ambassador/envoy/v3/v3listener.py
+++ b/python/ambassador/envoy/v3/v3listener.py
@@ -124,11 +124,13 @@ class V3Listener(dict):
         super().__init__()
 
         self.config = config
+        self.http3_enabled = irlistener.http3_enabled
+        self.socket_protocol = irlistener.socket_protocol
         self.bind_address = irlistener.bind_address
         self.port = irlistener.port
-        self.bind_to = f"{self.bind_address}-{self.port}"
+        self.bind_to = irlistener.bind_to()
 
-        bindstr = f"-{self.bind_address}" if (self.bind_address != "0.0.0.0") else ""
+        bindstr = f"-{irlistener.socket_protocol.lower()}-{self.bind_address}" if (self.bind_address != "0.0.0.0") else ""
         self.name = irlistener.name or f"ambassador-listener{bindstr}-{self.port}"
 
         self.use_proxy_proto = False
@@ -177,9 +179,13 @@ class V3Listener(dict):
                 # listener is OK with TLS-y things like a termination context, SNI,
                 # etc.
                 self._tls_ok = True
-                self.listener_filters.append({
-                    'name': 'envoy.filters.listener.tls_inspector'
-                })
+
+                ## When UDP we assume it is http/3 listener and configured for quic which has TLS built into the protocol
+                ## therefore, we only need to add this when socket_protocol is TCP
+                if self.isProtocolTCP():
+                    self.listener_filters.append({
+                        'name': 'envoy.filters.listener.tls_inspector'
+                    })
 
             if proto == "TCP":
                 # TCP doesn't require any specific listener filters, but it
@@ -193,7 +199,6 @@ class V3Listener(dict):
                     # ...and make sure the group in question wants the same bind
                     # address that we do.
                     if irgroup.bind_to() != self.bind_to:
-                        # self.config.ir.logger.debug("V3Listener %s: skip TCPMappingGroup on %s", self.bind_to, irgroup.bind_to())
                         continue
 
                     self.add_tcp_group(irgroup)
@@ -384,6 +389,12 @@ class V3Listener(dict):
             'normalize_path': True
         }
 
+        # Instructs the HTTP Connection Mananger to support http/3. This is required for both TCP and UDP Listeners
+        if self.http3_enabled:
+            base_http_config['http3_protocol_options'] = {}
+            if self.isProtocolUDP():
+                base_http_config['codec_type'] = "HTTP3"
+
         # Assemble base HTTP filters
         from .v3httpfilter import V3HTTPFilter
         for f in self.config.ir.filters:
@@ -551,7 +562,7 @@ class V3Listener(dict):
             "socket_address": {
                 "address": self.bind_address,
                 "port_value": self.port,
-                "protocol": "TCP"
+                "protocol": self.socket_protocol ## "TCP" or "UDP"
             }
         }
 
@@ -837,6 +848,12 @@ class V3Listener(dict):
 
             filter_chain: Optional[Dict[str, Any]] = None
 
+            # http/3 is built on quic which has TLS built-in. This means that our UDP Listener will only ever need routes
+            # that match the TLS Filter chain and will diverge from the TCP listener in that it will not support redirect
+            # therefore, we can exclude duplicating the filterchain and routes so hitting this endpoint using non-tls http will fail
+            if (chain.type == "http") and self.isProtocolUDP() and self.http3_enabled:
+                continue
+
             if chain.type == "http":
                 # All HTTP chains get collapsed into one here, using domains to separate them.
                 # This works because we don't need to offer TLS certs (we can't anyway), and
@@ -885,8 +902,8 @@ class V3Listener(dict):
                 if (len(chain_hosts) > 0) and ("*" not in chain_hosts):
                     filter_chain_match['server_names'] = chain_hosts
 
-                # Likewise, an HTTPS chain will ask for TLS.
-                filter_chain_match["transport_protocol"] = "tls"
+                # Likewise, an HTTPS chain will ask for TLS or QUIC (when udp)
+                filter_chain_match["transport_protocol"] = "quic" if self.isProtocolUDP() and self.http3_enabled else "tls"
 
                 if chain.context:
                     # ...uh. How could we not have a context if we're doing TLS?
@@ -894,13 +911,33 @@ class V3Listener(dict):
                     # filter_chain_match.
                     envoy_ctx = V3TLSContext(chain.context)
 
-                    filter_chain['transport_socket'] = {
+                    envoy_tls_config = {
                         'name': 'envoy.transport_sockets.tls',
                         'typed_config': {
                             '@type': 'type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext',
                             **envoy_ctx
                         }
                     }
+
+                    if self.isProtocolUDP():
+                        envoy_tls_config = {
+                            'name': 'envoy.transport_sockets.quic',
+                            'typed_config': {
+                                '@type': 'type.googleapis.com/envoy.extensions.transport_sockets.quic.v3.QuicDownstreamTransport',
+                                'downstream_tls_context':{
+                                    **envoy_ctx
+                                }
+                            }
+                        }
+
+                    filter_chain['transport_socket'] = envoy_tls_config
+
+                else:
+                    # Envoy doesn't like having a UDP Listener with QUIC filter chain that doesn't have a "transport_socket" set with a TLS
+                    # certificate. If the fall-back cert is removed or no certificate is provided then we should not add the quic filter chain
+                    if self.isProtocolUDP() and self.http3_enabled:
+                        self._irlistener.logger.warn(f"Listener: quic network protocol requires a TLSContext to be provided, no tls context found for Listener: {self._irlistener.bind_to()}")
+                        continue
 
                 # Finally, stash the match in the chain...
                 filter_chain["filter_chain_match"] = filter_chain_match
@@ -929,9 +966,23 @@ class V3Listener(dict):
                 if not vhost:
                     vhost = {
                         "name": f"{self.name}-{host.hostname}",
+                        "response_headers_to_add": [],
                         "domains": [ host.hostname ],
                         "routes": []
                     }
+
+                    if self.http3_enabled and (self.socket_protocol == "TCP"):
+                        # Setting the alternative service header, tells the client to use the alternate location for future requests.
+                        # Clients such as chrome/firefox, etc... require this to instruct it to start speaking http/3 with the server.
+                        #
+                        # Additional reading on alt-svc header: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Alt-Svc
+                        #
+                        # The default sets the max-age in seconds to be 1 day and supports clients that speak h3 & h3-29 specifications
+                        alt_svc_hdr = { "key": "alt-svc", "value": f'h3=":443"; ma=86400, h3-29=":443"; ma=86400'}
+
+                        vhost['response_headers_to_add'].append({ "header": alt_svc_hdr})
+                    else:
+                        del(vhost['response_headers_to_add'])
 
                     filter_chain["_vhosts"][host.hostname] = vhost
 
@@ -974,12 +1025,18 @@ class V3Listener(dict):
             self._filter_chains.append(filter_chain)
 
     def as_dict(self) -> dict:
-        listener = {
+        listener: dict = {
             "name": self.name,
             "address": self.address,
             "filter_chains": self._filter_chains,
             "traffic_direction": self.traffic_direction
         }
+
+        if self.isProtocolUDP():
+            listener['udp_listener_config'] = {
+                'quic_options': {},
+                'downstream_socket_config': { 'prefer_gro': True }
+            }
 
         # We only want to add the buffer limit setting to the listener if specified in the module.
         # Otherwise, we want to leave it unset and allow Envoys Default 1MiB setting.
@@ -1004,6 +1061,14 @@ class V3Listener(dict):
             "HTTP" if self._base_http_config else "TCP",
             self.name, self.bind_address, self.port, self._security_model
         )
+
+    def isProtocolTCP(self) -> bool:
+        """Whether the listener is configured to use the TCP protocol or not?"""
+        return (self.socket_protocol == "TCP")
+
+    def isProtocolUDP(self) -> bool:
+        """Whether the listener is configured to use the UDP protocol or not?"""
+        return (self.socket_protocol == "UDP")
 
     @classmethod
     def generate(cls, config: 'V3Config') -> None:

--- a/python/ambassador/ir/irresource.py
+++ b/python/ambassador/ir/irresource.py
@@ -193,8 +193,6 @@ class IRResource (Resource):
             raise Exception("post_error cannot be called before __init__")
 
         self.ir.post_error(error, resource=self, log_level=log_level)
-        # super().post_error(error)
-        # self.ir.logger.error("%s: %s" % (self, error))
 
     def skip_key(self, k: str) -> bool:
         if k.startswith('__') or k.startswith("_IRResource__"):

--- a/python/ambassador/ir/irtcpmapping.py
+++ b/python/ambassador/ir/irtcpmapping.py
@@ -89,7 +89,7 @@ class IRTCPMapping (IRBaseMapping):
 
     def bind_to(self) -> str:
         bind_addr = self.get('address') or '0.0.0.0'
-        return "%s-%s" % (bind_addr, self.port)
+        return f"tcp-{bind_addr}-{self.port}"
 
     def _group_id(self) -> str:
         # Yes, we're using a cryptographic hash here. Cope. [ :) ]

--- a/python/ambassador/ir/irtcpmappinggroup.py
+++ b/python/ambassador/ir/irtcpmappinggroup.py
@@ -102,12 +102,10 @@ class IRTCPMappingGroup (IRBaseMappingGroup):
 
         self.referenced_by(mapping)
 
-        # self.ir.logger.debug("%s: group now %s" % (self, self.as_json()))
-
     # Deliberately matches IRListener.bind_to()
     def bind_to(self) -> str:
         bind_addr = self.get('address') or Config.envoy_bind_address
-        return f"{bind_addr}-{self.port}"
+        return f"tcp-{bind_addr}-{self.port}"
 
     def add_cluster_for_mapping(self, mapping: IRBaseMapping,
                                 marker: Optional[str] = None) -> IRCluster:

--- a/python/ambassador/utils.py
+++ b/python/ambassador/utils.py
@@ -972,6 +972,16 @@ class NullSecretHandler(SecretHandler):
         return SecretInfo(secret_name, namespace, "fake-secret", "fake-tls-crt", "fake-tls-key", "fake-user-key",
                           decode_b64=False)
 
+class EmptySecretHandler(SecretHandler):
+    def __init__(self, logger: logging.Logger, source_root: Optional[str], cache_dir: Optional[str], version: str) -> None:
+        """
+        Returns a None to simulate no provided secrets
+        """
+        super().__init__(logger, "", "", version)
+
+    def load_secret(self, resource: 'IRResource', secret_name: str, namespace: str) -> Optional[SecretInfo]:
+        return None
+
 
 class FSSecretHandler(SecretHandler):
     # XXX NO LONGER USED

--- a/python/tests/unit/test_ir.py
+++ b/python/tests/unit/test_ir.py
@@ -1,0 +1,45 @@
+from dataclasses import dataclass
+from tests.utils import (Compile, logger, default_listener_manifests,
+  default_http3_listener_manifest, default_udp_listener_manifest, default_tcp_listener_manifest)
+from typing import List, Optional
+
+import pytest
+import logging
+
+def http3_quick_start_manifests():
+  return default_listener_manifests() + default_http3_listener_manifest()
+
+class TestIR:
+  def test_http3_enabled(self, caplog):
+    caplog.set_level(logging.WARNING, logger="ambassador")
+  
+    @dataclass
+    class TestCase:
+      name:str
+      inputYaml: str
+      expected: dict[str,bool]
+      expectedLog: Optional[str] = None
+
+    testcases = [
+      TestCase("quick-start", default_listener_manifests(), { "tcp-0.0.0.0-8080": False, "tcp-0.0.0.0-8443": False }),
+      TestCase("quick-start-with_http3", http3_quick_start_manifests(), { "tcp-0.0.0.0-8080": False, "tcp-0.0.0.0-8443": True, "udp-0.0.0.0-8443": True }),
+      TestCase("http3-only", default_http3_listener_manifest(),{ "udp-0.0.0.0-8443": True }),
+      TestCase("raw-udp", default_udp_listener_manifest(),{}),
+      TestCase("raw-tcp", default_tcp_listener_manifest(),{ "tcp-0.0.0.0-8443": False }),
+    ]
+
+    for case in testcases:
+      compiled_ir = Compile(logger, case.inputYaml, k8s=True)
+      result_ir = compiled_ir['ir']
+
+      listeners = result_ir.listeners
+
+      assert len(case.expected.items()) == len(listeners)
+
+      for listener_id, http3_enabled in case.expected.items():
+        listener = listeners.get(listener_id, None)
+        assert listener is not None
+        assert listener.http3_enabled == http3_enabled
+      
+      if case.expectedLog != None:
+        assert case.expectedLog in caplog.text

--- a/python/tests/unit/test_listener.py
+++ b/python/tests/unit/test_listener.py
@@ -1,0 +1,264 @@
+from dataclasses import dataclass
+from tests.utils import Compile, logger, default_http3_listener_manifest, econf_compile
+from typing import List, Optional
+
+from ambassador import IR
+from ambassador.compile import Compile
+from ambassador.config import Config
+from ambassador.fetch import ResourceFetcher
+from ambassador.envoy import EnvoyConfig
+from ambassador.utils import EmptySecretHandler
+
+import pytest
+
+def _ensure_alt_svc_header_injected(listener, expectedAltSvc):
+    """helper function to ensure that the alt-svc header is getting injected properly"""
+    filter_chains = listener['filter_chains']
+
+    for filter_chain in filter_chains:
+        hcm_typed_config =  filter_chain['filters'][0]['typed_config']
+        virtual_hosts = hcm_typed_config['route_config']['virtual_hosts']
+        for host in virtual_hosts:
+            response_headers_to_add = host['response_headers_to_add']
+            assert len(response_headers_to_add) == 1
+            header = response_headers_to_add[0]['header']
+            assert header['key'] == 'alt-svc'
+            assert header['value'] == expectedAltSvc
+
+def _verify_no_added_response_headers(listener):
+    """helper function to ensure response_headers_to_add do not exist """
+    filter_chains = listener['filter_chains']
+
+    for filter_chain in filter_chains:
+        hcm_typed_config =  filter_chain['filters'][0]['typed_config']
+        virtual_hosts = hcm_typed_config['route_config']['virtual_hosts']
+        for host in virtual_hosts:
+            assert 'response_headers_to_add' not in host
+
+
+def _generateListener(name: str, protocol: Optional[str], protocol_stack:Optional[List[str]]):
+    yaml = f"""
+apiVersion: getambassador.io/v3alpha1
+kind: Listener
+metadata:
+    name: {name}
+    namespace: ambassador
+spec:
+    port: 8443
+    {f"protocolStack: {protocol_stack}" if protocol == None else f"protocol: {protocol}"}
+    securityModel: XFP
+    hostBinding:
+        namespace:
+            from: ALL
+"""
+    return yaml
+
+class TestListener:
+
+    @pytest.mark.compilertest
+    def test_socket_protocol(self):
+        """ensure that we can identify the listener socket protocol based on the provided protocol and protocolStack"""
+
+        @dataclass
+        class TestCase:
+            name: str
+            protocol: Optional[str]
+            protocolStack: Optional[List[str]]
+            expectedSocketProtocol: Optional[str]
+
+        testcases = [
+                # test with emissary defined protcolStacks via pre-definied protocol enum
+                TestCase(name="http_protocol", protocol="HTTP", protocolStack=None, expectedSocketProtocol="TCP"),
+                TestCase(name="https_protocol", protocol="HTTPS", protocolStack=None, expectedSocketProtocol="TCP"),
+                TestCase(name="httpproxy_protocol", protocol="HTTPPROXY", protocolStack=None, expectedSocketProtocol="TCP"),
+                TestCase(name="httpsproxy_protocol", protocol="HTTPSPROXY", protocolStack=None, expectedSocketProtocol="TCP"),
+                TestCase(name="tcp_protocol", protocol="TCP", protocolStack=None, expectedSocketProtocol="TCP"),
+                TestCase(name="tls_protocol", protocol="TLS", protocolStack=None, expectedSocketProtocol="TCP"),
+
+                # test with custom stacks
+                TestCase(name="tcp_stack", protocol=None, protocolStack=["TLS", "HTTP", "TCP"], expectedSocketProtocol="TCP"),
+                TestCase(name="udp_stack", protocol=None, protocolStack=["TLS", "HTTP", "UDP"], expectedSocketProtocol="UDP"),
+                TestCase(name="invalid_stack", protocol=None, protocolStack=["TLS", "HTTP"], expectedSocketProtocol=None),
+                TestCase(name="empty_stack", protocol=None, protocolStack=[], expectedSocketProtocol=None),
+            ]
+        for case in testcases:
+            yaml = _generateListener(case.name, case.protocol, case.protocolStack)
+
+            compiled_ir = Compile(logger, yaml, k8s=True)
+            result_ir = compiled_ir['ir']
+            listeners = list(result_ir.listeners.values())
+            errors = result_ir.aconf.errors
+
+            if case.expectedSocketProtocol == None:
+                assert len(errors) == 1
+                assert len(listeners) == 0
+            else:
+                assert len(listeners) == 1
+                assert listeners[0].socket_protocol == case.expectedSocketProtocol
+
+    @pytest.mark.compilertest
+    def test_http3_valid_quic_listener(self):
+        """ensure that a valid http3 listener is created using QUIC"""
+
+        yaml = default_http3_listener_manifest()
+        econf = econf_compile(yaml)
+
+        listeners = econf['static_resources']['listeners']
+
+        assert len(listeners) == 1
+
+        # verify listener options
+        listener = listeners[0]
+        assert 'udp_listener_config' in listener
+        assert 'quic_options' in listener['udp_listener_config']
+        assert listener['udp_listener_config']["downstream_socket_config"]['prefer_gro'] == True
+
+        # verify filter chains
+        filter_chains = listener['filter_chains']
+        assert len(filter_chains) == 1
+        filter_chain = filter_chains[0]
+
+        assert filter_chain['filter_chain_match']['transport_protocol'] == 'quic'
+        assert filter_chain['transport_socket']['name'] == 'envoy.transport_sockets.quic'
+ 
+        # verify HCM typed_config
+        typed_config = filter_chain['filters'][0]['typed_config']
+        assert typed_config['codec_type'] == "HTTP3"
+        assert 'http3_protocol_options' in typed_config
+
+    @pytest.mark.compilertest
+    def test_http3_missing_tls_context(self):
+        """UDP listener supporting the Quic protocol requires that a the "transport_socket" be set 
+        in the filter_chains due to the fact that QUIC requires TLS. Envoy will reject the configuration
+        if it is not found. This test ensures that the HTTP/3 Listener is dropped when a valid TLSContext is not available.
+        """
+
+        yaml = """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Listener
+metadata:
+  name: listener-8443
+  namespace: default
+spec:
+  port: 8443
+  protocol: HTTPS
+  securityModel: XFP
+  hostBinding:
+    namespace:
+      from: ALL
+""" + default_http3_listener_manifest()
+
+        ## we don't use the Compile utils here because we want to make sure that a fake secret is not injected
+        aconf = Config()
+        fetcher = ResourceFetcher(logger, aconf)
+        fetcher.parse_yaml(yaml, k8s=True)
+        aconf.load_all(fetcher.sorted())
+        secret_handler = EmptySecretHandler(logger, source_root=None, cache_dir=None, version='V3')
+        ir = IR(aconf, secret_handler=secret_handler)
+        econf = EnvoyConfig.generate(ir, cache=None).as_dict()
+    
+        # the tcp/tls is more forgiving and doesn't crash envoy which is the current behavior 
+        # we observe pre v3. So we just verify that the only listener is the TCP listener.
+        listeners = econf['static_resources']['listeners']
+        assert len(listeners) == 1
+        tcp_listener = listeners[0]
+        assert tcp_listener['address']['socket_address']['protocol'] == "TCP"
+
+
+    @pytest.mark.compilertest
+    def test_http3_companion_listeners(self):
+        """ensure that when we have companion http3 (udp)/tcp listeners bound to same port that we properly set
+            port reuse, and ensure the TCP listener broadcast http/3 support
+        """
+
+        yaml = """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Listener
+metadata:
+  name: listener-8443
+  namespace: default
+spec:
+  port: 8443
+  protocol: HTTPS
+  securityModel: XFP
+  hostBinding:
+    namespace:
+      from: ALL
+""" + default_http3_listener_manifest()
+
+        econf = econf_compile(yaml)
+
+        listeners = econf['static_resources']['listeners']
+
+        assert len(listeners) == 2
+
+        ## check TCP Listener
+        tcp_listener = listeners[0]
+        assert tcp_listener['address']['socket_address']['protocol'] == "TCP"
+
+        tcp_filter_chains = tcp_listener['filter_chains']
+        assert len(tcp_filter_chains) == 2
+     
+
+        default_alt_svc = "h3=\":443\"; ma=86400, h3-29=\":443\"; ma=86400"
+        _ensure_alt_svc_header_injected(tcp_listener, default_alt_svc)
+       
+        ## check UDP Listener
+        udp_listener = listeners[1]
+        assert udp_listener['address']['socket_address']['protocol'] == "UDP"
+
+        udp_filter_chains = udp_listener['filter_chains']
+        assert len(udp_filter_chains) == 1
+
+        _verify_no_added_response_headers(udp_listener)
+
+    @pytest.mark.compilertest
+    def test_http3_non_matching_ports(self):
+        """support having the http (tcp) listener to be bound to different address:port, by default
+            the alt-svc will not be injected. Note, this test ensures that envoy can be configured
+            this way and will not crash. However, due to developer not setting the `alt-svc` most clients
+            will not be able to upgrade to HTTP/3.
+        """
+
+        yaml = """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Listener
+metadata:
+  name: listener-8500
+  namespace: default
+spec:
+  port: 8500
+  protocol: HTTPS
+  securityModel: XFP
+  hostBinding:
+    namespace:
+      from: ALL
+""" + default_http3_listener_manifest()
+
+        econf = econf_compile(yaml)
+
+        listeners = econf['static_resources']['listeners']
+
+        assert len(listeners) == 2
+
+        ## check TCP Listener
+        tcp_listener = listeners[0]
+        assert tcp_listener['address']['socket_address']['protocol'] == "TCP"
+
+        tcp_filter_chains = tcp_listener['filter_chains']
+        assert len(tcp_filter_chains) == 2
+
+        _verify_no_added_response_headers(tcp_listener)
+       
+        ## check UDP Listener
+        udp_listener = listeners[1]
+        assert udp_listener['address']['socket_address']['protocol'] == "UDP"
+
+        udp_filter_chains = udp_listener['filter_chains']
+        assert len(udp_filter_chains) == 1
+
+        _verify_no_added_response_headers(udp_listener)
+

--- a/python/tests/utils.py
+++ b/python/tests/utils.py
@@ -69,6 +69,63 @@ spec:
       from: ALL
 """
 
+def default_http3_listener_manifest():
+  return """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Listener
+metadata:
+  name: listener-http3-8443
+  namespace: default
+spec:
+  port: 8443
+  protocolStack:
+    - TLS
+    - HTTP
+    - UDP
+  securityModel: XFP
+  hostBinding:
+    namespace:
+      from: ALL  
+  """
+
+def default_udp_listener_manifest():
+  return """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Listener
+metadata:
+  name: listener-udp-8443
+  namespace: default
+spec:
+  port: 8443
+  protocolStack:
+    - TLS
+    - UDP
+  securityModel: XFP
+  hostBinding:
+    namespace:
+      from: ALL  
+  """
+def default_tcp_listener_manifest():
+  return """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Listener
+metadata:
+  name: listener-tcp-8443
+  namespace: default
+spec:
+  port: 8443
+  protocolStack:
+    - TLS
+    - TCP
+  securityModel: XFP
+  hostBinding:
+    namespace:
+      from: ALL  
+  """
+
 def module_and_mapping_manifests(module_confs, mapping_confs):
     yaml = default_listener_manifests() + """
 ---


### PR DESCRIPTION
## Description
This PR adds downstream support for HTTP/3 and is able to take advantage of the current developer experience by using the `protocolStack` field of the `Listener` CRD. 

HTTP/2 and HTTP/1 traffic will continue to be served using a TCP Listener configured for HTTP and now a second Listener configured for HTTP/3 can be done by setting the `protocalStack: [ "TLS", "HTTP", "UDP"]` on a Listener and binding to the **same address:port** as the TCP Listener

```yaml
# Listener that leverages TCP and will be used to server HTTP/2 and HTTP/1.1 traffic
apiVersion: getambassador.io/v3alpha1
kind: Listener
metadata:
  name: emissary-ingress-listener-8443
  namespace: emissary
spec:
  port: 8443
  protocol: HTTPS
  securityModel: XFP
  hostBinding:
    namespace:
      from: ALL
---
# Listener that leverages HTTP & UDP, will be used to serve HTTP/3 traffic
# NOTE: this does not add support for raw UDP traffic
apiVersion: getambassador.io/v3alpha1
kind: Listener
metadata:
  name: emissary-ingress-listener-udp-8443
  namespace: emissary
spec:
  port: 8443
  # order matters here with UDP required to be the last item
  protocolStack:
    - TLS
    - HTTP
    - UDP
  securityModel: XFP
  hostBinding:
    namespace:
      from: ALL
```

When a TCP Listener binds to the same address and port as the UDP Listener then it will inject the `alt-svc` header into the responses returned on the TCP Listener. This header advertises HTTP/3 support to the client and tells the client how to upgrade itself to http/3.

**NOTE - the alt-svc header is not configurable for the initial release but in the future we should make it available to the user**

> More info here on the header: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Alt-Svc.

## Related Issues
None 

## Testing
- additional unit tests were added to capture http/3 behavior
- Existing Kat tests were updated to handle and changes introduced

Deployed to multiple clusters and tested setting up in AKS, EKS and GKE.

## Checklist

 - [x] I made sure to update `CHANGELOG.md`.
 - [x] This is unlikely to impact how Ambassador performs at scale.
_It is a new feature and most of the heavy lifting is done in Envoy. Also, fallback to http/2 and http/1.1 is still possible. One potential thing we will need to keep an eye is that the routes are duplicated on both the TCP and UDP listeners. The UDP listener was able to exclude the http (non-tls) redirect routes due to QUIC requiring TLS so its not an exact duplication._
 - [x] My change is adequately tested.
 - [x] I updated `DEVELOPING.md` 
 - [x] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
