### PR TITLE
[v2.3] back-port KAT tests split

### DIFF
--- a/.github/workflows/execute-tests-and-promote.yml
+++ b/.github/workflows/execute-tests-and-promote.yml
@@ -134,14 +134,16 @@ jobs:
       matrix:
         test:
           - integration
-          - kat-envoy2-1-of-4
-          - kat-envoy2-2-of-4
-          - kat-envoy2-3-of-4
-          - kat-envoy2-4-of-4
-          - kat-envoy3-1-of-4
-          - kat-envoy3-2-of-4
-          - kat-envoy3-3-of-4
-          - kat-envoy3-4-of-4
+          - kat-envoy2-1-of-5
+          - kat-envoy2-2-of-5
+          - kat-envoy2-3-of-5
+          - kat-envoy2-4-of-5
+          - kat-envoy2-5-of-5
+          - kat-envoy3-1-of-5
+          - kat-envoy3-2-of-5
+          - kat-envoy3-3-of-5
+          - kat-envoy3-4-of-5
+          - kat-envoy3-5-of-5
           # FIXME(lukeshu): KAT_RUN_MODE=local is disabled because it
           # needs fixed for a world where annotations are already
           # unfolded in the snapshot.

--- a/.github/workflows/execute-tests-and-promote.yml
+++ b/.github/workflows/execute-tests-and-promote.yml
@@ -134,12 +134,14 @@ jobs:
       matrix:
         test:
           - integration
-          - kat-envoy2-g1
-          - kat-envoy2-g2
-          - kat-envoy2-g3
-          - kat-envoy3-g1
-          - kat-envoy3-g2
-          - kat-envoy3-g3
+          - kat-envoy2-1-of-4
+          - kat-envoy2-2-of-4
+          - kat-envoy2-3-of-4
+          - kat-envoy2-4-of-4
+          - kat-envoy3-1-of-4
+          - kat-envoy3-2-of-4
+          - kat-envoy3-3-of-4
+          - kat-envoy3-4-of-4
           # FIXME(lukeshu): KAT_RUN_MODE=local is disabled because it
           # needs fixed for a world where annotations are already
           # unfolded in the snapshot.

--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -326,13 +326,13 @@ build-aux/.pytest-kat.txt.stamp: $(OSS_HOME)/venv push-pytest-images FORCE
 build-aux/pytest-kat.txt: build-aux/%: build-aux/.%.stamp $(tools/copy-ifchanged)
 	$(tools/copy-ifchanged) $< $@
 clean: build-aux/.pytest-kat.txt.stamp.rm build-aux/pytest-kat.txt.rm
-pytest-kat-envoy3-g%: build-aux/pytest-kat.txt $(tools/py-split-tests)
-	$(MAKE) pytest KAT_RUN_MODE=envoy PYTEST_ARGS="$$PYTEST_ARGS -k '$$($(tools/py-split-tests) $* 3 <build-aux/pytest-kat.txt)' python/tests/kat"
+pytest-kat-envoy3-%: build-aux/pytest-kat.txt $(tools/py-split-tests)
+	$(MAKE) pytest KAT_RUN_MODE=envoy PYTEST_ARGS="$$PYTEST_ARGS -k '$$($(tools/py-split-tests) $(subst -of-, ,$*) <build-aux/pytest-kat.txt)' python/tests/kat"
 pytest-kat-envoy2: push-pytest-images # doing this all at once is too much for CI...
 	$(MAKE) pytest KAT_RUN_MODE=envoy AMBASSADOR_ENVOY_API_VERSION=V2 PYTEST_ARGS="$$PYTEST_ARGS python/tests/kat"
 # ... so we have a separate rule to run things split up
-pytest-kat-envoy2-g%: build-aux/pytest-kat.txt $(tools/py-split-tests)
-	$(MAKE) pytest KAT_RUN_MODE=envoy AMBASSADOR_ENVOY_API_VERSION=V2 PYTEST_ARGS="$$PYTEST_ARGS -k '$$($(tools/py-split-tests) $* 3 <build-aux/pytest-kat.txt)' python/tests/kat"
+pytest-kat-envoy2-%: build-aux/pytest-kat.txt $(tools/py-split-tests)
+	$(MAKE) pytest KAT_RUN_MODE=envoy AMBASSADOR_ENVOY_API_VERSION=V2 PYTEST_ARGS="$$PYTEST_ARGS -k '$$($(tools/py-split-tests) $(subst -of-, ,$*) <build-aux/pytest-kat.txt)' python/tests/kat"
 .PHONY: pytest-kat-%
 
 build-output/bin/envoy: docker/base-envoy.docker.tag.local


### PR DESCRIPTION
## Description
This back-ports the recent CI enhancements done in master to improve flakiness of KAT tests.

## Related Issues
N/A

## Testing
Already active in v3 line and CI should turn green.

## Checklist

 - [ ] I made sure to update `CHANGELOG.md`.
 - [ ] This is unlikely to impact how Ambassador performs at scale.
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
