### PR TITLE
dev: add vscode devcontainer for local development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,10 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.245.0/containers/ubuntu/.devcontainer/base.Dockerfile
+
+# [Choice] Ubuntu version (use ubuntu-22.04 or ubuntu-18.04 on local arm64/Apple Silicon): ubuntu-22.04, ubuntu-20.04, ubuntu-18.04
+ARG VARIANT="jammy"
+FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
+
+# [Optional] Uncomment this section to install additional OS packages.
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+  && apt-get -y install --no-install-recommends build-essential \
+  libarchive-tools jq gawk

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.245.0/containers/ubuntu
+{
+	"name": "Ubuntu",
+	"build": {
+		"dockerfile": "Dockerfile",
+		// Update 'VARIANT' to pick an Ubuntu version: jammy / ubuntu-22.04, focal / ubuntu-20.04, bionic /ubuntu-18.04
+		// Use ubuntu-22.04 or ubuntu-18.04 on local arm64/Apple Silicon.
+		"args": {
+			"--platform": "linux/amd64",
+			"VARIANT": "ubuntu-22.04"
+		}
+	},
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "uname -a",
+	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	// "remoteUser": "vscode",
+	"features": {
+		"docker-in-docker": "latest",
+		"kubectl-helm-minikube": "1.22",
+		"git": "os-provided",
+		"python": "3.9",
+		"golang": "1.18"
+	},
+	"extensions": [
+		"ms-azuretools.vscode-docker",
+		"eamodio.gitlens",
+		"golang.go",
+		"ms-python.python"
+	]
+}


### PR DESCRIPTION
## Description

This adds some QOL enhancements for Visual Studio Code users and developing on emissary-ingress which allows developing against this repository in a container. Some of the tests within this repository will start a container and then try to communicate with the host which due to Macs running docker in desktop in a VM doesn't play nice. By running the repository within a linux dev container these test can now be run and debugged properly.

Currently, the devcontainer uses a base image from the vscode team and will need to build itself the first time. In the future, we can consider providing a pre-built base image to reduce initial startup time.

To learn more see: https://code.visualstudio.com/docs/remote/containers#_getting-started

## Related Issues
n/a

## Testing
I had to use this to debug `pkg/gateway` tests so that they could run locally and I could figure out what was causing CI to fail. Now CI is green and I want to share this development method with others :).

## Checklist

 - [] I made sure to update `CHANGELOG.md`.
 - [x] This is unlikely to impact how Ambassador performs at scale.
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
