### PR TITLE
Make stats_name work in tracing, ratelimit and auth services

### DIFF
--- a/python/ambassador/ir/irauth.py
+++ b/python/ambassador/ir/irauth.py
@@ -179,6 +179,8 @@ class IRAuth(IRFilter):
                 f'AuthService: protocol_version {self.protocol_version} is unsupported, protocol_version must be "v3"'
             )
 
+        self["stats_name"] = module.get("stats_name", None)
+
         status_on_error = module.get("status_on_error", None)
         if status_on_error:
             self["status_on_error"] = status_on_error

--- a/python/ambassador/ir/irratelimit.py
+++ b/python/ambassador/ir/irratelimit.py
@@ -68,6 +68,8 @@ class IRRateLimit(IRFilter):
             )
             return False
 
+        self.stats_name = config.get("stats_name", None)
+
         # XXX host_rewrite actually isn't in the schema right now.
         self.host_rewrite = config.get("host_rewrite", None)
 

--- a/python/ambassador/ir/irtracing.py
+++ b/python/ambassador/ir/irtracing.py
@@ -109,6 +109,8 @@ class IRTracing(IRResource):
         self.tag_headers = config.get("tag_headers", [])
         self.sampling = config.get("sampling", {})
 
+        self.stats_name = config.get("stats_name", None)
+
         # XXX host_rewrite actually isn't in the schema right now.
         self.host_rewrite = config.get("host_rewrite", None)
 

--- a/python/tests/unit/test_irauth.py
+++ b/python/tests/unit/test_irauth.py
@@ -5,6 +5,7 @@ import sys
 import pytest
 
 from kat.harness import EDGE_STACK
+from tests.utils import econf_foreach_cluster
 
 logging.basicConfig(
     level=logging.INFO,
@@ -104,6 +105,40 @@ spec:
     assert ext_auth_config["typed_config"]["transport_api_version"] == "V3"
 
     assert "mycoolauthservice.default.1" not in econf.ir.aconf.errors
+
+
+def test_cluster_fields():
+    yaml = """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: AuthService
+metadata:
+  name:  mycoolauthservice
+  namespace: default
+spec:
+  auth_service: someservice
+  protocol_version: "v3"
+  proto: grpc
+  stats_name: authservice
+"""
+
+    econf = _get_envoy_config(yaml)
+
+    conf = econf.as_dict()
+    ext_auth_config = _get_ext_auth_config(conf)
+
+    cluster_name = "cluster_extauth_someservice_default"
+
+    assert ext_auth_config
+    assert (
+        ext_auth_config["typed_config"]["grpc_service"]["envoy_grpc"]["cluster_name"]
+        == cluster_name
+    )
+
+    def check_fields(cluster):
+        assert cluster["alt_stat_name"] == "authservice"
+
+    econf_foreach_cluster(econf, check_fields, name=cluster_name)
 
 
 @pytest.mark.compilertest

--- a/python/tests/unit/test_irauth.py
+++ b/python/tests/unit/test_irauth.py
@@ -138,7 +138,7 @@ spec:
     def check_fields(cluster):
         assert cluster["alt_stat_name"] == "authservice"
 
-    econf_foreach_cluster(econf, check_fields, name=cluster_name)
+    econf_foreach_cluster(econf.as_dict(), check_fields, name=cluster_name)
 
 
 @pytest.mark.compilertest

--- a/python/tests/unit/test_irratelimit.py
+++ b/python/tests/unit/test_irratelimit.py
@@ -148,7 +148,7 @@ spec:
     def check_fields(cluster):
         assert cluster["alt_stat_name"] == stats_name
 
-    econf_foreach_cluster(econf, check_fields, name="cluster_{}_default".format(SERVICE_NAME))
+    econf_foreach_cluster(econf.as_dict(), check_fields, name="cluster_{}_default".format(SERVICE_NAME))
 
 
 @pytest.mark.compilertest

--- a/python/tests/unit/test_irratelimit.py
+++ b/python/tests/unit/test_irratelimit.py
@@ -4,6 +4,8 @@ import sys
 
 import pytest
 
+from tests.utils import econf_foreach_cluster
+
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s test %(levelname)s: %(message)s",
@@ -113,6 +115,40 @@ spec:
     assert conf.get("typed_config") == _get_ratelimit_default_conf()
 
     assert "ir.ratelimit" not in econf.ir.aconf.errors
+
+
+@pytest.mark.compilertest
+def test_irratelimit_cluster_fields():
+
+    stats_name = "ratelimitservice"
+
+    yaml = """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: RateLimitService
+metadata:
+  name: myrls
+  namespace: default
+spec:
+  service: {}
+  protocol_version: "v3"
+  stats_name: {}
+""".format(
+        SERVICE_NAME, stats_name
+    )
+
+    econf = _get_envoy_config(yaml)
+    conf = _get_rl_config(econf.as_dict())
+
+    assert conf
+    assert conf.get("typed_config") == _get_ratelimit_default_conf()
+
+    assert "ir.ratelimit" not in econf.ir.aconf.errors
+
+    def check_fields(cluster):
+        assert cluster["alt_stat_name"] == stats_name
+
+    econf_foreach_cluster(econf, check_fields, name="cluster_{}_default".format(SERVICE_NAME))
 
 
 @pytest.mark.compilertest

--- a/python/tests/unit/test_irratelimit.py
+++ b/python/tests/unit/test_irratelimit.py
@@ -148,7 +148,9 @@ spec:
     def check_fields(cluster):
         assert cluster["alt_stat_name"] == stats_name
 
-    econf_foreach_cluster(econf.as_dict(), check_fields, name="cluster_{}_default".format(SERVICE_NAME))
+    econf_foreach_cluster(
+        econf.as_dict(), check_fields, name="cluster_{}_default".format(SERVICE_NAME)
+    )
 
 
 @pytest.mark.compilertest

--- a/python/tests/unit/test_tracing.py
+++ b/python/tests/unit/test_tracing.py
@@ -187,7 +187,7 @@ spec:
     def check_fields(cluster):
         assert cluster["alt_stat_name"] == "tracingservice"
 
-    econf_foreach_cluster(econf, check_fields, name=cluster_name)
+    econf_foreach_cluster(econf.as_dict(), check_fields, name=cluster_name)
 
 
 @pytest.mark.compilertest

--- a/python/tests/unit/test_tracing.py
+++ b/python/tests/unit/test_tracing.py
@@ -5,7 +5,11 @@ from typing import TYPE_CHECKING, Optional
 import pytest
 
 from tests.selfsigned import TLSCerts
-from tests.utils import assert_valid_envoy_config, module_and_mapping_manifests
+from tests.utils import (
+    assert_valid_envoy_config,
+    econf_foreach_cluster,
+    module_and_mapping_manifests,
+)
 
 logging.basicConfig(
     level=logging.INFO,
@@ -143,6 +147,47 @@ spec:
             },
         }
     }
+
+
+@pytest.mark.compilertest
+def test_tracing_cluster_fields():
+
+    yaml = """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: TracingService
+metadata:
+    name: myts
+    namespace: default
+spec:
+    service: zipkin-test:9411
+    driver: zipkin
+    stats_name: tracingservice
+"""
+
+    econf = _get_envoy_config(yaml)
+
+    bootstrap_config, _, _ = econf.split_config()
+    assert "tracing" in bootstrap_config
+
+    cluster_name = "cluster_tracing_zipkin_test_9411_default"
+    assert bootstrap_config["tracing"] == {
+        "http": {
+            "name": "envoy.zipkin",
+            "typed_config": {
+                "@type": "type.googleapis.com/envoy.config.trace.v3.ZipkinConfig",
+                "collector_endpoint": "/api/v2/spans",
+                "collector_endpoint_version": "HTTP_JSON",
+                "trace_id_128bit": True,
+                "collector_cluster": cluster_name,
+            },
+        }
+    }
+
+    def check_fields(cluster):
+        assert cluster["alt_stat_name"] == "tracingservice"
+
+    econf_foreach_cluster(econf, check_fields, name=cluster_name)
 
 
 @pytest.mark.compilertest

--- a/python/tests/utils.py
+++ b/python/tests/utils.py
@@ -292,7 +292,7 @@ def econf_foreach_hcm(econf, fn, chain_count=2):
 
 
 def econf_foreach_cluster(econf, fn, name="cluster_httpbin_default"):
-    for cluster in econf["static_resources"]["clusters"]:
+    for cluster in econf.static_resources["clusters"]:
         if cluster["name"] != name:
             continue
 

--- a/python/tests/utils.py
+++ b/python/tests/utils.py
@@ -292,7 +292,7 @@ def econf_foreach_hcm(econf, fn, chain_count=2):
 
 
 def econf_foreach_cluster(econf, fn, name="cluster_httpbin_default"):
-    for cluster in econf.static_resources["clusters"]:
+    for cluster in econf["static_resources"]["clusters"]:
         if cluster["name"] != name:
             continue
 


### PR DESCRIPTION
## Description
Setting stats_name in Tracing, RateLimit and Auth services did no have any effect. alt_stat_name in Envoy was not being updated.


## Testing
I have tested it with `make deploy`.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `CHANGELOG.md`.

   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations

 - [x] This is unlikely to impact how Ambassador performs at scale.

   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability

 - [ ] My change is adequately tested.

   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points

 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.

 - [ ] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
