### PR TITLE
change: envar typo + use parsebool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,7 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
   Host. The `tlsSecret` field in the Host has a new subfield `namespace` that will allow the use of
   secrets from different namespaces.
 
-- Change: Set `AMBASSADOR_EDS_BY_PASS` to `true` to bypass EDS handling of endpoints and have
+- Change: Set `AMBASSADOR_EDS_BYPASS` to `true` to bypass EDS handling of endpoints and have
   endpoints be inserted to clusters manually. This can help resolve with `503 UH` caused by
   certification rotation relating to a delay between EDS + CDS. The default is `false`.
 

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -45,7 +45,7 @@ items:
       - title: Allow bypassing of EDS for manual endpoint insertion
         type: change
         body: >-
-          Set `AMBASSADOR_EDS_BY_PASS` to `true` to bypass EDS handling of endpoints and have endpoints be
+          Set `AMBASSADOR_EDS_BYPASS` to `true` to bypass EDS handling of endpoints and have endpoints be
           inserted to clusters manually. This can help resolve with `503 UH` caused by certification rotation relating to
           a delay between EDS + CDS. The default is `false`.
 

--- a/pkg/ambex/main.go
+++ b/pkg/ambex/main.go
@@ -198,10 +198,10 @@ func parseArgs(ctx context.Context, rawArgs ...string) (*Args, error) {
 
 	// edsByPass will bypass using EDS and will insert the endpoints into the cluster data manually
 	// This is a stop gap solution to resolve 503s on certification rotation
-	edsByPass := os.Getenv("AMBASSADOR_EDS_BY_PASS")
-	if strings.ToLower(edsByPass) == "true" {
-		dlog.Info(ctx, "AMBASSADOR_EDS_BY_PASS has been set to true. EDS will not be bypassed and endpoints will be inserted manually.")
-		args.edsByPass = true
+	edsByPass := os.Getenv("AMBASSADOR_EDS_BYPASS")
+	if v, err := strconv.ParseBool(edsByPass); err == nil && v {
+		dlog.Info(ctx, "AMBASSADOR_EDS_BYPASS has been set to true. EDS will not be bypassed and endpoints will be inserted manually.")
+		args.edsByPass = v
 	}
 
 	return &args, nil

--- a/pkg/ambex/main.go
+++ b/pkg/ambex/main.go
@@ -138,9 +138,9 @@ type Args struct {
 	snapdirPath string
 	numsnaps    int
 
-	// edsByPass will bypass using EDS and will insert the endpoints into the cluster data manually
+	// edsBypass will bypass using EDS and will insert the endpoints into the cluster data manually
 	// This is a stop gap solution to resolve 503s on certification rotation
-	edsByPass bool
+	edsBypass bool
 }
 
 func parseArgs(ctx context.Context, rawArgs ...string) (*Args, error) {
@@ -196,12 +196,12 @@ func parseArgs(ctx context.Context, rawArgs ...string) (*Args, error) {
 		dlog.Errorf(ctx, "Invalid AMBASSADOR_AMBEX_SNAPSHOT_COUNT: %s, using %d", numsnapStr, args.numsnaps)
 	}
 
-	// edsByPass will bypass using EDS and will insert the endpoints into the cluster data manually
+	// edsBypass will bypass using EDS and will insert the endpoints into the cluster data manually
 	// This is a stop gap solution to resolve 503s on certification rotation
-	edsByPass := os.Getenv("AMBASSADOR_EDS_BYPASS")
-	if v, err := strconv.ParseBool(edsByPass); err == nil && v {
+	edsBypass := os.Getenv("AMBASSADOR_EDS_BYPASS")
+	if v, err := strconv.ParseBool(edsBypass); err == nil && v {
 		dlog.Info(ctx, "AMBASSADOR_EDS_BYPASS has been set to true. EDS will be bypassed and endpoints will be inserted manually.")
-		args.edsByPass = v
+		args.edsBypass = v
 	}
 
 	return &args, nil
@@ -425,7 +425,7 @@ func update(
 	ctx context.Context,
 	snapdirPath string,
 	numsnaps int,
-	edsByPass bool,
+	edsBypass bool,
 	config ecp_v2_cache.SnapshotCache,
 	configv3 ecp_v3_cache.SnapshotCache,
 	generation *int,
@@ -582,8 +582,8 @@ func update(
 	// warmup sequence in scenarios where the endpoint data for a cluster is really flapping into
 	// and out of existence. In that circumstance we want to faithfully relay to envoy that the
 	// cluster exists but currently has no endpoints.
-	endpoints := JoinEdsClusters(ctx, clusters, edsEndpoints, edsByPass)
-	endpointsv3 := JoinEdsClustersV3(ctx, clustersv3, edsEndpointsV3, edsByPass)
+	endpoints := JoinEdsClusters(ctx, clusters, edsEndpoints, edsBypass)
+	endpointsv3 := JoinEdsClustersV3(ctx, clustersv3, edsEndpointsV3, edsBypass)
 
 	// Create a new configuration snapshot from everything we have just loaded from disk.
 	curgen := *generation
@@ -831,7 +831,7 @@ func Main(
 			ctx,
 			args.snapdirPath,
 			args.numsnaps,
-			args.edsByPass,
+			args.edsBypass,
 			config,
 			configv3,
 			&generation,
@@ -854,7 +854,7 @@ func Main(
 					ctx,
 					args.snapdirPath,
 					args.numsnaps,
-					args.edsByPass,
+					args.edsBypass,
 					config,
 					configv3,
 					&generation,
@@ -878,7 +878,7 @@ func Main(
 					ctx,
 					args.snapdirPath,
 					args.numsnaps,
-					args.edsByPass,
+					args.edsBypass,
 					config,
 					configv3,
 					&generation,
@@ -897,7 +897,7 @@ func Main(
 					ctx,
 					args.snapdirPath,
 					args.numsnaps,
-					args.edsByPass,
+					args.edsBypass,
 					config,
 					configv3,
 					&generation,

--- a/pkg/ambex/main.go
+++ b/pkg/ambex/main.go
@@ -200,7 +200,7 @@ func parseArgs(ctx context.Context, rawArgs ...string) (*Args, error) {
 	// This is a stop gap solution to resolve 503s on certification rotation
 	edsByPass := os.Getenv("AMBASSADOR_EDS_BYPASS")
 	if v, err := strconv.ParseBool(edsByPass); err == nil && v {
-		dlog.Info(ctx, "AMBASSADOR_EDS_BYPASS has been set to true. EDS will not be bypassed and endpoints will be inserted manually.")
+		dlog.Info(ctx, "AMBASSADOR_EDS_BYPASS has been set to true. EDS will be bypassed and endpoints will be inserted manually.")
 		args.edsByPass = v
 	}
 

--- a/pkg/ambex/transforms.go
+++ b/pkg/ambex/transforms.go
@@ -246,7 +246,7 @@ func V3ListenerToRdsListener(lnr *apiv3_listener.Listener) (*apiv3_listener.List
 // the supplied list. If there is no map entry for a given cluster, an empty ClusterLoadAssignment
 // will be synthesized. The result is a set of endpoints that are consistent (by the
 // go-control-plane's definition of consistent) with the input clusters.
-func JoinEdsClusters(ctx context.Context, clusters []ecp_cache_types.Resource, edsEndpoints map[string]*apiv2.ClusterLoadAssignment, edsByPass bool) (endpoints []ecp_cache_types.Resource) {
+func JoinEdsClusters(ctx context.Context, clusters []ecp_cache_types.Resource, edsEndpoints map[string]*apiv2.ClusterLoadAssignment, edsBypass bool) (endpoints []ecp_cache_types.Resource) {
 	for _, clu := range clusters {
 		c := clu.(*apiv2.Cluster)
 		// Don't mess with non EDS clusters.
@@ -266,7 +266,7 @@ func JoinEdsClusters(ctx context.Context, clusters []ecp_cache_types.Resource, e
 		// During this wait period calls that are coming through get hit with a 503 since the cluster is in a warming state.
 		// The solution is to "hijack" the cluster and insert all the endpoints instead of relying on EDS.
 		// Now there will be a discrepancy between envoy/envoy.json and the config envoy.
-		if edsByPass {
+		if edsBypass {
 			if ep, ok := edsEndpoints[ref]; ok {
 				c.LoadAssignment = ep
 				c.EdsClusterConfig = nil
@@ -301,7 +301,7 @@ func JoinEdsClusters(ctx context.Context, clusters []ecp_cache_types.Resource, e
 // the supplied list. If there is no map entry for a given cluster, an empty ClusterLoadAssignment
 // will be synthesized. The result is a set of endpoints that are consistent (by the
 // go-control-plane's definition of consistent) with the input clusters.
-func JoinEdsClustersV3(ctx context.Context, clusters []ecp_cache_types.Resource, edsEndpoints map[string]*apiv3_endpoint.ClusterLoadAssignment, edsByPass bool) (endpoints []ecp_cache_types.Resource) {
+func JoinEdsClustersV3(ctx context.Context, clusters []ecp_cache_types.Resource, edsEndpoints map[string]*apiv3_endpoint.ClusterLoadAssignment, edsBypass bool) (endpoints []ecp_cache_types.Resource) {
 	for _, clu := range clusters {
 		c := clu.(*apiv3_cluster.Cluster)
 		// Don't mess with non EDS clusters.
@@ -321,7 +321,7 @@ func JoinEdsClustersV3(ctx context.Context, clusters []ecp_cache_types.Resource,
 		// During this wait period calls that are coming through get hit with a 503 since the cluster is in a warming state.
 		// The solution is to "hijack" the cluster and insert all the endpoints instead of relying on EDS.
 		// Now there will be a discrepancy between envoy/envoy.json and the config envoy.
-		if edsByPass {
+		if edsBypass {
 			if ep, ok := edsEndpoints[ref]; ok {
 				c.LoadAssignment = ep
 				c.EdsClusterConfig = nil


### PR DESCRIPTION
Signed-off-by: David Dymko <ddymko@datawire.io>

## Description
Changing env var typo from `BY_PASS` to `BYPASS` and using strconv.ParseBool to handle checking of said env var

## Related Issues
List related issues.

## Testing
A few sentences describing what testing you've done, e.g., manual tests, automated tests, deployed in production, etc.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `CHANGELOG.md`.

   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations

 - [ ] This is unlikely to impact how Ambassador performs at scale.

   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability

 - [x] My change is adequately tested.

   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points

 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.

 - [ ] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
