### PR TITLE
Suport secret namespacing for Hosts in 2x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,10 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
 
 ### Emissary-ingress and Ambassador Edge Stack
 
+- Feature: Previously the `Host` resource could only use secrets that are in the namespace as the
+  Host. The `tlsSecret` field in the Host has a new subfield `namespace` that will allow the use of
+  secrets from different namespaces.
+
 ## [2.3.2] August 01, 2022
 [2.3.2]: https://github.com/emissary-ingress/emissary/compare/v2.3.1...v2.3.2
 

--- a/cmd/entrypoint/secrets.go
+++ b/cmd/entrypoint/secrets.go
@@ -404,7 +404,11 @@ func findSecretRefs(ctx context.Context, resource kates.Object, secretNamespacin
 		// `namespace:` field (i.e. changing them to `core.v1.SecretReference`s) rather than by
 		// adopting the `{name}.{namespace}` notation.
 		if r.Spec.TLSSecret != nil && r.Spec.TLSSecret.Name != "" {
-			secretRef(r.GetNamespace(), r.Spec.TLSSecret.Name, false, action)
+			if r.Spec.TLSSecret.Namespace != "" {
+				secretRef(r.Spec.TLSSecret.Namespace, r.Spec.TLSSecret.Name, false, action)
+			} else {
+				secretRef(r.GetNamespace(), r.Spec.TLSSecret.Name, false, action)
+			}
 		}
 
 		if r.Spec.AcmeProvider != nil && r.Spec.AcmeProvider.PrivateKeySecret != nil &&

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -34,8 +34,13 @@ changelog: https://github.com/emissary-ingress/emissary/blob/$branch$/CHANGELOG.
 items:
   - version: 2.4.0
     date: 'TBD'
-    notes: []
-
+    notes:
+      - title: Add support for Host resources using secrets from different namespaces
+        type: feature
+        body: >-
+          Previously the <code>Host</code> resource could only use secrets that are in the namespace as the
+          Host. The <code>tlsSecret</code> field in the Host has a new subfield <code>namespace</code> that will allow
+          the use of secrets from different namespaces.
   - version: 2.3.2
     date: '2022-08-01'
     notes:

--- a/manifests/emissary/emissary-crds.yaml.in
+++ b/manifests/emissary/emissary-crds.yaml.in
@@ -920,22 +920,18 @@ spec:
                     type: string
                 type: object
               tlsSecret:
-                description: "Name of the Kubernetes secret into which to save generated
+                description: Name of the Kubernetes secret into which to save generated
                   certificates.  If ACME is enabled (see $acmeProvider), then the
-                  default is $hostname; otherwise the default is \"\".  If the value
-                  is \"\", then we do not do TLS for this Host. \n Note that this
-                  is a native-Kubernetes-style core.v1.LocalObjectReference, not an
-                  Ambassador-style `{name}.{namespace}` string.  Because we're opinionated,
-                  it does not support referencing a Secret in another namespace (because
-                  most native Kubernetes resources don't support that), but if we
-                  ever abandon that opinion and decide to support non-local references
-                  it, it would be by adding a `namespace:` field by changing it from
-                  a core.v1.LocalObjectReference to a core.v1.SecretReference, not
-                  by adopting the `{name}.{namespace}` notation."
+                  default is $hostname; otherwise the default is "".  If the value
+                  is "", then we do not do TLS for this Host.
                 properties:
                   name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    description: Name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: Namespace defines the space within which the secret
+                      name must be unique.
                     type: string
                 type: object
             type: object
@@ -1252,22 +1248,18 @@ spec:
                     type: string
                 type: object
               tlsSecret:
-                description: "Name of the Kubernetes secret into which to save generated
+                description: Name of the Kubernetes secret into which to save generated
                   certificates.  If ACME is enabled (see $acmeProvider), then the
-                  default is $hostname; otherwise the default is \"\".  If the value
-                  is \"\", then we do not do TLS for this Host. \n Note that this
-                  is a native-Kubernetes-style core.v1.LocalObjectReference, not an
-                  Ambassador-style `{name}.{namespace}` string.  Because we're opinionated,
-                  it does not support referencing a Secret in another namespace (because
-                  most native Kubernetes resources don't support that), but if we
-                  ever abandon that opinion and decide to support non-local references
-                  it, it would be by adding a `namespace:` field by changing it from
-                  a core.v1.LocalObjectReference to a core.v1.SecretReference, not
-                  by adopting the `{name}.{namespace}` notation."
+                  default is $hostname; otherwise the default is "".  If the value
+                  is "", then we do not do TLS for this Host.
                 properties:
                   name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    description: Name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: Namespace defines the space within which the secret
+                      name must be unique.
                     type: string
                 type: object
             type: object

--- a/pkg/api/getambassador.io/crds.yaml
+++ b/pkg/api/getambassador.io/crds.yaml
@@ -940,8 +940,12 @@ spec:
                   by adopting the `{name}.{namespace}` notation."
                 properties:
                   name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    description: Name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: Namespace defines the space within which the secret
+                      name must be unique.
                     type: string
                 type: object
             type: object
@@ -1271,8 +1275,12 @@ spec:
                   by adopting the `{name}.{namespace}` notation."
                 properties:
                   name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    description: Name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: Namespace defines the space within which the secret
+                      name must be unique.
                     type: string
                 type: object
             type: object

--- a/pkg/api/getambassador.io/crds.yaml
+++ b/pkg/api/getambassador.io/crds.yaml
@@ -926,18 +926,10 @@ spec:
                     type: string
                 type: object
               tlsSecret:
-                description: "Name of the Kubernetes secret into which to save generated
+                description: Name of the Kubernetes secret into which to save generated
                   certificates.  If ACME is enabled (see $acmeProvider), then the
-                  default is $hostname; otherwise the default is \"\".  If the value
-                  is \"\", then we do not do TLS for this Host. \n Note that this
-                  is a native-Kubernetes-style core.v1.LocalObjectReference, not an
-                  Ambassador-style `{name}.{namespace}` string.  Because we're opinionated,
-                  it does not support referencing a Secret in another namespace (because
-                  most native Kubernetes resources don't support that), but if we
-                  ever abandon that opinion and decide to support non-local references
-                  it, it would be by adding a `namespace:` field by changing it from
-                  a core.v1.LocalObjectReference to a core.v1.SecretReference, not
-                  by adopting the `{name}.{namespace}` notation."
+                  default is $hostname; otherwise the default is "".  If the value
+                  is "", then we do not do TLS for this Host.
                 properties:
                   name:
                     description: Name is unique within a namespace to reference a
@@ -1261,18 +1253,10 @@ spec:
                     type: string
                 type: object
               tlsSecret:
-                description: "Name of the Kubernetes secret into which to save generated
+                description: Name of the Kubernetes secret into which to save generated
                   certificates.  If ACME is enabled (see $acmeProvider), then the
-                  default is $hostname; otherwise the default is \"\".  If the value
-                  is \"\", then we do not do TLS for this Host. \n Note that this
-                  is a native-Kubernetes-style core.v1.LocalObjectReference, not an
-                  Ambassador-style `{name}.{namespace}` string.  Because we're opinionated,
-                  it does not support referencing a Secret in another namespace (because
-                  most native Kubernetes resources don't support that), but if we
-                  ever abandon that opinion and decide to support non-local references
-                  it, it would be by adding a `namespace:` field by changing it from
-                  a core.v1.LocalObjectReference to a core.v1.SecretReference, not
-                  by adopting the `{name}.{namespace}` notation."
+                  default is $hostname; otherwise the default is "".  If the value
+                  is "", then we do not do TLS for this Host.
                 properties:
                   name:
                     description: Name is unique within a namespace to reference a

--- a/pkg/api/getambassador.io/v2/crd_host.go
+++ b/pkg/api/getambassador.io/v2/crd_host.go
@@ -106,15 +106,7 @@ type HostSpec struct {
 	// certificates.  If ACME is enabled (see $acmeProvider), then the
 	// default is $hostname; otherwise the default is "".  If the value
 	// is "", then we do not do TLS for this Host.
-	//
-	// Note that this is a native-Kubernetes-style core.v1.LocalObjectReference, not
-	// an Ambassador-style `{name}.{namespace}` string.  Because we're opinionated, it
-	// does not support referencing a Secret in another namespace (because most native
-	// Kubernetes resources don't support that), but if we ever abandon that opinion
-	// and decide to support non-local references it, it would be by adding a
-	// `namespace:` field by changing it from a core.v1.LocalObjectReference to a
-	// core.v1.SecretReference, not by adopting the `{name}.{namespace}` notation.
-	TLSSecret *corev1.LocalObjectReference `json:"tlsSecret,omitempty"`
+	TLSSecret *corev1.SecretReference `json:"tlsSecret,omitempty"`
 
 	// Request policy definition.
 	RequestPolicy *RequestPolicy `json:"requestPolicy,omitempty"`

--- a/pkg/api/getambassador.io/v2/zz_generated.deepcopy.go
+++ b/pkg/api/getambassador.io/v2/zz_generated.deepcopy.go
@@ -954,7 +954,7 @@ func (in *HostSpec) DeepCopyInto(out *HostSpec) {
 	}
 	if in.TLSSecret != nil {
 		in, out := &in.TLSSecret, &out.TLSSecret
-		*out = new(v1.LocalObjectReference)
+		*out = new(v1.SecretReference)
 		**out = **in
 	}
 	if in.RequestPolicy != nil {

--- a/pkg/api/getambassador.io/v3alpha1/crd_host.go
+++ b/pkg/api/getambassador.io/v3alpha1/crd_host.go
@@ -103,15 +103,7 @@ type HostSpec struct {
 	// certificates.  If ACME is enabled (see $acmeProvider), then the
 	// default is $hostname; otherwise the default is "".  If the value
 	// is "", then we do not do TLS for this Host.
-	//
-	// Note that this is a native-Kubernetes-style core.v1.LocalObjectReference, not
-	// an Ambassador-style `{name}.{namespace}` string.  Because we're opinionated, it
-	// does not support referencing a Secret in another namespace (because most native
-	// Kubernetes resources don't support that), but if we ever abandon that opinion
-	// and decide to support non-local references it, it would be by adding a
-	// `namespace:` field by changing it from a core.v1.LocalObjectReference to a
-	// core.v1.SecretReference, not by adopting the `{name}.{namespace}` notation.
-	TLSSecret *corev1.LocalObjectReference `json:"tlsSecret,omitempty"`
+	TLSSecret *corev1.SecretReference `json:"tlsSecret,omitempty"`
 
 	// Request policy definition.
 	RequestPolicy *RequestPolicy `json:"requestPolicy,omitempty"`

--- a/pkg/api/getambassador.io/v3alpha1/zz_generated.deepcopy.go
+++ b/pkg/api/getambassador.io/v3alpha1/zz_generated.deepcopy.go
@@ -1011,7 +1011,7 @@ func (in *HostSpec) DeepCopyInto(out *HostSpec) {
 	}
 	if in.TLSSecret != nil {
 		in, out := &in.TLSSecret, &out.TLSSecret
-		*out = new(v1.LocalObjectReference)
+		*out = new(v1.SecretReference)
 		**out = **in
 	}
 	if in.RequestPolicy != nil {

--- a/python/ambassador/ir/irhost.py
+++ b/python/ambassador/ir/irhost.py
@@ -1,7 +1,6 @@
 import copy
-from typing import Dict, List, Optional, TYPE_CHECKING
-
 import os
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 from ..utils import SavedSecret, dump_json
 from ..config import Config
@@ -85,12 +84,22 @@ class IRHost(IRResource):
 
         if self.get('tlsSecret', None):
             tls_secret = self.tlsSecret
-            tls_name = tls_secret.get('name', None)
+            tls_name = tls_secret.get("name", None)
+            tls_namespace = tls_secret.get("namespace", None)
 
             if tls_name:
-                ir.logger.debug(f"Host {self.name}: resolving spec.tlsSecret.name: {tls_name}")
+                # Either take the name of the secret, or add on the namespace if it exists.
+                # This is important for how the implicit TLSContext handles secret names
+                tls_full_name = tls_name
+                if tls_namespace:
+                    ir.logger.debug(
+                        f"Host {self.name}: resolving spec.tlsSecret.name.namespace: {tls_name}.{tls_namespace}"
+                    )
+                    tls_full_name = tls_full_name + "." + tls_namespace
+                else:
+                    ir.logger.debug(f"Host {self.name}: resolving spec.tlsSecret.name: {tls_name}")
 
-                tls_ss = self.resolve(ir, tls_name)
+                tls_ss = self.resolve(ir=ir, secret_name=tls_name, secret_namespace=tls_namespace)
 
                 if tls_ss:
                     # OK, we have a TLS secret! Fire up a TLS context for it, if one doesn't
@@ -125,7 +134,7 @@ class IRHost(IRResource):
                         # context to make sure it works for us, and save it if so.
                         ir.logger.debug(f"Host {self.name}: resolving spec.tlsContext: {host_tls_context_name}")
 
-                        if not self.save_context(ir, host_tls_context_name, tls_ss, tls_name):
+                        if not self.save_context(ir, host_tls_context_name, tls_ss, tls_full_name):
                             return False
 
                     elif host_tls_config:
@@ -173,7 +182,15 @@ class IRHost(IRResource):
                             namespace=self.namespace,
                             location=self.location,
                             hosts=[self.hostname or self.name],
-                            secret=tls_name,
+                            secret=tls_full_name,
+                        )
+
+                        # Ensure that we handle the secret properly even if tls_secret_namespacing is False in the Module
+                        if tls_namespace:
+                            tls_context_init["secret_namespacing"] = True
+
+                        tls_config_context = IRTLSContext(
+                            ir, aconf, **tls_context_init, **host_tls_config
                         )
 
                         tls_config_context = IRTLSContext(ir, aconf, **tls_context_init, **host_tls_config)
@@ -206,7 +223,7 @@ class IRHost(IRResource):
                         # correct name for this Host already exists. Save that, if it works out for us.
                         ir.logger.debug(f"Host {self.name}: TLSContext {ctx_name} already exists")
 
-                        if not self.save_context(ir, ctx_name, tls_ss, tls_name):
+                        if not self.save_context(ir, ctx_name, tls_ss, tls_full_name):
                             return False
                     else:
                         ir.logger.debug(f"Host {self.name}: creating TLSContext {ctx_name}")
@@ -216,9 +233,13 @@ class IRHost(IRResource):
                             name=ctx_name,
                             namespace=self.namespace,
                             location=self.location,
-                            hosts=[ self.hostname or self.name ],
-                            secret=tls_name
+                            hosts=[self.hostname or self.name],
+                            secret=tls_full_name,
                         )
+
+                        # Ensure that we handle the secret properly even if tls_secret_namespacing is False in the Module
+                        if tls_namespace:
+                            new_ctx["secret_namespacing"] = True
 
                         ctx = IRTLSContext(ir, aconf, **new_ctx)
 
@@ -239,7 +260,9 @@ class IRHost(IRResource):
                         else:
                             ir.logger.error(f"Host {self.name}: new TLSContext {ctx_name} is not valid")
                 else:
-                    ir.logger.error(f"Host {self.name}: invalid TLS secret {tls_name}, marking inactive")
+                    ir.logger.error(
+                        f"Host {self.name}: invalid TLS secret {tls_full_name}, marking inactive"
+                    )
                     return False
 
         if self.get('acmeProvider', None):
@@ -287,7 +310,7 @@ class IRHost(IRResource):
                 if pkey_name:
                     ir.logger.debug(f"Host {self.name}: ACME private key name is {pkey_name}")
 
-                    pkey_ss = self.resolve(ir, pkey_name)
+                    pkey_ss = self.resolve(ir=ir, secret_name=pkey_name, secret_namespace=None)
 
                     if not pkey_ss:
                         ir.logger.error(f"Host {self.name}: continuing with invalid private key secret {pkey_name}; ACME will not be able to renew this certificate")
@@ -316,7 +339,7 @@ class IRHost(IRResource):
             # This is a little weird. Basically we're going to resolve the secret (which should just
             # be a cache lookup here) so that we can use SavedSecret.__str__() as a serializer to
             # compare the configurations.
-            context_ss = self.resolve(ir, secret_name)
+            context_ss = self.resolve(ir, secret_name, None)
 
             self.logger.debug(f"Host {self.name}, ctx {ctx.name}, secret {secret_name}, resolved {context_ss}")
 
@@ -417,7 +440,12 @@ class IRHost(IRResource):
             insecure_action, insecure_addl_port
         )
 
-    def resolve(self, ir: 'IR', secret_name: str) -> SavedSecret:
+    def resolve(
+        self, ir: "IR", secret_name: str, secret_namespace: Union[str, None]
+    ) -> SavedSecret:
+        if secret_namespace:
+            return ir.resolve_secret(self, secret_name, secret_namespace)
+
         # Try to use our namespace for secret resolution. If we somehow have no
         # namespace, fall back to the Ambassador's namespace.
         namespace = self.namespace or ir.ambassador_namespace

--- a/python/tests/integration/manifests/crds.yaml
+++ b/python/tests/integration/manifests/crds.yaml
@@ -910,8 +910,12 @@ spec:
                   by adopting the `{name}.{namespace}` notation."
                 properties:
                   name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    description: Name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: Namespace defines the space within which the secret
+                      name must be unique.
                     type: string
                 type: object
             type: object
@@ -1242,8 +1246,12 @@ spec:
                   by adopting the `{name}.{namespace}` notation."
                 properties:
                   name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    description: Name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: Namespace defines the space within which the secret
+                      name must be unique.
                     type: string
                 type: object
             type: object

--- a/python/tests/integration/manifests/crds.yaml
+++ b/python/tests/integration/manifests/crds.yaml
@@ -896,18 +896,10 @@ spec:
                     type: string
                 type: object
               tlsSecret:
-                description: "Name of the Kubernetes secret into which to save generated
+                description: Name of the Kubernetes secret into which to save generated
                   certificates.  If ACME is enabled (see $acmeProvider), then the
-                  default is $hostname; otherwise the default is \"\".  If the value
-                  is \"\", then we do not do TLS for this Host. \n Note that this
-                  is a native-Kubernetes-style core.v1.LocalObjectReference, not an
-                  Ambassador-style `{name}.{namespace}` string.  Because we're opinionated,
-                  it does not support referencing a Secret in another namespace (because
-                  most native Kubernetes resources don't support that), but if we
-                  ever abandon that opinion and decide to support non-local references
-                  it, it would be by adding a `namespace:` field by changing it from
-                  a core.v1.LocalObjectReference to a core.v1.SecretReference, not
-                  by adopting the `{name}.{namespace}` notation."
+                  default is $hostname; otherwise the default is "".  If the value
+                  is "", then we do not do TLS for this Host.
                 properties:
                   name:
                     description: Name is unique within a namespace to reference a
@@ -1232,18 +1224,10 @@ spec:
                     type: string
                 type: object
               tlsSecret:
-                description: "Name of the Kubernetes secret into which to save generated
+                description: Name of the Kubernetes secret into which to save generated
                   certificates.  If ACME is enabled (see $acmeProvider), then the
-                  default is $hostname; otherwise the default is \"\".  If the value
-                  is \"\", then we do not do TLS for this Host. \n Note that this
-                  is a native-Kubernetes-style core.v1.LocalObjectReference, not an
-                  Ambassador-style `{name}.{namespace}` string.  Because we're opinionated,
-                  it does not support referencing a Secret in another namespace (because
-                  most native Kubernetes resources don't support that), but if we
-                  ever abandon that opinion and decide to support non-local references
-                  it, it would be by adding a `namespace:` field by changing it from
-                  a core.v1.LocalObjectReference to a core.v1.SecretReference, not
-                  by adopting the `{name}.{namespace}` notation."
+                  default is $hostname; otherwise the default is "".  If the value
+                  is "", then we do not do TLS for this Host.
                 properties:
                   name:
                     description: Name is unique within a namespace to reference a

--- a/python/tests/kat/t_hosts.py
+++ b/python/tests/kat/t_hosts.py
@@ -1893,3 +1893,374 @@ spec:
             query.sni = True  # Use query.headers["Host"] instead of urlparse(query.url).hostname for SNI
             query.ca_cert = TLSCerts["tls-context-host-1"].pubcert
             yield (r[0], query)
+
+
+class HostCRDCrossNamespaceNoNamespacing(AmbassadorTest):
+    """
+    HostCRDCrossNamespaceNoNamespacing tests that the value of tls_secret_namespacing does not interfere
+    with the function of being able to specify atlsSecret in another namespace due to the way that the
+    implicit TLSContext handles secret names.
+    """
+
+    target: ServiceType
+
+    def init(self):
+        self.edge_stack_cleartext_host = False
+        self.target1 = HTTP(name="target")
+
+    def manifests(self) -> str:
+        return (
+            namespace_manifest("foobar")
+            + self.format(
+                """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: {self.path.k8s}-host-1
+  labels:
+    kat-ambassador-id: {self.ambassador_id}
+spec:
+  ambassador_id: [ {self.ambassador_id} ]
+  hostname: tls-context-host-1
+  acmeProvider:
+    authority: none
+  mappingSelector:
+    matchLabels:
+      hostname: tls-context-host-1
+  tlsSecret:
+    name: {self.path.k8s}.test.tlscontext.secret
+    namespace: foobar
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {self.path.k8s}.test.tlscontext.secret
+  namespace: foobar
+  labels:
+    kat-ambassador-id: {self.ambassador_id}
+type: kubernetes.io/tls
+data:
+  tls.crt: """
+                + TLSCerts["tls-context-host-1"].k8s_crt
+                + """
+  tls.key: """
+                + TLSCerts["tls-context-host-1"].k8s_key
+                + """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: {self.path.k8s}-host-1-mapping
+  labels:
+    hostname: tls-context-host-1
+    kat-ambassador-id: {self.ambassador_id}
+spec:
+  ambassador_id: [ {self.ambassador_id} ]
+  hostname: tls-context-host-1
+  prefix: /target/
+  service: {self.target1.path.fqdn}
+"""
+            )
+            + super().manifests()
+        )
+
+    def scheme(self) -> str:
+        return "https"
+
+    def queries(self):
+        # Get some info from diagd for self.check() to inspect
+        yield Query(
+            self.url("ambassador/v0/diag/?json=true&filter=errors"),
+            headers={"Host": "tls-context-host-1"},
+            insecure=True,
+            sni=True,
+        )
+
+        yield Query(
+            self.url("target/", scheme="https"),
+            headers={"Host": "tls-context-host-1"},
+            sni=True,
+            insecure=True,
+            expected=200,
+        )
+        yield Query(
+            self.url("target/", scheme="http"),
+            headers={"Host": "tls-context-host-1"},
+            expected=301,
+        )
+
+    def check(self):
+        # XXX If self.results[0].json is empty, the harness won't convert it to a response.
+        errors = self.results[0].json or []
+        num_errors = len(errors)
+        assert num_errors == 0, "expected 0 errors, got {} -\n{}".format(num_errors, errors)
+
+        idx = 0
+
+        for result in self.results:
+            if result.status == 200 and result.query.headers and result.tls:
+                host_header = result.query.headers["Host"]
+                tls_common_name = result.tls[0]["Subject"]["CommonName"]
+
+                assert host_header == tls_common_name, "test %d wanted CN %s, but got %s" % (
+                    idx,
+                    host_header,
+                    tls_common_name,
+                )
+
+            idx += 1
+
+    def requirements(self):
+        # We're replacing super()'s requirements deliberately here. Without a Host header they can't work.
+        yield (
+            "url",
+            Query(
+                self.url("ambassador/v0/check_ready"),
+                headers={"Host": "tls-context-host-1"},
+                insecure=True,
+                sni=True,
+            ),
+        )
+        yield (
+            "url",
+            Query(
+                self.url("ambassador/v0/check_alive"),
+                headers={"Host": "tls-context-host-1"},
+                insecure=True,
+                sni=True,
+            ),
+        )
+
+
+class HostCRDDoubleCrossNamespace(AmbassadorTest):
+    """
+    HostCRDDouble: We have two Hosts, each with a
+    manually-configured TLS secret, the secrets have
+    the same name but are in different namespaces.
+    """
+
+    target1: ServiceType
+    target2: ServiceType
+
+    def init(self):
+        self.edge_stack_cleartext_host = False
+        self.target1 = HTTP(name="target1")
+        self.target2 = HTTP(name="target2")
+
+    def manifests(self) -> str:
+        return (
+            namespace_manifest("bar")
+            + namespace_manifest("foo")
+            + self.format(
+                """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: {self.path.k8s}-host-1
+  labels:
+    kat-ambassador-id: {self.ambassador_id}
+spec:
+  ambassador_id: [ {self.ambassador_id} ]
+  hostname: tls-context-host-1
+  acmeProvider:
+    authority: none
+  mappingSelector:
+    matchLabels:
+      hostname: tls-context-host-1
+  tlsSecret:
+    name: {self.path.k8s}-test-tlscontext-secret
+    namespace: foo
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {self.path.k8s}-test-tlscontext-secret
+  namespace: foo
+  labels:
+    kat-ambassador-id: {self.ambassador_id}
+type: kubernetes.io/tls
+data:
+  tls.crt: """
+                + TLSCerts["tls-context-host-1"].k8s_crt
+                + """
+  tls.key: """
+                + TLSCerts["tls-context-host-1"].k8s_key
+                + """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: {self.path.k8s}-host-1-mapping
+  labels:
+    hostname: tls-context-host-1
+    kat-ambassador-id: {self.ambassador_id}
+spec:
+  ambassador_id: [ {self.ambassador_id} ]
+  hostname: tls-context-host-1
+  prefix: /target-1/
+  service: {self.target1.path.fqdn}
+
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: {self.path.k8s}-host-2
+  labels:
+    kat-ambassador-id: {self.ambassador_id}
+spec:
+  ambassador_id: [ {self.ambassador_id} ]
+  hostname: tls-context-host-2
+  acmeProvider:
+    authority: none
+  tlsSecret:
+    name: {self.path.k8s}-test-tlscontext-secret
+    namespace: bar
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {self.path.k8s}-test-tlscontext-secret
+  namespace: bar
+  labels:
+    kat-ambassador-id: {self.ambassador_id}
+type: kubernetes.io/tls
+data:
+  tls.crt: """
+                + TLSCerts["tls-context-host-2"].k8s_crt
+                + """
+  tls.key: """
+                + TLSCerts["tls-context-host-2"].k8s_key
+                + """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: {self.path.k8s}-host-2-mapping
+  labels:
+    hostname: tls-context-host-2
+    kat-ambassador-id: {self.ambassador_id}
+spec:
+  ambassador_id: [ {self.ambassador_id} ]
+  hostname: tls-context-host-2
+  prefix: /target-2/
+  service: {self.target2.path.fqdn}
+"""
+            )
+            + super().manifests()
+        )
+
+    def scheme(self) -> str:
+        return "https"
+
+    def queries(self):
+        # Get some info from diagd for self.check() to inspect
+        yield Query(
+            self.url("ambassador/v0/diag/?json=true&filter=errors"),
+            headers={"Host": "tls-context-host-1"},
+            insecure=True,
+            sni=True,
+        )
+
+        # Host #1 - TLS
+        yield Query(
+            self.url("target-1/", scheme="https"),
+            headers={"Host": "tls-context-host-1"},
+            sni=True,
+            insecure=True,
+            expected=200,
+        )
+        yield Query(
+            self.url("target-2/", scheme="https"),
+            headers={"Host": "tls-context-host-1"},
+            sni=True,
+            insecure=True,
+            expected=404,
+        )
+        yield Query(
+            self.url("target-1/", scheme="http"),
+            headers={"Host": "tls-context-host-1"},
+            expected=301,
+        )
+
+        # Host #2 - TLS
+        yield Query(
+            self.url("target-1/", scheme="https"),
+            headers={"Host": "tls-context-host-2"},
+            sni=True,
+            insecure=True,
+            expected=404,
+        )
+        yield Query(
+            self.url("target-2/", scheme="https"),
+            headers={"Host": "tls-context-host-2"},
+            sni=True,
+            insecure=True,
+            expected=200,
+        )
+        yield Query(
+            self.url("target-2/", scheme="http"),
+            headers={"Host": "tls-context-host-2"},
+            expected=301,
+        )
+
+    def check(self):
+        # XXX If self.results[0].json is empty, the harness won't convert it to a response.
+        errors = self.results[0].json or []
+        num_errors = len(errors)
+        assert num_errors == 0, "expected 0 errors, got {} -\n{}".format(num_errors, errors)
+
+        idx = 0
+
+        for result in self.results:
+            if result.status == 200 and result.query.headers and result.tls:
+                host_header = result.query.headers["Host"]
+                tls_common_name = result.tls[0]["Subject"]["CommonName"]
+
+                assert host_header == tls_common_name, "test %d wanted CN %s, but got %s" % (
+                    idx,
+                    host_header,
+                    tls_common_name,
+                )
+
+            idx += 1
+
+    def requirements(self):
+        # We're replacing super()'s requirements deliberately here. Without a Host header they can't work.
+        yield (
+            "url",
+            Query(
+                self.url("ambassador/v0/check_ready"),
+                headers={"Host": "tls-context-host-1"},
+                insecure=True,
+                sni=True,
+            ),
+        )
+        yield (
+            "url",
+            Query(
+                self.url("ambassador/v0/check_alive"),
+                headers={"Host": "tls-context-host-1"},
+                insecure=True,
+                sni=True,
+            ),
+        )
+        yield (
+            "url",
+            Query(
+                self.url("ambassador/v0/check_ready"),
+                headers={"Host": "tls-context-host-2"},
+                insecure=True,
+                sni=True,
+            ),
+        )
+        yield (
+            "url",
+            Query(
+                self.url("ambassador/v0/check_alive"),
+                headers={"Host": "tls-context-host-2"},
+                insecure=True,
+                sni=True,
+            ),
+        )


### PR DESCRIPTION
## Description
Currently it is only possible to use a secret within a `Host` if that secret shares the same namespace as the `Host`. While originally this was a design decision, we've seen users experiencing friction due to this restriction. These changes will allow you to use secrets from any namespace within a `Host` like so:

```
tlsSecret:
  name: tls-cert
  namespace: foobar # new field!
```

## Related Issues
Cherry-pick of https://github.com/emissary-ingress/emissary/pull/4423 for 2.x. In the future I'll start on the 2.x branch since I forgot about the repatriation. 

## Testing
Manual tests and added some test cases to the existing `Host` tests.
## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `CHANGELOG.md`.

   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations

 - [x] This is unlikely to impact how Ambassador performs at scale.

   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability

 - [x] My change is adequately tested.

   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points

 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.

 - [x] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
