### PR TITLE
Fix : Bypass EDS to resolve 503s for cert rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,10 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
   Host. The `tlsSecret` field in the Host has a new subfield `namespace` that will allow the use of
   secrets from different namespaces.
 
+- Change: Set `AMBASSADOR_EDS_BY_PASS` to `true` to bypass EDS handling of endpoints and have
+  endpoints be inserted to clusters manually. This can help resolve with `503 UH` caused by
+  certification rotation relating to a delay between EDS + CDS. The default is `false`.
+
 ## [2.3.2] August 01, 2022
 [2.3.2]: https://github.com/emissary-ingress/emissary/compare/v2.3.1...v2.3.2
 

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -41,6 +41,14 @@ items:
           Previously the <code>Host</code> resource could only use secrets that are in the namespace as the
           Host. The <code>tlsSecret</code> field in the Host has a new subfield <code>namespace</code> that will allow
           the use of secrets from different namespaces.
+
+      - title: Allow bypassing of EDS for manual endpoint insertion
+        type: change
+        body: >-
+          Set `AMBASSADOR_EDS_BY_PASS` to `true` to bypass EDS handling of endpoints and have endpoints be
+          inserted to clusters manually. This can help resolve with `503 UH` caused by certification rotation relating to
+          a delay between EDS + CDS. The default is `false`.
+
   - version: 2.3.2
     date: '2022-08-01'
     notes:

--- a/pkg/ambex/main.go
+++ b/pkg/ambex/main.go
@@ -138,7 +138,7 @@ type Args struct {
 	snapdirPath string
 	numsnaps    int
 
-	// edsByPass will bypass using EDS and will insert the endpoints into the custer data manually
+	// edsByPass will bypass using EDS and will insert the endpoints into the cluster data manually
 	// This is a stop gap solution to resolve 503s on certification rotation
 	edsByPass bool
 }
@@ -196,10 +196,11 @@ func parseArgs(ctx context.Context, rawArgs ...string) (*Args, error) {
 		dlog.Errorf(ctx, "Invalid AMBASSADOR_AMBEX_SNAPSHOT_COUNT: %s, using %d", numsnapStr, args.numsnaps)
 	}
 
-	// edsByPass will bypass using EDS and will insert the endpoints into the custer data manually
+	// edsByPass will bypass using EDS and will insert the endpoints into the cluster data manually
 	// This is a stop gap solution to resolve 503s on certification rotation
 	edsByPass := os.Getenv("AMBASSADOR_EDS_BY_PASS")
-	if edsByPass == "true" {
+	if strings.ToLower(edsByPass) == "true" {
+		dlog.Info(ctx, "AMBASSADOR_EDS_BY_PASS has been set to true. EDS will not be bypassed and endpoints will be inserted manually.")
 		args.edsByPass = true
 	}
 

--- a/pkg/ambex/transforms.go
+++ b/pkg/ambex/transforms.go
@@ -246,7 +246,7 @@ func V3ListenerToRdsListener(lnr *apiv3_listener.Listener) (*apiv3_listener.List
 // the supplied list. If there is no map entry for a given cluster, an empty ClusterLoadAssignment
 // will be synthesized. The result is a set of endpoints that are consistent (by the
 // go-control-plane's definition of consistent) with the input clusters.
-func JoinEdsClusters(ctx context.Context, clusters []ecp_cache_types.Resource, edsEndpoints map[string]*apiv2.ClusterLoadAssignment) (endpoints []ecp_cache_types.Resource) {
+func JoinEdsClusters(ctx context.Context, clusters []ecp_cache_types.Resource, edsEndpoints map[string]*apiv2.ClusterLoadAssignment, edsByPass bool) (endpoints []ecp_cache_types.Resource) {
 	for _, clu := range clusters {
 		c := clu.(*apiv2.Cluster)
 		// Don't mess with non EDS clusters.
@@ -254,27 +254,42 @@ func JoinEdsClusters(ctx context.Context, clusters []ecp_cache_types.Resource, e
 			continue
 		}
 
-		// By default envoy will use the cluster name to lookup ClusterLoadAssignments unless the
+		// By default, envoy will use the cluster name to lookup ClusterLoadAssignments unless the
 		// ServiceName is supplied in the EdsClusterConfig.
 		ref := c.EdsClusterConfig.ServiceName
 		if ref == "" {
 			ref = c.Name
 		}
 
-		var source string
-		ep, ok := edsEndpoints[ref]
-		if ok {
-			source = "found"
-		} else {
-			ep = &apiv2.ClusterLoadAssignment{
-				ClusterName: ref,
-				Endpoints:   []*apiv2_endpoint.LocalityLbEndpoints{},
-			}
-			source = "synthesized"
-		}
+		// This change was introduced as a stop gap solution to mitigate the 503 issues when certificates are rotated.
+		// The issue is CDS gets updated and waits for EDS to send ClusterLoadAssignment.
+		// During this wait period calls that are coming through get hit with a 503 since the cluster is in a warming state.
+		// The solution is to "hijack" the cluster and insert all the endpoints instead of relying on EDS.
+		// Not there will be a discrepancy between envoy/envoy.json and the config envoy has
+		if edsByPass {
+			if ep, ok := edsEndpoints[ref]; ok {
+				c.LoadAssignment = ep
+				c.EdsClusterConfig = nil
 
-		dlog.Debugf(ctx, "%s envoy v2 ClusterLoadAssignment for cluster %s: %v", source, c.Name, ep)
-		endpoints = append(endpoints, ep)
+				// Type 1 is STRICT_DNS
+				c.ClusterDiscoveryType = &apiv2.Cluster_Type{Type: 1}
+			}
+		} else {
+			var source string
+			ep, ok := edsEndpoints[ref]
+			if ok {
+				source = "found"
+			} else {
+				ep = &apiv2.ClusterLoadAssignment{
+					ClusterName: ref,
+					Endpoints:   []*apiv2_endpoint.LocalityLbEndpoints{},
+				}
+				source = "synthesized"
+			}
+
+			dlog.Debugf(ctx, "%s envoy v2 ClusterLoadAssignment for cluster %s: %v", source, c.Name, ep)
+			endpoints = append(endpoints, ep)
+		}
 	}
 
 	return
@@ -286,7 +301,7 @@ func JoinEdsClusters(ctx context.Context, clusters []ecp_cache_types.Resource, e
 // the supplied list. If there is no map entry for a given cluster, an empty ClusterLoadAssignment
 // will be synthesized. The result is a set of endpoints that are consistent (by the
 // go-control-plane's definition of consistent) with the input clusters.
-func JoinEdsClustersV3(ctx context.Context, clusters []ecp_cache_types.Resource, edsEndpoints map[string]*apiv3_endpoint.ClusterLoadAssignment) (endpoints []ecp_cache_types.Resource) {
+func JoinEdsClustersV3(ctx context.Context, clusters []ecp_cache_types.Resource, edsEndpoints map[string]*apiv3_endpoint.ClusterLoadAssignment, edsByPass bool) (endpoints []ecp_cache_types.Resource) {
 	for _, clu := range clusters {
 		c := clu.(*apiv3_cluster.Cluster)
 		// Don't mess with non EDS clusters.
@@ -294,27 +309,43 @@ func JoinEdsClustersV3(ctx context.Context, clusters []ecp_cache_types.Resource,
 			continue
 		}
 
-		// By default envoy will use the cluster name to lookup ClusterLoadAssignments unless the
+		// By default, envoy will use the cluster name to lookup ClusterLoadAssignments unless the
 		// ServiceName is supplied in the EdsClusterConfig.
 		ref := c.EdsClusterConfig.ServiceName
 		if ref == "" {
 			ref = c.Name
 		}
 
-		var source string
-		ep, ok := edsEndpoints[ref]
-		if ok {
-			source = "found"
-		} else {
-			ep = &apiv3_endpoint.ClusterLoadAssignment{
-				ClusterName: ref,
-				Endpoints:   []*apiv3_endpoint.LocalityLbEndpoints{},
+		// This change was introduced as a stop gap solution to mitigate the 503 issues when certificates are rotated.
+		// The issue is CDS gets updated and waits for EDS to send ClusterLoadAssignment.
+		// During this wait period calls that are coming through get hit with a 503 since the cluster is in a warming state.
+		// The solution is to "hijack" the cluster and insert all the endpoints instead of relying on EDS.
+		// Not there will be a discrepancy between envoy/envoy.json and the config envoy has
+		if edsByPass {
+			if ep, ok := edsEndpoints[ref]; ok {
+				c.LoadAssignment = ep
+				c.EdsClusterConfig = nil
+
+				// Type 1 is STRICT_DNS
+				c.ClusterDiscoveryType = &apiv3_cluster.Cluster_Type{Type: 1}
 			}
-			source = "synthesized"
+		} else {
+			var source string
+			ep, ok := edsEndpoints[ref]
+			if ok {
+				source = "found"
+			} else {
+				ep = &apiv3_endpoint.ClusterLoadAssignment{
+					ClusterName: ref,
+					Endpoints:   []*apiv3_endpoint.LocalityLbEndpoints{},
+				}
+				source = "synthesized"
+			}
+
+			dlog.Debugf(ctx, "%s envoy v3 ClusterLoadAssignment for cluster %s: %v", source, c.Name, ep)
+			endpoints = append(endpoints, ep)
 		}
 
-		dlog.Debugf(ctx, "%s envoy v3 ClusterLoadAssignment for cluster %s: %v", source, c.Name, ep)
-		endpoints = append(endpoints, ep)
 	}
 
 	return

--- a/pkg/ambex/transforms.go
+++ b/pkg/ambex/transforms.go
@@ -265,14 +265,14 @@ func JoinEdsClusters(ctx context.Context, clusters []ecp_cache_types.Resource, e
 		// The issue is CDS gets updated and waits for EDS to send ClusterLoadAssignment.
 		// During this wait period calls that are coming through get hit with a 503 since the cluster is in a warming state.
 		// The solution is to "hijack" the cluster and insert all the endpoints instead of relying on EDS.
-		// Not there will be a discrepancy between envoy/envoy.json and the config envoy has
+		// Now there will be a discrepancy between envoy/envoy.json and the config envoy.
 		if edsByPass {
 			if ep, ok := edsEndpoints[ref]; ok {
 				c.LoadAssignment = ep
 				c.EdsClusterConfig = nil
 
-				// Type 1 is STRICT_DNS
-				c.ClusterDiscoveryType = &apiv2.Cluster_Type{Type: 1}
+				// Type 0 is STATIC
+				c.ClusterDiscoveryType = &apiv2.Cluster_Type{Type: 0}
 			}
 		} else {
 			var source string
@@ -320,14 +320,14 @@ func JoinEdsClustersV3(ctx context.Context, clusters []ecp_cache_types.Resource,
 		// The issue is CDS gets updated and waits for EDS to send ClusterLoadAssignment.
 		// During this wait period calls that are coming through get hit with a 503 since the cluster is in a warming state.
 		// The solution is to "hijack" the cluster and insert all the endpoints instead of relying on EDS.
-		// Not there will be a discrepancy between envoy/envoy.json and the config envoy has
+		// Now there will be a discrepancy between envoy/envoy.json and the config envoy.
 		if edsByPass {
 			if ep, ok := edsEndpoints[ref]; ok {
 				c.LoadAssignment = ep
 				c.EdsClusterConfig = nil
 
-				// Type 1 is STRICT_DNS
-				c.ClusterDiscoveryType = &apiv3_cluster.Cluster_Type{Type: 1}
+				// Type 0 is STATIC
+				c.ClusterDiscoveryType = &apiv3_cluster.Cluster_Type{Type: 0}
 			}
 		} else {
 			var source string


### PR DESCRIPTION
## Description
When we rotate a cert this causes envoy to create a new Cluster, which has the same name as the old one, but since it is a new cluster the transport socket changes. This will then cause the cluster to be put in a "warming" state until it gets a ClusterLoadAssignment from xDS which will supply the endpoints from k8. 

The solution here is to manually update the cluster configuration and insert the endpoints instead of relying on EDS when using the endpoint resolver.


**NOTE** This doesn't change the default behavior which is to use EDS when you are using endpoint resolver. To bypass eds you must set a new environmental variable called `AMBASSADOR_EDS_BY_PASS` to true.


## Related Issues
List related issues.

## Testing
Tested this manually on k8 clusters to make sure behavior has stayed the same 

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `CHANGELOG.md`.

   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations

 - [ ] This is unlikely to impact how Ambassador performs at scale.

   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability

 - [x] My change is adequately tested.

   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points

 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.

 - [ ] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
