### PR TITLE
deps: pin python3 to 3.9.13 patch version

### DIFF
--- a/docker/base-python/Dockerfile
+++ b/docker/base-python/Dockerfile
@@ -41,7 +41,7 @@ RUN apk --no-cache add \
   ncurses=6.3_p20211120-r1 \
   openssl-dev=1.1.1q-r0 \
   py3-pip=~20.3.4 \
-  python3=~3.9.7 \
+  python3=~3.9.13 \
   python3-dev \
   rust \
   cargo \


### PR DESCRIPTION
## Description
Alpine 3.15 removed 3.9.7 from the main registry index.
This updates the pin to the latest patch release in apk 3.15

## Related Issues
N/a

## Testing
CI will go green

## Checklist
 - [ ] I made sure to update `CHANGELOG.md`.
 - [x] This is unlikely to impact how Ambassador performs at scale.
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
