### PR TITLE
fix: properly propagate stats_name from tracing, ratelimit and auth services to envoy config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,11 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
   option. Set `failure_mode_deny: true`, then Envoy will  deny traffic when it is unable to
   communicate to the RateLimitService  returning a 500.
 
+- Bugfix: Previously, setting the `stats_name` for the `TracingService`, `RateLimitService`  or the
+  `AuthService` would have no affect because it was not being properly passed to the Envoy cluster
+  config. This has been fixed and the `alt_stats_name` field in the cluster config is now set
+  correctly. (Thanks to <a href="https://github.com/psalaberria002">Paul</a>!)
+
 [#4354]: https://github.com/emissary-ingress/emissary/issues/4354
 
 ## [3.1.1] TBD
@@ -244,6 +249,11 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
 - Change: Set `AMBASSADOR_EDS_BYPASS` to `true` to bypass EDS handling of endpoints and have
   endpoints be inserted to clusters manually. This can help resolve with `503 UH` caused by
   certification rotation relating to a delay between EDS + CDS. The default is `false`.
+
+- Bugfix: Previously, setting the `stats_name` for the `TracingService`, `RateLimitService`  or the
+  `AuthService` would have no affect because it was not being properly passed to the Envoy cluster
+  config. This has been fixed and the `alt_stats_name` field in the cluster config is now set
+  correctly. (Thanks to <a href="https://github.com/psalaberria002">Paul</a>!)
 
 ## [1.14.5] TBD
 [1.14.5]: https://github.com/emissary-ingress/emissary/compare/v2.3.2...v1.14.5

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -75,6 +75,14 @@ items:
           returning a 500.
         docs: https://www.getambassador.io/docs/emissary/latest/topics/running/services/rate-limit-service/
 
+      - title: Properly populate alt_state_name for Tracing, Auth and RateLimit Services
+        type: bugfix
+        body: >-
+          Previously, setting the <code>stats_name</code> for the <code>TracingService</code>, <code>RateLimitService</code> 
+          or the <code>AuthService</code> would have no affect because it was not being properly passed to the Envoy cluster
+          config. This has been fixed and the <code>alt_stats_name</code> field in the cluster config is now set correctly.
+          (Thanks to <a href="https://github.com/psalaberria002">Paul</a>!)
+
   - version: 3.1.1
     prevVersion: 3.1.0
     date: 'TBD'
@@ -273,6 +281,14 @@ items:
           Set `AMBASSADOR_EDS_BYPASS` to `true` to bypass EDS handling of endpoints and have endpoints be
           inserted to clusters manually. This can help resolve with `503 UH` caused by certification rotation relating to
           a delay between EDS + CDS. The default is `false`.
+
+      - title: Properly populate alt_state_name for Tracing, Auth and RateLimit Services
+        type: bugfix
+        body: >-
+          Previously, setting the <code>stats_name</code> for the <code>TracingService</code>, <code>RateLimitService</code> 
+          or the <code>AuthService</code> would have no affect because it was not being properly passed to the Envoy cluster
+          config. This has been fixed and the <code>alt_stats_name</code> field in the cluster config is now set correctly.
+          (Thanks to <a href="https://github.com/psalaberria002">Paul</a>!)
 
   - version: 1.14.5
     date: 'TBD'

--- a/python/ambassador/ir/irauth.py
+++ b/python/ambassador/ir/irauth.py
@@ -179,6 +179,8 @@ class IRAuth(IRFilter):
                 f'AuthService: protocol_version {self.protocol_version} is unsupported, protocol_version must be "v3"'
             )
 
+        self["stats_name"] = module.get("stats_name", None)
+
         status_on_error = module.get("status_on_error", None)
         if status_on_error:
             self["status_on_error"] = status_on_error

--- a/python/ambassador/ir/irratelimit.py
+++ b/python/ambassador/ir/irratelimit.py
@@ -68,6 +68,8 @@ class IRRateLimit(IRFilter):
             )
             return False
 
+        self.stats_name = config.get("stats_name", None)
+
         # XXX host_rewrite actually isn't in the schema right now.
         self.host_rewrite = config.get("host_rewrite", None)
 

--- a/python/ambassador/ir/irtracing.py
+++ b/python/ambassador/ir/irtracing.py
@@ -109,6 +109,8 @@ class IRTracing(IRResource):
         self.tag_headers = config.get("tag_headers", [])
         self.sampling = config.get("sampling", {})
 
+        self.stats_name = config.get("stats_name", None)
+
         # XXX host_rewrite actually isn't in the schema right now.
         self.host_rewrite = config.get("host_rewrite", None)
 

--- a/python/tests/unit/test_irauth.py
+++ b/python/tests/unit/test_irauth.py
@@ -5,6 +5,7 @@ import sys
 import pytest
 
 from kat.harness import EDGE_STACK
+from tests.utils import econf_foreach_cluster
 
 logging.basicConfig(
     level=logging.INFO,
@@ -104,6 +105,40 @@ spec:
     assert ext_auth_config["typed_config"]["transport_api_version"] == "V3"
 
     assert "mycoolauthservice.default.1" not in econf.ir.aconf.errors
+
+
+def test_cluster_fields():
+    yaml = """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: AuthService
+metadata:
+  name:  mycoolauthservice
+  namespace: default
+spec:
+  auth_service: someservice
+  protocol_version: "v3"
+  proto: grpc
+  stats_name: authservice
+"""
+
+    econf = _get_envoy_config(yaml)
+
+    conf = econf.as_dict()
+    ext_auth_config = _get_ext_auth_config(conf)
+
+    cluster_name = "cluster_extauth_someservice_default"
+
+    assert ext_auth_config
+    assert (
+        ext_auth_config["typed_config"]["grpc_service"]["envoy_grpc"]["cluster_name"]
+        == cluster_name
+    )
+
+    def check_fields(cluster):
+        assert cluster["alt_stat_name"] == "authservice"
+
+    econf_foreach_cluster(econf.as_dict(), check_fields, name=cluster_name)
 
 
 @pytest.mark.compilertest

--- a/python/tests/unit/test_irratelimit.py
+++ b/python/tests/unit/test_irratelimit.py
@@ -4,6 +4,8 @@ import sys
 
 import pytest
 
+from tests.utils import econf_foreach_cluster
+
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s test %(levelname)s: %(message)s",
@@ -114,6 +116,42 @@ spec:
     assert conf.get("typed_config") == _get_ratelimit_default_conf()
 
     assert "ir.ratelimit" not in econf.ir.aconf.errors
+
+
+@pytest.mark.compilertest
+def test_irratelimit_cluster_fields():
+
+    stats_name = "ratelimitservice"
+
+    yaml = """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: RateLimitService
+metadata:
+  name: myrls
+  namespace: default
+spec:
+  service: {}
+  protocol_version: "v3"
+  stats_name: {}
+""".format(
+        SERVICE_NAME, stats_name
+    )
+
+    econf = _get_envoy_config(yaml)
+    conf = _get_rl_config(econf.as_dict())
+
+    assert conf
+    assert conf.get("typed_config") == _get_ratelimit_default_conf()
+
+    assert "ir.ratelimit" not in econf.ir.aconf.errors
+
+    def check_fields(cluster):
+        assert cluster["alt_stat_name"] == stats_name
+
+    econf_foreach_cluster(
+        econf.as_dict(), check_fields, name="cluster_{}_default".format(SERVICE_NAME)
+    )
 
 
 @pytest.mark.compilertest


### PR DESCRIPTION
## Description

>I talked with @psalaberria002  and this PR supersedes #4265  due to current CI process requiring maintainer privileges. At this point it is just cleaning up notes and getting a second review from the team.

The TracingService, RateLimitService and AuthService allow the user to set the `stats_name` which is used for observability clusters. However, this field is not being propagated to the envoy configuration for the clusters (`alt_stats_name`) that these services point at. 

This PR fixes that and adds testing to ensure the generated envoy configuration includes the user provided `stats_name`.

## Related Issues
N/A

## Testing

Additional testing was added, CI is green and a manual test verifying behavior was completed.

## Checklist
 - [x] I made sure to update `CHANGELOG.md`.
 - [x] This is unlikely to impact how Ambassador performs at scale.
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
