### PR TITLE
WIP: Fix URL for API Documentation

### DIFF
--- a/pkg/agent/api_docs.go
+++ b/pkg/agent/api_docs.go
@@ -251,7 +251,7 @@ func newOpenAPI(ctx context.Context, docBytes []byte, baseURL string, prefix str
 	}
 
 	// Get prefix out of first server URL. E.g. if it's
-	// http://example.com/v1, we want to to add /v1 after the Ambassador
+	// http://example.com/v1, we want to add /v1 after the Ambassador
 	// prefix.
 	existingPrefix := ""
 	if doc.Servers != nil && doc.Servers[0] != nil {
@@ -269,7 +269,12 @@ func newOpenAPI(ctx context.Context, docBytes []byte, baseURL string, prefix str
 		dlog.Debugf(ctx, "could not parse URL %q", baseURL)
 	} else {
 		if prefix != "" {
-			if existingPrefix != "" && keepExistingPrefix {
+
+			if existingPrefix != "" &&
+				keepExistingPrefix &&
+				strings.TrimRight(prefix, "/") != strings.TrimRight(existingPrefix, "/") &&
+				!strings.HasSuffix(strings.TrimRight(prefix, "/"), strings.TrimRight(existingPrefix, "/")) {
+
 				base.Path = path.Join(base.Path, prefix, existingPrefix)
 			} else {
 				base.Path = path.Join(base.Path, prefix)

--- a/pkg/agent/api_docs_test.go
+++ b/pkg/agent/api_docs_test.go
@@ -187,6 +187,276 @@ func TestAPIDocsStore(t *testing.T) {
 				Data: []byte(`{"components":{},"info":{"title":"Sample API","version":"0.0"},"openapi":"3.0.0","paths":{},"servers":[{"url":""}]}`),
 			}},
 		},
+		{
+			name: "will handle prefix if it's already declared in the API Docs",
+			mappings: []*amb.Mapping{
+				{
+					TypeMeta: kates.TypeMeta{
+						Kind: "Mapping",
+					},
+					Spec: amb.MappingSpec{
+						Prefix:  "/prefix/",
+						Rewrite: agent.StrToPointer("/prefix/"),
+						Service: "some-svc:8080",
+						Docs: &amb.DocsInfo{
+							DisplayName: "docs-display-name",
+							Path:        "/docs-location",
+						},
+						DeprecatedHost: "mapping-host",
+					},
+					ObjectMeta: kates.ObjectMeta{
+						Name:      "some-endpoint",
+						Namespace: "default",
+					},
+				},
+			},
+
+			rawJSONDocsContent: `{"openapi":"3.0.0", "info":{"title": "Sample API", "version":"0.0"}, "paths":{}, "servers":[{"url":"http://mapping-host/prefix/"}]}`,
+
+			expectedRequestURL:     "http://some-svc.default:8080/prefix/docs-location",
+			expectedRequestHost:    "mapping-host",
+			expectedRequestHeaders: []agent.Header{},
+			expectedSOTW: []*snapshotTypes.APIDoc{{
+				TypeMeta: &kates.TypeMeta{
+					Kind:       "OpenAPI",
+					APIVersion: "v3",
+				},
+				Metadata: &kates.ObjectMeta{
+					Name: "docs-display-name",
+				},
+				TargetRef: &kates.ObjectReference{
+					Kind:      "Mapping",
+					Name:      "some-endpoint",
+					Namespace: "default",
+				},
+				Data: []byte(`{"components":{},"info":{"title":"Sample API","version":"0.0"},"openapi":"3.0.0","paths":{},"servers":[{"url":"mapping-host/prefix"}]}`),
+			}},
+		},
+		{
+			name: "will handle prefix (no trailing slash) if it's already declared in the API Docs",
+			mappings: []*amb.Mapping{
+				{
+					TypeMeta: kates.TypeMeta{
+						Kind: "Mapping",
+					},
+					Spec: amb.MappingSpec{
+						Prefix:  "/prefix",
+						Rewrite: agent.StrToPointer("/prefix/"),
+						Service: "some-svc:8080",
+						Docs: &amb.DocsInfo{
+							DisplayName: "docs-display-name",
+							Path:        "/docs-location",
+						},
+						DeprecatedHost: "mapping-host",
+					},
+					ObjectMeta: kates.ObjectMeta{
+						Name:      "some-endpoint",
+						Namespace: "default",
+					},
+				},
+			},
+
+			rawJSONDocsContent: `{"openapi":"3.0.0", "info":{"title": "Sample API", "version":"0.0"}, "paths":{}, "servers":[{"url":"http://mapping-host/prefix/"}]}`,
+
+			expectedRequestURL:     "http://some-svc.default:8080/prefix/docs-location",
+			expectedRequestHost:    "mapping-host",
+			expectedRequestHeaders: []agent.Header{},
+			expectedSOTW: []*snapshotTypes.APIDoc{{
+				TypeMeta: &kates.TypeMeta{
+					Kind:       "OpenAPI",
+					APIVersion: "v3",
+				},
+				Metadata: &kates.ObjectMeta{
+					Name: "docs-display-name",
+				},
+				TargetRef: &kates.ObjectReference{
+					Kind:      "Mapping",
+					Name:      "some-endpoint",
+					Namespace: "default",
+				},
+				Data: []byte(`{"components":{},"info":{"title":"Sample API","version":"0.0"},"openapi":"3.0.0","paths":{},"servers":[{"url":"mapping-host/prefix"}]}`),
+			}},
+		},
+		{
+			name: "will handle prefix if it's already declared in the API Docs - BasePath with no trailing slash",
+			mappings: []*amb.Mapping{
+				{
+					TypeMeta: kates.TypeMeta{
+						Kind: "Mapping",
+					},
+					Spec: amb.MappingSpec{
+						Prefix:  "/prefix/",
+						Rewrite: agent.StrToPointer("/prefix/"),
+						Service: "some-svc:8080",
+						Docs: &amb.DocsInfo{
+							DisplayName: "docs-display-name",
+							Path:        "/docs-location",
+						},
+						DeprecatedHost: "mapping-host",
+					},
+					ObjectMeta: kates.ObjectMeta{
+						Name:      "some-endpoint",
+						Namespace: "default",
+					},
+				},
+			},
+
+			rawJSONDocsContent: `{"openapi":"3.0.0", "info":{"title": "Sample API", "version":"0.0"}, "paths":{}, "servers":[{"url":"http://mapping-host/prefix"}]}`,
+
+			expectedRequestURL:     "http://some-svc.default:8080/prefix/docs-location",
+			expectedRequestHost:    "mapping-host",
+			expectedRequestHeaders: []agent.Header{},
+			expectedSOTW: []*snapshotTypes.APIDoc{{
+				TypeMeta: &kates.TypeMeta{
+					Kind:       "OpenAPI",
+					APIVersion: "v3",
+				},
+				Metadata: &kates.ObjectMeta{
+					Name: "docs-display-name",
+				},
+				TargetRef: &kates.ObjectReference{
+					Kind:      "Mapping",
+					Name:      "some-endpoint",
+					Namespace: "default",
+				},
+				Data: []byte(`{"components":{},"info":{"title":"Sample API","version":"0.0"},"openapi":"3.0.0","paths":{},"servers":[{"url":"mapping-host/prefix"}]}`),
+			}},
+		},
+		{
+			name: "will handle prefix if it's already declared in the API Docs and include the rewrite",
+			mappings: []*amb.Mapping{
+				{
+					TypeMeta: kates.TypeMeta{
+						Kind: "Mapping",
+					},
+					Spec: amb.MappingSpec{
+						Prefix:  "/subpath/prefix/",
+						Rewrite: agent.StrToPointer("/prefix/"),
+						Service: "some-svc:8080",
+						Docs: &amb.DocsInfo{
+							DisplayName: "docs-display-name",
+							Path:        "/docs-location",
+						},
+						DeprecatedHost: "mapping-host",
+					},
+					ObjectMeta: kates.ObjectMeta{
+						Name:      "some-endpoint",
+						Namespace: "default",
+					},
+				},
+			},
+
+			rawJSONDocsContent: `{"openapi":"3.0.0", "info":{"title": "Sample API", "version":"0.0"}, "paths":{}, "servers":[{"url":"http://mapping-host/prefix/"}]}`,
+
+			expectedRequestURL:     "http://some-svc.default:8080/prefix/docs-location",
+			expectedRequestHost:    "mapping-host",
+			expectedRequestHeaders: []agent.Header{},
+			expectedSOTW: []*snapshotTypes.APIDoc{{
+				TypeMeta: &kates.TypeMeta{
+					Kind:       "OpenAPI",
+					APIVersion: "v3",
+				},
+				Metadata: &kates.ObjectMeta{
+					Name: "docs-display-name",
+				},
+				TargetRef: &kates.ObjectReference{
+					Kind:      "Mapping",
+					Name:      "some-endpoint",
+					Namespace: "default",
+				},
+				Data: []byte(`{"components":{},"info":{"title":"Sample API","version":"0.0"},"openapi":"3.0.0","paths":{},"servers":[{"url":"mapping-host/subpath/prefix"}]}`),
+			}},
+		},
+		{
+			name: "will concatenate prefix and rewrite",
+			mappings: []*amb.Mapping{
+				{
+					TypeMeta: kates.TypeMeta{
+						Kind: "Mapping",
+					},
+					Spec: amb.MappingSpec{
+						Prefix:  "/prefix1/",
+						Rewrite: agent.StrToPointer("/prefix/"),
+						Service: "some-svc:8080",
+						Docs: &amb.DocsInfo{
+							DisplayName: "docs-display-name",
+							Path:        "/docs-location",
+						},
+						DeprecatedHost: "mapping-host",
+					},
+					ObjectMeta: kates.ObjectMeta{
+						Name:      "some-endpoint",
+						Namespace: "default",
+					},
+				},
+			},
+
+			rawJSONDocsContent: `{"openapi":"3.0.0", "info":{"title": "Sample API", "version":"0.0"}, "paths":{}, "servers":[{"url":"http://mapping-host/prefix"}]}`,
+
+			expectedRequestURL:     "http://some-svc.default:8080/prefix/docs-location",
+			expectedRequestHost:    "mapping-host",
+			expectedRequestHeaders: []agent.Header{},
+			expectedSOTW: []*snapshotTypes.APIDoc{{
+				TypeMeta: &kates.TypeMeta{
+					Kind:       "OpenAPI",
+					APIVersion: "v3",
+				},
+				Metadata: &kates.ObjectMeta{
+					Name: "docs-display-name",
+				},
+				TargetRef: &kates.ObjectReference{
+					Kind:      "Mapping",
+					Name:      "some-endpoint",
+					Namespace: "default",
+				},
+				Data: []byte(`{"components":{},"info":{"title":"Sample API","version":"0.0"},"openapi":"3.0.0","paths":{},"servers":[{"url":"mapping-host/prefix1/prefix"}]}`),
+			}},
+		},
+		{
+			name: "will handle prefix if it's already declared in the API Docs and include the rewrite",
+			mappings: []*amb.Mapping{
+				{
+					TypeMeta: kates.TypeMeta{
+						Kind: "Mapping",
+					},
+					Spec: amb.MappingSpec{
+						Prefix:  "/whatever/",
+						Rewrite: agent.StrToPointer("/subpath/prefix/"),
+						Service: "some-svc:8080",
+						Docs: &amb.DocsInfo{
+							DisplayName: "docs-display-name",
+							Path:        "/docs-location",
+						},
+						DeprecatedHost: "mapping-host",
+					},
+					ObjectMeta: kates.ObjectMeta{
+						Name:      "some-endpoint",
+						Namespace: "default",
+					},
+				},
+			},
+
+			rawJSONDocsContent: `{"openapi":"3.0.0", "info":{"title": "Sample API", "version":"0.0"}, "paths":{}, "servers":[{"url":"http://mapping-host/subpath/prefix"}]}`,
+
+			expectedRequestURL:     "http://some-svc.default:8080/subpath/prefix/docs-location",
+			expectedRequestHost:    "mapping-host",
+			expectedRequestHeaders: []agent.Header{},
+			expectedSOTW: []*snapshotTypes.APIDoc{{
+				TypeMeta: &kates.TypeMeta{
+					Kind:       "OpenAPI",
+					APIVersion: "v3",
+				},
+				Metadata: &kates.ObjectMeta{
+					Name: "docs-display-name",
+				},
+				TargetRef: &kates.ObjectReference{
+					Kind:      "Mapping",
+					Name:      "some-endpoint",
+					Namespace: "default",
+				},
+				Data: []byte(`{"components":{},"info":{"title":"Sample API","version":"0.0"},"openapi":"3.0.0","paths":{},"servers":[{"url":"mapping-host/whatever/subpath/prefix"}]}`),
+			}},
+		},
 	}
 	for _, c := range cases {
 		c := c


### PR DESCRIPTION
## Description
Emissary automatically adds the prefixes from the mappings to the swagger APIs on the fly. The issue with that is that sometimes, the swagger contract already contains a base path.
As a solution, we should also read the rewrite field from the mapping, and avoid adding the prefix if it matches the rewrite.

## Related Issues
emissary-ingress/emissary #4360 

## Testing
A few sentences describing what testing you've done, e.g., manual tests, automated tests, deployed in production, etc.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `CHANGELOG.md`.

   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations

 - [ ] This is unlikely to impact how Ambassador performs at scale.

   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability

 - [ ] My change is adequately tested.

   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points

 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.

 - [ ] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
