### PR TITLE
change: 503 EDS bypass handling when no EPs are present

### DIFF
--- a/pkg/ambex/transforms.go
+++ b/pkg/ambex/transforms.go
@@ -267,12 +267,17 @@ func JoinEdsClusters(ctx context.Context, clusters []ecp_cache_types.Resource, e
 		// The solution is to "hijack" the cluster and insert all the endpoints instead of relying on EDS.
 		// Now there will be a discrepancy between envoy/envoy.json and the config envoy.
 		if edsBypass {
+			c.EdsClusterConfig = nil
+			// Type 0 is STATIC
+			c.ClusterDiscoveryType = &apiv2.Cluster_Type{Type: 0}
+
 			if ep, ok := edsEndpoints[ref]; ok {
 				c.LoadAssignment = ep
-				c.EdsClusterConfig = nil
-
-				// Type 0 is STATIC
-				c.ClusterDiscoveryType = &apiv2.Cluster_Type{Type: 0}
+			} else {
+				c.LoadAssignment = &apiv2.ClusterLoadAssignment{
+					ClusterName: ref,
+					Endpoints:   []*apiv2_endpoint.LocalityLbEndpoints{},
+				}
 			}
 		} else {
 			var source string
@@ -322,12 +327,17 @@ func JoinEdsClustersV3(ctx context.Context, clusters []ecp_cache_types.Resource,
 		// The solution is to "hijack" the cluster and insert all the endpoints instead of relying on EDS.
 		// Now there will be a discrepancy between envoy/envoy.json and the config envoy.
 		if edsBypass {
+			c.EdsClusterConfig = nil
+			// Type 0 is STATIC
+			c.ClusterDiscoveryType = &apiv3_cluster.Cluster_Type{Type: 0}
+
 			if ep, ok := edsEndpoints[ref]; ok {
 				c.LoadAssignment = ep
-				c.EdsClusterConfig = nil
-
-				// Type 0 is STATIC
-				c.ClusterDiscoveryType = &apiv3_cluster.Cluster_Type{Type: 0}
+			} else {
+				c.LoadAssignment = &apiv3_endpoint.ClusterLoadAssignment{
+					ClusterName: ref,
+					Endpoints:   []*apiv3_endpoint.LocalityLbEndpoints{},
+				}
 			}
 		} else {
 			var source string


### PR DESCRIPTION
Signed-off-by: David Dymko <ddymko@datawire.io>

## Description
Currently, when using the Endpoint resolver with the flag `AMBASSADOR_EDS_BYPASS` we will bypass using EDS and insert the endpoints of your pods manually into the cluster data. This works fine until there are no endpoints available this will trip the following error 

`V3 Snapshot inconsistency: mismatched endpoint reference and resource lengths`

This is due to there being no endpoints and not properly handling the removal of the manually inserted endpoint.

The current solution here is if we are using `eds` and `we have endpoints` then do the manual insertion. If `eds` and `we don't have endpoints` then we will insert an empty LB assignment

```sh
☁  ~  k scale --replicas=0 deployment/quote
deployment.apps/quote scaled
☁  ~  k exec -ti emissary-ingress-7bf745d475-6l4gv -n emissary -- /bin/sh
/ambassador $ curl localhost:8001/config_dump
   {
     "version_info": "v3",
     "cluster": {
      "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
      "name": "cluster_quote_default_otls_tls_default_er_round_robin",
      "type": "STATIC",
      "connect_timeout": "3s",
      "dns_lookup_family": "V4_ONLY",
      "transport_socket": {
       "name": "envoy.transport_sockets.tls",
       "typed_config": {
        "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
        "common_tls_context": {
         "tls_certificates": [
          {
           "certificate_chain": {
            "filename": "/ambassador/snapshots/default/secrets-decoded/tls-cert-20/F471EE14000A2B0787B5CE60EB0565E8F82F7AA9.crt"
           },
           "private_key": {
            "filename": "[redacted]"
           }
          }
         ]
        }
       }
      },
      "alt_stat_name": "quote_default",
      "load_assignment": {
       "cluster_name": "k8s/default/quote/443"
      }
     },
```

## Related Issues
List related issues.

## Testing
Tested on a k8 cluster by scaling down a deployment to 0 and checking logs + envoy config

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `CHANGELOG.md`.

   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations

 - [x] This is unlikely to impact how Ambassador performs at scale.

   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability

 - [x] My change is adequately tested.

   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points

 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.

 - [ ] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
