### PR TITLE
backport: Fix cooldown feature to properly manage several instances of emissary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,15 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
 
 ## RELEASE NOTES
 
+## [2.3.2] TBD
+[2.3.2]: https://github.com/emissary-ingress/emissary/compare/v2.3.1...v2.3.2
+
+### Emissary-ingress and Ambassador Edge Stack
+
+- Bugfix: A regression was introduced in 2.3.0 causing the agent to miss some of the metrics coming
+  from emissary ingress before sending them to Ambassador cloud. This issue has been resolved to
+  ensure that all the nodes composing the emissary ingress cluster are reporting properly.
+
 ## [2.3.1] June 09, 2022
 [2.3.1]: https://github.com/emissary-ingress/emissary/compare/v2.3.0...v2.3.1
 

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -32,6 +32,16 @@
 
 changelog: https://github.com/emissary-ingress/emissary/blob/$branch$/CHANGELOG.md
 items:
+  - version: 2.3.2
+    date: 'TBD'
+    notes:
+      - title: fix regression in the agent for the metrics transfer.
+        type: bugfix
+        body: >-
+          A regression was introduced in 2.3.0 causing the agent to miss some of the metrics coming from
+          emissary ingress before sending them to Ambassador cloud. This issue has been resolved to ensure
+          that all the nodes composing the emissary ingress cluster are reporting properly.
+
   - version: 2.3.1
     date: '2022-06-09'
     notes:

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	envoyMetrics "github.com/datawire/ambassador/v2/pkg/api/envoy/service/metrics/v3"
-	io_prometheus_client "github.com/prometheus/client_model/go"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -14,6 +12,9 @@ import (
 	"sync"
 	"time"
 
+	envoyMetrics "github.com/datawire/ambassador/v2/pkg/api/envoy/service/metrics/v3"
+	io_prometheus_client "github.com/prometheus/client_model/go"
+	"google.golang.org/grpc/peer"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -111,6 +112,9 @@ type Agent struct {
 	// Cloud API.
 	metricsBackoffUntil time.Time
 
+	// Used to accumulate metrics for a same timestamp before pushing them to the cloud.
+	aggregatedMetrics map[string][]*io_prometheus_client.MetricFamily
+
 	// Extra headers to inject into RPC requests to ambassador cloud.
 	rpcExtraHeaders []string
 }
@@ -169,8 +173,9 @@ func NewAgent(directiveHandler DirectiveHandler, rolloutsGetterFactory rolloutsG
 		directiveHandler:             directiveHandler,
 		reportRunning:                atomicBool{value: false},
 		agentWatchFieldSelector:      getEnvWithDefault("AGENT_WATCH_FIELD_SELECTOR", "metadata.namespace!=kube-system"),
-		metricsBackoffUntil:          time.Now(),
+		metricsBackoffUntil:          time.Now().Add(defaultMinReportPeriod),
 		rpcExtraHeaders:              rpcExtraHeaders,
+		aggregatedMetrics:            map[string][]*io_prometheus_client.MetricFamily{},
 	}
 }
 
@@ -635,58 +640,73 @@ var allowedMetricsSuffixes = []string{"upstream_rq_total", "upstream_rq_time", "
 
 // MetricsRelayHandler is invoked as a callback when the agent receive metrics from Envoy (sink).
 func (a *Agent) MetricsRelayHandler(
-	logCtx context.Context,
+	ctx context.Context,
 	in *envoyMetrics.StreamMetricsMessage,
 ) {
-	a.metricsRelayMutex.Lock()
-	defer a.metricsRelayMutex.Unlock()
-
 	metrics := in.GetEnvoyMetrics()
-	metricCount := len(metrics)
-
-	if !time.Now().After(a.metricsBackoffUntil) {
-		dlog.Debugf(logCtx, "Drop %d metric(s); next push scheduled for %s",
-			metricCount, a.metricsBackoffUntil.String())
-		return
-	}
 
 	if a.comm != nil && !a.reportingStopped {
+		p, ok := peer.FromContext(ctx)
 
-		dlog.Infof(logCtx, "Received %d metric(s)", metricCount)
+		if !ok {
+			dlog.Warnf(ctx, "peer not found in context")
+			return
+		}
 
 		a.ambassadorAPIKeyMutex.Lock()
 		apikey := a.ambassadorAPIKey
 		a.ambassadorAPIKeyMutex.Unlock()
 
-		outMetrics := make([]*io_prometheus_client.MetricFamily, 0, len(metrics))
+		newMetrics := make([]*io_prometheus_client.MetricFamily, 0, len(metrics))
 
 		for _, metricFamily := range metrics {
 			for _, suffix := range allowedMetricsSuffixes {
 				if strings.HasSuffix(metricFamily.GetName(), suffix) {
-					outMetrics = append(outMetrics, metricFamily)
+					newMetrics = append(newMetrics, metricFamily)
 					break
 				}
 			}
 		}
 
+		instanceID := p.Addr.String()
+
+		a.metricsRelayMutex.Lock()
+		defer a.metricsRelayMutex.Unlock()
+		// Collect metrics until next report.
+		if time.Now().Before(a.metricsBackoffUntil) {
+			dlog.Infof(ctx, "Append %d metric(s) to stack from %s",
+				len(newMetrics), instanceID,
+			)
+			a.aggregatedMetrics[instanceID] = newMetrics
+			return
+		}
+
+		// Otherwise, we reached a new batch of metric, send everything.
 		outMessage := &agent.StreamMetricsMessage{
 			Identity:     a.agentID,
-			EnvoyMetrics: outMetrics,
+			EnvoyMetrics: []*io_prometheus_client.MetricFamily{},
+		}
+
+		for key, instanceMetrics := range a.aggregatedMetrics {
+			outMessage.EnvoyMetrics = append(outMessage.EnvoyMetrics, instanceMetrics...)
+			delete(a.aggregatedMetrics, key)
 		}
 
 		if relayedMetricCount := len(outMessage.GetEnvoyMetrics()); relayedMetricCount > 0 {
 
-			dlog.Infof(logCtx, "Relaying %d metric(s)", relayedMetricCount)
+			dlog.Infof(ctx, "Relaying %d metric(s)", relayedMetricCount)
 
-			if err := a.comm.StreamMetrics(logCtx, outMessage, apikey); err != nil {
-				dlog.Errorf(logCtx, "error streaming metric(s): %+v", err)
+			if err := a.comm.StreamMetrics(ctx, outMessage, apikey); err != nil {
+				dlog.Errorf(ctx, "error streaming metric(s): %+v", err)
 			}
-
-			a.metricsBackoffUntil = time.Now().Add(defaultMinReportPeriod)
-
-			dlog.Infof(logCtx, "Next metrics relay scheduled for %s",
-				a.metricsBackoffUntil.UTC().String())
 		}
+
+		// Configure next push.
+		a.metricsBackoffUntil = time.Now().Add(defaultMinReportPeriod)
+
+		dlog.Infof(ctx, "Next metrics relay scheduled for %s",
+			a.metricsBackoffUntil.UTC().String())
+
 	}
 }
 

--- a/pkg/agent/agent_metrics_test.go
+++ b/pkg/agent/agent_metrics_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/datawire/dlib/dlog"
 	io_prometheus_client "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/peer"
+	"net"
 	"testing"
 	"time"
 )
@@ -46,6 +48,7 @@ func agentMetricsSetupTest() (*MockClient, *Agent) {
 		comm: &RPCComm{
 			client: clientMock,
 		},
+		aggregatedMetrics: map[string][]*io_prometheus_client.MetricFamily{},
 	}
 
 	return clientMock, stubbedAgent
@@ -53,26 +56,36 @@ func agentMetricsSetupTest() (*MockClient, *Agent) {
 
 func TestMetricsRelayHandler(t *testing.T) {
 
-	t.Run("will relay the metrics", func(t *testing.T) {
+	t.Run("will relay metrics from the stack", func(t *testing.T) {
 		//given
 		clientMock, stubbedAgent := agentMetricsSetupTest()
-		ctx := dlog.NewTestContext(t, true)
+		ctx := peer.NewContext(dlog.NewTestContext(t, true), &peer.Peer{
+			Addr: &net.IPAddr{
+				IP: net.ParseIP("192.168.0.1"),
+			},
+		})
+		stubbedAgent.aggregatedMetrics["192.168.0.1"] = []*io_prometheus_client.MetricFamily{acceptedMetric}
 
 		//when
 		stubbedAgent.MetricsRelayHandler(ctx, &envoyMetrics.StreamMetricsMessage{
-			Identifier:   nil,
+			Identifier: nil,
+			// ignored since time to report.
 			EnvoyMetrics: []*io_prometheus_client.MetricFamily{ignoredMetric, acceptedMetric},
 		})
 
 		//then
 		assert.Equal(t, []*agent.StreamMetricsMessage{{
 			EnvoyMetrics: []*io_prometheus_client.MetricFamily{acceptedMetric},
-		}}, clientMock.SentMetrics)
+		}}, clientMock.SentMetrics, "metrics should be propagated to cloud")
 	})
 	t.Run("will not relay the metrics since it is in cool down period.", func(t *testing.T) {
 		//given
 		clientMock, stubbedAgent := agentMetricsSetupTest()
-		ctx := dlog.NewTestContext(t, true)
+		ctx := peer.NewContext(dlog.NewTestContext(t, true), &peer.Peer{
+			Addr: &net.IPAddr{
+				IP: net.ParseIP("192.168.0.1"),
+			},
+		})
 		stubbedAgent.metricsBackoffUntil = time.Now().Add(defaultMinReportPeriod)
 
 		//when
@@ -82,6 +95,43 @@ func TestMetricsRelayHandler(t *testing.T) {
 		})
 
 		//then
-		assert.Equal(t, 0, len(clientMock.SentMetrics))
+		assert.Equal(t, stubbedAgent.aggregatedMetrics["192.168.0.1"],
+			[]*io_prometheus_client.MetricFamily{acceptedMetric},
+			"metrics should be added to the stack")
+		assert.Equal(t, 0, len(clientMock.SentMetrics), "nothing send to cloud")
+	})
+	t.Run("peer IP is not available", func(t *testing.T) {
+		// given
+		clientMock, stubbedAgent := agentMetricsSetupTest()
+		ctx := dlog.NewTestContext(t, true)
+
+		//when
+		stubbedAgent.MetricsRelayHandler(ctx, &envoyMetrics.StreamMetricsMessage{
+			Identifier:   nil,
+			EnvoyMetrics: []*io_prometheus_client.MetricFamily{acceptedMetric},
+		})
+
+		//then
+		assert.Equal(t, 0, len(stubbedAgent.aggregatedMetrics), "no metrics")
+		assert.Equal(t, 0, len(clientMock.SentMetrics), "nothing send to cloud")
+	})
+	t.Run("not metrics available in aggregatedMetrics", func(t *testing.T) {
+		// given
+		clientMock, stubbedAgent := agentMetricsSetupTest()
+		ctx := peer.NewContext(dlog.NewTestContext(t, true), &peer.Peer{
+			Addr: &net.IPAddr{
+				IP: net.ParseIP("192.168.0.1"),
+			},
+		})
+
+		//when
+		stubbedAgent.MetricsRelayHandler(ctx, &envoyMetrics.StreamMetricsMessage{
+			Identifier:   nil,
+			EnvoyMetrics: []*io_prometheus_client.MetricFamily{},
+		})
+
+		//then
+		assert.Equal(t, 0, len(stubbedAgent.aggregatedMetrics), "no metrics")
+		assert.Equal(t, 0, len(clientMock.SentMetrics), "nothing send to cloud")
 	})
 }


### PR DESCRIPTION
## Description

_This commit comes from [the version 3](https://github.com/emissary-ingress/emissary/pull/4293) and is a backport._

----

Previously, we added a cooldown step (30s) for the metrics[ to avoid to send too many requests](https://github.com/emissary-ingress/emissary/pull/4122) to the ambassador cloud API.

Although, some values were not consistent, and we figured out that the way the metrics are sent to the agent are **one request per emissary node**, and not **one for all**.

It means that the previous iterations of the code were wrong for two reasons : 
* If we forward the metrics directly to the cloud, we won't be able to identify what node corresponds to what metric.
* If we put a simple cooldown of 30s, for 3 nodes, we'll miss 2 out of 3 sets of metrics.

As a workaround, with minimal changes, this PR changes the logic to make the metric relay handler to accumulate metrics in a map per nodes' IP, and unload them after the cooldown period.

![image](https://user-images.githubusercontent.com/16439060/174813045-efd7a022-c8ff-42b8-9bb8-458977cd8483.png)

## Testing

Adapted existing tests, & tested it in a dev cluster.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `CHANGELOG.md`.

   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations

 - [x] This is unlikely to impact how Ambassador performs at scale.

   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability

 - [x] My change is adequately tested.

   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points

 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.

 - [x] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
