### PR TITLE
Synthetic v3 RateLimitService for Edge-Stack

### DIFF
--- a/cmd/entrypoint/syntheticratelimit.go
+++ b/cmd/entrypoint/syntheticratelimit.go
@@ -1,0 +1,113 @@
+package entrypoint
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/datawire/dlib/dlog"
+	"github.com/emissary-ingress/emissary/v3/pkg/api/getambassador.io/v3alpha1"
+	"github.com/emissary-ingress/emissary/v3/pkg/kates"
+)
+
+func iterateOverRateLimitServices(sh *SnapshotHolder, cb func(
+	rateLimitService *v3alpha1.RateLimitService, // rateLimitService
+	name string, // name to unambiguously refer to the rateLimitServices by; might be more complex than "name.namespace" if it's an annotation
+	parentName string, // name of the thing that the annotation is on (or empty if not an annotation)
+	idx int, // index of the rateLimitService; either in sh.k8sSnapshot.RateLimitServices or in sh.k8sSnapshot.Annotations[parentName]
+)) {
+	envAmbID := GetAmbassadorID()
+
+	for i, rateLimitService := range sh.k8sSnapshot.RateLimitServices {
+		if rateLimitService.Spec.AmbassadorID.Matches(envAmbID) {
+			name := rateLimitService.TypeMeta.Kind + "/" + rateLimitService.ObjectMeta.Name + "." + rateLimitService.ObjectMeta.Namespace
+			cb(rateLimitService, name, "", i)
+		}
+	}
+
+	for parentName, list := range sh.k8sSnapshot.Annotations {
+		for i, obj := range list {
+			if rateLimitService, ok := obj.(*v3alpha1.RateLimitService); ok && rateLimitService.Spec.AmbassadorID.Matches(envAmbID) {
+				name := fmt.Sprintf("%s#%d", parentName, i)
+				cb(rateLimitService, name, parentName, i)
+			}
+		}
+	}
+}
+
+// ReconcileRateLimit is a hack to remove all RateLimitService using protocol_version: v2 only when running Edge-Stack and then inject an
+// RateLimitService with protocol_version: v3 if needed. The purpose of this hack is to prevent Edge-Stack 2.3 from
+// using any other RateLimitService than the default one running as part of amb-sidecar and force the protocol version to v3.
+func ReconcileRateLimit(ctx context.Context, sh *SnapshotHolder, deltas *[]*kates.Delta) error {
+	// We only want to remove RateLimitServices if this is an instance of Edge-Stack
+	if isEdgeStack, err := IsEdgeStack(); err != nil {
+		return fmt.Errorf("ReconcileRateLimitServices: %w", err)
+	} else if !isEdgeStack {
+		return nil
+	}
+
+	// using a name with underscores prevents it from colliding with anything real in the
+	// cluster--Kubernetes resources can't have underscores in their name.
+	const syntheticRateLimitServiceName = "synthetic_edge_stack_rate_limit"
+
+	var (
+		numRateLimitServices  uint64
+		syntheticRateLimit    *v3alpha1.RateLimitService
+		syntheticRateLimitIdx int
+	)
+
+	iterateOverRateLimitServices(sh, func(rateLimitService *v3alpha1.RateLimitService, name, parentName string, i int) {
+		numRateLimitServices++
+		if IsLocalhost8500(rateLimitService.Spec.Service) {
+			if parentName == "" && rateLimitService.ObjectMeta.Name == syntheticRateLimitServiceName {
+				syntheticRateLimit = rateLimitService
+				syntheticRateLimitIdx = i
+			}
+			if rateLimitService.Spec.ProtocolVersion != "v3" {
+				// Force the Edge Stack RateLimitService to be protocol_version=v3.  This
+				// is important so that <2.3 and >=2.3 installations can coexist.
+				// This is important, because for zero-downtime upgrades, they must
+				// coexist briefly while the new Deployment is getting rolled out.
+				dlog.Debugf(ctx, "ReconcileRateLimitServices: Forcing protocol_version=v3 on %s", name)
+				rateLimitService.Spec.ProtocolVersion = "v3"
+			}
+		}
+	})
+
+	switch {
+	case numRateLimitServices == 0: // add the synthetic rate limit service
+		dlog.Debug(ctx, "ReconcileRateLimitServices: No user-provided RateLimitServices detected; injecting synthetic RateLimitService")
+		syntheticRateLimit = &v3alpha1.RateLimitService{
+			TypeMeta: kates.TypeMeta{
+				Kind:       "RateLimitService",
+				APIVersion: "getambassador.io/v3alpha1",
+			},
+			ObjectMeta: kates.ObjectMeta{
+				Name:      syntheticRateLimitServiceName,
+				Namespace: GetAmbassadorNamespace(),
+			},
+			Spec: v3alpha1.RateLimitServiceSpec{
+				AmbassadorID:    []string{GetAmbassadorID()},
+				Service:         "127.0.0.1:8500",
+				ProtocolVersion: "v3",
+			},
+		}
+		sh.k8sSnapshot.RateLimitServices = append(sh.k8sSnapshot.RateLimitServices, syntheticRateLimit)
+		*deltas = append(*deltas, &kates.Delta{
+			TypeMeta:   syntheticRateLimit.TypeMeta,
+			ObjectMeta: syntheticRateLimit.ObjectMeta,
+			DeltaType:  kates.ObjectAdd,
+		})
+	case numRateLimitServices > 1 && syntheticRateLimit != nil: // remove the synthetic rate limit service
+		dlog.Debugf(ctx, "ReconcileRateLimitServices: %d user-provided RateLimitServices detected; removing synthetic RateLimitServices", numRateLimitServices-1)
+		sh.k8sSnapshot.RateLimitServices = append(
+			sh.k8sSnapshot.RateLimitServices[:syntheticRateLimitIdx],
+			sh.k8sSnapshot.RateLimitServices[syntheticRateLimitIdx+1:]...)
+		*deltas = append(*deltas, &kates.Delta{
+			TypeMeta:   syntheticRateLimit.TypeMeta,
+			ObjectMeta: syntheticRateLimit.ObjectMeta,
+			DeltaType:  kates.ObjectDelete,
+		})
+	}
+
+	return nil
+}

--- a/cmd/entrypoint/testutil_fake_k8s_store_test.go
+++ b/cmd/entrypoint/testutil_fake_k8s_store_test.go
@@ -254,7 +254,7 @@ func canonGVK(rawString string) (canonKind string, canonGroupVersion string, err
 	case "module", "modules":
 		return "Module", "getambassador.io/v3alpha1", nil
 	case "ratelimitservice", "ratelimitservices":
-		return "RateLimitServices", "getambassador.io/v3alpha1", nil
+		return "RateLimitService", "getambassador.io/v3alpha1", nil
 	case "tcpmapping", "tcpmappings":
 		return "TCPMapping", "getambassador.io/v3alpha1", nil
 	case "tlscontext", "tlscontexts":

--- a/cmd/entrypoint/testutil_fake_syntheticratelimit_test.go
+++ b/cmd/entrypoint/testutil_fake_syntheticratelimit_test.go
@@ -1,0 +1,479 @@
+package entrypoint_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/emissary-ingress/emissary/v3/cmd/entrypoint"
+	v3bootstrap "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/bootstrap/v3"
+	v3cluster "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/cluster/v3"
+	"github.com/emissary-ingress/emissary/v3/pkg/snapshot/v1"
+)
+
+// This predicate is used to check k8s snapshots for an RateLimitService matching the provided name and
+// namespace.
+func HasRateLimitService(namespace, name string) func(snapshot *snapshot.Snapshot) bool {
+	return func(snapshot *snapshot.Snapshot) bool {
+		for _, m := range snapshot.Kubernetes.RateLimitServices {
+			if m.Namespace == namespace && m.Name == name {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// Tests the synthetic rateLimit generation when a valid RateLimitService is created.  This RateLimitService has
+// `protocol_version: v3` and should not be replaced by the synthetic RateLimitService.
+func TestSyntheticRateLimitValid(t *testing.T) {
+	for _, apiVersion := range []string{"v2", "v3alpha1"} {
+		apiVersion := apiVersion // capture loop variable
+		t.Run(apiVersion, func(t *testing.T) {
+			t.Setenv("EDGE_STACK", "true")
+
+			f := entrypoint.RunFake(t, entrypoint.FakeConfig{EnvoyConfig: true}, nil)
+
+			err := f.UpsertYAML(`
+---
+apiVersion: getambassador.io/` + apiVersion + `
+kind: RateLimitService
+metadata:
+  name: edge-stack-ratelimit-test
+  namespace: foo
+spec:
+  protocol_version: "v3"
+  service: 127.0.0.1:8500
+`)
+			assert.NoError(t, err)
+			f.Flush()
+
+			// Use the predicate above to check that the snapshot contains the
+			// RateLimitService defined above.  The RateLimitService has `protocol_version: v3` so
+			// it should not be removed/replaced by the synthetic RateLimitService injected
+			// by syntheticratelimit.go
+			snap, err := f.GetSnapshot(HasRateLimitService("foo", "edge-stack-ratelimit-test"))
+			assert.NoError(t, err)
+			assert.NotNil(t, snap)
+
+			// In edge-stack we should only ever have 1 RateLimitService.
+			assert.Equal(t, 1, len(snap.Kubernetes.RateLimitServices))
+			assert.Equal(t, "edge-stack-ratelimit-test", snap.Kubernetes.RateLimitServices[0].Name)
+
+			// Check for a cluster name matching the provided RateLimitService
+			isRateLimitCluster := func(c *v3cluster.Cluster) bool {
+				return strings.Contains(c.Name, "cluster_127_0_0_1_8500_foo")
+			}
+
+			// Grab the next Envoy config that has an Edge Stack ratelimit cluster on
+			// 127.0.0.1:8500
+			envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
+				return FindCluster(envoy, isRateLimitCluster) != nil
+			})
+			require.NoError(t, err)
+
+			// Make sure an Envoy Config containing a cluster for the
+			// RateLimitService that was defined.
+			assert.NotNil(t, envoyConfig)
+		})
+	}
+}
+
+// This tests with a provided RateLimitService that has no protocol_version (which defaults to v2).  It
+// should get forcibly overridden to be v3.
+func TestSyntheticRateLimitReplace(t *testing.T) {
+	for _, apiVersion := range []string{"v2", "v3alpha1"} {
+		apiVersion := apiVersion // capture loop variable
+		t.Run(apiVersion, func(t *testing.T) {
+			t.Setenv("EDGE_STACK", "true")
+
+			f := entrypoint.RunFake(t, entrypoint.FakeConfig{EnvoyConfig: true}, nil)
+
+			err := f.UpsertYAML(`
+---
+apiVersion: getambassador.io/` + apiVersion + `
+kind: RateLimitService
+metadata:
+  name: edge-stack-ratelimit-test
+  namespace: foo
+spec:
+  service: 127.0.0.1:8500
+`)
+			assert.NoError(t, err)
+			f.Flush()
+
+			// The RateLimitService does not have `protocol_version: v3` so it should be
+			// forcibly edited to say `protocol_version: v3` by syntheticratelimit.go
+			snap, err := f.GetSnapshot(HasRateLimitService("foo", "edge-stack-ratelimit-test"))
+			assert.NoError(t, err)
+			assert.NotNil(t, snap)
+
+			// In edge-stack we should only ever have 1 RateLimitService.
+			assert.Equal(t, 1, len(snap.Kubernetes.RateLimitServices))
+			// The snapshot should only have the one defined above.
+			assert.Equal(t, "edge-stack-ratelimit-test", snap.Kubernetes.RateLimitServices[0].Name)
+			// The protocol version should be forcibly set to v3.
+			assert.Equal(t, "v3", snap.Kubernetes.RateLimitServices[0].Spec.ProtocolVersion)
+
+			// Check for a cluster name matching the provided RateLimitService
+			isRateLimitCluster := func(c *v3cluster.Cluster) bool {
+				return strings.Contains(c.Name, "cluster_127_0_0_1_8500_foo")
+			}
+
+			// Grab the next Envoy config that has an Edge Stack rateLimit cluster on
+			// 127.0.0.1:8500
+			envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
+				return FindCluster(envoy, isRateLimitCluster) != nil
+			})
+			require.NoError(t, err)
+
+			// Make sure an Envoy Config containing a cluster for the
+			// RateLimitService that was defined.
+			assert.NotNil(t, envoyConfig)
+		})
+	}
+}
+
+// Tests the synthetic rateLimit generation when an invalid RateLimitService is created.  This RateLimitService has
+// `protocol_version: v3` and should not be replaced by the synthetic RateLimitService even though it has
+// a bogus value because the bogus field will be dropped when it is loaded, and we will be left with
+// a valid RateLimitService.
+func TestSyntheticRateLimitBogusField(t *testing.T) {
+	for _, apiVersion := range []string{"v2", "v3alpha1"} {
+		apiVersion := apiVersion // capture loop variable
+		t.Run(apiVersion, func(t *testing.T) {
+			t.Setenv("EDGE_STACK", "true")
+
+			f := entrypoint.RunFake(t, entrypoint.FakeConfig{EnvoyConfig: true}, nil)
+
+			err := f.UpsertYAML(`
+---
+apiVersion: getambassador.io/` + apiVersion + `
+kind: RateLimitService
+metadata:
+  name: edge-stack-ratelimit-test
+  namespace: foo
+spec:
+  service: 127.0.0.1:8500
+  bogus_field: "foo"
+`)
+			assert.NoError(t, err)
+			f.Flush()
+
+			// Use the predicate above to check that the snapshot contains the
+			// RateLimitService defined above.  The RateLimitService has `protocol_version: v3` so
+			// it should not be removed/replaced by the synthetic RateLimitService injected
+			// by syntheticratelimit.go
+			snap, err := f.GetSnapshot(HasRateLimitService("foo", "edge-stack-ratelimit-test"))
+			assert.NoError(t, err)
+			assert.NotNil(t, snap)
+
+			// In edge-stack we should only ever have 1 RateLimitService.
+			assert.Equal(t, 1, len(snap.Kubernetes.RateLimitServices))
+			assert.Equal(t, "edge-stack-ratelimit-test", snap.Kubernetes.RateLimitServices[0].Name)
+
+			// Check for a cluster name matching the provided RateLimitService
+			isRateLimitCluster := func(c *v3cluster.Cluster) bool {
+				return strings.Contains(c.Name, "cluster_127_0_0_1_8500_foo")
+			}
+
+			// Grab the next Envoy config that has an Edge Stack rateLimit cluster on
+			// 127.0.0.1:8500
+			envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
+				return FindCluster(envoy, isRateLimitCluster) != nil
+			})
+			require.NoError(t, err)
+
+			// Make sure an Envoy Config containing a cluster for the
+			// RateLimitService that was defined.
+			assert.NotNil(t, envoyConfig)
+		})
+	}
+}
+
+// Tests the synthetic rateLimit generation when an invalid RateLimitService (because the protocol_version is
+// invalid for the supported enums).  This RateLimitService should be tossed out and the synthetic
+// RateLimitService should be injected.
+func TestSyntheticRateLimitInvalidProtocolVer(t *testing.T) {
+	t.Setenv("EDGE_STACK", "true")
+
+	f := entrypoint.RunFake(t, entrypoint.FakeConfig{EnvoyConfig: true}, nil)
+
+	err := f.UpsertYAML(`
+---
+apiVersion: getambassador.io/v2
+kind: RateLimitService
+metadata:
+  name: edge-stack-ratelimit-test
+  namespace: foo
+spec:
+  protocol_version: "vBogus"
+  bogus_field: "foo"
+`)
+	assert.NoError(t, err)
+	f.Flush()
+
+	// Use the predicate above to check that the snapshot contains the synthetic RateLimitService.
+	// The RateLimitService has `protocol_version: v3`, but it has a bogus field, so it should not be
+	// validated, and instead we inject the synthetic RateLimitService.
+	snap, err := f.GetSnapshot(HasRateLimitService("default", "synthetic_edge_stack_rate_limit"))
+	assert.NoError(t, err)
+	assert.NotNil(t, snap)
+
+	// In edge-stack we should only ever have 1 RateLimitService.
+	assert.Equal(t, 1, len(snap.Kubernetes.RateLimitServices))
+	// The snapshot should only have the synthetic RateLimitService and not the one defined above.
+	assert.Equal(t, "synthetic_edge_stack_rate_limit", snap.Kubernetes.RateLimitServices[0].Name)
+
+	// Check for a cluster name matching the provided RateLimitService
+	isRateLimitCluster := func(c *v3cluster.Cluster) bool {
+		return strings.Contains(c.Name, "cluster_127_0_0_1_8500_default")
+	}
+
+	// Grab the next Envoy config that has an Edge Stack rateLimit cluster on
+	// 127.0.0.1:8500
+	envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
+		return FindCluster(envoy, isRateLimitCluster) != nil
+	})
+	require.NoError(t, err)
+
+	// Make sure an Envoy Config containing a cluster for the
+	// RateLimitService that was defined.
+	assert.NotNil(t, envoyConfig)
+}
+
+// Tests the synthetic rateLimit generation when an invalid RateLimitService is created and edited several
+// times in succession.  After the config is edited several times, we should see that the final
+// result is our provided valid RateLimitService.  There should not be any duplicate RateLimitService
+// resources, and the synthetic RateLimitService that gets created when the first invalid RateLimitService is
+// applied should be removed when the final edit makes it a valid RateLimitService.
+func TestSyntheticRateLimitChurn(t *testing.T) {
+	t.Setenv("EDGE_STACK", "true")
+
+	f := entrypoint.RunFake(t, entrypoint.FakeConfig{EnvoyConfig: true}, nil)
+	f.AutoFlush(true)
+
+	err := f.UpsertYAML(`
+---
+apiVersion: getambassador.io/v3alpha1
+kind: RateLimitService
+metadata:
+  name: edge-stack-ratelimit-test
+  namespace: foo
+spec:
+  service: 127.0.0.1:8500
+`)
+	assert.NoError(t, err)
+	err = f.UpsertYAML(`
+---
+apiVersion: getambassador.io/v3alpha1
+kind: RateLimitService
+metadata:
+  name: edge-stack-ratelimit-test
+  namespace: foo
+spec:
+  service: 127.0.0.1:8500
+  protocol_version: "v3"
+`)
+	assert.NoError(t, err)
+	err = f.UpsertYAML(`
+---
+apiVersion: getambassador.io/v3alpha1
+kind: RateLimitService
+metadata:
+  name: edge-stack-ratelimit-test
+  namespace: foo
+spec:
+  service: 127.0.0.1:8500
+`)
+	assert.NoError(t, err)
+	err = f.UpsertYAML(`
+---
+apiVersion: getambassador.io/v3alpha1
+kind: RateLimitService
+metadata:
+  name: edge-stack-ratelimit-test
+  namespace: foo
+spec:
+  service: 127.0.0.1:8500
+  protocol_version: "v3"
+`)
+	assert.NoError(t, err)
+
+	// Use the predicate above to check that the snapshot contains the RateLimitService defined
+	// above.  The RateLimitService has `protocol_version: v3` so it should not be removed/replaced
+	// by the synthetic RateLimitService injected by syntheticratelimit.go
+	snap, err := f.GetSnapshot(HasRateLimitService("foo", "edge-stack-ratelimit-test"))
+	assert.NoError(t, err)
+	assert.NotNil(t, snap)
+
+	// In edge-stack we should only ever have 1 RateLimitService.
+	assert.Equal(t, 1, len(snap.Kubernetes.RateLimitServices))
+	// The snapshot should only have the synthetic RateLimitService and not the one defined above.
+	assert.Equal(t, "edge-stack-ratelimit-test", snap.Kubernetes.RateLimitServices[0].Name)
+
+	// Check for a cluster name matching the provided RateLimitService
+	isRateLimitCluster := func(c *v3cluster.Cluster) bool {
+		return strings.Contains(c.Name, "cluster_127_0_0_1_8500_foo")
+	}
+
+	// Grab the next Envoy config that has an Edge Stack rateLimit cluster on
+	// 127.0.0.1:8500
+	envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
+		return FindCluster(envoy, isRateLimitCluster) != nil
+	})
+	require.NoError(t, err)
+
+	// Make sure an Envoy Config containing a cluster for the
+	// RateLimitService that was defined.
+	assert.NotNil(t, envoyConfig)
+}
+
+// Tests the synthetic rateLimit generation by first creating an invalid RateLimitService and confirming that
+// the synthetic RateLimitService gets injected.  Afterwards, a valid RateLimitService is applied and we
+// expect the synthetic RateLimitService to be removed in favor of the new valid RateLimitService.
+func TestSyntheticRateLimitInjectAndRemove(t *testing.T) {
+	t.Setenv("EDGE_STACK", "true")
+
+	f := entrypoint.RunFake(t, entrypoint.FakeConfig{EnvoyConfig: true}, nil)
+	f.AutoFlush(true)
+
+	// This will cause a synthethic RateLimitService to be injected.
+	err := f.UpsertYAML(`
+---
+apiVersion: getambassador.io/v3alpha1
+kind: RateLimitService
+metadata:
+  name: edge-stack-ratelimit-test
+  namespace: foo
+spec:
+  service: 127.0.0.1:8500
+  protocol_version: "vBogus"
+`)
+	assert.NoError(t, err)
+
+	// Use the predicate above to check that the snapshot contains the synthetic RateLimitService.
+	// The user-provided RateLimitService is invalid and so it should be ignored and instead we
+	// inject the synthetic RateLimitService.
+	snap, err := f.GetSnapshot(HasRateLimitService("default", "synthetic_edge_stack_rate_limit"))
+	assert.NoError(t, err)
+	assert.NotNil(t, snap)
+
+	// We should only have 1 RateLimitService.
+	assert.Equal(t, 1, len(snap.Kubernetes.RateLimitServices))
+	// The snapshot should only have the synthetic RateLimitService and not the one defined above.
+	assert.Equal(t, "synthetic_edge_stack_rate_limit", snap.Kubernetes.RateLimitServices[0].Name)
+
+	// Check for a cluster name matching the provided RateLimitService
+	isRateLimitCluster := func(c *v3cluster.Cluster) bool {
+		return strings.Contains(c.Name, "cluster_127_0_0_1_8500_default")
+	}
+
+	// Grab the next Envoy config that has an Edge Stack rateLimit cluster on
+	// 127.0.0.1:8500
+	envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
+		return FindCluster(envoy, isRateLimitCluster) != nil
+	})
+	require.NoError(t, err)
+
+	// Make sure an Envoy Config containing a cluster for the
+	// RateLimitService that was defined.
+	assert.NotNil(t, envoyConfig)
+
+	// Updating the yaml for that RateLimitService to include `protocol_version: v3` should make it
+	// valid and then remove our synthetic RateLimitService and allow the now valid RateLimitService to be
+	// used.
+	err = f.UpsertYAML(`
+---
+apiVersion: getambassador.io/v3alpha1
+kind: RateLimitService
+metadata:
+  name: edge-stack-ratelimit-test
+  namespace: foo
+spec:
+  service: 127.0.0.1:8500
+  protocol_version: "v3"
+`)
+	assert.NoError(t, err)
+
+	// Use the predicate above to check that the snapshot contains the RateLimitService defined
+	// above.  The RateLimitService has `protocol_version: v3` so it should not be removed/replaced
+	// by the synthetic RateLimitService injected by syntheticratelimit.go
+	snap, err = f.GetSnapshot(HasRateLimitService("foo", "edge-stack-ratelimit-test"))
+	assert.NoError(t, err)
+	assert.NotNil(t, snap)
+
+	// In edge-stack we should only ever have 1 RateLimitService.
+	assert.Equal(t, 1, len(snap.Kubernetes.RateLimitServices))
+	assert.Equal(t, "edge-stack-ratelimit-test", snap.Kubernetes.RateLimitServices[0].Name)
+
+	// Check for a cluster name matching the provided RateLimitService
+	isRateLimitCluster = func(c *v3cluster.Cluster) bool {
+		return strings.Contains(c.Name, "cluster_127_0_0_1_8500_foo")
+	}
+
+	// Grab the next Envoy config that has an Edge Stack rateLimit cluster on
+	// 127.0.0.1:8500
+	envoyConfig, err = f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
+		return FindCluster(envoy, isRateLimitCluster) != nil
+	})
+	require.NoError(t, err)
+
+	// Make sure an Envoy Config containing a cluster for the
+	// RateLimitService that was defined.
+	assert.NotNil(t, envoyConfig)
+}
+
+// This RateLimitService points at 127.0.0.1:8500, but it does not have `protocol_version: v3`.  It also
+// has additional fields set.  The correct action is to edit the RateLimitService to say
+// `protocol_version: v3`.
+func TestSyntheticRateLimitCopyFields(t *testing.T) {
+	t.Setenv("EDGE_STACK", "true")
+
+	f := entrypoint.RunFake(t, entrypoint.FakeConfig{EnvoyConfig: true}, nil)
+
+	err := f.UpsertYAML(`
+---
+apiVersion: getambassador.io/v2
+kind: RateLimitService
+metadata:
+  name: edge-stack-ratelimit-test
+  namespace: foo
+spec:
+  service: 127.0.0.1:8500
+  timeout_ms: 12345
+`)
+	assert.NoError(t, err)
+	f.Flush()
+
+	// Use the predicate above to check that the snapshot contains the RateLimitService.
+	snap, err := f.GetSnapshot(HasRateLimitService("foo", "edge-stack-ratelimit-test"))
+	assert.NoError(t, err)
+	assert.NotNil(t, snap)
+
+	// In edge-stack we should only ever have 1 RateLimitService.
+	assert.Equal(t, 1, len(snap.Kubernetes.RateLimitServices))
+	// It should be that user-provided RateLimitService...
+	assert.Equal(t, "edge-stack-ratelimit-test", snap.Kubernetes.RateLimitServices[0].Name)
+	assert.Equal(t, int64(12345), snap.Kubernetes.RateLimitServices[0].Spec.Timeout.Duration.Milliseconds())
+	// ... but with `protocol_version: v3` set.
+	assert.Equal(t, "v3", snap.Kubernetes.RateLimitServices[0].Spec.ProtocolVersion)
+
+	// Check for a cluster name matching the provided RateLimitService
+	isRateLimitCluster := func(c *v3cluster.Cluster) bool {
+		return strings.Contains(c.Name, "cluster_127_0_0_1_8500_foo")
+	}
+
+	// Grab the next Envoy config that has an Edge Stack rateLimit cluster on
+	// 127.0.0.1:8500
+	envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
+		return FindCluster(envoy, isRateLimitCluster) != nil
+	})
+	require.NoError(t, err)
+
+	// Make sure an Envoy Config containing a cluster for the
+	// RateLimitService that was defined.
+	assert.NotNil(t, envoyConfig)
+}

--- a/cmd/entrypoint/watcher.go
+++ b/cmd/entrypoint/watcher.go
@@ -372,6 +372,7 @@ func (sh *SnapshotHolder) K8sUpdate(
 	reconcileSecretsTimer := dbg.Timer("reconcileSecrets")
 	reconcileConsulTimer := dbg.Timer("reconcileConsul")
 	reconcileAuthServicesTimer := dbg.Timer("reconcileAuthServices")
+	reconcileRateLimitServicesTimer := dbg.Timer("reconcileRateLimitServices")
 
 	endpointsChanged := false
 	dispatcherChanged := false
@@ -454,6 +455,13 @@ func (sh *SnapshotHolder) K8sUpdate(
 		})
 		if err != nil {
 			dlog.Errorf(ctx, "[WATCHER]: ERROR reconciling AuthServices: %v", err)
+			return false, err
+		}
+		reconcileRateLimitServicesTimer.Time(func() {
+			err = ReconcileRateLimit(ctx, sh, &deltas)
+		})
+		if err != nil {
+			dlog.Errorf(ctx, "[WATCHER]: ERROR reconciling RateLimitServices: %v", err)
 			return false, err
 		}
 


### PR DESCRIPTION
Signed-off-by: David Dymko <ddymko@datawire.io>

## Description
This adds a pre-compiler hook for injecting a synthetic `RateLimitService` for Edge-Stack similar to what exists for the `AuthService`.  This is required because Edge-Stack only allows for a single RateLimitService to be available.

A synthetic RateLimitService will be injected in the following scenarios:
1. no RateLimitService provided
2. invalid RateLimitService (bad settings, doesn't exist, doesn't point at localhost)

If a valid RateLimitService is provided that points at `127.0.0.1:8500` then the provided one will be used to ensure we capture custom settings from users.. If the service does not provide the `protocol_version` field or it  is NOT set to `v3` then the service will automatically be upgraded to `v3`.

This is to ensure Edge-Stack always has a single RateLimitService available that speaks v3 protocol and points to the EdgeStack provided service.

## Related Issues
None

## Testing
Added integration tests to ensure the proper envoy config is generated.

## Checklist
 - [ ] I made sure to update `CHANGELOG.md`.
 - [x] This is unlikely to impact how Ambassador performs at scale.
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
