### PR TITLE
[DO NOT MERGE] 1.14 gzip devbuild

### DIFF
--- a/python/ambassador/envoy/v3/v3listener.py
+++ b/python/ambassador/envoy/v3/v3listener.py
@@ -199,9 +199,6 @@ def v3filter_gzip(gzip: IRGzip, v3config: 'V3Config'):
                     'window_bits': gzip.window_bits,
                 }
             },
-            'request_direction_config': {
-                'common_config': common_config,
-            },
             'response_direction_config': {
                 'disable_on_etag_header': gzip.disable_on_etag_header,
                 'remove_accept_encoding_header': gzip.remove_accept_encoding_header,


### PR DESCRIPTION
## Description
This is a branch for backporting the gzip bugfix from https://github.com/emissary-ingress/emissary/pull/3967 to 1.14 for a hotfix build. No changelog since we will not be issuing a new release of 1.14, only a hotfix devbuild image. 

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - ~~[ ] I made sure to update `CHANGELOG.md`.~~
  No changelog since this is only for a hotfix and will not be merged. 

 - [x] This is unlikely to impact how Ambassador performs at scale.

   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability

 - [ ] My change is adequately tested.
 
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.

 - [ ] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
