### PR TITLE
fix regression in tracing service that leaks zipkin config into other drivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,18 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
 
 ## RELEASE NOTES
 
+## [2.3.1] TBD
+[2.3.1]: https://github.com/emissary-ingress/emissary/compare/v2.3.0...v2.3.1
+
+### Emissary-ingress and Ambassador Edge Stack
+
+- Bugfix: A regression was introduced in 2.3.0 that leaked zipkin default config fields into the
+  configuration for the other drivers (lightstep, etc...). This caused Emissary-ingress to crash on
+  startup. This issue has been resolved to ensure that the defaults are only applied when driver is
+  `zipkin` ([#4267])
+
+[#4267]: https://github.com/emissary-ingress/emissary/issues/4267
+
 ## [2.3.0] June 06, 2022
 [2.3.0]: https://github.com/emissary-ingress/emissary/compare/v2.2.2...v2.3.0
 

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -32,6 +32,18 @@
 
 changelog: https://github.com/emissary-ingress/emissary/blob/$branch$/CHANGELOG.md
 items:
+  - version: 2.3.1
+    date: "TBD"
+    notes:
+      - title: fix regression in tracing service config
+        type: bugfix
+        body: >-
+          A regression was introduced in 2.3.0 that leaked zipkin default config fields into the configuration
+          for the other drivers (lightstep, etc...). This caused $productName$ to crash on startup. This issue has been resolved
+          to ensure that the defaults are only applied when driver is <code>zipkin</code>
+        github:
+          - title: "#4267"
+            link: https://github.com/emissary-ingress/emissary/issues/4267
   - version: 2.3.0
     date: '2022-06-06'
     notes:

--- a/python/ambassador/ir/irtracing.py
+++ b/python/ambassador/ir/irtracing.py
@@ -74,24 +74,26 @@ class IRTracing(IRResource):
         # envoyv2 untyped "config" field. We actually use a "typed_config" in the final Envoy
         # config, see envoy/v2/v2tracer.py.
         driver_config = config.get("config", {})
-        # fill defaults
-        if not driver_config.get('collector_endpoint'):
-            driver_config['collector_endpoint'] = {
-                'V2': '/api/v1/spans',
-                'V3': '/api/v2/spans',
-            }[aconf.envoy_api_version]
-        if not driver_config.get('collector_endpoint_version'):
-            driver_config['collector_endpoint_version'] = {
-                'V2': 'HTTP_JSON_V1',
-                'V3': 'HTTP_JSON',
-            }[aconf.envoy_api_version]
-        if not 'trace_id_128bit' in driver_config:
-            # Make 128-bit traceid the default
-            driver_config['trace_id_128bit'] = True
-        # validate
-        if driver_config['collector_endpoint_version'] not in ['HTTP_JSON_V1', 'HTTP_JSON', 'HTTP_PROTO']:
-            self.post_error(RichStatus.fromError("collector_endpoint_version must be one of 'HTTP_JSON_V1, HTTP_JSON, HTTP_PROTO'"))
-            return False
+
+        if driver == "zipkin":
+            # fill zipkin defaults
+            if not driver_config.get('collector_endpoint'):
+                driver_config['collector_endpoint'] = {
+                    'V2': '/api/v1/spans',
+                    'V3': '/api/v2/spans',
+                }[aconf.envoy_api_version]
+            if not driver_config.get('collector_endpoint_version'):
+                driver_config['collector_endpoint_version'] = {
+                    'V2': 'HTTP_JSON_V1',
+                    'V3': 'HTTP_JSON',
+                }[aconf.envoy_api_version]
+            if not 'trace_id_128bit' in driver_config:
+                # Make 128-bit traceid the default
+                driver_config['trace_id_128bit'] = True
+            # validate
+            if driver_config['collector_endpoint_version'] not in ['HTTP_JSON_V1', 'HTTP_JSON', 'HTTP_PROTO']:
+                self.post_error(RichStatus.fromError("collector_endpoint_version must be one of 'HTTP_JSON_V1, HTTP_JSON, HTTP_PROTO'"))
+                return False
 
         # OK, we have a valid config.
         self.sourced_by(config)


### PR DESCRIPTION
## Description

A recent change to ensure that `zipkin` defaults were set correctly and support transition from the V1 api's introduced a regression. See issue #4267 for details.


## Related Issues
- #4267

## Testing

A unit test for this already exists in `python/tests/unit/test_tracing.py`. I verfied locally that it was failing and then applied the following fix and verified that it was passing.

Additional Kat testing should be added in future PR's to ensure this regression doesn't occur again.

## Checklist
 - [x] I made sure to update `CHANGELOG.md`.
 - [x] This is unlikely to impact how Ambassador performs at scale.
 - [x] My change is adequately tested. - _yes, but we should add additional testing after doing more analysis_
 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [x] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
