### PR TITLE
fix: inject direct response to side car acme-challenge 

### DIFF
--- a/python/ambassador/envoy/v3/v3listener.py
+++ b/python/ambassador/envoy/v3/v3listener.py
@@ -868,33 +868,23 @@ class V3Listener(dict):
 
             # If we're on Edge Stack and we don't already have an ACME route, add one.
             if self.config.ir.edge_stack_allowed and not found_acme:
-                # The target cluster doesn't actually matter -- the auth service grabs the
-                # challenge and does the right thing. But we do need a cluster that actually
-                # exists, so use the sidecar cluster.
-
-                if not self.config.ir.sidecar_cluster_name:
-                    # Uh whut? how is Edge Stack running exactly?
-                    raise Exception(
-                        "Edge Stack claims to be running, but we have no sidecar cluster??"
-                    )
+                # This route is needed to trigger an ExtAuthz request for the AuthService.
+                # The auth service grabs the challenge and does the right thing.
+                # Rather than try to route to some existing cluster we can just return a
+                # direct response. What we return doesn't really matter but
+                # to match existing Edge Stack behavior we return a 404 response.
 
                 if self._log_debug:
                     logger.debug("      punching a hole for ACME")
 
-                # Make sure to include _host_constraints in here for now.
-                #
-                # XXX This is needed only because we're dictifying the V3Route too early.
-
+                # Make sure to include _host_constraints in here for now so it can be
+                # applied to the correct vhost during future proccessing
                 chain.routes.insert(
                     0,
                     {
                         "_host_constraints": set(),
                         "match": {"case_sensitive": True, "prefix": "/.well-known/acme-challenge/"},
-                        "route": {
-                            "cluster": self.config.ir.sidecar_cluster_name,
-                            "prefix_rewrite": "/.well-known/acme-challenge/",
-                            "timeout": "3.000s",
-                        },
+                        "direct_response": {"status": 404},
                     },
                 )
 

--- a/python/ambassador/ir/ir.py
+++ b/python/ambassador/ir/ir.py
@@ -1025,7 +1025,7 @@ class IR:
             self.clusters[cluster.name] = cluster
 
             if cluster.is_edge_stack_sidecar():
-                # self.logger.debug(f"IR: cluster {cluster.name} is the sidecar")
+                self.logger.debug(f"IR: cluster {cluster.name} is the sidecar cluster name")
                 self.sidecar_cluster_name = cluster.name
         else:
             self.logger.debug(


### PR DESCRIPTION
## Description

When emissary adds routes for the sidecar acme-challenge it would assign an arbitrary cluster that was pointing at the side car localhost (127.0.0.1:8500). This cluster name was captured on the IR in `sidecar_cluster_name`. 

When emissary sees a cluster name that is longer than 60 characters it will go through a process of shortening the cluster and potential merging it with other clusters that have naming collisions. However, this is only done on the `envoy_name` field of a cluster and would not be propagated back to the `side_cluster_name`. Thus this causes diagd to output invalid envoy configuration due to the acme-challenge route not pointing to a valid cluster.

By chance we had been lucky to not run into this but a recent addition of the injected RateLimitService means the injected route could be assigned to a cluster that has a name longer than 60 characters pending which order the RateLimitService and AuthService clusters are added, namespace size, etc...

Rather than try to keep all of these things in sync, the route will now return a direct 404 response. This will maintain compatibility with the current behavior of the sidecar handler and it simplifies the logic.

To keep this PR succinct and to ensure a smooth release I left the `side_cluster_name` variable still in tact but I think analysis should be cleaned up. I wanted to make sure I didn't break anything or have too many moving parts during the RC process.


## Related Issues
N/A

## Testing
I had a Unit test but it was brittle due to changing OS environment variables so I didn't commit it. Rather CI for Emissary and Edge Stack are now green.

## Checklist

 - [ ] I made sure to update `CHANGELOG.md`.
 - [x] This is unlikely to impact how Ambassador performs at scale.
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
