### PR TITLE
Rearrange `make lint` so the log output is easier to scan

### DIFF
--- a/.github/workflows/execute-tests-and-promote.yml
+++ b/.github/workflows/execute-tests-and-promote.yml
@@ -22,6 +22,9 @@ jobs:
         uses: ./.github/actions/setup-deps
       - shell: bash
         run: |
+          make lint-deps
+      - shell: bash
+        run: |
           make lint
       - uses: ./.github/actions/after-job
         if: always()

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -833,7 +833,7 @@ We strongly recommend using an editor that can do realtime type checking
 can do this now) and also running the type checker by hand before submitting
 anything:
 
-- `make mypy` will check all the Ambassador code
+- `make lint/mypy` will check all the Ambassador code
 
 Ambassador code should produce *no* warnings and *no* errors.
 

--- a/build-aux/lint.mk
+++ b/build-aux/lint.mk
@@ -1,46 +1,66 @@
 include build-aux/tools.mk
 
-lint/go-dirs = $(OSS_HOME)
+#
+# Go
 
-lint:
-	@PS4=; set +ex; r=0; { \
-		printf "$(CYN)==>$(END) Linting $(BLU)Go$(END)...\n"; \
-		go_status=0; $(MAKE) golint || { go_status=$$?; r=$$go_status; }; \
-		\
-		printf "$(CYN)==>$(END) Linting $(BLU)Python$(END)...\n"; \
-		py_status=0; $(MAKE) mypy || { py_status=$$?; r=$$py_status; }; \
-		\
-		printf "$(CYN)==>$(END) Linting $(BLU)Helm$(END)...\n"; \
-		helm_status=0; $(MAKE) lint-chart || { helm_status=$$?; r=$$helm_status; }; \
-		\
-		set +x; \
-		printf "$(CYN)==>$(END) $(BLU)Go$(END)      lint $$(if [[ $$go_status     == 0 ]]; then printf "$(GRN)OK"; else printf "$(RED)FAIL"; fi)$(END)\n"; \
-		printf "$(CYN)==>$(END) $(BLU)Python$(END)  lint $$(if [[ $$py_status     == 0 ]]; then printf "$(GRN)OK"; else printf "$(RED)FAIL"; fi)$(END)\n"; \
-		printf "$(CYN)==>$(END) $(BLU)Helm$(END)    lint $$(if [[ $$helm_status   == 0 ]]; then printf "$(GRN)OK"; else printf "$(RED)FAIL"; fi)$(END)\n"; \
-		set -x; \
-		\
-		exit $$r; \
+lint-deps += $(tools/golangci-lint)
+lint-goals += lint/go
+lint/go: $(tools/golangci-lint)
+	$(tools/golangci-lint) run ./...
+.PHONY: lint/go
+
+format-goals += format/go
+format/go: $(tools/golangci-lint)
+	$(tools/golangci-lint) run --fix ./... || true
+.PHONY: format/go
+
+#
+# Python
+
+lint-deps += $(OSS_HOME)/venv
+lint-goals += lint/mypy
+lint/mypy: $(OSS_HOME)/venv
+	set -e; { \
+	  . $(OSS_HOME)/venv/bin/activate; \
+	  time mypy \
+	    --cache-fine-grained \
+	    --ignore-missing-imports \
+	    --check-untyped-defs \
+	    ./python/; \
 	}
-.PHONY: lint
+.PHONY: lint/mypy
 clean: .dmypy.json.rm .mypy_cache.rm-r
 
-golint: $(tools/golangci-lint)
-	@PS4=; set -x; r=0; { \
-		for dir in $(lint/go-dirs); do \
-			(cd $$dir && $(tools/golangci-lint) run ./...) || r=$$?; \
-		done; \
-		exit $$r; \
-	}
-.PHONY: golint
+#
+# Helm
 
-format: $(tools/golangci-lint)
-	@PS4=; set -x; { \
-		for dir in $(lint/go-dirs); do \
-			(cd $$dir && $(tools/golangci-lint) run --fix ./...) || true; \
-		done; \
-	}
-.PHONY: format
-
-lint-chart: $(tools/ct) $(chart_dir)
+lint-deps += $(tools/ct) $(chart_dir)
+lint-goals += lint/chart
+lint/chart: $(tools/ct) $(chart_dir)
 	cd $(chart_dir) && $(abspath $(tools/ct)) lint --config=./ct.yaml
-.PHONY: lint-chart
+.PHONY: lint/chart
+
+#
+# All together now
+
+lint-deps: ## (QA) Everything necessary to lint (useful to separate out in the logs)
+lint-deps: $(lint-deps)
+.PHONY: lint-deps
+
+lint: ## (QA) Run the linters
+lint: lint-deps
+	@printf "$(GRN)==> $(BLU)Running linters...$(END)\n"
+	@{ \
+	  r=0; \
+	  for goal in $(lint-goals); do \
+	    printf " $(BLU)=> $${goal}$(END)\n"; \
+	    echo "$(MAKE) $${goal}"; \
+	    $(MAKE) "$${goal}" || r=$$?; \
+	  done; \
+	  exit $$r; \
+	}
+.PHONY: lint
+
+format: ## (QA) Automatically fix linter complaints
+format: $(format-goals)
+.PHONY: format

--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -337,17 +337,6 @@ pytest-kat-envoy2-g%: build-aux/pytest-kat.txt $(tools/py-split-tests)
 pytest-gold:
 	sh $(COPY_GOLD) $(PYTEST_GOLD_DIR)
 
-mypy: $(OSS_HOME)/venv
-	set -e; { \
-	  . $(OSS_HOME)/venv/bin/activate; \
-	  time mypy \
-	    --cache-fine-grained \
-	    --ignore-missing-imports \
-	    --check-untyped-defs \
-	    ./python/; \
-	}
-.PHONY: mypy
-
 $(OSS_HOME)/venv: python/requirements.txt python/requirements-dev.txt
 	rm -rf $@
 	python3 -m venv $@


### PR DESCRIPTION
## Description
I'm sick and tired of `make lint` failing in CI, but CI's `make lint` output being mostly build noise and so I can't actually find the statement of why it's failing.

So, borrow a trick from Telepresence and factor out a `make lint-deps` step so that the build noise can happen in a separate CI step so that the output is easy to scan.

## Testing
I've validated that `make lint`'s output is relatively clean if `make lint-deps` has previously been run.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `CHANGELOG.md`. - no applicable changes

   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations

 - [x] This is unlikely to impact how Ambassador performs at scale. - not a runtime change

   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability

 - [x] My change is adequately tested. - I'd say so

   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points

 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently. - I did update a reference to a renamed `make` target

 - [ ] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
