### PR TITLE
update list of releasers within MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,21 +7,23 @@ describes governance guidelines and maintainer responsibilities.
 
 Maintainers are listed in alphabetical order.
 
-| Maintainer | GitHub ID | Affiliation |
-| ---------- | --------- | ----------- |
-| Aidan Hahn | [aidanhahn](https://github.com/aidanhahn) | unaffiliated |
-| Alex Gervais | [alexgervais](https://github.com/alexgervais) | [Ambassador Labs](https://www.github.com/datawire/) |
-| Alice Wasko | [aliceproxy](https://github.com/aliceproxy) | [Ambassador Labs](https://www.github.com/datawire/) |
-| Flynn | [kflynn](https://github.com/kflynn) | unaffiliated |
-| Luke Shumaker | [lukeshu](https://github.com/lukeshu) | [Ambassador Labs](https://www.github.com/datawire/) |
-| Rafael Schloming | [rhs](https://github.com/rhs) | [Ambassador Labs](https://www.github.com/datawire/) |
+| Maintainer       | GitHub ID                                     | Affiliation                                         |
+| ---------------- | --------------------------------------------- | --------------------------------------------------- |
+| Aidan Hahn       | [aidanhahn](https://github.com/aidanhahn)     | unaffiliated                                        |
+| Alex Gervais     | [alexgervais](https://github.com/alexgervais) | [Ambassador Labs](https://www.github.com/datawire/) |
+| Alice Wasko      | [aliceproxy](https://github.com/aliceproxy)   | [Ambassador Labs](https://www.github.com/datawire/) |
+| Flynn            | [kflynn](https://github.com/kflynn)           | unaffiliated                                        |
+| Luke Shumaker    | [lukeshu](https://github.com/lukeshu)         | [Ambassador Labs](https://www.github.com/datawire/) |
+| Rafael Schloming | [rhs](https://github.com/rhs)                 | [Ambassador Labs](https://www.github.com/datawire/) |
 
-In addition to the maintainers, Emissary releases may be created by any 
+In addition to the maintainers, Emissary releases may be created by any
 of the following (also listed in alphabetical order):
 
-| Releaser | GitHub ID | Affiliation |
-| -------- | --------- | ----------- |
-| Will Hardin | [w-h37](https://github.com/w-h37) | [Ambassador Labs](https://www.github.com/datawire/) |
+| Releaser     | GitHub ID                           | Affiliation                                         |
+| ------------ | ----------------------------------- | --------------------------------------------------- |
+| David Dymko  | [ddymko](https://github.com/ddymko) | [Ambassador Labs](https://www.github.com/datawire/) |
+| Hamzah Qudsi | [haq204](https://github.com/haq204) | [Ambassador Labs](https://www.github.com/datawire/) |
+| Will Hardin  | [w-h37](https://github.com/w-h37)   | [Ambassador Labs](https://www.github.com/datawire/) |
 
 ## Maintainers Emeriti
 
@@ -31,4 +33,3 @@ of the following (also listed in alphabetical order):
 ## Releasers Emeriti
 
 * Noah Krause ([iNoahNothing](https://github.com/iNoahNothing))
-


### PR DESCRIPTION
## Description
This adds David and Hamzah who are engineers at Ambassador Labs.

They will be contributing to the project and assisting with releases.
Once they have met the governance guidelines they will be nominated
to become maintainers.