### PR TITLE
ratelimit: add failure_mode_deny field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,12 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
 - Bugfix: Distinct services with names that are the same in the first forty characters will no
   longer be incorrectly mapped to the same cluster. ([#4354])
 
+- Feature: By default, when Envoy is unable to communicate with the configured RateLimitService then
+  it will allow traffic through. The  `RateLimitService` resource now exposes the  <a
+  href="https://www.envoyproxy.io/docs/envoy/v1.23.0/configuration/http/http_filters/rate_limit_filter">failure_mode_deny</a>
+  option. Set `failure_mode_deny: true`, then Envoy will  deny traffic when it is unable to
+  communicate to the RateLimitService  returning a 500.
+
 [#4354]: https://github.com/emissary-ingress/emissary/issues/4354
 
 ## [3.1.1] TBD

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -63,6 +63,17 @@ items:
         github:
         - title: "#4354"
           link: https://github.com/emissary-ingress/emissary/issues/4354
+      - title: Add failure_mode_deny option to the RateLimitService
+        type: feature
+        body: >-
+          By default, when Envoy is unable to communicate with the configured
+          RateLimitService then it will allow traffic through. The 
+          <code>RateLimitService</code> resource now exposes the 
+          <a href="https://www.envoyproxy.io/docs/envoy/v1.23.0/configuration/http/http_filters/rate_limit_filter">failure_mode_deny</a> 
+          option. Set <code>failure_mode_deny: true</code>, then Envoy will 
+          deny traffic when it is unable to communicate to the RateLimitService 
+          returning a 500.
+        docs: https://www.getambassador.io/docs/emissary/latest/topics/running/services/rate-limit-service/
 
   - version: 3.1.1
     prevVersion: 3.1.0

--- a/manifests/emissary/emissary-crds.yaml.in
+++ b/manifests/emissary/emissary-crds.yaml.in
@@ -3098,6 +3098,10 @@ spec:
             properties:
               domain:
                 type: string
+              failure_mode_deny:
+                description: FailureModeDeny when set to true, envoy will deny traffic
+                  if it is unable to communicate with the rate limit service.
+                type: boolean
               protocol_version:
                 enum:
                 - v2
@@ -3143,6 +3147,10 @@ spec:
                 type: array
               domain:
                 type: string
+              failure_mode_deny:
+                description: FailureModeDeny when set to true, envoy will deny traffic
+                  if it is unable to communicate with the rate limit service.
+                type: boolean
               protocol_version:
                 description: ProtocolVersion is the envoy api transport protocol version
                 enum:

--- a/pkg/api/getambassador.io/crds.yaml
+++ b/pkg/api/getambassador.io/crds.yaml
@@ -3159,6 +3159,10 @@ spec:
                 - type: array
               domain:
                 type: string
+              failure_mode_deny:
+                description: FailureModeDeny when set to true, envoy will deny traffic
+                  if it is unable to communicate with the rate limit service.
+                type: boolean
               protocol_version:
                 enum:
                 - v2
@@ -3208,6 +3212,10 @@ spec:
                 type: array
               domain:
                 type: string
+              failure_mode_deny:
+                description: FailureModeDeny when set to true, envoy will deny traffic
+                  if it is unable to communicate with the rate limit service.
+                type: boolean
               protocol_version:
                 description: ProtocolVersion is the envoy api transport protocol version
                 enum:

--- a/pkg/api/getambassador.io/v2/crd_ratelimitservice.go
+++ b/pkg/api/getambassador.io/v2/crd_ratelimitservice.go
@@ -39,6 +39,12 @@ type RateLimitServiceSpec struct {
 
 	// +k8s:conversion-gen:rename=StatsName
 	V3StatsName string `json:"v3StatsName,omitempty"`
+
+	// +k8s:conversion-gen:rename=FailureModeDeny
+	//
+	// FailureModeDeny when set to true, envoy will deny traffic if it
+	// is unable to communicate with the rate limit service.
+	V3FailureModeDeny bool `json:"failure_mode_deny,omitempty"`
 }
 
 // RateLimitService is the Schema for the ratelimitservices API

--- a/pkg/api/getambassador.io/v2/testdata/ratelimitsvc.yaml
+++ b/pkg/api/getambassador.io/v2/testdata/ratelimitsvc.yaml
@@ -6,6 +6,7 @@
       namespace: "default"
   spec:
       service: "ratelimitsvc"
+      protocol_version: "v3"
 - apiVersion: "getambassador.io/v2"
   kind: "RateLimitService"
   metadata:
@@ -14,6 +15,7 @@
       namespace: "default"
   spec:
       service: "ratelimitsvc"
+      protocol_version: "v3"
       timeout_ms: 500
 - apiVersion: "getambassador.io/v2"
   kind: "RateLimitService"
@@ -23,4 +25,15 @@
       namespace: "default"
   spec:
       service: "ratelimitsvc"
+      protocol_version: "v3"
       timeout_ms: 0
+- apiVersion: "getambassador.io/v2"
+  kind: "RateLimitService"
+  metadata:
+      creationTimestamp: "2020-07-03T02:19:06Z"
+      name: "ratelimitsvc-failure-mode-deny"
+      namespace: "default"
+  spec:
+      service: "ratelimitsvc"
+      protocol_version: "v3"
+      failure_mode_deny: true

--- a/pkg/api/getambassador.io/v2/zz_generated.conversion.go
+++ b/pkg/api/getambassador.io/v2/zz_generated.conversion.go
@@ -4762,6 +4762,10 @@ func autoConvert_v2_RateLimitServiceSpec_To_v3alpha1_RateLimitServiceSpec(in *Ra
 		in, out := &in.V3StatsName, &out.StatsName
 		*out = *in
 	}
+	if true {
+		in, out := &in.V3FailureModeDeny, &out.FailureModeDeny
+		*out = *in
+	}
 	return nil
 }
 
@@ -4804,6 +4808,10 @@ func autoConvert_v3alpha1_RateLimitServiceSpec_To_v2_RateLimitServiceSpec(in *v3
 	}
 	if true {
 		in, out := &in.StatsName, &out.V3StatsName
+		*out = *in
+	}
+	if true {
+		in, out := &in.FailureModeDeny, &out.V3FailureModeDeny
 		*out = *in
 	}
 	// WARNING: in.V2ExplicitTLS requires manual conversion: does not exist in peer-type

--- a/pkg/api/getambassador.io/v3alpha1/crd_ratelimitservice.go
+++ b/pkg/api/getambassador.io/v3alpha1/crd_ratelimitservice.go
@@ -40,6 +40,10 @@ type RateLimitServiceSpec struct {
 	ProtocolVersion string `json:"protocol_version,omitempty"`
 	StatsName       string `json:"stats_name,omitempty"`
 
+	// FailureModeDeny when set to true, envoy will deny traffic if it
+	// is unable to communicate with the rate limit service.
+	FailureModeDeny bool `json:"failure_mode_deny,omitempty"`
+
 	V2ExplicitTLS *V2ExplicitTLS `json:"v2ExplicitTLS,omitempty"`
 }
 

--- a/python/ambassador/ir/irratelimit.py
+++ b/python/ambassador/ir/irratelimit.py
@@ -80,6 +80,7 @@ class IRRateLimit(IRFilter):
             "domain": self.domain,
             "timeout_ms": config.get("timeout_ms", 20),
             "request_type": "both",  # XXX configurability!
+            "failure_mode_deny": config.get("failure_mode_deny", False),
         }
 
         self.sourced_by(config)

--- a/python/tests/integration/manifests/crds.yaml
+++ b/python/tests/integration/manifests/crds.yaml
@@ -3031,6 +3031,10 @@ spec:
             properties:
               domain:
                 type: string
+              failure_mode_deny:
+                description: FailureModeDeny when set to true, envoy will deny traffic
+                  if it is unable to communicate with the rate limit service.
+                type: boolean
               protocol_version:
                 enum:
                 - v2
@@ -3076,6 +3080,10 @@ spec:
                 type: array
               domain:
                 type: string
+              failure_mode_deny:
+                description: FailureModeDeny when set to true, envoy will deny traffic
+                  if it is unable to communicate with the rate limit service.
+                type: boolean
               protocol_version:
                 description: ProtocolVersion is the envoy api transport protocol version
                 enum:

--- a/python/tests/unit/test_irratelimit.py
+++ b/python/tests/unit/test_irratelimit.py
@@ -51,6 +51,7 @@ def _get_ratelimit_default_conf():
         "domain": "ambassador",
         "request_type": "both",
         "timeout": "0.020s",
+        "failure_mode_deny": False,
         "rate_limit_service": {
             "transport_api_version": "V3",
             "grpc_service": {
@@ -186,6 +187,7 @@ spec:
   timeout_ms: 500
   tls: rl-tls-context
   protocol_version: v3
+  failure_mode_deny: True
 """.format(
         SERVICE_NAME
     )
@@ -196,6 +198,7 @@ spec:
     ] = "cluster_{}_someotherns".format(SERVICE_NAME)
     config["timeout"] = "0.500s"
     config["domain"] = "otherdomain"
+    config["failure_mode_deny"] = True
 
     econf = _get_envoy_config(yaml)
     conf = _get_rl_config(econf.as_dict())


### PR DESCRIPTION
## Description

By default, Envoy will fail open when it is unable to communicate with the configured service. This can be surprising and potentially lead to taking down upstream services. The `failure_mode_deny` field has been added to the `RateLimitService` resource so that Envoy can be configured to reject request when it is unable to communicate with the service. When this happens Envoy will return a 500.


## Related Issues

https://github.com/emissary-ingress/emissary/issues/4465


## Testing

Updated unit test for diagd and CRD conversion to test new field. CI is green and also manually tested by setting up a cluster with the RateLimitService set to talk with a service that doesn't exist. The default value allows traffic through like existing behavior. When setting `failure_mode_deny: true` then it will return a 500 as seen here:

```shell
curl -v http://xx.xxx.xxx.xxx/ratelimit-v3/
*   Trying xx.xxx.xxx.xxx...
* Connected to xx.xxx.xxx.xxx (xx.xxx.xxx.xxx) port 80 (#0)
> GET /ratelimit-v3/ HTTP/1.1
> Host: xx.xxx.xxx.xxx
> User-Agent: curl/7.85.0-DEV
> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< content-type: application/json
< date: Fri, 26 Aug 2022 15:57:05 GMT
< content-length: 158
< x-envoy-upstream-service-time: 0
< server: envoy
<
{
    "server": "jovial-mango-35wuwv6r",
    "quote": "The last sentence you read is often sensible nonsense.",
    "time": "2022-08-26T15:57:05.596169812Z"

}

curl -v http://xx.xxx.xxx.xxx/ratelimit-v3/
* Connected to xx.xxx.xxx.xxx(xx.xxx.xxx.xxx) port 80 (#0)
> GET /ratelimit-v3/ HTTP/1.1
> Host: xx.xxx.xxx.xxx
> User-Agent: curl/7.85.0-DEV
> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 500 Internal Server Error
< date: Fri, 26 Aug 2022 15:56:36 GMT
< server: envoy
< content-length: 0
<

```


## Checklist
 - [x] I made sure to update `CHANGELOG.md`.
 - [x] This is unlikely to impact how Ambassador performs at scale.
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
