### PR TITLE
[v2.4] .github: Skip over v3.0 and v3.1 when repatriating

### DIFF
--- a/.github/workflows/repatriate.yml
+++ b/.github/workflows/repatriate.yml
@@ -29,7 +29,7 @@ jobs:
           this_branch=release/${this_ver}
           echo "::set-output name=this_branch::${this_branch}"
 
-          next_ver=$(git for-each-ref --format='%(refname:lstrip=4)' 'refs/remotes/origin/release/v*' | sort --version-sort | grep -A1 -Fx "$this_ver" | sed 1d)
+          next_ver=$(git for-each-ref --format='%(refname:lstrip=4)' 'refs/remotes/origin/release/v*' | sort --version-sort | grep -vFx -e 'v3.0' -e 'v3.1' | grep -A1 -Fx "$this_ver" | sed 1d)
           if test -n "$next_ver"; then
             if test "$next_ver" = v2.0; then
               next_ver=v2.4


### PR DESCRIPTION
## Description

Besides just the tedium of having to merge a 2.4→3.0 PR then a 3.0→3.1 PR then a 3.1→3.2 PR, even just landing the 2.4→3.0 PR would be problematic because it would contain features, and 3.0 is feature-frozen. So have 2.4 repatriate straight in to 3.2.