### PR TITLE
ci: add container cve scanning to ci build process

### DIFF
--- a/.github/workflows/execute-tests-and-promote.yml
+++ b/.github/workflows/execute-tests-and-promote.yml
@@ -8,7 +8,6 @@ name: job-promote-to-passed
   pull_request: {}
 
 jobs:
-
   lint: ########################################################################
     runs-on: ubuntu-latest
     env:
@@ -251,6 +250,8 @@ jobs:
       DEV_REGISTRY: ${{ secrets.DEV_REGISTRY }}
       # See docker/base-python.docker.gen
       BASE_PYTHON_REPO: ${{ secrets.BASE_PYTHON_REPO }}
+    outputs:
+      image-tag: ${{ steps.build-image.outputs.image-tag }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -268,12 +269,46 @@ jobs:
         shell: bash
         run: |
           make push
+      - name: "capture image tag"
+        id: build-image
+        shell: bash
+        run: |
+          echo "::set-output name=image-tag::$(tools/build/version.sh)"
       - name: "make push-dev"
         shell: bash
         run: |
           make push-dev
       - uses: ./.github/actions/after-job
         if: always()
+
+  ######################################################################
+  ######################### CVE Scanning ###############################
+  trivy-container-scan:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      # upload of results to github uses git so checkout of code is needed
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: "Log image-tag"
+        shell: bash
+        run: echo ${{needs.build.outputs.image-tag}}
+      - name: Scan
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: "${{secrets.DEV_REGISTRY}}/emissary:${{needs.build.outputs.image-tag}}"
+          format: "sarif"
+          exit-code: 0 # only warn for now until we have backed it into our processes
+          output: "trivy-results.sarif"
+          ignore-unfixed: true
+          vuln-type: "os,library"
+          severity: "CRITICAL,HIGH"
+      - name: Upload Scan to GitHub Security Tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: "trivy-results.sarif"
 
   ##############################################################################
   pass:
@@ -287,6 +322,7 @@ jobs:
       - check-pytest
       - check-pytest-unit
       - check-chart
+      - trivy-container-scan
     runs-on: ubuntu-latest
     steps:
       - name: No-Op

--- a/tools/build/version.sh
+++ b/tools/build/version.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euE -o pipefail
+
+# capture Go psuedo version
+version="$(go run ./tools/src/goversion)"
+
+# output the tag version so that it can be used by CI for things such as container scanning
+echo "${version:1}"


### PR DESCRIPTION
## Description

We already use code scanning for our own code dependencies but we also pull in other packages during our container build process via alpine package manager. This adds a cve scanner to our built containers so that we can proactively investigate cve's to determine if Emissary-ingress is vulnerable to them or not. This will ensure that we keep our dependencies up-to-date and address potential vulnerabilities quickly.

This adds support for two open source scanners Trivy and Grype. When evaluating them both they seem to catch different CVE's. Due to the fact that they run fast and do not have a big impact on CI time
both tools will be used to scan. They are both set to warning for now as well so that we become more familiar with them and how they will fit into our CI processes.

## Related Issues
N/A

## Testing
Tested Github Actions and CI in a personal project to verify setup was correct and to verify how to configure the Github Actions.

## Checklist
 - [ ] I made sure to update `CHANGELOG.md`.
 - [x] This is unlikely to impact how Ambassador performs at scale.
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
