### PR TITLE
[Don't merge] syntheticauth: check for localhost authservices

### DIFF
--- a/cmd/entrypoint/syntheticauth.go
+++ b/cmd/entrypoint/syntheticauth.go
@@ -2,6 +2,9 @@ package entrypoint
 
 import (
 	"context"
+	"net"
+	"net/url"
+	"strings"
 
 	"github.com/datawire/ambassador/v2/pkg/api/getambassador.io/v3alpha1"
 	"github.com/datawire/ambassador/v2/pkg/kates"
@@ -22,6 +25,26 @@ func annotationsContainAuthService(annotations map[string]snapshot.AnnotationLis
 		}
 	}
 	return false
+}
+
+// Checks if the provided string is a loopback IP address with port 8500
+func IsLocalhost8500(svcStr string) bool {
+	if strings.Contains(svcStr, ":") && !strings.HasPrefix(strings.TrimLeft(svcStr, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+-."), "://") {
+		svcStr = "bogus://" + svcStr
+	}
+	svcURL, _ := url.Parse(svcStr)
+	if svcURL == nil {
+		return false
+	}
+	if port, _ := net.LookupPort("ip", svcURL.Port()); port != 8500 {
+		return false
+	}
+	// while net.ParseIP() would be sufficient for most cases, it does not resolve "localhost:8500" so we use LookupIP instead
+	ips, _ := net.LookupIP(svcURL.Hostname())
+	if len(ips) == 0 {
+		return false
+	}
+	return ips[0].IsLoopback()
 }
 
 // This is a gross hack to remove all AuthServices using protocol_version: v2 only when running Edge-Stack and then inject an
@@ -62,16 +85,29 @@ func ReconcileAuthServices(ctx context.Context, sh *SnapshotHolder, deltas *[]*k
 	var authServices []*v3alpha1.AuthService
 	syntheticAuthExists := false
 	for _, authService := range sh.k8sSnapshot.AuthServices {
-		// Keep any AuthServices already using protocol_version: v3
-		if authService.Spec.ProtocolVersion == "v3" {
-			injectSyntheticAuth = false
-			if authService.ObjectMeta.Name == "synthetic-edge-stack-auth" {
-				syntheticAuthExists = true
+		// check if the AuthService points at 127.0.0.1:8500 (edge-stack)
+		if IsLocalhost8500(authService.Spec.AuthService) {
+			// If it does point at localhost, make sure it is v3, otherwise we need to inject the synthetic AuthService
+			if authService.Spec.ProtocolVersion == "v3" {
+				injectSyntheticAuth = false
+				if authService.ObjectMeta.Name == "synthetic-edge-stack-auth" {
+					syntheticAuthExists = true
+				} else {
+					authServices = append(authServices, authService)
+				}
 			} else {
-				authServices = append(authServices, authService)
+				// In the event that there is an AuthService that does not have protocol_version: v3
+				// Then we use the spec of that AuthService as the Synthetic v3 AuthService we will inject later
+				syntheticAuth.Spec = authService.Spec
+				syntheticAuth.Spec.ProtocolVersion = "v3"
 			}
+		} else {
+			// By default we keep any custom AuthServices that do not point at localhost
+			authServices = append(authServices, authService)
+			injectSyntheticAuth = false
 		}
 	}
+
 	// TODO if there are v3 authServices, still remove any that are not `v3`
 
 	// Also loop over the annotations and remove authservices that are not v3. We do
@@ -87,12 +123,26 @@ func ReconcileAuthServices(ctx context.Context, sh *SnapshotHolder, deltas *[]*k
 			for _, obj := range list {
 				switch annotationObj := obj.(type) {
 				case *v3alpha1.AuthService:
-					// This _is_ an AuthService, so we'll check its protocol version.
-					// Anything other than v3 gets tossed.
-					if annotationObj.Spec.ProtocolVersion == "v3" {
-						// Whoa, it's a v3! Keep it.
-						editedList = append(editedList, annotationObj)
+					if IsLocalhost8500(annotationObj.Spec.AuthService) {
+						// If it does point at localhost, make sure it is v3, otherwise we need to inject the synthetic AuthService
+						if annotationObj.Spec.ProtocolVersion == "v3" {
+							injectSyntheticAuth = false
+							if annotationObj.ObjectMeta.Name == "synthetic-edge-stack-auth" {
+								syntheticAuthExists = true
+							} else {
+								authServices = append(authServices, annotationObj)
+								editedList = append(editedList, annotationObj)
+							}
+						} else {
+							// In the event that there is an AuthService that does not have protocol_version: v3
+							// Then we use the spec of that AuthService as the Synthetic v3 AuthService we will inject later
+							syntheticAuth.Spec = annotationObj.Spec
+							syntheticAuth.Spec.ProtocolVersion = "v3"
+						}
+					} else {
+						// By default we keep any custom AuthServices that do not point at localhost
 						authServices = append(authServices, annotationObj)
+						editedList = append(editedList, annotationObj)
 						injectSyntheticAuth = false
 					}
 				default:


### PR DESCRIPTION
Signed-off-by: AliceProxy <alicewasko@datawire.io>

## Description
A small modification to the way we inject synthetic `AuthService`s. Instead of throwing away the definitions of `AuthService`s that do not use `protocol_version :v3` in Edge-Stack, we instead first check if the `AuthService` points to `127.0.0.1:8500` (amb-sidecar). If it does not use amb-sidecar as the authorization service, then there is no need to replace it with a synthetic `AuthService`. If it does indeed point at amb-sidecar, then we still do not need to throw away the definition of the `AuthService` we are replacing. Instead we make a copy of it and include `protocol_version: v3` so that any config on the `AuthService` will be preserved. 

## Related Issues
Also see https://github.com/emissary-ingress/emissary/pull/4264 for additions to this.

## Testing
Added a few more tests to the suite to cover the new code additions. 

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `CHANGELOG.md`.

   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations

 - [x] This is unlikely to impact how Ambassador performs at scale.

   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability

 - [x] My change is adequately tested.

   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points

 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.

 - [ ] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
