### PR TITLE
Fix cooldown feature to properly manage several instances of emissary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,8 +80,12 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
 - Feature: The agent is now able to parse api contracts using swagger 2, and to convert them to
   OpenAPI 3, making them available for use in the dev portal.
 
+- Bugfix: A regression was introduced in 2.3.0 causing the agent to miss some of the metrics coming
+  from emissary ingress before sending them to Ambassador cloud. This issue has been resolved to
+  ensure that all the nodes composing the emissary ingress cluster are reporting properly.
+
 ## [3.0.0] June 27, 2022
-[3.0.0]: https://github.com/emissary-ingress/emissary/compare/v2.3.1...v3.0.0
+[3.0.0]: https://github.com/emissary-ingress/emissary/compare/v2.3.2...v3.0.0
 
 ### Emissary-ingress and Ambassador Edge Stack
 
@@ -150,6 +154,15 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
 - Feature: With the ugprade to Envoy 1.22, Emissary-ingress can now be configured to listen for
   HTTP/3 connections using QUIC and the UDP network protocol. It currently only supports for
   connections between downstream clients and Emissary-ingress.
+
+## [2.3.2] TBD
+[2.3.2]: https://github.com/emissary-ingress/emissary/compare/v2.3.1...v2.3.2
+
+### Emissary-ingress and Ambassador Edge Stack
+
+- Bugfix: A regression was introduced in 2.3.0 causing the agent to miss some of the metrics coming
+  from emissary ingress before sending them to Ambassador cloud. This issue has been resolved to
+  ensure that all the nodes composing the emissary ingress cluster are reporting properly.
 
 ## [2.3.1] June 09, 2022
 [2.3.1]: https://github.com/emissary-ingress/emissary/compare/v2.3.0...v2.3.1

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -41,6 +41,13 @@ items:
           The agent is now able to parse api contracts using swagger 2, and to convert them to OpenAPI 3, making them
           available for use in the dev portal.
 
+      - title: fix regression in the agent for the metrics transfer.
+        type: bugfix
+        body: >-
+          A regression was introduced in 2.3.0 causing the agent to miss some of the metrics coming from
+          emissary ingress before sending them to Ambassador cloud. This issue has been resolved to ensure
+          that all the nodes composing the emissary ingress cluster are reporting properly.
+
   - version: 3.0.0
     date: '2022-06-27'
     notes:
@@ -134,6 +141,16 @@ items:
           With the ugprade to Envoy 1.22, $productName$ can now be configured to listen for HTTP/3
           connections using QUIC and the UDP network protocol. It currently only supports for connections
           between downstream clients and $productName$.
+  - version: 2.3.2
+    date: 'TBD'
+    notes:
+      - title: fix regression in the agent for the metrics transfer.
+        type: bugfix
+        body: >-
+          A regression was introduced in 2.3.0 causing the agent to miss some of the metrics coming from
+          emissary ingress before sending them to Ambassador cloud. This issue has been resolved to ensure
+          that all the nodes composing the emissary ingress cluster are reporting properly.
+
   - version: 2.3.1
     date: '2022-06-09'
     notes:

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -824,7 +824,7 @@ func (a *Agent) MetricsRelayHandler(
 		p, ok := peer.FromContext(ctx)
 
 		if !ok {
-			dlog.Errorf(ctx, "peer not found in context")
+			dlog.Warnf(ctx, "peer not found in context")
 			return
 		}
 

--- a/pkg/agent/agent_metrics_test.go
+++ b/pkg/agent/agent_metrics_test.go
@@ -48,7 +48,7 @@ func agentMetricsSetupTest() (*MockClient, *Agent) {
 		comm: &RPCComm{
 			client: clientMock,
 		},
-		metricStack: map[string][]*io_prometheus_client.MetricFamily{},
+		aggregatedMetrics: map[string][]*io_prometheus_client.MetricFamily{},
 	}
 
 	return clientMock, stubbedAgent
@@ -64,7 +64,7 @@ func TestMetricsRelayHandler(t *testing.T) {
 				IP: net.ParseIP("192.168.0.1"),
 			},
 		})
-		stubbedAgent.metricStack["192.168.0.1"] = []*io_prometheus_client.MetricFamily{acceptedMetric}
+		stubbedAgent.aggregatedMetrics["192.168.0.1"] = []*io_prometheus_client.MetricFamily{acceptedMetric}
 
 		//when
 		stubbedAgent.MetricsRelayHandler(ctx, &envoyMetrics.StreamMetricsMessage{
@@ -95,7 +95,7 @@ func TestMetricsRelayHandler(t *testing.T) {
 		})
 
 		//then
-		assert.Equal(t, stubbedAgent.metricStack["192.168.0.1"],
+		assert.Equal(t, stubbedAgent.aggregatedMetrics["192.168.0.1"],
 			[]*io_prometheus_client.MetricFamily{acceptedMetric},
 			"metrics should be added to the stack")
 		assert.Equal(t, 0, len(clientMock.SentMetrics), "nothing send to cloud")


### PR DESCRIPTION
## Description

Previously, we added a cooldown step (30s) for the metrics[ to avoid to send too many requests](https://github.com/emissary-ingress/emissary/pull/4122) to the ambassador cloud API.

Although, some values were not consistent, and we figured out that the way the metrics are sent to the agent are **one request per emissary node**, and not **one for all**.

It means that the previous iterations of the code were wrong for two reasons : 
* If we forward the metrics directly to the cloud, we won't be able to identify what node corresponds to what metric.
* If we put a simple cooldown of 30s, for 3 nodes, we'll miss 2 out of 3 sets of metrics.

As a workaround, with minimal changes, this PR changes the logic to make the metric relay handler to accumulate metrics in a map per nodes' IP, and unload them after the cooldown period.

![image](https://user-images.githubusercontent.com/16439060/174813045-efd7a022-c8ff-42b8-9bb8-458977cd8483.png)

## Testing

Adapted existing tests, & tested it in a dev cluster.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `CHANGELOG.md`.

   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations

 - [x] This is unlikely to impact how Ambassador performs at scale.

   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability

 - [x] My change is adequately tested.

   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points

 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.

 - [x] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
