### PR TITLE
deps: bump multiple dependencies in base-python

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -3,7 +3,7 @@ following Free and Open Source software:
 
     Name                                                                                       Version                                      License(s)
     ----                                                                                       -------                                      ----------
-    the Go language standard library ("std")                                                   v1.17.6                                      3-clause BSD license
+    the Go language standard library ("std")                                                   v1.17.12                                     3-clause BSD license
     cloud.google.com/go/compute                                                                v1.2.0                                       Apache License 2.0
     github.com/Azure/go-ansiterm                                                               v0.0.0-20210617225240-d185dfc1b5a1           MIT license
     github.com/Azure/go-autorest                                                               v14.2.0+incompatible                         Apache License 2.0

--- a/docker/base-python/Dockerfile
+++ b/docker/base-python/Dockerfile
@@ -25,32 +25,32 @@ WORKDIR /buildroot
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin:/buildroot/bin
 
 RUN apk --no-cache add \
-    bash \
-    gcc \
-    make \
-    musl-dev \
-    curl \
-    cython \
-    docker-cli \
-    git \
-    iptables \
-    jq \
-    libcap \
-    libcap-dev \
-    libffi-dev \
-    ncurses \
-    openssl-dev \
-    py3-pip=~20.3.4 \
-    python3=~3.9.7 \
-    python3-dev \
-    rust \
-    cargo \
-    patchelf \
-    rsync \
-    sudo \
-    yaml-dev \
-    && ln -s /usr/bin/python3 /usr/bin/python \
-    && chmod u+s $(which docker)
+  bash \
+  gcc \
+  make \
+  musl-dev \
+  curl \
+  cython \
+  docker-cli \
+  git \
+  iptables \
+  jq \
+  libcap \
+  libcap-dev \
+  libffi-dev \
+  ncurses \
+  openssl-dev \
+  py3-pip=~20.3.4 \
+  python3=~3.9.7 \
+  python3-dev \
+  rust \
+  cargo \
+  patchelf \
+  rsync \
+  sudo \
+  yaml-dev \
+  && ln -s /usr/bin/python3 /usr/bin/python \
+  && chmod u+s $(which docker)
 
 # Consult
 # https://github.com/jazzband/pip-tools/#versions-and-compatibility to
@@ -61,7 +61,7 @@ RUN pip3 install pip-tools==6.3.1
 RUN curl --fail -L https://dl.google.com/go/go1.17.6.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 
 RUN curl --fail -L https://storage.googleapis.com/kubernetes-release/release/v1.23.3/bin/linux/amd64/kubectl -o /usr/bin/kubectl && \
-    chmod a+x /usr/bin/kubectl
+  chmod a+x /usr/bin/kubectl
 
 # The YAML parser is... special. To get the C version, we need to install Cython and libyaml, then
 # build it locally -- just using pip won't work.

--- a/docker/base-python/Dockerfile
+++ b/docker/base-python/Dockerfile
@@ -29,7 +29,7 @@ RUN apk --no-cache add \
   gcc \
   make \
   musl-dev \
-  curl \
+  curl=~7.80.0-r2 \
   cython \
   docker-cli \
   git \
@@ -38,8 +38,8 @@ RUN apk --no-cache add \
   libcap \
   libcap-dev \
   libffi-dev \
-  ncurses \
-  openssl-dev \
+  ncurses=6.3_p20211120-r1 \
+  openssl-dev=1.1.1q-r0 \
   py3-pip=~20.3.4 \
   python3=~3.9.7 \
   python3-dev \
@@ -58,7 +58,7 @@ RUN apk --no-cache add \
 # 'python3' versions above.
 RUN pip3 install pip-tools==6.3.1
 
-RUN curl --fail -L https://dl.google.com/go/go1.17.6.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+RUN curl --fail -L https://dl.google.com/go/go1.17.12.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 
 RUN curl --fail -L https://storage.googleapis.com/kubernetes-release/release/v1.23.3/bin/linux/amd64/kubectl -o /usr/bin/kubectl && \
   chmod a+x /usr/bin/kubectl


### PR DESCRIPTION
Bumps multiple dependencies in our base-python that ultimately end up in our final builds. As far as I can tell that we are not directly vulnerable to these and not from an end user runtime perspective. 

However, out of an abundance of caution we want to make sure we are updated to the latest releases that address these vulnerabilities.

Bump to Golang 1.17.12:
- https://nvd.nist.gov/vuln/detail/CVE-2022-23806
- https://nvd.nist.gov/vuln/detail/CVE-2022-28327
- https://nvd.nist.gov/vuln/detail/CVE-2022-24675
- https://nvd.nist.gov/vuln/detail/CVE-2022-24921
- https://nvd.nist.gov/vuln/detail/CVE-2022-23772

Bump curl to 7.80.0-r2:
- https://nvd.nist.gov/vuln/detail/CVE-2022-32207
- https://nvd.nist.gov/vuln/detail/CVE-2022-27782
- https://nvd.nist.gov/vuln/detail/CVE-2022-27781
- https://nvd.nist.gov/vuln/detail/CVE-2022-27780

Bump openSSL-dev 1.1.1q-r0:
_this CVE only affects 32-bit platforms but out of caution we
are upgrading to make sure we are on the latest patch release_

- https://nvd.nist.gov/vuln/detail/CVE-2022-2097

Bumps ncurses to 6.3_p20211120-r1:
- https://nvd.nist.gov/vuln/detail/CVE-2022-29458

Signed-off-by: Lance Austin <laustin@datawire.io>

## Description
A few sentences describing the overall goals of the pull request's commits.

## Related Issues
List related issues.

## Testing
A few sentences describing what testing you've done, e.g., manual tests, automated tests, deployed in production, etc.

## Checklist

 - [ ] I made sure to update `CHANGELOG.md`.
**Note, I have captured this to add externally as part of the upcoming release steps**

 - [x] This is unlikely to impact how Ambassador performs at scale.
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [x] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
