### PR TITLE
Disabled diagnostics reporting feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,13 +80,6 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
 - Feature: The agent is now able to parse api contracts using swagger 2, and to convert them to
   OpenAPI 3, making them available for use in the dev portal.
 
-- Feature: The agent now has the ability to report diagnostics information to Ambassador Cloud. If
-  you previously connected your installation to Ambassador Cloud, you may choose to enable this
-  functionality by setting the following environment variables on your agent `Deployment`:
-  `AES_REPORT_DIAGNOSTICS_TO_CLOUD=true`,
-  `AES_DIAGNOSTICS_URL="http://[ambassador-admin]:8877/ambassador/v0/diag/?json=true"`. This
-  capability is enabled by default in the standard published `.yaml` files and Helm chart.
-
 - Change: In the standard published `.yaml` files, the `Module` resource enables serving remote
   client requests to the `:8877/ambassador/v0/diag/` endpoint. The associated Helm chart release
   also now enables it by default.

--- a/charts/emissary-ingress/CHANGELOG.md
+++ b/charts/emissary-ingress/CHANGELOG.md
@@ -5,7 +5,6 @@ numbering uses [semantic versioning](http://semver.org).
 
 ## Next Release
 
-- Feature: The Agent Deployment is now configured to report diagnostics information to Ambassador Cloud by default.
 - Change: The default for the `module` value has changed to enable serving remote client requests to the <code>:8877/ambassador/v0/diag/</code> endpoint by default.
 
 ## v8.0.0

--- a/charts/emissary-ingress/templates/ambassador-agent.yaml
+++ b/charts/emissary-ingress/templates/ambassador-agent.yaml
@@ -241,14 +241,8 @@ spec:
           value: {{ include "ambassador.fullname" . }}-agent-cloud-token
         - name: RPC_CONNECTION_ADDRESS
           value: {{ .Values.agent.rpcAddress }}
-        {{- if .Values.agent.diagnostics }}
-        - name: AES_REPORT_DIAGNOSTICS_TO_CLOUD
-          value: "true"
-        {{- end }}
         - name: AES_SNAPSHOT_URL
           value: "http://{{ include "ambassador.fullname" . }}-admin.{{ include "ambassador.namespace" . }}:{{ .Values.adminService.snapshotPort }}/snapshot-external"
-        - name: AES_DIAGNOSTICS_URL
-          value: "http://{{ include "ambassador.fullname" . }}-admin.{{ include "ambassador.namespace" . }}:{{ .Values.adminService.port }}/ambassador/v0/diag/?json=true"
   {{ if .Values.progressDeadlines }}
   {{ if hasKey .Values.progressDeadlines "agent" }}
   progressDeadlineSeconds: {{ .Values.progressDeadlines.agent }}

--- a/charts/emissary-ingress/values.yaml.in
+++ b/charts/emissary-ingress/values.yaml.in
@@ -388,8 +388,6 @@ prometheusExporter: # +doc-gen:break
 agent:
   # If `true`, installs the ambassador-agent Deployment, ServiceAccount and ClusterRole in the ambassador namespace, enabling the Ambassador Cloud connectivity.
   enabled: true
-  # If `true`, will report diagnostics information.
-  diagnostics: true
   # API token for reporting snapshots to [Ambassador Cloud](https://app.getambassador.io/cloud/);
   # If empty, agent will not report snapshots
   cloudConnectToken: ''

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -40,16 +40,6 @@ items:
         body: >-
           The agent is now able to parse api contracts using swagger 2, and to convert them to OpenAPI 3, making them
           available for use in the dev portal.
-      - title:
-        type: feature
-        body: >-
-          The agent now has the ability to report diagnostics information to Ambassador Cloud.
-          If you previously connected your installation to Ambassador Cloud, you may choose to enable this functionality
-          by setting the following environment variables on your agent <code>Deployment</code>:
-          <code>AES_REPORT_DIAGNOSTICS_TO_CLOUD=true</code>,
-          <code>AES_DIAGNOSTICS_URL="http://[ambassador-admin]:8877/ambassador/v0/diag/?json=true"</code>.
-          This capability is enabled by default in the standard published <code>.yaml</code> files and Helm chart.
-        docs: ../../../cloud/latest/service-catalog/reference/diagnostics/
       - title: Default YAML enables the diagnostics interface from non-local clients on the admin service port
         type: change
         body: >-

--- a/manifests/emissary/emissary-defaultns.yaml.in
+++ b/manifests/emissary/emissary-defaultns.yaml.in
@@ -636,12 +636,8 @@ spec:
           value: emissary-ingress-agent-cloud-token
         - name: RPC_CONNECTION_ADDRESS
           value: https://app.getambassador.io/
-        - name: AES_REPORT_DIAGNOSTICS_TO_CLOUD
-          value: "true"
         - name: AES_SNAPSHOT_URL
           value: http://emissary-ingress-admin.default:8005/snapshot-external
-        - name: AES_DIAGNOSTICS_URL
-          value: http://emissary-ingress-admin.default:8877/ambassador/v0/diag/?json=true
         image: $imageRepo$:$version$
         imagePullPolicy: IfNotPresent
         name: agent

--- a/manifests/emissary/emissary-emissaryns.yaml.in
+++ b/manifests/emissary/emissary-emissaryns.yaml.in
@@ -636,12 +636,8 @@ spec:
           value: emissary-ingress-agent-cloud-token
         - name: RPC_CONNECTION_ADDRESS
           value: https://app.getambassador.io/
-        - name: AES_REPORT_DIAGNOSTICS_TO_CLOUD
-          value: "true"
         - name: AES_SNAPSHOT_URL
           value: http://emissary-ingress-admin.emissary:8005/snapshot-external
-        - name: AES_DIAGNOSTICS_URL
-          value: http://emissary-ingress-admin.emissary:8877/ambassador/v0/diag/?json=true
         image: $imageRepo$:$version$
         imagePullPolicy: IfNotPresent
         name: agent


### PR DESCRIPTION
Signed-off-by: alex <alex@datawire.io>

## Description
Disable diagnostics reporting to Ambassador Cloud by default with the feature flag.

## Related Issues
None

## Testing
None

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `CHANGELOG.md`.

   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations

 - [x] This is unlikely to impact how Ambassador performs at scale.

   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability

 - [ ] My change is adequately tested.

   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points

 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.

 - [ ] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
