### PR TITLE
deps: pin curl in optimized container

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -79,7 +79,7 @@ ADD go.sum go.sum
 
 RUN --mount=type=cache,target=/root/.cache/go-build \
     mkdir -p /go/bin && \
-	time go build -mod=vendor -o /go/bin/ ./cmd/...
+    time go build -mod=vendor -o /go/bin/ ./cmd/...
 
 ########################################
 # The artifact build stage
@@ -126,7 +126,7 @@ ARG py_version="i-forgot-to-set-build-arg-py-version"
 RUN adduser ambassador -u 8888 -G root -D -H -s /bin/false
 
 # External stuff that should change infrequently
-RUN apk --no-cache add bash curl python3=${py_version} libcap htop
+RUN apk --no-cache add bash curl=~7.80 python3=${py_version} libcap htop
 RUN apk upgrade --no-cache
 RUN ln -s /usr/bin/python3 /usr/bin/python
 COPY --from=artifacts /usr/bin/kubectl /usr/bin/kubectl

--- a/docker/base-python/Dockerfile
+++ b/docker/base-python/Dockerfile
@@ -29,7 +29,7 @@ RUN apk --no-cache add \
   gcc \
   make \
   musl-dev \
-  curl=~7.80.0-r2 \
+  curl=~7.80 \
   cython \
   docker-cli \
   git \


### PR DESCRIPTION

Signed-off-by: Lance Austin <laustin@datawire.io>

## Description
We previously pinned curl in the base-python but in `builder/Dockerfile`
we redownload curl using apk without
it being pinned.

This ensures we are pulling the curl version into the optimized
container and the base-python container.

**Note** - this will need to be cherry-picked to `rel/v2.3.2` so that it will get merged back into the `release/v2.3` after release.

## Related Issues

## Testing
CI green and build image and execute into it to verify correct curl version.

## Checklist
 - [x] I made sure to update `CHANGELOG.md`.
 - [x] This is unlikely to impact how Ambassador performs at scale.
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
