### PR TITLE
Fix label selector to match standard kubernetes behaviour 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ refer both to Emissary-ingress and to the Ambassador Edge Stack.
 
 ## UPCOMING BREAKING CHANGES
 
+### Emissary 3.1.0
+ - Changes to label matching will change how Hosts match Mappings. Hosts were matching any labels found in Mappings, now it's changed to match `all labels`. To avoid unexpected behaviour after the upgrade, add all labels that Hosts have in their mappingSelector to Mappings you want it to match.
+
 ### Emissary 3.0.0
 
  - **No `protocol_version: v2`**: Support for specifying `protocol_version: v2` in `AuthService`,

--- a/python/ambassador/ir/irutils.py
+++ b/python/ambassador/ir/irutils.py
@@ -182,14 +182,13 @@ def selector_matches(
         logger.debug("    no incoming labels => False")
         return False
 
-    selmatch = False
-
+    # For every label in mappingSelector, there must be a label with same value in Mapping itself.
     for k, v in match.items():
         if labels.get(k) == v:
             logger.debug("    selector match for %s=%s => True", k, v)
-            return True
+        else:
+            logger.debug("    selector miss for %s=%s => False", k, v)
+            return False
 
-        logger.debug("    selector miss on %s=%s", k, v)
-
-    logger.debug("    all selectors miss => False")
-    return False
+    logger.debug(f"    all selectors match => True")
+    return True


### PR DESCRIPTION
Signed-off-by: Filip Herceg <filip.herceg@superbet.com>

## Description
This fixes label matching to match all labels instead of any label. As is the usual behaviour in Kubernetes.

I'm putting this as a fix because I expected this label selector to behave as any other Kubernetes label selector, as mentioned in the documentation.

Docs reference - https://www.getambassador.io/docs/emissary/latest/topics/running/host-crd/#controlling-association-with-mappings
```
The selector is a Kubernetes [label selector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#labelselector-v1-meta), but in 2.0, only matchLabels is supported, for example:
```

## Related Issues
Mapping matches more Hosts than it should with mapping selector #4316 

## Testing
I have tested this by creating multiple `Mappings` with different `metadata.labels` and `hostnames` and I've created multiple `Hosts` with different `mappingSelectors` to validate that behaviour is as would be expected. (mappingSelector to match all labels instead of any label).

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - ☑️ I made sure to update `CHANGELOG.md`.

   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations

 - ☑️  This is unlikely to impact how Ambassador performs at scale.

   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability

 - [ ] My change is adequately tested.

   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points

 - ☑️  I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.

 - ☑️  The changes in this PR have been reviewed for security concerns and adherence to security best practices.
