### PR TITLE
Enable fips mode when building envoy

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -510,6 +510,17 @@ and tests on a RAM disk (see the `/etc/fstab` line above).
     3. Don't push the build of Envoy to a Docker cache (since you're
        still actively working on it).
 
+3. To build Envoy in FIPS mode, set the following variable:
+
+   ```shell
+   export FIPS_MODE=true
+   ```
+
+   It is important to note that while building Envoy in FIPS mode is
+   required for FIPS compliance, additional steps may be necessary.
+   Emissary does not claim to be FIPS compliant or certified.
+   See [here](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/security/ssl#fips-140-2) for more information on FIPS and Envoy.
+
 #### 3. Hacking on Envoy
 
 Modify the sources in `./_cxx/envoy/`.


### PR DESCRIPTION
## Description
The following PR enables building envoy/emissary in FIPS mode. This will ensure that the envoy uses FIPS certified cryptographic algorithms when decrypting data.
Developers can set this by using the `export FIPS_MODE=true` option before doing `make update-base`.

## Related Issues
https://github.com/emissary-ingress/emissary/issues/4277

## Testing
After adding my changes I was able to to build envoy using `make update-base`. The resulting image was tagged as a FIPS enabled image-

```
# docker run -it --entrypoint envoy-static-stripped  emissaryingress/base-envoy:envoy-0.-.opt --version

envoy-static-stripped  version: 4ce93dc3ace00ae9108b179d0afaceac13f4602a/1.17.4/Modified/RELEASE/BoringSSL-FIPS
```

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `CHANGELOG.md`. _Not required_

   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations

 - [x] This is unlikely to impact how Ambassador performs at scale.

   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability

 - [x] My change is adequately tested.
    Not sure exactly how I can Unit test my changes. I have automations in place that follow the described build steps to create an Envoy image. These images do contain the FIPS suffix at the end of the version. 
    When omitting the option, it generates the appropriate image with out the suffix.

   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points

 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.

 - [x] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
