### PR TITLE
[v3.0.0] Fixes (mostly for Edge Stack)

### DIFF
--- a/cmd/entrypoint/consul.go
+++ b/cmd/entrypoint/consul.go
@@ -325,7 +325,7 @@ func watchConsul(
 
 	w.Watch(func(endpoints consulwatch.Endpoints, e error) {
 		if endpoints.Id == "" {
-			// For Ambassador, overwrite the Id with the resolver's datacenter -- the
+			// For Ambassador, overwrite the ID with the resolver's datacenter -- the
 			// Consul watcher doesn't actually hand back the DC, and we need it.
 			endpoints.Id = resolver.Spec.Datacenter
 		}

--- a/cmd/entrypoint/consul.go
+++ b/cmd/entrypoint/consul.go
@@ -20,16 +20,18 @@ type consulMapping struct {
 }
 
 func ReconcileConsul(ctx context.Context, consulWatcher *consulWatcher, s *snapshotTypes.KubernetesSnapshot) error {
+	envAmbID := GetAmbassadorID()
+
 	var mappings []consulMapping
 	for _, list := range s.Annotations {
 		for _, a := range list {
 			switch m := a.(type) {
 			case *amb.Mapping:
-				if include(m.Spec.AmbassadorID) {
+				if m.Spec.AmbassadorID.Matches(envAmbID) {
 					mappings = append(mappings, consulMapping{Service: m.Spec.Service, Resolver: m.Spec.Resolver})
 				}
 			case *amb.TCPMapping:
-				if include(m.Spec.AmbassadorID) {
+				if m.Spec.AmbassadorID.Matches(envAmbID) {
 					mappings = append(mappings, consulMapping{Service: m.Spec.Service, Resolver: m.Spec.Resolver})
 				}
 			}
@@ -38,19 +40,19 @@ func ReconcileConsul(ctx context.Context, consulWatcher *consulWatcher, s *snaps
 
 	var resolvers []*amb.ConsulResolver
 	for _, cr := range s.ConsulResolvers {
-		if include(cr.Spec.AmbassadorID) {
+		if cr.Spec.AmbassadorID.Matches(envAmbID) {
 			resolvers = append(resolvers, cr)
 		}
 	}
 
 	for _, m := range s.Mappings {
-		if include(m.Spec.AmbassadorID) {
+		if m.Spec.AmbassadorID.Matches(envAmbID) {
 			mappings = append(mappings, consulMapping{Service: m.Spec.Service, Resolver: m.Spec.Resolver})
 		}
 	}
 
 	for _, tm := range s.TCPMappings {
-		if include(tm.Spec.AmbassadorID) {
+		if tm.Spec.AmbassadorID.Matches(envAmbID) {
 			mappings = append(mappings, consulMapping{Service: tm.Spec.Service, Resolver: tm.Spec.Resolver})
 		}
 	}

--- a/cmd/entrypoint/endpoints.go
+++ b/cmd/entrypoint/endpoints.go
@@ -63,6 +63,8 @@ func newEndpointRoutingInfo() endpointRoutingInfo {
 }
 
 func (eri *endpointRoutingInfo) reconcileEndpointWatches(ctx context.Context, s *snapshotTypes.KubernetesSnapshot) {
+	envAmbID := GetAmbassadorID()
+
 	// Reset our state except for the previous endpoint watches. We keep them so we can detect if
 	// the set of things we are interested in has changed.
 	eri.resolverTypes = map[string]ResolverType{}
@@ -78,7 +80,7 @@ func (eri *endpointRoutingInfo) reconcileEndpointWatches(ctx context.Context, s 
 			if _, isInvalid := a.(*kates.Unstructured); isInvalid {
 				continue
 			}
-			if include(GetAmbID(ctx, a)) {
+			if GetAmbID(ctx, a).Matches(envAmbID) {
 				eri.checkResourcePhase1(ctx, a, "annotation")
 			}
 		}
@@ -89,25 +91,25 @@ func (eri *endpointRoutingInfo) reconcileEndpointWatches(ctx context.Context, s 
 	// need to test every resource, and no need to walk over things we're not
 	// interested in.
 	for _, m := range s.Modules {
-		if include(m.Spec.AmbassadorID) {
+		if m.Spec.AmbassadorID.Matches(envAmbID) {
 			eri.checkModule(ctx, m, "CRD")
 		}
 	}
 
 	for _, r := range s.KubernetesServiceResolvers {
-		if include(r.Spec.AmbassadorID) {
+		if r.Spec.AmbassadorID.Matches(envAmbID) {
 			eri.saveResolver(ctx, r.GetName(), KubernetesServiceResolver, "CRD")
 		}
 	}
 
 	for _, r := range s.KubernetesEndpointResolvers {
-		if include(r.Spec.AmbassadorID) {
+		if r.Spec.AmbassadorID.Matches(envAmbID) {
 			eri.saveResolver(ctx, r.GetName(), KubernetesEndpointResolver, "CRD")
 		}
 	}
 
 	for _, r := range s.ConsulResolvers {
-		if include(r.Spec.AmbassadorID) {
+		if r.Spec.AmbassadorID.Matches(envAmbID) {
 			eri.saveResolver(ctx, r.GetName(), ConsulResolver, "CRD")
 		}
 	}
@@ -128,20 +130,20 @@ func (eri *endpointRoutingInfo) reconcileEndpointWatches(ctx context.Context, s 
 			if _, isInvalid := a.(*kates.Unstructured); isInvalid {
 				continue
 			}
-			if include(GetAmbID(ctx, a)) {
+			if GetAmbID(ctx, a).Matches(envAmbID) {
 				eri.checkResourcePhase2(ctx, a, "annotation")
 			}
 		}
 	}
 
 	for _, m := range s.Mappings {
-		if include(m.Spec.AmbassadorID) {
+		if m.Spec.AmbassadorID.Matches(envAmbID) {
 			eri.checkMapping(ctx, m, "CRD")
 		}
 	}
 
 	for _, t := range s.TCPMappings {
-		if include(t.Spec.AmbassadorID) {
+		if t.Spec.AmbassadorID.Matches(envAmbID) {
 			eri.checkTCPMapping(ctx, t, "CRD")
 		}
 	}

--- a/cmd/entrypoint/endpoints.go
+++ b/cmd/entrypoint/endpoints.go
@@ -78,7 +78,7 @@ func (eri *endpointRoutingInfo) reconcileEndpointWatches(ctx context.Context, s 
 			if _, isInvalid := a.(*kates.Unstructured); isInvalid {
 				continue
 			}
-			if include(GetAmbId(ctx, a)) {
+			if include(GetAmbID(ctx, a)) {
 				eri.checkResourcePhase1(ctx, a, "annotation")
 			}
 		}
@@ -128,7 +128,7 @@ func (eri *endpointRoutingInfo) reconcileEndpointWatches(ctx context.Context, s 
 			if _, isInvalid := a.(*kates.Unstructured); isInvalid {
 				continue
 			}
-			if include(GetAmbId(ctx, a)) {
+			if include(GetAmbID(ctx, a)) {
 				eri.checkResourcePhase2(ctx, a, "annotation")
 			}
 		}

--- a/cmd/entrypoint/entrypoint.go
+++ b/cmd/entrypoint/entrypoint.go
@@ -77,8 +77,6 @@ import (
 // manager (e.g. kubernetes) is expected to take note and restart if
 // appropriate.
 
-const envAmbassadorDemoMode string = "AMBASSADOR_DEMO_MODE"
-
 func Main(ctx context.Context, Version string, args ...string) error {
 	// Setup logging according to AES_LOG_LEVEL
 	busy.SetLogLevel(logutil.DefaultLogLevel)
@@ -105,8 +103,6 @@ func Main(ctx context.Context, Version string, args ...string) error {
 		// Demo mode!
 		dlog.Infof(ctx, "DEMO MODE")
 		demoMode = true
-		// Set an environment variable so that other parts of the code can check if demo mode is active (mainly used for disabling synthetic authservice injection)
-		os.Setenv(envAmbassadorDemoMode, "true")
 	}
 
 	clusterID := GetClusterID(ctx)

--- a/cmd/entrypoint/entrypoint.go
+++ b/cmd/entrypoint/entrypoint.go
@@ -221,7 +221,7 @@ func Main(ctx context.Context, Version string, args ...string) error {
 }
 
 func clusterIDFromRootID(rootID string) string {
-	clusterUrl := fmt.Sprintf("d6e_id://%s/%s", rootID, GetAmbassadorId())
+	clusterUrl := fmt.Sprintf("d6e_id://%s/%s", rootID, GetAmbassadorID())
 	uid := uuid.NewSHA1(uuid.NameSpaceURL, []byte(clusterUrl))
 
 	return strings.ToLower(uid.String())

--- a/cmd/entrypoint/env.go
+++ b/cmd/entrypoint/env.go
@@ -19,7 +19,7 @@ func GetAgentService() string {
 	return ""
 }
 
-func GetAmbassadorId() string {
+func GetAmbassadorID() string {
 	id := os.Getenv("AMBASSADOR_ID")
 	if id != "" {
 		return id
@@ -67,7 +67,7 @@ func GetEnvoyBootstrapFile() string {
 	return env("ENVOY_BOOTSTRAP_FILE", path.Join(GetAmbassadorConfigBaseDir(), "bootstrap-ads.json"))
 }
 
-func GetEnvoyBaseId() string {
+func GetEnvoyBaseID() string {
 	return env("AMBASSADOR_ENVOY_BASE_ID", "0")
 }
 
@@ -149,7 +149,7 @@ func isDebug(name string) bool {
 }
 
 func GetEnvoyFlags() []string {
-	result := []string{"-c", GetEnvoyBootstrapFile(), "--base-id", GetEnvoyBaseId()}
+	result := []string{"-c", GetEnvoyBootstrapFile(), "--base-id", GetEnvoyBaseID()}
 	svc := GetAgentService()
 	if svc != "" {
 		result = append(result, "--drain-time-s", "1")

--- a/cmd/entrypoint/helpers.go
+++ b/cmd/entrypoint/helpers.go
@@ -78,7 +78,7 @@ func include(id amb.AmbassadorID) bool {
 
 	// It's not "_automatic_", so we have to actually do the work. Grab
 	// our AmbassadorID...
-	me := GetAmbassadorId()
+	me := GetAmbassadorID()
 
 	// ...force an empty AmbassadorID to "default", per the documentation...
 	if len(id) == 0 {

--- a/cmd/entrypoint/helpers.go
+++ b/cmd/entrypoint/helpers.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/datawire/dlib/dexec"
-	amb "github.com/emissary-ingress/emissary/v3/pkg/api/getambassador.io/v3alpha1"
 )
 
 func envbool(name string) bool {
@@ -63,34 +62,4 @@ func convert(in interface{}, out interface{}) error {
 	}
 
 	return nil
-}
-
-// Should we pay attention to a given AmbassadorID set?
-//
-// XXX Yes, amb.AmbassadorID is a singular name for a plural type. Sigh.
-func include(id amb.AmbassadorID) bool {
-	// We always pay attention to the "_automatic_" ID -- it gives us a
-	// to easily always include certain configuration resources for Edge
-	// Stack.
-	if len(id) == 1 && id[0] == "_automatic_" {
-		return true
-	}
-
-	// It's not "_automatic_", so we have to actually do the work. Grab
-	// our AmbassadorID...
-	me := GetAmbassadorID()
-
-	// ...force an empty AmbassadorID to "default", per the documentation...
-	if len(id) == 0 {
-		id = amb.AmbassadorID{"default"}
-	}
-
-	// ...and then see if our AmbassadorID is in the list.
-	for _, name := range id {
-		if me == name {
-			return true
-		}
-	}
-
-	return false
 }

--- a/cmd/entrypoint/secrets.go
+++ b/cmd/entrypoint/secrets.go
@@ -190,7 +190,7 @@ func ReconcileSecrets(ctx context.Context, sh *SnapshotHolder) error {
 			if _, isInvalid := a.(*kates.Unstructured); isInvalid {
 				continue
 			}
-			if include(GetAmbId(ctx, a)) {
+			if include(GetAmbID(ctx, a)) {
 				resources = append(resources, a)
 			}
 		}

--- a/cmd/entrypoint/snapshot.go
+++ b/cmd/entrypoint/snapshot.go
@@ -19,8 +19,8 @@ func NewKubernetesSnapshot() *snapshotTypes.KubernetesSnapshot {
 	return a
 }
 
-// GetAmbId extracts the AmbassadorId from the kubernetes resource.
-func GetAmbId(ctx context.Context, resource kates.Object) amb.AmbassadorID {
+// GetAmbID extracts the AmbassadorID from the kubernetes resource.
+func GetAmbID(ctx context.Context, resource kates.Object) amb.AmbassadorID {
 	switch r := resource.(type) {
 	case *amb.Host:
 		var id amb.AmbassadorID

--- a/cmd/entrypoint/syntheticauth.go
+++ b/cmd/entrypoint/syntheticauth.go
@@ -42,10 +42,6 @@ func ReconcileAuthServices(ctx context.Context, sh *SnapshotHolder, deltas *[]*k
 	} else if !isEdgeStack {
 		return nil
 	}
-	// We also dont want to do anything with AuthServices if the Docker demo mode is running
-	if envbool("AMBASSADOR_DEMO_MODE") {
-		return nil
-	}
 
 	// Construct a synthetic AuthService to be injected if we dont find any valid AuthServices
 	injectSyntheticAuth := true

--- a/cmd/entrypoint/testutil_fake_filtersecrets_test.go
+++ b/cmd/entrypoint/testutil_fake_filtersecrets_test.go
@@ -67,7 +67,6 @@ type: Opaque
 			snap, err := f.GetSnapshot(hasSecret("namespaced-secret", "bar"))
 			require.NoError(t, err)
 			assert.NotNil(t, snap)
-			t.Setenv("EDGE_STACK", "")
 		})
 	}
 }
@@ -112,7 +111,6 @@ type: Opaque
 			snap, err := f.GetSnapshot(hasSecret("namespaced-secret", "foo"))
 			require.NoError(t, err)
 			assert.NotNil(t, snap)
-			t.Setenv("EDGE_STACK", "")
 		})
 	}
 }

--- a/cmd/entrypoint/testutil_fake_syntheticauth_test.go
+++ b/cmd/entrypoint/testutil_fake_syntheticauth_test.go
@@ -13,7 +13,8 @@ import (
 	"github.com/emissary-ingress/emissary/v3/pkg/snapshot/v1"
 )
 
-// This predicate is used to check k8s snapshots for an AuthService matching the provided name and namespace
+// This predicate is used to check k8s snapshots for an AuthService matching the provided name and
+// namespace.
 func HasAuthService(namespace, name string) func(snapshot *snapshot.Snapshot) bool {
 	return func(snapshot *snapshot.Snapshot) bool {
 		for _, m := range snapshot.Kubernetes.AuthServices {
@@ -25,8 +26,8 @@ func HasAuthService(namespace, name string) func(snapshot *snapshot.Snapshot) bo
 	}
 }
 
-// Tests the synthetic auth generation when a valid AuthService is created
-// This authservice has protocol_Version: v3 and should not be replaced by the synthetic AuthService
+// Tests the synthetic auth generation when a valid AuthService is created.  This AuthService has
+// `protocol_version: v3` and should not be replaced by the synthetic AuthService.
 func TestSyntheticAuthValid(t *testing.T) {
 	t.Setenv("EDGE_STACK", "true")
 
@@ -47,9 +48,9 @@ spec:
 	assert.NoError(t, err)
 	f.Flush()
 
-	// Use the predicate above to check that the snapshot contains the AuthService defined above
-	// The AuthService has protocol_Version: v3 so it should not be removed/replaced by the synthetic AuthService
-	// injected by syntheticauth.go
+	// Use the predicate above to check that the snapshot contains the AuthService defined
+	// above.  The AuthService has `protocol_version: v3` so it should not be removed/replaced
+	// by the synthetic AuthService injected by syntheticauth.go
 	snap, err := f.GetSnapshot(HasAuthService("foo", "edge-stack-auth-test"))
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
@@ -58,8 +59,9 @@ spec:
 	// In edge-stack we should only ever have 1 AuthService.
 	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
 
-	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are harder to check since they always have the same name)
-	// the namespace for this extauthz cluster should be foo (since that is the namespace of the valid AuthService above)
+	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are
+	// harder to check since they always have the same name).  The namespace for this extauthz
+	// cluster should be foo (since that is the namespace of the valid AuthService above).
 	isAuthCluster := func(c *v3cluster.Cluster) bool {
 		return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_foo")
 	}
@@ -70,12 +72,14 @@ spec:
 	})
 	require.NoError(t, err)
 
-	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was defined
+	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was
+	// defined.
 	assert.NotNil(t, envoyConfig)
 }
 
-// Tests the synthetic auth generation when a valid AuthService is created as a getambassador.io/v2 resource
-// This authservice has protocol_Version: v3 and should not be replaced by the synthetic AuthService
+// Tests the synthetic auth generation when a valid AuthService is created as a getambassador.io/v2
+// resource.  This AuthService has `protocol_version: v3` and should not be replaced by the
+// synthetic AuthService.
 func TestSyntheticAuthValidV2(t *testing.T) {
 	t.Setenv("EDGE_STACK", "true")
 
@@ -96,9 +100,9 @@ spec:
 	assert.NoError(t, err)
 	f.Flush()
 
-	// Use the predicate above to check that the snapshot contains the AuthService defined above
-	// The AuthService has protocol_Version: v3 so it should not be removed/replaced by the synthetic AuthService
-	// injected by syntheticauth.go
+	// Use the predicate above to check that the snapshot contains the AuthService defined
+	// above.  The AuthService has `protocol_version: v3` so it should not be removed/replaced
+	// by the synthetic AuthService injected by syntheticauth.go
 	snap, err := f.GetSnapshot(HasAuthService("foo", "edge-stack-auth-test"))
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
@@ -107,8 +111,9 @@ spec:
 	// In edge-stack we should only ever have 1 AuthService.
 	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
 
-	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are harder to check since they always have the same name)
-	// the namespace for this extauthz cluster should be foo (since that is the namespace of the valid AuthService above)
+	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are
+	// harder to check since they always have the same name).  The namespace for this extauthz
+	// cluster should be foo (since that is the namespace of the valid AuthService above).
 	isAuthCluster := func(c *v3cluster.Cluster) bool {
 		return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_foo")
 	}
@@ -119,12 +124,13 @@ spec:
 	})
 	require.NoError(t, err)
 
-	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was defined
+	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was
+	// defined.
 	assert.NotNil(t, envoyConfig)
 }
 
-// This tests with a provided AuthService that has no protocol_version (which defaults to v2)
-// The synthetic AuthService should be created instead
+// This tests with a provided AuthService that has no protocol_version (which defaults to v2).  The
+// synthetic AuthService should be created instead.
 func TestSyntheticAuthReplace(t *testing.T) {
 	t.Setenv("EDGE_STACK", "true")
 
@@ -144,20 +150,21 @@ spec:
 	assert.NoError(t, err)
 	f.Flush()
 
-	// Use the predicate above to check that the snapshot contains the AuthService defined above
-	// The AuthService does not have protocol_Version: v3 so it should be removed and replaced by the synthetic AuthService
-	// injected by syntheticauth.go
+	// Use the predicate above to check that the snapshot contains the AuthService defined
+	// above.  The AuthService does not have `protocol_version: v3` so it should be removed and
+	// replaced by the synthetic AuthService injected by syntheticauth.go
 	snap, err := f.GetSnapshot(HasAuthService("default", "synthetic-edge-stack-auth"))
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
 
-	// The snapshot should only have the synthetic AuthService and not the one defined above
+	// The snapshot should only have the synthetic AuthService and not the one defined above.
 	assert.Equal(t, "synthetic-edge-stack-auth", snap.Kubernetes.AuthServices[0].Name)
 	// In edge-stack we should only ever have 1 AuthService.
 	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
 
-	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are harder to check since they always have the same name)
-	// the namespace for this extauthz cluster should be default (since that is the namespace of the synthetic AuthService)
+	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are
+	// harder to check since they always have the same name).  The namespace for this extauthz
+	// cluster should be default (since that is the namespace of the synthetic AuthService).
 	isAuthCluster := func(c *v3cluster.Cluster) bool {
 		return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_default")
 	}
@@ -168,12 +175,13 @@ spec:
 	})
 	require.NoError(t, err)
 
-	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was defined
+	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was
+	// defined.
 	assert.NotNil(t, envoyConfig)
 }
 
-// This tests with a provided AuthService that has no protocol_version (which defaults to v2)
-// The synthetic AuthService should be created instead
+// This tests with a provided AuthService that has no protocol_version (which defaults to v2).  The
+// synthetic AuthService should be created instead.
 func TestSyntheticAuthReplaceV2(t *testing.T) {
 	t.Setenv("EDGE_STACK", "true")
 
@@ -193,20 +201,21 @@ spec:
 	assert.NoError(t, err)
 	f.Flush()
 
-	// Use the predicate above to check that the snapshot contains the AuthService defined above
-	// The AuthService does not have protocol_Version: v3 so it should be removed and replaced by the synthetic AuthService
-	// injected by syntheticauth.go
+	// Use the predicate above to check that the snapshot contains the AuthService defined
+	// above.  The AuthService does not have `protocol_version: v3` so it should be removed and
+	// replaced by the synthetic AuthService injected by syntheticauth.go
 	snap, err := f.GetSnapshot(HasAuthService("default", "synthetic-edge-stack-auth"))
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
 
-	// The snapshot should only have the synthetic AuthService and not the one defined above
+	// The snapshot should only have the synthetic AuthService and not the one defined above.
 	assert.Equal(t, "synthetic-edge-stack-auth", snap.Kubernetes.AuthServices[0].Name)
 	// In edge-stack we should only ever have 1 AuthService.
 	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
 
-	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are harder to check since they always have the same name)
-	// the namespace for this extauthz cluster should be default (since that is the namespace of the synthetic AuthService)
+	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are
+	// harder to check since they always have the same name).  The namespace for this extauthz
+	// cluster should be default (since that is the namespace of the synthetic AuthService).
 	isAuthCluster := func(c *v3cluster.Cluster) bool {
 		return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_default")
 	}
@@ -217,13 +226,15 @@ spec:
 	})
 	require.NoError(t, err)
 
-	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was defined
+	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was
+	// defined.
 	assert.NotNil(t, envoyConfig)
 }
 
-// Tests the synthetic auth generation when an invalid AuthService is created as a getambassador.io/v2 resource
-// This authservice has protocol_Version: v3 and should not be replaced by the synthetic AuthService even though it has a bogus value
-// because the bogus field will be dropped when it is loaded and we will be left with a Valid AuthService
+// Tests the synthetic auth generation when an invalid AuthService is created.  This AuthService has
+// `protocol_version: v3` and should not be replaced by the synthetic AuthService even though it has
+// a bogus value because the bogus field will be dropped when it is loaded and we will be left with
+// a valid AuthService.
 func TestSyntheticAuthBogusField(t *testing.T) {
 	t.Setenv("EDGE_STACK", "true")
 
@@ -245,9 +256,9 @@ spec:
 	assert.NoError(t, err)
 	f.Flush()
 
-	// Use the predicate above to check that the snapshot contains the AuthService defined above
-	// The AuthService has protocol_Version: v3 so it should not be removed/replaced by the synthetic AuthService
-	// injected by syntheticauth.go
+	// Use the predicate above to check that the snapshot contains the AuthService defined
+	// above.  The AuthService has `protocol_version: v3` so it should not be removed/replaced by
+	// the synthetic AuthService injected by syntheticauth.go
 	snap, err := f.GetSnapshot(HasAuthService("foo", "edge-stack-auth-test"))
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
@@ -256,8 +267,9 @@ spec:
 	// In edge-stack we should only ever have 1 AuthService.
 	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
 
-	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are harder to check since they always have the same name)
-	// the namespace for this extauthz cluster should be foo (since that is the namespace of the valid AuthService above)
+	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are
+	// harder to check since they always have the same name).  The namespace for this extauthz
+	// cluster should be foo (since that is the namespace of the valid AuthService above).
 	isAuthCluster := func(c *v3cluster.Cluster) bool {
 		return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_foo")
 	}
@@ -268,12 +280,14 @@ spec:
 	})
 	require.NoError(t, err)
 
-	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was defined
+	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was
+	// defined.
 	assert.NotNil(t, envoyConfig)
 }
 
-// Tests the synthetic auth generation when an invalid AuthService is created as a getambassador.io/v2 resource
-// This authservice has protocol_Version: v3 and should be replaced by the synthetic AuthService because it contains a bogus field and is not valid.
+// Tests the synthetic auth generation when an invalid AuthService is created as a
+// getambassador.io/v2 resource.  This AuthService has `protocol_version: v3` and should be replaced
+// by the synthetic AuthService because it contains a bogus field and is not valid.
 func TestSyntheticAuthBogusFieldV2(t *testing.T) {
 	t.Setenv("EDGE_STACK", "true")
 
@@ -295,9 +309,9 @@ spec:
 	assert.NoError(t, err)
 	f.Flush()
 
-	// Use the predicate above to check that the snapshot contains the AuthService defined above
-	// The AuthService has protocol_Version: v3 so it should not be removed/replaced by the synthetic AuthService
-	// injected by syntheticauth.go
+	// Use the predicate above to check that the snapshot contains the AuthService defined
+	// above.  The AuthService has `protocol_version: v3` so it should not be removed/replaced
+	// by the synthetic AuthService injected by syntheticauth.go
 	snap, err := f.GetSnapshot(HasAuthService("foo", "edge-stack-auth-test"))
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
@@ -306,8 +320,9 @@ spec:
 	// In edge-stack we should only ever have 1 AuthService.
 	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
 
-	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are harder to check since they always have the same name)
-	// the namespace for this extauthz cluster should be foo (since that is the namespace of the valid AuthService above)
+	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are
+	// harder to check since they always have the same name).  The namespace for this extauthz
+	// cluster should be foo (since that is the namespace of the valid AuthService above).
 	isAuthCluster := func(c *v3cluster.Cluster) bool {
 		return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_foo")
 	}
@@ -318,12 +333,14 @@ spec:
 	})
 	require.NoError(t, err)
 
-	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was defined
+	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was
+	// defined.
 	assert.NotNil(t, envoyConfig)
 }
 
-// Tests the synthetic auth generation when an invalid AuthService (because the protocol_version is invalid for the supported enums)
-// This AuthService should be tossed out an the synthetic AuthService should be injected
+// Tests the synthetic auth generation when an invalid AuthService (because the protocol_version is
+// invalid for the supported enums).  This AuthService should be tossed out an the synthetic
+// AuthService should be injected.
 func TestSyntheticAuthInvalidProtocolVer(t *testing.T) {
 	t.Setenv("EDGE_STACK", "true")
 
@@ -345,19 +362,21 @@ spec:
 	assert.NoError(t, err)
 	f.Flush()
 
-	// Use the predicate above to check that the snapshot contains the Synthetic AuthService
-	// The AuthService has protocol_Version: v3, but it has a bogus field so it should not be validated and instead we inject the synthetic authservice
+	// Use the predicate above to check that the snapshot contains the synthetic AuthService.
+	// The AuthService has `protocol_version: v3`, but it has a bogus field so it should not be
+	// validated and instead we inject the synthetic AuthService.
 	snap, err := f.GetSnapshot(HasAuthService("default", "synthetic-edge-stack-auth"))
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
 
-	// The snapshot should only have the synthetic AuthService and not the one defined above
+	// The snapshot should only have the synthetic AuthService and not the one defined above.
 	assert.Equal(t, "synthetic-edge-stack-auth", snap.Kubernetes.AuthServices[0].Name)
 	// In edge-stack we should only ever have 1 AuthService.
 	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
 
-	// Check for an ext_authz cluster name matching the synthetic AuthService.
-	// the namespace for this extauthz cluster should be default (since that is the namespace of the synthetic AuthService)
+	// Check for an ext_authz cluster name matching the synthetic AuthService.  The namespace
+	// for this extauthz cluster should be default (since that is the namespace of the synthetic
+	// AuthService).
 	isAuthCluster := func(c *v3cluster.Cluster) bool {
 		return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_default")
 	}
@@ -368,14 +387,16 @@ spec:
 	})
 	require.NoError(t, err)
 
-	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was defined
+	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was
+	// defined.
 	assert.NotNil(t, envoyConfig)
 }
 
-// Tests the synthetic auth generation when an invalid AuthService is created and edited several times in succession.
-// After the config is edited several times, we should see that the final result is our provided valid AuthService.
-// There should not be any duplicate AuthService resources, and the synthetic AuthService that gets created when the first
-// Invalid AuthService is applied should be removed when the final edit makes it a valid AuthService.
+// Tests the synthetic auth generation when an invalid AuthService is created and edited several
+// times in succession.  After the config is edited several times, we should see that the final
+// result is our provided valid AuthService.  There should not be any duplicate AuthService
+// resources, and the synthetic AuthService that gets created when the first invalid AuthService is
+// applied should be removed when the final edit makes it a valid AuthService.
 func TestSyntheticAuthChurn(t *testing.T) {
 	t.Setenv("EDGE_STACK", "true")
 
@@ -433,20 +454,21 @@ spec:
 `)
 	assert.NoError(t, err)
 
-	// Use the predicate above to check that the snapshot contains the AuthService defined above
-	// The AuthService has protocol_Version: v3 so it should not be removed/replaced by the synthetic AuthService
-	// injected by syntheticauth.go
+	// Use the predicate above to check that the snapshot contains the AuthService defined
+	// above.  The AuthService has `protocol_version: v3` so it should not be removed/replaced
+	// by the synthetic AuthService injected by syntheticauth.go
 	snap, err := f.GetSnapshot(HasAuthService("foo", "edge-stack-auth-test"))
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
 
-	// The snapshot should only have the synthetic AuthService and not the one defined above
+	// The snapshot should only have the synthetic AuthService and not the one defined above.
 	assert.Equal(t, "edge-stack-auth-test", snap.Kubernetes.AuthServices[0].Name)
 	// In edge-stack we should only ever have 1 AuthService.
 	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
 
-	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are harder to check since they always have the same name)
-	// the namespace for this extauthz cluster should be foo (since that is the namespace of the valid AuthService above)
+	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are
+	// harder to check since they always have the same name).  The namespace for this extauthz
+	// cluster should be foo (since that is the namespace of the valid AuthService above)
 	isAuthCluster := func(c *v3cluster.Cluster) bool {
 		return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_foo")
 	}
@@ -461,15 +483,16 @@ spec:
 	assert.NotNil(t, envoyConfig)
 }
 
-// Tests the synthetic auth generation by first creating an invalid AuthService and confirming that the synthetic AuthService gets injected.
-// Afterwards, a valid AuthService is applied and we expect the synthetic AuthService to be removed in favor of the new valid AuthService.
+// Tests the synthetic auth generation by first creating an invalid AuthService and confirming that
+// the synthetic AuthService gets injected.  Afterwards, a valid AuthService is applied and we
+// expect the synthetic AuthService to be removed in favor of the new valid AuthService.
 func TestSyntheticAuthInjectAndRemove(t *testing.T) {
 	t.Setenv("EDGE_STACK", "true")
 
 	f := entrypoint.RunFake(t, entrypoint.FakeConfig{EnvoyConfig: true}, nil)
 	f.AutoFlush(true)
 
-	// This will cause a synthethic authservice to be injected
+	// This will cause a synthethic AuthService to be injected.
 	err := f.UpsertYAML(`
 ---
 apiVersion: getambassador.io/v3alpha1
@@ -484,19 +507,21 @@ spec:
 `)
 	assert.NoError(t, err)
 
-	// Use the predicate above to check that the snapshot contains the Synthetic AuthService
-	// The AuthService has protocol_Version: v3, but it has a bogus field so it should not be validated and instead we inject the synthetic authservice
+	// Use the predicate above to check that the snapshot contains the synthetic AuthService.
+	// The AuthService has `protocol_version: v3`, but it has a bogus field so it should not be
+	// validated and instead we inject the synthetic AuthService.
 	snap, err := f.GetSnapshot(HasAuthService("default", "synthetic-edge-stack-auth"))
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
 
-	// The snapshot should only have the synthetic AuthService and not the one defined above
+	// The snapshot should only have the synthetic AuthService and not the one defined above.
 	assert.Equal(t, "synthetic-edge-stack-auth", snap.Kubernetes.AuthServices[0].Name)
 	// We should only have 1 AuthService.
 	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
 
-	// Check for an ext_authz cluster name matching the synthetic AuthService.
-	// the namespace for this extauthz cluster should be default (since that is the namespace of the synthetic AuthService)
+	// Check for an ext_authz cluster name matching the synthetic AuthService.  The namespace
+	// for this extauthz cluster should be default (since that is the namespace of the synthetic
+	// AuthService).
 	isAuthCluster := func(c *v3cluster.Cluster) bool {
 		return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_default")
 	}
@@ -507,13 +532,15 @@ spec:
 	})
 	require.NoError(t, err)
 
-	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was defined
+	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was
+	// defined.
 	assert.NotNil(t, envoyConfig)
 
 	t.Setenv("EDGE_STACK", "")
 
-	// Updating the yaml for that AuthService to include protocol_version: v3 should make it valid and then
-	// Remove our synthetic AuthService and allow the now valid AuthService to be used.
+	// Updating the yaml for that AuthService to include `protocol_version: v3` should make it
+	// valid and then remove our synthetic AuthService and allow the now valid AuthService to be
+	// used.
 	err = f.UpsertYAML(`
 ---
 apiVersion: getambassador.io/v3alpha1
@@ -528,9 +555,9 @@ spec:
 `)
 	assert.NoError(t, err)
 
-	// Use the predicate above to check that the snapshot contains the AuthService defined above
-	// The AuthService has protocol_Version: v3 so it should not be removed/replaced by the synthetic AuthService
-	// injected by syntheticauth.go
+	// Use the predicate above to check that the snapshot contains the AuthService defined
+	// above.  The AuthService has `protocol_version: v3` so it should not be removed/replaced
+	// by the synthetic AuthService injected by syntheticauth.go
 	snap, err = f.GetSnapshot(HasAuthService("foo", "edge-stack-auth-test"))
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
@@ -539,8 +566,9 @@ spec:
 	// In edge-stack we should only ever have 1 AuthService.
 	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
 
-	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are harder to check since they always have the same name)
-	// the namespace for this extauthz cluster should be foo (since that is the namespace of the valid AuthService above)
+	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are
+	// harder to check since they always have the same name).  The namespace for this extauthz
+	// cluster should be foo (since that is the namespace of the valid AuthService above).
 	isAuthCluster = func(c *v3cluster.Cluster) bool {
 		return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_foo")
 	}
@@ -551,12 +579,14 @@ spec:
 	})
 	require.NoError(t, err)
 
-	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was defined
+	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was
+	// defined.
 	assert.NotNil(t, envoyConfig)
 }
 
-// This AuthService points at 127.0.0.1:8500, but it does not have protocol_version: v3. It also has additional fields set.
-// The correct action is to create a SyntheticAuth copy of this AuthService with the same fields but with protocol_version: v3
+// This AuthService points at 127.0.0.1:8500, but it does not have `protocol_version: v3`.  It also
+// has additional fields set.  The correct action is to create a SyntheticAuth copy of this
+// AuthService with the same fields but with `protocol_version: v3`.
 func TestSyntheticAuthCopyFields(t *testing.T) {
 	t.Setenv("EDGE_STACK", "true")
 
@@ -578,10 +608,10 @@ spec:
 	assert.NoError(t, err)
 	f.Flush()
 
-	// Use the predicate above to check that the snapshot contains the Synthetic AuthService
-	// The AuthService has protocol_Version: v3, but it is missing the protocol_version: v3 field.
-	// We expect the synthetic AuthService to be injected, but later we will check that the synthetic AuthService has
-	// Our custom timeout_ms field
+	// Use the predicate above to check that the snapshot contains the synthetic AuthService.
+	// The AuthService has `protocol_version: v3`, but it is missing the `protocol_version: v3`
+	// field.  We expect the synthetic AuthService to be injected, but later we will check that
+	// the synthetic AuthService has Our custom timeout_ms field.
 	snap, err := f.GetSnapshot(HasAuthService("default", "synthetic-edge-stack-auth"))
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
@@ -591,14 +621,16 @@ spec:
 	// In edge-stack we should only ever have 1 AuthService.
 	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
 
-	// Even though it is the synthetic AuthService, we should have the custom timeout_ms and v3 protocol version
+	// Even though it is the synthetic AuthService, we should have the custom timeout_ms and v3
+	// protocol version.
 	for _, authService := range snap.Kubernetes.AuthServices {
 		assert.Equal(t, int64(12345), authService.Spec.Timeout.Duration.Milliseconds())
 		assert.Equal(t, "v3", authService.Spec.ProtocolVersion)
 	}
 
-	// Check for an ext_authz cluster name matching the synthetic AuthService.
-	// the namespace for this extauthz cluster should be default (since that is the namespace of the synthetic AuthService)
+	// Check for an ext_authz cluster name matching the synthetic AuthService.  The namespace
+	// for this extauthz cluster should be default (since that is the namespace of the synthetic
+	// AuthService).
 	isAuthCluster := func(c *v3cluster.Cluster) bool {
 		return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_default")
 	}
@@ -609,11 +641,13 @@ spec:
 	})
 	require.NoError(t, err)
 
-	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was defined
+	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was
+	// defined.
 	assert.NotNil(t, envoyConfig)
 }
 
-// This AuthService does not point at 127.0.0.1:8500, we leave it alone rather than adding a synthetic one
+// This AuthService does not point at 127.0.0.1:8500, we leave it alone rather than adding a
+// synthetic one.
 func TestSyntheticAuthCustomAuthService(t *testing.T) {
 	t.Setenv("EDGE_STACK", "true")
 
@@ -635,9 +669,9 @@ spec:
 	assert.NoError(t, err)
 	f.Flush()
 
-	// Use the predicate above to check that the snapshot contains the AuthService defined above
-	// The AuthService has protocol_Version: v3 so it should not be removed/replaced by the synthetic AuthService
-	// injected by syntheticauth.go
+	// Use the predicate above to check that the snapshot contains the AuthService defined
+	// above.  The AuthService has `protocol_version: v3` so it should not be removed/replaced
+	// by the synthetic AuthService injected by syntheticauth.go
 	snap, err := f.GetSnapshot(HasAuthService("foo", "edge-stack-auth-test"))
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
@@ -650,8 +684,9 @@ spec:
 		assert.Equal(t, "dummy-service", authService.Spec.AuthService)
 	}
 
-	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are harder to check since they always have the same name)
-	// the namespace for this extauthz cluster should be foo (since that is the namespace of the valid AuthService above)
+	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are
+	// harder to check since they always have the same name).  the namespace for this extauthz
+	// cluster should be foo (since that is the namespace of the valid AuthService above).
 	isAuthCluster := func(c *v3cluster.Cluster) bool {
 		return strings.Contains(c.Name, "cluster_extauth_dummy_service_foo")
 	}
@@ -662,12 +697,13 @@ spec:
 	})
 	require.NoError(t, err)
 
-	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was defined
+	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was
+	// defined.
 	assert.NotNil(t, envoyConfig)
 }
 
-// When deciding if we need to inject a synthetic AuthService or not, we need to be able to reliably determine if that
-// AuthService points at a localhost:8500 or not
+// When deciding if we need to inject a synthetic AuthService or not, we need to be able to reliably
+// determine if that AuthService points at a localhost:8500 or not.
 func TestIsLocalhost8500(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entrypoint/testutil_fake_syntheticauth_test.go
+++ b/cmd/entrypoint/testutil_fake_syntheticauth_test.go
@@ -29,11 +29,13 @@ func HasAuthService(namespace, name string) func(snapshot *snapshot.Snapshot) bo
 // Tests the synthetic auth generation when a valid AuthService is created.  This AuthService has
 // `protocol_version: v3` and should not be replaced by the synthetic AuthService.
 func TestSyntheticAuthValid(t *testing.T) {
-	t.Setenv("EDGE_STACK", "true")
+	if true {
+		if true {
+			t.Setenv("EDGE_STACK", "true")
 
-	f := entrypoint.RunFake(t, entrypoint.FakeConfig{EnvoyConfig: true}, nil)
+			f := entrypoint.RunFake(t, entrypoint.FakeConfig{EnvoyConfig: true}, nil)
 
-	err := f.UpsertYAML(`
+			err := f.UpsertYAML(`
 ---
 apiVersion: getambassador.io/v3alpha1
 kind: AuthService
@@ -45,47 +47,54 @@ spec:
   protocol_version: "v3"
   proto: "grpc"
 `)
-	assert.NoError(t, err)
-	f.Flush()
+			assert.NoError(t, err)
+			f.Flush()
 
-	// Use the predicate above to check that the snapshot contains the AuthService defined
-	// above.  The AuthService has `protocol_version: v3` so it should not be removed/replaced
-	// by the synthetic AuthService injected by syntheticauth.go
-	snap, err := f.GetSnapshot(HasAuthService("foo", "edge-stack-auth-test"))
-	assert.NoError(t, err)
-	assert.NotNil(t, snap)
+			// Use the predicate above to check that the snapshot contains the
+			// AuthService defined above.  The AuthService has `protocol_version: v3` so
+			// it should not be removed/replaced by the synthetic AuthService injected
+			// by syntheticauth.go
+			snap, err := f.GetSnapshot(HasAuthService("foo", "edge-stack-auth-test"))
+			assert.NoError(t, err)
+			assert.NotNil(t, snap)
 
-	assert.Equal(t, "edge-stack-auth-test", snap.Kubernetes.AuthServices[0].Name)
-	// In edge-stack we should only ever have 1 AuthService.
-	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
+			assert.Equal(t, "edge-stack-auth-test", snap.Kubernetes.AuthServices[0].Name)
+			// In edge-stack we should only ever have 1 AuthService.
+			assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
 
-	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are
-	// harder to check since they always have the same name).  The namespace for this extauthz
-	// cluster should be foo (since that is the namespace of the valid AuthService above).
-	isAuthCluster := func(c *v3cluster.Cluster) bool {
-		return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_foo")
+			// Check for an ext_authz cluster name matching the provided AuthService
+			// (Http_Filters are harder to check since they always have the same name).
+			// The namespace for this extauthz cluster should be foo (since that is the
+			// namespace of the valid AuthService above).
+			isAuthCluster := func(c *v3cluster.Cluster) bool {
+				return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_foo")
+			}
+
+			// Grab the next Envoy config that has an Edge Stack auth cluster on
+			// 127.0.0.1:8500
+			envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
+				return FindCluster(envoy, isAuthCluster) != nil
+			})
+			require.NoError(t, err)
+
+			// Make sure an Envoy Config containing a extauth cluster for the
+			// AuthService that was defined.
+			assert.NotNil(t, envoyConfig)
+		}
 	}
-
-	// Grab the next Envoy config that has an Edge Stack auth cluster on 127.0.0.1:8500
-	envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
-		return FindCluster(envoy, isAuthCluster) != nil
-	})
-	require.NoError(t, err)
-
-	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was
-	// defined.
-	assert.NotNil(t, envoyConfig)
 }
 
 // Tests the synthetic auth generation when a valid AuthService is created as a getambassador.io/v2
 // resource.  This AuthService has `protocol_version: v3` and should not be replaced by the
 // synthetic AuthService.
 func TestSyntheticAuthValidV2(t *testing.T) {
-	t.Setenv("EDGE_STACK", "true")
+	if true {
+		if true {
+			t.Setenv("EDGE_STACK", "true")
 
-	f := entrypoint.RunFake(t, entrypoint.FakeConfig{EnvoyConfig: true}, nil)
+			f := entrypoint.RunFake(t, entrypoint.FakeConfig{EnvoyConfig: true}, nil)
 
-	err := f.UpsertYAML(`
+			err := f.UpsertYAML(`
 ---
 apiVersion: getambassador.io/v2
 kind: AuthService
@@ -97,46 +106,53 @@ spec:
   protocol_version: "v3"
   proto: "grpc"
 `)
-	assert.NoError(t, err)
-	f.Flush()
+			assert.NoError(t, err)
+			f.Flush()
 
-	// Use the predicate above to check that the snapshot contains the AuthService defined
-	// above.  The AuthService has `protocol_version: v3` so it should not be removed/replaced
-	// by the synthetic AuthService injected by syntheticauth.go
-	snap, err := f.GetSnapshot(HasAuthService("foo", "edge-stack-auth-test"))
-	assert.NoError(t, err)
-	assert.NotNil(t, snap)
+			// Use the predicate above to check that the snapshot contains the
+			// AuthService defined above.  The AuthService has `protocol_version: v3` so
+			// it should not be removed/replaced by the synthetic AuthService injected
+			// by syntheticauth.go
+			snap, err := f.GetSnapshot(HasAuthService("foo", "edge-stack-auth-test"))
+			assert.NoError(t, err)
+			assert.NotNil(t, snap)
 
-	assert.Equal(t, "edge-stack-auth-test", snap.Kubernetes.AuthServices[0].Name)
-	// In edge-stack we should only ever have 1 AuthService.
-	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
+			assert.Equal(t, "edge-stack-auth-test", snap.Kubernetes.AuthServices[0].Name)
+			// In edge-stack we should only ever have 1 AuthService.
+			assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
 
-	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are
-	// harder to check since they always have the same name).  The namespace for this extauthz
-	// cluster should be foo (since that is the namespace of the valid AuthService above).
-	isAuthCluster := func(c *v3cluster.Cluster) bool {
-		return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_foo")
+			// Check for an ext_authz cluster name matching the provided AuthService
+			// (Http_Filters are harder to check since they always have the same name).
+			// The namespace for this extauthz cluster should be foo (since that is the
+			// namespace of the valid AuthService above).
+			isAuthCluster := func(c *v3cluster.Cluster) bool {
+				return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_foo")
+			}
+
+			// Grab the next Envoy config that has an Edge Stack auth cluster on
+			// 127.0.0.1:8500
+			envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
+				return FindCluster(envoy, isAuthCluster) != nil
+			})
+			require.NoError(t, err)
+
+			// Make sure an Envoy Config containing a extauth cluster for the
+			// AuthService that was defined.
+			assert.NotNil(t, envoyConfig)
+		}
 	}
-
-	// Grab the next Envoy config that has an Edge Stack auth cluster on 127.0.0.1:8500
-	envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
-		return FindCluster(envoy, isAuthCluster) != nil
-	})
-	require.NoError(t, err)
-
-	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was
-	// defined.
-	assert.NotNil(t, envoyConfig)
 }
 
 // This tests with a provided AuthService that has no protocol_version (which defaults to v2).  The
 // synthetic AuthService should be created instead.
 func TestSyntheticAuthReplace(t *testing.T) {
-	t.Setenv("EDGE_STACK", "true")
+	if true {
+		if true {
+			t.Setenv("EDGE_STACK", "true")
 
-	f := entrypoint.RunFake(t, entrypoint.FakeConfig{EnvoyConfig: true}, nil)
+			f := entrypoint.RunFake(t, entrypoint.FakeConfig{EnvoyConfig: true}, nil)
 
-	err := f.UpsertYAML(`
+			err := f.UpsertYAML(`
 ---
 apiVersion: getambassador.io/v3alpha1
 kind: AuthService
@@ -147,47 +163,55 @@ spec:
   auth_service: 127.0.0.1:8500
   proto: "grpc"
 `)
-	assert.NoError(t, err)
-	f.Flush()
+			assert.NoError(t, err)
+			f.Flush()
 
-	// Use the predicate above to check that the snapshot contains the AuthService defined
-	// above.  The AuthService does not have `protocol_version: v3` so it should be removed and
-	// replaced by the synthetic AuthService injected by syntheticauth.go
-	snap, err := f.GetSnapshot(HasAuthService("default", "synthetic-edge-stack-auth"))
-	assert.NoError(t, err)
-	assert.NotNil(t, snap)
+			// Use the predicate above to check that the snapshot contains the
+			// AuthService defined above.  The AuthService does not have
+			// `protocol_version: v3` so it should be removed and replaced by the
+			// synthetic AuthService injected by syntheticauth.go
+			snap, err := f.GetSnapshot(HasAuthService("default", "synthetic-edge-stack-auth"))
+			assert.NoError(t, err)
+			assert.NotNil(t, snap)
 
-	// The snapshot should only have the synthetic AuthService and not the one defined above.
-	assert.Equal(t, "synthetic-edge-stack-auth", snap.Kubernetes.AuthServices[0].Name)
-	// In edge-stack we should only ever have 1 AuthService.
-	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
+			// The snapshot should only have the synthetic AuthService and not the one
+			// defined above.
+			assert.Equal(t, "synthetic-edge-stack-auth", snap.Kubernetes.AuthServices[0].Name)
+			// In edge-stack we should only ever have 1 AuthService.
+			assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
 
-	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are
-	// harder to check since they always have the same name).  The namespace for this extauthz
-	// cluster should be default (since that is the namespace of the synthetic AuthService).
-	isAuthCluster := func(c *v3cluster.Cluster) bool {
-		return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_default")
+			// Check for an ext_authz cluster name matching the provided AuthService
+			// (Http_Filters are harder to check since they always have the same name).
+			// The namespace for this extauthz cluster should be default (since that is
+			// the namespace of the synthetic AuthService).
+			isAuthCluster := func(c *v3cluster.Cluster) bool {
+				return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_default")
+			}
+
+			// Grab the next Envoy config that has an Edge Stack auth cluster on
+			// 127.0.0.1:8500
+			envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
+				return FindCluster(envoy, isAuthCluster) != nil
+			})
+			require.NoError(t, err)
+
+			// Make sure an Envoy Config containing a extauth cluster for the
+			// AuthService that was defined.
+			assert.NotNil(t, envoyConfig)
+		}
 	}
-
-	// Grab the next Envoy config that has an Edge Stack auth cluster on 127.0.0.1:8500
-	envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
-		return FindCluster(envoy, isAuthCluster) != nil
-	})
-	require.NoError(t, err)
-
-	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was
-	// defined.
-	assert.NotNil(t, envoyConfig)
 }
 
 // This tests with a provided AuthService that has no protocol_version (which defaults to v2).  The
 // synthetic AuthService should be created instead.
 func TestSyntheticAuthReplaceV2(t *testing.T) {
-	t.Setenv("EDGE_STACK", "true")
+	if true {
+		if true {
+			t.Setenv("EDGE_STACK", "true")
 
-	f := entrypoint.RunFake(t, entrypoint.FakeConfig{EnvoyConfig: true}, nil)
+			f := entrypoint.RunFake(t, entrypoint.FakeConfig{EnvoyConfig: true}, nil)
 
-	err := f.UpsertYAML(`
+			err := f.UpsertYAML(`
 ---
 apiVersion: getambassador.io/v2
 kind: AuthService
@@ -198,37 +222,43 @@ spec:
   auth_service: 127.0.0.1:8500
   proto: "grpc"
 `)
-	assert.NoError(t, err)
-	f.Flush()
+			assert.NoError(t, err)
+			f.Flush()
 
-	// Use the predicate above to check that the snapshot contains the AuthService defined
-	// above.  The AuthService does not have `protocol_version: v3` so it should be removed and
-	// replaced by the synthetic AuthService injected by syntheticauth.go
-	snap, err := f.GetSnapshot(HasAuthService("default", "synthetic-edge-stack-auth"))
-	assert.NoError(t, err)
-	assert.NotNil(t, snap)
+			// Use the predicate above to check that the snapshot contains the
+			// AuthService defined above.  The AuthService does not have
+			// `protocol_version: v3` so it should be removed and replaced by the
+			// synthetic AuthService injected by syntheticauth.go
+			snap, err := f.GetSnapshot(HasAuthService("default", "synthetic-edge-stack-auth"))
+			assert.NoError(t, err)
+			assert.NotNil(t, snap)
 
-	// The snapshot should only have the synthetic AuthService and not the one defined above.
-	assert.Equal(t, "synthetic-edge-stack-auth", snap.Kubernetes.AuthServices[0].Name)
-	// In edge-stack we should only ever have 1 AuthService.
-	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
+			// The snapshot should only have the synthetic AuthService and not the one
+			// defined above.
+			assert.Equal(t, "synthetic-edge-stack-auth", snap.Kubernetes.AuthServices[0].Name)
+			// In edge-stack we should only ever have 1 AuthService.
+			assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
 
-	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are
-	// harder to check since they always have the same name).  The namespace for this extauthz
-	// cluster should be default (since that is the namespace of the synthetic AuthService).
-	isAuthCluster := func(c *v3cluster.Cluster) bool {
-		return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_default")
+			// Check for an ext_authz cluster name matching the provided AuthService
+			// (Http_Filters are harder to check since they always have the same name).
+			// The namespace for this extauthz cluster should be default (since that is
+			// the namespace of the synthetic AuthService).
+			isAuthCluster := func(c *v3cluster.Cluster) bool {
+				return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_default")
+			}
+
+			// Grab the next Envoy config that has an Edge Stack auth cluster on
+			// 127.0.0.1:8500
+			envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
+				return FindCluster(envoy, isAuthCluster) != nil
+			})
+			require.NoError(t, err)
+
+			// Make sure an Envoy Config containing a extauth cluster for the
+			// AuthService that was defined.
+			assert.NotNil(t, envoyConfig)
+		}
 	}
-
-	// Grab the next Envoy config that has an Edge Stack auth cluster on 127.0.0.1:8500
-	envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
-		return FindCluster(envoy, isAuthCluster) != nil
-	})
-	require.NoError(t, err)
-
-	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was
-	// defined.
-	assert.NotNil(t, envoyConfig)
 }
 
 // Tests the synthetic auth generation when an invalid AuthService is created.  This AuthService has
@@ -236,11 +266,13 @@ spec:
 // a bogus value because the bogus field will be dropped when it is loaded and we will be left with
 // a valid AuthService.
 func TestSyntheticAuthBogusField(t *testing.T) {
-	t.Setenv("EDGE_STACK", "true")
+	if true {
+		if true {
+			t.Setenv("EDGE_STACK", "true")
 
-	f := entrypoint.RunFake(t, entrypoint.FakeConfig{EnvoyConfig: true}, nil)
+			f := entrypoint.RunFake(t, entrypoint.FakeConfig{EnvoyConfig: true}, nil)
 
-	err := f.UpsertYAML(`
+			err := f.UpsertYAML(`
 ---
 apiVersion: getambassador.io/v3alpha1
 kind: AuthService
@@ -253,47 +285,54 @@ spec:
   proto: "grpc"
   bogus_field: "foo"
 `)
-	assert.NoError(t, err)
-	f.Flush()
+			assert.NoError(t, err)
+			f.Flush()
 
-	// Use the predicate above to check that the snapshot contains the AuthService defined
-	// above.  The AuthService has `protocol_version: v3` so it should not be removed/replaced by
-	// the synthetic AuthService injected by syntheticauth.go
-	snap, err := f.GetSnapshot(HasAuthService("foo", "edge-stack-auth-test"))
-	assert.NoError(t, err)
-	assert.NotNil(t, snap)
+			// Use the predicate above to check that the snapshot contains the
+			// AuthService defined above.  The AuthService has `protocol_version: v3` so
+			// it should not be removed/replaced by the synthetic AuthService injected
+			// by syntheticauth.go
+			snap, err := f.GetSnapshot(HasAuthService("foo", "edge-stack-auth-test"))
+			assert.NoError(t, err)
+			assert.NotNil(t, snap)
 
-	assert.Equal(t, "edge-stack-auth-test", snap.Kubernetes.AuthServices[0].Name)
-	// In edge-stack we should only ever have 1 AuthService.
-	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
+			assert.Equal(t, "edge-stack-auth-test", snap.Kubernetes.AuthServices[0].Name)
+			// In edge-stack we should only ever have 1 AuthService.
+			assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
 
-	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are
-	// harder to check since they always have the same name).  The namespace for this extauthz
-	// cluster should be foo (since that is the namespace of the valid AuthService above).
-	isAuthCluster := func(c *v3cluster.Cluster) bool {
-		return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_foo")
+			// Check for an ext_authz cluster name matching the provided AuthService
+			// (Http_Filters are harder to check since they always have the same name).
+			// The namespace for this extauthz cluster should be foo (since that is the
+			// namespace of the valid AuthService above).
+			isAuthCluster := func(c *v3cluster.Cluster) bool {
+				return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_foo")
+			}
+
+			// Grab the next Envoy config that has an Edge Stack auth cluster on
+			// 127.0.0.1:8500
+			envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
+				return FindCluster(envoy, isAuthCluster) != nil
+			})
+			require.NoError(t, err)
+
+			// Make sure an Envoy Config containing a extauth cluster for the
+			// AuthService that was defined.
+			assert.NotNil(t, envoyConfig)
+		}
 	}
-
-	// Grab the next Envoy config that has an Edge Stack auth cluster on 127.0.0.1:8500
-	envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
-		return FindCluster(envoy, isAuthCluster) != nil
-	})
-	require.NoError(t, err)
-
-	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was
-	// defined.
-	assert.NotNil(t, envoyConfig)
 }
 
 // Tests the synthetic auth generation when an invalid AuthService is created as a
 // getambassador.io/v2 resource.  This AuthService has `protocol_version: v3` and should be replaced
 // by the synthetic AuthService because it contains a bogus field and is not valid.
 func TestSyntheticAuthBogusFieldV2(t *testing.T) {
-	t.Setenv("EDGE_STACK", "true")
+	if true {
+		if true {
+			t.Setenv("EDGE_STACK", "true")
 
-	f := entrypoint.RunFake(t, entrypoint.FakeConfig{EnvoyConfig: true}, nil)
+			f := entrypoint.RunFake(t, entrypoint.FakeConfig{EnvoyConfig: true}, nil)
 
-	err := f.UpsertYAML(`
+			err := f.UpsertYAML(`
 ---
 apiVersion: getambassador.io/v2
 kind: AuthService
@@ -306,36 +345,41 @@ spec:
   proto: "grpc"
   bogus_field: "foo"
 `)
-	assert.NoError(t, err)
-	f.Flush()
+			assert.NoError(t, err)
+			f.Flush()
 
-	// Use the predicate above to check that the snapshot contains the AuthService defined
-	// above.  The AuthService has `protocol_version: v3` so it should not be removed/replaced
-	// by the synthetic AuthService injected by syntheticauth.go
-	snap, err := f.GetSnapshot(HasAuthService("foo", "edge-stack-auth-test"))
-	assert.NoError(t, err)
-	assert.NotNil(t, snap)
+			// Use the predicate above to check that the snapshot contains the
+			// AuthService defined above.  The AuthService has `protocol_version: v3` so
+			// it should not be removed/replaced by the synthetic AuthService injected
+			// by syntheticauth.go
+			snap, err := f.GetSnapshot(HasAuthService("foo", "edge-stack-auth-test"))
+			assert.NoError(t, err)
+			assert.NotNil(t, snap)
 
-	assert.Equal(t, "edge-stack-auth-test", snap.Kubernetes.AuthServices[0].Name)
-	// In edge-stack we should only ever have 1 AuthService.
-	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
+			assert.Equal(t, "edge-stack-auth-test", snap.Kubernetes.AuthServices[0].Name)
+			// In edge-stack we should only ever have 1 AuthService.
+			assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
 
-	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are
-	// harder to check since they always have the same name).  The namespace for this extauthz
-	// cluster should be foo (since that is the namespace of the valid AuthService above).
-	isAuthCluster := func(c *v3cluster.Cluster) bool {
-		return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_foo")
+			// Check for an ext_authz cluster name matching the provided AuthService
+			// (Http_Filters are harder to check since they always have the same name).
+			// The namespace for this extauthz cluster should be foo (since that is the
+			// namespace of the valid AuthService above).
+			isAuthCluster := func(c *v3cluster.Cluster) bool {
+				return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_foo")
+			}
+
+			// Grab the next Envoy config that has an Edge Stack auth cluster on
+			// 127.0.0.1:8500
+			envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
+				return FindCluster(envoy, isAuthCluster) != nil
+			})
+			require.NoError(t, err)
+
+			// Make sure an Envoy Config containing a extauth cluster for the
+			// AuthService that was defined.
+			assert.NotNil(t, envoyConfig)
+		}
 	}
-
-	// Grab the next Envoy config that has an Edge Stack auth cluster on 127.0.0.1:8500
-	envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
-		return FindCluster(envoy, isAuthCluster) != nil
-	})
-	require.NoError(t, err)
-
-	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was
-	// defined.
-	assert.NotNil(t, envoyConfig)
 }
 
 // Tests the synthetic auth generation when an invalid AuthService (because the protocol_version is

--- a/cmd/entrypoint/testutil_fake_syntheticauth_test.go
+++ b/cmd/entrypoint/testutil_fake_syntheticauth_test.go
@@ -59,9 +59,9 @@ spec:
 			assert.NoError(t, err)
 			assert.NotNil(t, snap)
 
-			assert.Equal(t, "edge-stack-auth-test", snap.Kubernetes.AuthServices[0].Name)
 			// In edge-stack we should only ever have 1 AuthService.
 			assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
+			assert.Equal(t, "edge-stack-auth-test", snap.Kubernetes.AuthServices[0].Name)
 
 			// Check for an ext_authz cluster name matching the provided AuthService
 			// (Http_Filters are harder to check since they always have the same name).
@@ -117,11 +117,11 @@ spec:
 			assert.NoError(t, err)
 			assert.NotNil(t, snap)
 
+			// In edge-stack we should only ever have 1 AuthService.
+			assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
 			// The snapshot should only have the synthetic AuthService and not the one
 			// defined above.
 			assert.Equal(t, "synthetic-edge-stack-auth", snap.Kubernetes.AuthServices[0].Name)
-			// In edge-stack we should only ever have 1 AuthService.
-			assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
 
 			// Check for an ext_authz cluster name matching the provided AuthService
 			// (Http_Filters are harder to check since they always have the same name).
@@ -181,9 +181,9 @@ spec:
 			assert.NoError(t, err)
 			assert.NotNil(t, snap)
 
-			assert.Equal(t, "edge-stack-auth-test", snap.Kubernetes.AuthServices[0].Name)
 			// In edge-stack we should only ever have 1 AuthService.
 			assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
+			assert.Equal(t, "edge-stack-auth-test", snap.Kubernetes.AuthServices[0].Name)
 
 			// Check for an ext_authz cluster name matching the provided AuthService
 			// (Http_Filters are harder to check since they always have the same name).
@@ -238,10 +238,10 @@ spec:
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
 
-	// The snapshot should only have the synthetic AuthService and not the one defined above.
-	assert.Equal(t, "synthetic-edge-stack-auth", snap.Kubernetes.AuthServices[0].Name)
 	// In edge-stack we should only ever have 1 AuthService.
 	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
+	// The snapshot should only have the synthetic AuthService and not the one defined above.
+	assert.Equal(t, "synthetic-edge-stack-auth", snap.Kubernetes.AuthServices[0].Name)
 
 	// Check for an ext_authz cluster name matching the synthetic AuthService.  The namespace
 	// for this extauthz cluster should be default (since that is the namespace of the synthetic
@@ -330,10 +330,10 @@ spec:
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
 
-	// The snapshot should only have the synthetic AuthService and not the one defined above.
-	assert.Equal(t, "edge-stack-auth-test", snap.Kubernetes.AuthServices[0].Name)
 	// In edge-stack we should only ever have 1 AuthService.
 	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
+	// The snapshot should only have the synthetic AuthService and not the one defined above.
+	assert.Equal(t, "edge-stack-auth-test", snap.Kubernetes.AuthServices[0].Name)
 
 	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are
 	// harder to check since they always have the same name).  The namespace for this extauthz
@@ -383,10 +383,10 @@ spec:
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
 
-	// The snapshot should only have the synthetic AuthService and not the one defined above.
-	assert.Equal(t, "synthetic-edge-stack-auth", snap.Kubernetes.AuthServices[0].Name)
 	// We should only have 1 AuthService.
 	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
+	// The snapshot should only have the synthetic AuthService and not the one defined above.
+	assert.Equal(t, "synthetic-edge-stack-auth", snap.Kubernetes.AuthServices[0].Name)
 
 	// Check for an ext_authz cluster name matching the synthetic AuthService.  The namespace
 	// for this extauthz cluster should be default (since that is the namespace of the synthetic
@@ -431,9 +431,9 @@ spec:
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
 
-	assert.Equal(t, "edge-stack-auth-test", snap.Kubernetes.AuthServices[0].Name)
 	// In edge-stack we should only ever have 1 AuthService.
 	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
+	assert.Equal(t, "edge-stack-auth-test", snap.Kubernetes.AuthServices[0].Name)
 
 	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are
 	// harder to check since they always have the same name).  The namespace for this extauthz
@@ -485,10 +485,10 @@ spec:
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
 
-	// The snapshot should only have the synthetic AuthService
-	assert.Equal(t, "synthetic-edge-stack-auth", snap.Kubernetes.AuthServices[0].Name)
 	// In edge-stack we should only ever have 1 AuthService.
 	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
+	// The snapshot should only have the synthetic AuthService
+	assert.Equal(t, "synthetic-edge-stack-auth", snap.Kubernetes.AuthServices[0].Name)
 
 	// Even though it is the synthetic AuthService, we should have the custom timeout_ms and v3
 	// protocol version.
@@ -545,9 +545,9 @@ spec:
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
 
-	assert.Equal(t, "edge-stack-auth-test", snap.Kubernetes.AuthServices[0].Name)
 	// In edge-stack we should only ever have 1 AuthService.
 	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
+	assert.Equal(t, "edge-stack-auth-test", snap.Kubernetes.AuthServices[0].Name)
 
 	for _, authService := range snap.Kubernetes.AuthServices {
 		assert.Equal(t, "dummy-service", authService.Spec.AuthService)

--- a/cmd/entrypoint/testutil_fake_syntheticauth_test.go
+++ b/cmd/entrypoint/testutil_fake_syntheticauth_test.go
@@ -72,8 +72,6 @@ spec:
 
 	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was defined
 	assert.NotNil(t, envoyConfig)
-
-	t.Setenv("EDGE_STACK", "")
 }
 
 // Tests the synthetic auth generation when a valid AuthService is created as a getambassador.io/v2 resource
@@ -123,8 +121,6 @@ spec:
 
 	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was defined
 	assert.NotNil(t, envoyConfig)
-
-	t.Setenv("EDGE_STACK", "")
 }
 
 // This tests with a provided AuthService that has no protocol_version (which defaults to v2)
@@ -174,8 +170,6 @@ spec:
 
 	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was defined
 	assert.NotNil(t, envoyConfig)
-
-	t.Setenv("EDGE_STACK", "")
 }
 
 // This tests with a provided AuthService that has no protocol_version (which defaults to v2)
@@ -225,8 +219,6 @@ spec:
 
 	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was defined
 	assert.NotNil(t, envoyConfig)
-
-	t.Setenv("EDGE_STACK", "")
 }
 
 // Tests the synthetic auth generation when an invalid AuthService is created as a getambassador.io/v2 resource
@@ -278,8 +270,6 @@ spec:
 
 	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was defined
 	assert.NotNil(t, envoyConfig)
-
-	t.Setenv("EDGE_STACK", "")
 }
 
 // Tests the synthetic auth generation when an invalid AuthService is created as a getambassador.io/v2 resource
@@ -330,9 +320,6 @@ spec:
 
 	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was defined
 	assert.NotNil(t, envoyConfig)
-
-	t.Setenv("EDGE_STACK", "")
-
 }
 
 // Tests the synthetic auth generation when an invalid AuthService (because the protocol_version is invalid for the supported enums)
@@ -383,8 +370,6 @@ spec:
 
 	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was defined
 	assert.NotNil(t, envoyConfig)
-
-	t.Setenv("EDGE_STACK", "")
 }
 
 // Tests the synthetic auth generation when an invalid AuthService is created and edited several times in succession.
@@ -474,8 +459,6 @@ spec:
 
 	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was defined
 	assert.NotNil(t, envoyConfig)
-
-	t.Setenv("EDGE_STACK", "")
 }
 
 // Tests the synthetic auth generation by first creating an invalid AuthService and confirming that the synthetic AuthService gets injected.
@@ -570,9 +553,6 @@ spec:
 
 	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was defined
 	assert.NotNil(t, envoyConfig)
-
-	t.Setenv("EDGE_STACK", "")
-
 }
 
 // This AuthService points at 127.0.0.1:8500, but it does not have protocol_version: v3. It also has additional fields set.
@@ -631,8 +611,6 @@ spec:
 
 	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was defined
 	assert.NotNil(t, envoyConfig)
-
-	t.Setenv("EDGE_STACK", "")
 }
 
 // This AuthService does not point at 127.0.0.1:8500, we leave it alone rather than adding a synthetic one
@@ -686,8 +664,6 @@ spec:
 
 	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was defined
 	assert.NotNil(t, envoyConfig)
-
-	t.Setenv("EDGE_STACK", "")
 }
 
 // When deciding if we need to inject a synthetic AuthService or not, we need to be able to reliably determine if that

--- a/cmd/entrypoint/watcher.go
+++ b/cmd/entrypoint/watcher.go
@@ -44,7 +44,7 @@ func WatchAllTheThings(
 	interestingTypes := GetInterestingTypes(ctx, serverTypeList)
 	queries := GetQueries(ctx, interestingTypes)
 
-	ambassadorMeta := getAmbassadorMeta(GetAmbassadorId(), clusterID, version, client)
+	ambassadorMeta := getAmbassadorMeta(GetAmbassadorID(), clusterID, version, client)
 
 	// **** SETUP DONE for the Kubernetes Watcher
 

--- a/pkg/api/getambassador.io/v3alpha1/common.go
+++ b/pkg/api/getambassador.io/v3alpha1/common.go
@@ -130,6 +130,11 @@ func (aid AmbassadorID) Matches(envVar string) bool {
 		if item == envVar {
 			return true
 		}
+		if item == "_automatic_" {
+			// We always pay attention to the "_automatic_" ID -- it gives us a to
+			// easily always include certain configuration resources for Edge Stack.
+			return true
+		}
 	}
 	return false
 }

--- a/python/ambassador/envoy/v3/v3httpfilter.py
+++ b/python/ambassador/envoy/v3/v3httpfilter.py
@@ -237,11 +237,11 @@ function envoy_on_request(request_handle)
    request_handle:respond(
       {[":status"] = "500",
        ["content-type"] = "application/json"},
-      '{'..
-      '  "message": "the """+auth.rkey+""" AuthService is misconfigured; see the logs for more information",'..
-      '  "request_id": "'..request_handle:headers():get('x-request-id')..'",'..
-      '  "status_code": 500,'..
-      '}')
+      '{\\n'..
+      '  "message": "the """+auth.rkey+""" AuthService is misconfigured; see the logs for more information",\\n'..
+      '  "request_id": "'..request_handle:headers():get('x-request-id')..'",\\n'..
+      '  "status_code": 500\\n'..
+      '}\\n')
 end
 """,
             },

--- a/python/tests/kat/t_extauth.py
+++ b/python/tests/kat/t_extauth.py
@@ -1004,6 +1004,13 @@ service: {self.target.path.fqdn}
 
     def check(self):
         if self.expected_protocol_version == 'invalid':
+            for i, result in enumerate(self.results):
+                # Verify the basic structure of the HTTP 500's JSON body.
+                assert result.json, f"self.results[{i}] does not have a JSON body"
+                assert result.json['status_code'] == 500, f"self.results[{i}] JSON body={repr(result.json)} does not have status_code=500"
+                assert result.json['request_id'], f"self.results[{i}] JSON body={repr(result.json)} does not have request_id"
+                assert self.path.k8s in result.json['message'], f"self.results[{i}] JSON body={repr(result.json)} does not have thing-containing-the-annotation-containing-the-AuthService name {repr(self.path.k8s)} in message"
+                assert 'AuthService' in result.json['message'], f"self.results[{i}] JSON body={repr(result.json)} does not have type 'AuthService' in message"
             return
 
         # [0] Verifies all request headers sent to the authorization server.


### PR DESCRIPTION
## Description

Commit-by-commit:
 - (first 8 commits) Miscellaneous cleanup in `cmd/entrypoint`; not actually fixing anything.
 - (penultimate commit) Fix some problems with synthetic AuthService injection. This only affects Edge Stack.
 - (ultimate commit) Fix the JSON error response when an invalid AuthService is given. This affects both Edge Stack and Emissary.

The only commit that I think merits much discussion is the synthetic AuthService injection one.  It's sort of a rewrite.  And I sort of feel bad about that. I had a hard time following what it was doing (can't fit big function in small Friday afternoon brain? can't fit big function on small laptop screen? take your pick).  At first I was just trying to factor out a `iterateOverAuthServices` function so that the big chunk wouldn't need to be repeated twice.  And I ended up with this.  At least one bug in the old code:
```go
var newDeltas []*kates.Delta
*deltas = append(*deltas, &kates.Delta{
	TypeMeta:   syntheticAuth.TypeMeta,
	ObjectMeta: syntheticAuth.ObjectMeta,
	DeltaType:  kates.ObjectDelete,
})
*deltas = newDeltas
```
which results in `*deltas` always getting set to `nil`. But because I couldn't follow the code, there might have been more bugs too.  My version does have one change: When it sees an Edge Stack AuthService (localhost:8500) with the wrong protocol version, it just overrides the protocol version of that AuthService, rather than dropping that AuthService and injecting a fully-synthetic one.
.

## Testing
https://github.com/datawire/apro/actions/runs/2559567404 turned green

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `CHANGELOG.md`. - no applicable changes

   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations

 - [x] This is unlikely to impact how Ambassador performs at scale.

   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability

 - [x] My change is adequately tested.

   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points

 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently. - no tricks

 - [ ] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
