### PR TITLE
[v2.4] Fix the chart changelog entry not having a leading "v"

### DIFF
--- a/charts/emissary-ingress/CHANGELOG.md
+++ b/charts/emissary-ingress/CHANGELOG.md
@@ -3,7 +3,7 @@
 This file documents all notable changes to Ambassador Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
-## 7.5.0
+## v7.5.0
 
 - Upgrade Emissary to v2.4.0 [CHANGELOG](https://github.com/emissary-ingress/emissary/blob/master/CHANGELOG.md)
 
@@ -21,7 +21,7 @@ numbering uses [semantic versioning](http://semver.org).
 - Add "lifecycle" option to main container. This can be used, for example, to add a lifecycle.preStop hook. Thanks to [Eric Totten](https://github.com/etotten) for the contribution!
 - Add `ambassador_id` to listener manifests rendered when using `createDefaultListeners: true` with `AMBASSADOR_ID` set in environment variables. Thanks to [Jennifer Reed](https://github.com/ServerNinja) for the contribution!
 - Feature: Added configurable IngressClass resource to be compliant with Kubernetes 1.22+ ingress specification.
-  
+
 ## v7.2.2
 
 - Update Emissary chart image to version v2.1.2: [CHANGELOG](https://github.com/emissary-ingress/emissary/blob/master/CHANGELOG.md)

--- a/releng/prepare-y-bump
+++ b/releng/prepare-y-bump
@@ -81,7 +81,7 @@ gawk -i inplace \
      '
        BEGIN { done=0 }
        /^## v/ && !done {
-         print "## " chart_next_xy ".0"
+         print "## v" chart_next_xy ".0"
          print ""
          print "- Upgrade Emissary to v" next_xy ".0 [CHANGELOG](https://github.com/emissary-ingress/emissary/blob/master/CHANGELOG.md)"
          print ""


### PR DESCRIPTION
Noticed a minor mistake in the `prepare-y-bump` script.