### PR TITLE
cmd/entrypoint: add additional pprof endpoints to healthcheck server

### DIFF
--- a/cmd/entrypoint/healthcheck_server.go
+++ b/cmd/entrypoint/healthcheck_server.go
@@ -74,6 +74,10 @@ func healthCheckHandler(ctx context.Context, ambwatch *acp.AmbassadorWatcher) er
 
 	// Serve pprof endpoints to aid in live debugging.
 	sm.HandleFunc("/debug/pprof/", pprof.Index)
+	sm.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	sm.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	sm.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	sm.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
 
 	// For everything else, use a ReverseProxy to forward it to diagd.
 	//


### PR DESCRIPTION
Signed-off-by: Hamzah Qudsi <hqudsi@datawire.io>

## Description

Add additional pprof endpoints to healthcheck server such as CPU profiling and tracing to aid in live debugging. `pprof.Index` does not include all pprof types.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] This is unlikely to impact how Ambassador performs at scale.

   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability
