### PR TITLE
ci: fix cron expression on generate-base-python job

### DIFF
--- a/.github/workflows/generate-base-python.yml
+++ b/.github/workflows/generate-base-python.yml
@@ -1,9 +1,9 @@
 name: generate-base-python
 on:
   schedule:
-    # run 15 minutes after midnight (UTC) weekly on mondays
-    - cron: '0 15 0 ? * MON *'
-
+    # run 15 minutes after midnight (UTC) weekly on sundays
+    # used https://crontab.guru/ to generate
+    - cron: '15 0 * * SUN'
 jobs:
   generate: ####################################################################
       runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

This updates the cron expression because "0 15 0 ? * MON *" was not
valid to Github despite being generated via an online generator.

This new format was generated from <https://crontab.guru/> this time
and seems to pass Githubs regex.

I switched it to run Sunday since that is when the new base-python is
looked for when running `make generate`.

**Again this is still meant to be a temporary work-around.**

## Related Issues
None

## Testing
verified on different cron generator site recommend by a blog post.

## Checklist
 - [ ] I made sure to update `CHANGELOG.md`.
 - [x] This is unlikely to impact how Ambassador performs at scale.
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
