### PR TITLE
Support setting secret namespace in a host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,10 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
   patch release of 1.23. This provides Emissary-ingress with the latest security patches,
   performances enhancments, and features offered by the envoy proxy.
 
+- Feature: Previously the `Host` resource could only use secrets that are in the namespace as the
+  Host. The `tlsSecret` field in the Host has a new subfield `namespace` that will allow the use of
+  secrets from different namespaces.
+
 ## [3.1.0] August 01, 2022
 [3.1.0]: https://github.com/emissary-ingress/emissary/compare/v3.0.0...v3.1.0
 

--- a/cmd/entrypoint/secrets.go
+++ b/cmd/entrypoint/secrets.go
@@ -460,7 +460,11 @@ func findSecretRefs(ctx context.Context, resource kates.Object, secretNamespacin
 		// `namespace:` field (i.e. changing them to `core.v1.SecretReference`s) rather than by
 		// adopting the `{name}.{namespace}` notation.
 		if r.Spec.TLSSecret != nil && r.Spec.TLSSecret.Name != "" {
-			secretRef(r.GetNamespace(), r.Spec.TLSSecret.Name, false, action)
+			if r.Spec.TLSSecret.Namespace != "" {
+				secretRef(r.Spec.TLSSecret.Namespace, r.Spec.TLSSecret.Name, false, action)
+			} else {
+				secretRef(r.GetNamespace(), r.Spec.TLSSecret.Name, false, action)
+			}
 		}
 
 		if r.Spec.AcmeProvider != nil && r.Spec.AcmeProvider.PrivateKeySecret != nil &&

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -42,6 +42,12 @@ items:
           release of 1.23. This provides $productName$ with the latest security patches, performances enhancments,
           and features offered by the envoy proxy.
         docs: https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.23/v1.23.0
+      - title: Add support for Host resources using secrets from different namespaces
+        type: feature
+        body: >-
+          Previously the <code>Host</code> resource could only use secrets that are in the namespace as the
+          Host. The <code>tlsSecret</code> field in the Host has a new subfield <code>namespace</code> that will allow
+          the use of secrets from different namespaces.
   - version: 3.1.0
     date: '2022-08-01'
     notes:

--- a/manifests/emissary/emissary-crds.yaml.in
+++ b/manifests/emissary/emissary-crds.yaml.in
@@ -921,22 +921,18 @@ spec:
                     type: string
                 type: object
               tlsSecret:
-                description: "Name of the Kubernetes secret into which to save generated
+                description: Name of the Kubernetes secret into which to save generated
                   certificates.  If ACME is enabled (see $acmeProvider), then the
-                  default is $hostname; otherwise the default is \"\".  If the value
-                  is \"\", then we do not do TLS for this Host. \n Note that this
-                  is a native-Kubernetes-style core.v1.LocalObjectReference, not an
-                  Ambassador-style `{name}.{namespace}` string.  Because we're opinionated,
-                  it does not support referencing a Secret in another namespace (because
-                  most native Kubernetes resources don't support that), but if we
-                  ever abandon that opinion and decide to support non-local references
-                  it, it would be by adding a `namespace:` field by changing it from
-                  a core.v1.LocalObjectReference to a core.v1.SecretReference, not
-                  by adopting the `{name}.{namespace}` notation."
+                  default is $hostname; otherwise the default is "".  If the value
+                  is "", then we do not do TLS for this Host.
                 properties:
                   name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    description: Name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: Namespace defines the space within which the secret
+                      name must be unique.
                     type: string
                 type: object
             type: object
@@ -1253,22 +1249,18 @@ spec:
                     type: string
                 type: object
               tlsSecret:
-                description: "Name of the Kubernetes secret into which to save generated
+                description: Name of the Kubernetes secret into which to save generated
                   certificates.  If ACME is enabled (see $acmeProvider), then the
-                  default is $hostname; otherwise the default is \"\".  If the value
-                  is \"\", then we do not do TLS for this Host. \n Note that this
-                  is a native-Kubernetes-style core.v1.LocalObjectReference, not an
-                  Ambassador-style `{name}.{namespace}` string.  Because we're opinionated,
-                  it does not support referencing a Secret in another namespace (because
-                  most native Kubernetes resources don't support that), but if we
-                  ever abandon that opinion and decide to support non-local references
-                  it, it would be by adding a `namespace:` field by changing it from
-                  a core.v1.LocalObjectReference to a core.v1.SecretReference, not
-                  by adopting the `{name}.{namespace}` notation."
+                  default is $hostname; otherwise the default is "".  If the value
+                  is "", then we do not do TLS for this Host.
                 properties:
                   name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    description: Name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: Namespace defines the space within which the secret
+                      name must be unique.
                     type: string
                 type: object
             type: object

--- a/pkg/api/getambassador.io/crds.yaml
+++ b/pkg/api/getambassador.io/crds.yaml
@@ -941,8 +941,12 @@ spec:
                   by adopting the `{name}.{namespace}` notation."
                 properties:
                   name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    description: Name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: Namespace defines the space within which the secret
+                      name must be unique.
                     type: string
                 type: object
             type: object
@@ -1272,8 +1276,12 @@ spec:
                   by adopting the `{name}.{namespace}` notation."
                 properties:
                   name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    description: Name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: Namespace defines the space within which the secret
+                      name must be unique.
                     type: string
                 type: object
             type: object

--- a/pkg/api/getambassador.io/crds.yaml
+++ b/pkg/api/getambassador.io/crds.yaml
@@ -927,18 +927,10 @@ spec:
                     type: string
                 type: object
               tlsSecret:
-                description: "Name of the Kubernetes secret into which to save generated
+                description: Name of the Kubernetes secret into which to save generated
                   certificates.  If ACME is enabled (see $acmeProvider), then the
-                  default is $hostname; otherwise the default is \"\".  If the value
-                  is \"\", then we do not do TLS for this Host. \n Note that this
-                  is a native-Kubernetes-style core.v1.LocalObjectReference, not an
-                  Ambassador-style `{name}.{namespace}` string.  Because we're opinionated,
-                  it does not support referencing a Secret in another namespace (because
-                  most native Kubernetes resources don't support that), but if we
-                  ever abandon that opinion and decide to support non-local references
-                  it, it would be by adding a `namespace:` field by changing it from
-                  a core.v1.LocalObjectReference to a core.v1.SecretReference, not
-                  by adopting the `{name}.{namespace}` notation."
+                  default is $hostname; otherwise the default is "".  If the value
+                  is "", then we do not do TLS for this Host.
                 properties:
                   name:
                     description: Name is unique within a namespace to reference a
@@ -1262,18 +1254,10 @@ spec:
                     type: string
                 type: object
               tlsSecret:
-                description: "Name of the Kubernetes secret into which to save generated
+                description: Name of the Kubernetes secret into which to save generated
                   certificates.  If ACME is enabled (see $acmeProvider), then the
-                  default is $hostname; otherwise the default is \"\".  If the value
-                  is \"\", then we do not do TLS for this Host. \n Note that this
-                  is a native-Kubernetes-style core.v1.LocalObjectReference, not an
-                  Ambassador-style `{name}.{namespace}` string.  Because we're opinionated,
-                  it does not support referencing a Secret in another namespace (because
-                  most native Kubernetes resources don't support that), but if we
-                  ever abandon that opinion and decide to support non-local references
-                  it, it would be by adding a `namespace:` field by changing it from
-                  a core.v1.LocalObjectReference to a core.v1.SecretReference, not
-                  by adopting the `{name}.{namespace}` notation."
+                  default is $hostname; otherwise the default is "".  If the value
+                  is "", then we do not do TLS for this Host.
                 properties:
                   name:
                     description: Name is unique within a namespace to reference a

--- a/pkg/api/getambassador.io/v2/crd_host.go
+++ b/pkg/api/getambassador.io/v2/crd_host.go
@@ -106,15 +106,7 @@ type HostSpec struct {
 	// certificates.  If ACME is enabled (see $acmeProvider), then the
 	// default is $hostname; otherwise the default is "".  If the value
 	// is "", then we do not do TLS for this Host.
-	//
-	// Note that this is a native-Kubernetes-style core.v1.LocalObjectReference, not
-	// an Ambassador-style `{name}.{namespace}` string.  Because we're opinionated, it
-	// does not support referencing a Secret in another namespace (because most native
-	// Kubernetes resources don't support that), but if we ever abandon that opinion
-	// and decide to support non-local references it, it would be by adding a
-	// `namespace:` field by changing it from a core.v1.LocalObjectReference to a
-	// core.v1.SecretReference, not by adopting the `{name}.{namespace}` notation.
-	TLSSecret *corev1.LocalObjectReference `json:"tlsSecret,omitempty"`
+	TLSSecret *corev1.SecretReference `json:"tlsSecret,omitempty"`
 
 	// Request policy definition.
 	RequestPolicy *RequestPolicy `json:"requestPolicy,omitempty"`

--- a/pkg/api/getambassador.io/v2/zz_generated.deepcopy.go
+++ b/pkg/api/getambassador.io/v2/zz_generated.deepcopy.go
@@ -954,7 +954,7 @@ func (in *HostSpec) DeepCopyInto(out *HostSpec) {
 	}
 	if in.TLSSecret != nil {
 		in, out := &in.TLSSecret, &out.TLSSecret
-		*out = new(v1.LocalObjectReference)
+		*out = new(v1.SecretReference)
 		**out = **in
 	}
 	if in.RequestPolicy != nil {

--- a/pkg/api/getambassador.io/v3alpha1/crd_host.go
+++ b/pkg/api/getambassador.io/v3alpha1/crd_host.go
@@ -103,15 +103,7 @@ type HostSpec struct {
 	// certificates.  If ACME is enabled (see $acmeProvider), then the
 	// default is $hostname; otherwise the default is "".  If the value
 	// is "", then we do not do TLS for this Host.
-	//
-	// Note that this is a native-Kubernetes-style core.v1.LocalObjectReference, not
-	// an Ambassador-style `{name}.{namespace}` string.  Because we're opinionated, it
-	// does not support referencing a Secret in another namespace (because most native
-	// Kubernetes resources don't support that), but if we ever abandon that opinion
-	// and decide to support non-local references it, it would be by adding a
-	// `namespace:` field by changing it from a core.v1.LocalObjectReference to a
-	// core.v1.SecretReference, not by adopting the `{name}.{namespace}` notation.
-	TLSSecret *corev1.LocalObjectReference `json:"tlsSecret,omitempty"`
+	TLSSecret *corev1.SecretReference `json:"tlsSecret,omitempty"`
 
 	// Request policy definition.
 	RequestPolicy *RequestPolicy `json:"requestPolicy,omitempty"`

--- a/pkg/api/getambassador.io/v3alpha1/zz_generated.deepcopy.go
+++ b/pkg/api/getambassador.io/v3alpha1/zz_generated.deepcopy.go
@@ -1011,7 +1011,7 @@ func (in *HostSpec) DeepCopyInto(out *HostSpec) {
 	}
 	if in.TLSSecret != nil {
 		in, out := &in.TLSSecret, &out.TLSSecret
-		*out = new(v1.LocalObjectReference)
+		*out = new(v1.SecretReference)
 		**out = **in
 	}
 	if in.RequestPolicy != nil {

--- a/python/tests/integration/manifests/crds.yaml
+++ b/python/tests/integration/manifests/crds.yaml
@@ -897,18 +897,10 @@ spec:
                     type: string
                 type: object
               tlsSecret:
-                description: "Name of the Kubernetes secret into which to save generated
+                description: Name of the Kubernetes secret into which to save generated
                   certificates.  If ACME is enabled (see $acmeProvider), then the
-                  default is $hostname; otherwise the default is \"\".  If the value
-                  is \"\", then we do not do TLS for this Host. \n Note that this
-                  is a native-Kubernetes-style core.v1.LocalObjectReference, not an
-                  Ambassador-style `{name}.{namespace}` string.  Because we're opinionated,
-                  it does not support referencing a Secret in another namespace (because
-                  most native Kubernetes resources don't support that), but if we
-                  ever abandon that opinion and decide to support non-local references
-                  it, it would be by adding a `namespace:` field by changing it from
-                  a core.v1.LocalObjectReference to a core.v1.SecretReference, not
-                  by adopting the `{name}.{namespace}` notation."
+                  default is $hostname; otherwise the default is "".  If the value
+                  is "", then we do not do TLS for this Host.
                 properties:
                   name:
                     description: Name is unique within a namespace to reference a
@@ -1233,18 +1225,10 @@ spec:
                     type: string
                 type: object
               tlsSecret:
-                description: "Name of the Kubernetes secret into which to save generated
+                description: Name of the Kubernetes secret into which to save generated
                   certificates.  If ACME is enabled (see $acmeProvider), then the
-                  default is $hostname; otherwise the default is \"\".  If the value
-                  is \"\", then we do not do TLS for this Host. \n Note that this
-                  is a native-Kubernetes-style core.v1.LocalObjectReference, not an
-                  Ambassador-style `{name}.{namespace}` string.  Because we're opinionated,
-                  it does not support referencing a Secret in another namespace (because
-                  most native Kubernetes resources don't support that), but if we
-                  ever abandon that opinion and decide to support non-local references
-                  it, it would be by adding a `namespace:` field by changing it from
-                  a core.v1.LocalObjectReference to a core.v1.SecretReference, not
-                  by adopting the `{name}.{namespace}` notation."
+                  default is $hostname; otherwise the default is "".  If the value
+                  is "", then we do not do TLS for this Host.
                 properties:
                   name:
                     description: Name is unique within a namespace to reference a

--- a/python/tests/integration/manifests/crds.yaml
+++ b/python/tests/integration/manifests/crds.yaml
@@ -911,8 +911,12 @@ spec:
                   by adopting the `{name}.{namespace}` notation."
                 properties:
                   name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    description: Name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: Namespace defines the space within which the secret
+                      name must be unique.
                     type: string
                 type: object
             type: object
@@ -1243,8 +1247,12 @@ spec:
                   by adopting the `{name}.{namespace}` notation."
                 properties:
                   name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    description: Name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: Namespace defines the space within which the secret
+                      name must be unique.
                     type: string
                 type: object
             type: object


### PR DESCRIPTION
## Description
Currently it is only possible to use a secret within a `Host` if that secret shares the same namespace as the `Host`. While originally this was a design decision, we've seen users experiencing friction due to this restriction. These changes will allow you to use secrets from any namespace within a `Host` like so:

```
tlsSecret:
  name: tls-cert
  namespace: foobar # new field!
```

## Related Issues
List related issues.

## Testing
Manual tests and added some test cases to the existing `Host` tests.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `CHANGELOG.md`.

   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations

 - [x] This is unlikely to impact how Ambassador performs at scale.

   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability

 - [x] My change is adequately tested.

   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points

 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.

 - [ ] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
