### PR TITLE
KAT: Split the tests 5 ways instead of 3

### DIFF
--- a/.github/workflows/execute-tests-and-promote.yml
+++ b/.github/workflows/execute-tests-and-promote.yml
@@ -135,12 +135,14 @@ jobs:
       matrix:
         test:
           - integration
-          - kat-envoy2-g1
-          - kat-envoy2-g2
-          - kat-envoy2-g3
-          - kat-envoy3-g1
-          - kat-envoy3-g2
-          - kat-envoy3-g3
+          - kat-envoy2-1-of-4
+          - kat-envoy2-2-of-4
+          - kat-envoy2-3-of-4
+          - kat-envoy2-4-of-4
+          - kat-envoy3-1-of-4
+          - kat-envoy3-2-of-4
+          - kat-envoy3-3-of-4
+          - kat-envoy3-4-of-4
           # FIXME(lukeshu): KAT_RUN_MODE=local is disabled because it
           # needs fixed for a world where annotations are already
           # unfolded in the snapshot.

--- a/.github/workflows/execute-tests-and-promote.yml
+++ b/.github/workflows/execute-tests-and-promote.yml
@@ -135,14 +135,16 @@ jobs:
       matrix:
         test:
           - integration
-          - kat-envoy2-1-of-4
-          - kat-envoy2-2-of-4
-          - kat-envoy2-3-of-4
-          - kat-envoy2-4-of-4
-          - kat-envoy3-1-of-4
-          - kat-envoy3-2-of-4
-          - kat-envoy3-3-of-4
-          - kat-envoy3-4-of-4
+          - kat-envoy2-1-of-5
+          - kat-envoy2-2-of-5
+          - kat-envoy2-3-of-5
+          - kat-envoy2-4-of-5
+          - kat-envoy2-5-of-5
+          - kat-envoy3-1-of-5
+          - kat-envoy3-2-of-5
+          - kat-envoy3-3-of-5
+          - kat-envoy3-4-of-5
+          - kat-envoy3-5-of-5
           # FIXME(lukeshu): KAT_RUN_MODE=local is disabled because it
           # needs fixed for a world where annotations are already
           # unfolded in the snapshot.

--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -325,13 +325,13 @@ build-aux/.pytest-kat.txt.stamp: $(OSS_HOME)/venv push-pytest-images FORCE
 build-aux/pytest-kat.txt: build-aux/%: build-aux/.%.stamp $(tools/copy-ifchanged)
 	$(tools/copy-ifchanged) $< $@
 clean: build-aux/.pytest-kat.txt.stamp.rm build-aux/pytest-kat.txt.rm
-pytest-kat-envoy3-g%: build-aux/pytest-kat.txt $(tools/py-split-tests)
-	$(MAKE) pytest KAT_RUN_MODE=envoy PYTEST_ARGS="$$PYTEST_ARGS -k '$$($(tools/py-split-tests) $* 3 <build-aux/pytest-kat.txt)' python/tests/kat"
+pytest-kat-envoy3-%: build-aux/pytest-kat.txt $(tools/py-split-tests)
+	$(MAKE) pytest KAT_RUN_MODE=envoy PYTEST_ARGS="$$PYTEST_ARGS -k '$$($(tools/py-split-tests) $(subst -of-, ,$*) <build-aux/pytest-kat.txt)' python/tests/kat"
 pytest-kat-envoy2: push-pytest-images # doing this all at once is too much for CI...
 	$(MAKE) pytest KAT_RUN_MODE=envoy AMBASSADOR_ENVOY_API_VERSION=V2 PYTEST_ARGS="$$PYTEST_ARGS python/tests/kat"
 # ... so we have a separate rule to run things split up
-pytest-kat-envoy2-g%: build-aux/pytest-kat.txt $(tools/py-split-tests)
-	$(MAKE) pytest KAT_RUN_MODE=envoy AMBASSADOR_ENVOY_API_VERSION=V2 PYTEST_ARGS="$$PYTEST_ARGS -k '$$($(tools/py-split-tests) $* 3 <build-aux/pytest-kat.txt)' python/tests/kat"
+pytest-kat-envoy2-%: build-aux/pytest-kat.txt $(tools/py-split-tests)
+	$(MAKE) pytest KAT_RUN_MODE=envoy AMBASSADOR_ENVOY_API_VERSION=V2 PYTEST_ARGS="$$PYTEST_ARGS -k '$$($(tools/py-split-tests) $(subst -of-, ,$*) <build-aux/pytest-kat.txt)' python/tests/kat"
 .PHONY: pytest-kat-%
 
 pytest-gold:


### PR DESCRIPTION
## Description
A common test flake that we see is a bunch of 503s or 504s coming from the KAT tests; indicating that there just isn't enough CPU for things to respond in time.  So split the tests in to more groups.

To avoid this being quite such 1-off work, instead of having `builder.mk` hard-code a number of groups, let the targets be named `…-N-of-M` rather than `…-gN`, so that how to split it is determined by the caller.

## Related Issues
None.

## Testing
Let's see if CI flakes on this one.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `CHANGELOG.md`. - no applicable changes

   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations

 - [x] This is unlikely to impact how Ambassador performs at scale. - not a runtime change

   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability

 - [ ] My change is adequately tested.

   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points

 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently. - no tricks

 - [ ] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
