### PR TITLE
Allow the Agent to watch Secret resources

### DIFF
--- a/charts/emissary-ingress/CHANGELOG.md
+++ b/charts/emissary-ingress/CHANGELOG.md
@@ -6,6 +6,7 @@ numbering uses [semantic versioning](http://semver.org).
 ## Next Release
 
 - Change: The default for the `module` value has changed to enable serving remote client requests to the <code>:8877/ambassador/v0/diag/</code> endpoint by default.
+- Bugfix: The default Role configuration of the Ambassador Agent Deployment will allow it to correctly watch Secret resources for Ambassador Cloud tokens.
 
 ## v8.0.0
 

--- a/charts/emissary-ingress/templates/ambassador-agent.yaml
+++ b/charts/emissary-ingress/templates/ambassador-agent.yaml
@@ -67,7 +67,7 @@ rules:
   verbs: [ "get", "list", "watch" ]
 - apiGroups: [""]
   resources: [ "secrets"]
-  verbs: [ "get", "create", "delete", "patch"]
+  verbs: [ "get", "create", "delete", "patch", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/manifests/emissary/emissary-defaultns.yaml.in
+++ b/manifests/emissary/emissary-defaultns.yaml.in
@@ -576,6 +576,7 @@ rules:
   - create
   - delete
   - patch
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/manifests/emissary/emissary-emissaryns.yaml.in
+++ b/manifests/emissary/emissary-emissaryns.yaml.in
@@ -576,6 +576,7 @@ rules:
   - create
   - delete
   - patch
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
Signed-off-by: alex <alex@datawire.io>

## Description
Allow the Agent to watch Secret resources in order to read Ambassador Cloud Tokens from Secrets instead of ConfigMaps.

## Related Issues
https://github.com/datawire/apro/issues/3022

## Testing
Manually validated the RBAC change allows the agent to correctly configure a cloud token using a Secret resource.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `CHANGELOG.md`.

   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations

 - [x] This is unlikely to impact how Ambassador performs at scale.

   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability

 - [x] My change is adequately tested.

   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points

 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.

 - [ ] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
