### PR TITLE
Tidy up xDS and ECP imports, and related

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
     - gofmt
     - goimports
     - govet
+    - importas
     - unused
 linters-settings: # please keep this list sorted
   depguard:
@@ -32,13 +33,56 @@ linters-settings: # please keep this list sorted
     # back it broke support for having multiple named prefixes in the
     # same section together.
     local-prefixes: github.com/emissary-ingress,github.com/datawire
+  importas:
+    no-unaliased: true
+    alias:
+      ######################################################################
+      # Envoy API                                                          #
+      ######################################################################
+      # special cases
+      - pkg: github.com/emissary-ingress/emissary/v3/pkg/api/envoy/type
+        alias: apiv2_type
+      - pkg: github.com/emissary-ingress/emissary/v3/pkg/api/envoy/extensions/filters/network/http_connection_manager/(?P<version>.*)
+        alias: api${version}_httpman
+      # ex: apiv2_route "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/api/v2/route"
+      - pkg: github.com/emissary-ingress/emissary/v3/pkg/api/envoy/api/(?P<version>v[0-9][^/]*)/(?P<name>.*)
+        alias: api${version}_${name}
+      # ex: apiv3_svc_cluster "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/service/cluster/v3"
+      - pkg: github.com/emissary-ingress/emissary/v3/pkg/api/envoy/service/(?P<name>[^/]+)/(?P<version>v[0-9][^/]*)
+        alias: api${version}_svc_${name}
+      # ex: apiv3_cluster "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/cluster/v3"
+      - pkg: github.com/emissary-ingress/emissary/v3/pkg/api/envoy/([^se].*/)?(?P<name>[^/]+)/(?P<version>v[0-9][^/]*)
+        alias: api${version}_${name}
+      ######################################################################
+      # Envoy-control-plane                                                #
+      ######################################################################
+      # 1 word without version
+      # ex: ecp_wellknown "github.com/emissary-ingress/emissary/v3/pkg/envoy-control-plane/wellknown"
+      - pkg: github.com/emissary-ingress/emissary/v3/pkg/envoy-control-plane/(?P<name>[^/]+)
+        alias: ecp_${name}
+      # 2 words without version
+      # ex: ecp_cache_types "github.com/emissary-ingress/emissary/v3/pkg/envoy-control-plane/cache/types"
+      - pkg: github.com/emissary-ingress/emissary/v3/pkg/envoy-control-plane/(?P<name1>[^/]+)/(?P<name2>[^v][^/]*)
+        alias: ecp_${name1}_${name2}
+      # 1 word with version
+      # ex: ecp_v3_cache "github.com/emissary-ingress/emissary/v3/pkg/envoy-control-plane/cache/v3"
+      - pkg: github.com/emissary-ingress/emissary/v3/pkg/envoy-control-plane/(?P<name>[^/]+)/(?P<version>v[0-9][^/]*)
+        alias: ecp_${version}_${name}
+      # 2 words with version
+      # ex: ecp_v3_server_stream "github.com/emissary-ingress/emissary/v3/pkg/envoy-control-plane/server/stream/v3"
+      - pkg: github.com/emissary-ingress/emissary/v3/pkg/envoy-control-plane/(?P<name1>[^/]+)/(?P<name2>[^/]+)/(?P<version>v[0-9][^/]*)
+        alias: ecp_${version}_${name1}_${name2}
   unused:
     # treat code as a program (not a library) and report unused
     # exported identifiers
     check-exported: true
 issues:
   exclude-rules:
-    - linters: [govet, errcheck, unused]
+    - linters:
+        - errcheck
+        - govet
+        - importas
+        - unused
       path: pkg/envoy-control-plane/
     - linters: [depguard]
       path: "pkg/envoy-control-plane/(test/|.*_test\\.go)"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@ linters:
     - depguard
     - errcheck
     - gofmt
+    - goimports
     - govet
     - unused
 linters-settings: # please keep this list sorted
@@ -25,6 +26,12 @@ linters-settings: # please keep this list sorted
       - "(net/http.ResponseWriter).Write"
   gofmt:
     simplify: true
+  goimports:
+    # TODO: replace 'goimports' with 'gci', which lets us be more
+    # prescriptive.  The blocker switching to gci that is that a while
+    # back it broke support for having multiple named prefixes in the
+    # same section together.
+    local-prefixes: github.com/emissary-ingress,github.com/datawire
   unused:
     # treat code as a program (not a library) and report unused
     # exported identifiers

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,15 +2,13 @@
 # back on.
 linters:
   disable-all: true
-  enable:
+  enable: # please keep this list sorted
+    - depguard
+    - errcheck
     - gofmt
     - govet
-    - depguard
     - unused
-    - errcheck
-linters-settings:
-  gofmt:
-    simplify: true
+linters-settings: # please keep this list sorted
   depguard:
     list-type: blacklist
     include-go-root: true
@@ -22,13 +20,15 @@ linters-settings:
       - github.com/golang/protobuf:     "Use `google.golang.org/protobuf` instead of `github.com/golang/protobuf`"
       - github.com/google/shlex:        "Use `github.com/kballard/go-shellquote` instead of `github.com/google/shlex`"
       - golang.org/x/net/http2/h2c:     "Use `github.com/datawire/dlib/dhttp` instead of `golang.org/x/net/http2/h2c`"
+  errcheck:
+    exclude-functions:
+      - "(net/http.ResponseWriter).Write"
+  gofmt:
+    simplify: true
   unused:
     # treat code as a program (not a library) and report unused
     # exported identifiers
     check-exported: true
-  errcheck:
-    exclude-functions:
-      - "(net/http.ResponseWriter).Write"
 issues:
   exclude-rules:
     - linters: [govet, errcheck, unused]

--- a/cmd/entrypoint/endpoint_routing_test.go
+++ b/cmd/entrypoint/endpoint_routing_test.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/emissary-ingress/emissary/v3/cmd/entrypoint"
 	"github.com/emissary-ingress/emissary/v3/pkg/ambex"
-	v3bootstrap "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/bootstrap/v3"
-	v3cluster "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/cluster/v3"
+	apiv3_bootstrap "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/bootstrap/v3"
+	apiv3_cluster "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/cluster/v3"
 	amb "github.com/emissary-ingress/emissary/v3/pkg/api/getambassador.io/v3alpha1"
 	"github.com/emissary-ingress/emissary/v3/pkg/kates"
 	"github.com/emissary-ingress/emissary/v3/pkg/snapshot/v1"
@@ -135,7 +135,7 @@ func TestEndpointRoutingIP(t *testing.T) {
 	f.Flush()
 
 	// Check that the envoy config embeds the IP address directly in the cluster config.
-	config, err := f.GetEnvoyConfig(func(config *v3bootstrap.Bootstrap) bool {
+	config, err := f.GetEnvoyConfig(func(config *apiv3_bootstrap.Bootstrap) bool {
 		return FindCluster(config, ClusterNameContains("4_3_2_1")) != nil
 	})
 	require.NoError(t, err)
@@ -180,8 +180,8 @@ spec:
 	assert.Equal(t, "1.2.3.4", endpoints.Entries["k8s/default/foo/80"][0].Ip)
 }
 
-func ClusterNameContains(substring string) func(*v3cluster.Cluster) bool {
-	return func(c *v3cluster.Cluster) bool {
+func ClusterNameContains(substring string) func(*apiv3_cluster.Cluster) bool {
+	return func(c *apiv3_cluster.Cluster) bool {
 		return strings.Contains(c.Name, substring)
 	}
 }

--- a/cmd/entrypoint/fswatcher.go
+++ b/cmd/entrypoint/fswatcher.go
@@ -11,8 +11,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/datawire/dlib/dlog"
 	"github.com/fsnotify/fsnotify"
+
+	"github.com/datawire/dlib/dlog"
 )
 
 // FSWatcher is a thing that can watch the filesystem for us, and

--- a/cmd/entrypoint/host_semantic_test.go
+++ b/cmd/entrypoint/host_semantic_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/emissary-ingress/emissary/v3/cmd/entrypoint"
-	bootstrap "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/bootstrap/v3"
+	apiv3_bootstrap "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/bootstrap/v3"
 	"github.com/emissary-ingress/emissary/v3/pkg/api/getambassador.io/v3alpha1"
 	"github.com/emissary-ingress/emissary/v3/pkg/kates"
 	"github.com/emissary-ingress/emissary/v3/pkg/snapshot/v1"
@@ -103,7 +103,7 @@ func testSemanticSet(t *testing.T, inputFile string, expectedFile string) {
 	require.NoError(t, err)
 	require.NotNil(t, snap)
 
-	envoyConfig, err := f.GetEnvoyConfig(func(config *bootstrap.Bootstrap) bool {
+	envoyConfig, err := f.GetEnvoyConfig(func(config *apiv3_bootstrap.Bootstrap) bool {
 		for _, cluster := range neededClusters {
 			if FindCluster(config, ClusterNameContains(cluster)) == nil {
 				return false

--- a/cmd/entrypoint/internal/testqueue/queue_test.go
+++ b/cmd/entrypoint/internal/testqueue/queue_test.go
@@ -4,8 +4,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/emissary-ingress/emissary/v3/cmd/entrypoint/internal/testqueue"
 	"github.com/stretchr/testify/require"
+
+	"github.com/emissary-ingress/emissary/v3/cmd/entrypoint/internal/testqueue"
 )
 
 func TestFakeQueueGet(t *testing.T) {

--- a/cmd/entrypoint/testutil_fake_collision_test.go
+++ b/cmd/entrypoint/testutil_fake_collision_test.go
@@ -8,12 +8,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/emissary-ingress/emissary/v3/cmd/entrypoint"
-	v3bootstrap "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/bootstrap/v3"
-	v3cluster "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/cluster/v3"
+	apiv3_bootstrap "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/bootstrap/v3"
+	apiv3_cluster "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/cluster/v3"
 )
 
-func ClusterHasAltName(altName string) func(*v3cluster.Cluster) bool {
-	return func(c *v3cluster.Cluster) bool {
+func ClusterHasAltName(altName string) func(*apiv3_cluster.Cluster) bool {
+	return func(c *apiv3_cluster.Cluster) bool {
 		return c.AltStatName == altName
 	}
 }
@@ -35,7 +35,7 @@ func TestFakeCollision(t *testing.T) {
 	// "subway_staging_stable_staging_3000", and one with an AltStatName of
 	// "subway_staging_stable_staging_3001".
 
-	envoyConfig, err := f.GetEnvoyConfig(func(config *v3bootstrap.Bootstrap) bool {
+	envoyConfig, err := f.GetEnvoyConfig(func(config *apiv3_bootstrap.Bootstrap) bool {
 		// Three clusters...
 		if len(config.StaticResources.Clusters) != 3 {
 			return false
@@ -121,7 +121,7 @@ func TestFakeCollision(t *testing.T) {
 	// AltStatName of "subway_staging_stable_staging_3000", like one of our original
 	// clusters.
 
-	envoyConfig, err = f.GetEnvoyConfig(func(config *v3bootstrap.Bootstrap) bool {
+	envoyConfig, err = f.GetEnvoyConfig(func(config *apiv3_bootstrap.Bootstrap) bool {
 		// Four clusters...
 		if len(config.StaticResources.Clusters) != 4 {
 			return false

--- a/cmd/entrypoint/testutil_fake_findutils_test.go
+++ b/cmd/entrypoint/testutil_fake_findutils_test.go
@@ -3,13 +3,14 @@ package entrypoint_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	bootstrap "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/bootstrap/v3"
 	v3listener "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/listener/v3"
 	route "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/route/v3"
 	http "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/extensions/filters/network/http_connection_manager/v3"
 	"github.com/emissary-ingress/emissary/v3/pkg/envoy-control-plane/resource/v3"
 	"github.com/emissary-ingress/emissary/v3/pkg/envoy-control-plane/wellknown"
-	"github.com/stretchr/testify/assert"
 )
 
 // findListener finds the first listener in a given Envoy configuration that matches a

--- a/cmd/entrypoint/testutil_fake_findutils_test.go
+++ b/cmd/entrypoint/testutil_fake_findutils_test.go
@@ -5,12 +5,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	bootstrap "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/bootstrap/v3"
-	v3listener "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/listener/v3"
-	route "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/route/v3"
-	http "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/extensions/filters/network/http_connection_manager/v3"
-	"github.com/emissary-ingress/emissary/v3/pkg/envoy-control-plane/resource/v3"
-	"github.com/emissary-ingress/emissary/v3/pkg/envoy-control-plane/wellknown"
+	apiv3_bootstrap "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/bootstrap/v3"
+	apiv3_listener "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/listener/v3"
+	apiv3_route "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/route/v3"
+	apiv3_httpman "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/extensions/filters/network/http_connection_manager/v3"
+	ecp_v3_resource "github.com/emissary-ingress/emissary/v3/pkg/envoy-control-plane/resource/v3"
+	ecp_wellknown "github.com/emissary-ingress/emissary/v3/pkg/envoy-control-plane/wellknown"
 )
 
 // findListener finds the first listener in a given Envoy configuration that matches a
@@ -18,7 +18,7 @@ import (
 //
 // Obviously, in a perfect world, the given predicate would be constructed to match only
 // a single listener...
-func findListener(envoyConfig *bootstrap.Bootstrap, predicate func(*v3listener.Listener) bool) *v3listener.Listener {
+func findListener(envoyConfig *apiv3_bootstrap.Bootstrap, predicate func(*apiv3_listener.Listener) bool) *apiv3_listener.Listener {
 	for _, listener := range envoyConfig.StaticResources.Listeners {
 		if predicate(listener) {
 			return listener
@@ -28,15 +28,15 @@ func findListener(envoyConfig *bootstrap.Bootstrap, predicate func(*v3listener.L
 }
 
 // findListenerByName finds uses findListener to find a listener with a given name.
-func findListenerByName(envoyConfig *bootstrap.Bootstrap, name string) *v3listener.Listener {
-	return findListener(envoyConfig, func(listener *v3listener.Listener) bool {
+func findListenerByName(envoyConfig *apiv3_bootstrap.Bootstrap, name string) *apiv3_listener.Listener {
+	return findListener(envoyConfig, func(listener *apiv3_listener.Listener) bool {
 		return listener.Name == name
 	})
 }
 
 // mustFindListenerByName looks for a listener with a given name, and asserts that it
 // must be present.
-func mustFindListenerByName(t *testing.T, envoyConfig *bootstrap.Bootstrap, name string) *v3listener.Listener {
+func mustFindListenerByName(t *testing.T, envoyConfig *apiv3_bootstrap.Bootstrap, name string) *apiv3_listener.Listener {
 	listener := findListenerByName(envoyConfig, name)
 	assert.NotNil(t, listener)
 	return listener
@@ -44,21 +44,21 @@ func mustFindListenerByName(t *testing.T, envoyConfig *bootstrap.Bootstrap, name
 
 // findRoutes finds all the routes within a given listener that match a
 // given predicate. If no matching routes are found, an empty list is returned.
-func findRoutes(listener *v3listener.Listener, predicate func(*route.Route) bool) []*route.Route {
-	routes := make([]*route.Route, 0)
+func findRoutes(listener *apiv3_listener.Listener, predicate func(*apiv3_route.Route) bool) []*apiv3_route.Route {
+	routes := make([]*apiv3_route.Route, 0)
 
 	// fmt.Printf("---- findRoutes\n")
 
 	for _, chain := range listener.FilterChains {
 		for _, filter := range chain.Filters {
-			if filter.Name != wellknown.HTTPConnectionManager {
+			if filter.Name != ecp_wellknown.HTTPConnectionManager {
 				continue
 			}
 
-			hcm := resource.GetHTTPConnectionManager(filter)
+			hcm := ecp_v3_resource.GetHTTPConnectionManager(filter)
 
 			if hcm != nil {
-				rs, ok := hcm.RouteSpecifier.(*http.HttpConnectionManager_RouteConfig)
+				rs, ok := hcm.RouteSpecifier.(*apiv3_httpman.HttpConnectionManager_RouteConfig)
 
 				if ok {
 					for _, vh := range rs.RouteConfig.VirtualHosts {
@@ -81,9 +81,9 @@ func findRoutes(listener *v3listener.Listener, predicate func(*route.Route) bool
 }
 
 // findRoutesToCluster finds all the routes in a listener that route to a given cluster.
-func findRoutesToCluster(l *v3listener.Listener, cluster_name string) []*route.Route {
-	return findRoutes(l, func(r *route.Route) bool {
-		routeAction, ok := r.Action.(*route.Route_Route)
+func findRoutesToCluster(l *apiv3_listener.Listener, cluster_name string) []*apiv3_route.Route {
+	return findRoutes(l, func(r *apiv3_route.Route) bool {
+		routeAction, ok := r.Action.(*apiv3_route.Route_Route)
 
 		if !ok {
 			return false
@@ -95,7 +95,7 @@ func findRoutesToCluster(l *v3listener.Listener, cluster_name string) []*route.R
 
 // mustFindRoutesToCluster uses findRoutesToCluster to find all the routes that route to
 // a given cluster, and asserts that some must be present.
-func mustFindRoutesToCluster(t *testing.T, listener *v3listener.Listener, cluster_name string) []*route.Route {
+func mustFindRoutesToCluster(t *testing.T, listener *apiv3_listener.Listener, cluster_name string) []*apiv3_route.Route {
 	routes := findRoutesToCluster(listener, cluster_name)
 	assert.NotEmpty(t, routes)
 	return routes
@@ -104,9 +104,9 @@ func mustFindRoutesToCluster(t *testing.T, listener *v3listener.Listener, cluste
 // findRouteAction finds uses findVirtualHostRoute to find a route whose action
 // is Route, and matches a given predicate. The RouteAction is returned if found; otherwise,
 // nil is returned.
-func findRouteAction(listener *v3listener.Listener, predicate func(*route.RouteAction) bool) *route.RouteAction {
-	routes := findRoutes(listener, func(r *route.Route) bool {
-		routeAction, ok := r.Action.(*route.Route_Route)
+func findRouteAction(listener *apiv3_listener.Listener, predicate func(*apiv3_route.RouteAction) bool) *apiv3_route.RouteAction {
+	routes := findRoutes(listener, func(r *apiv3_route.Route) bool {
+		routeAction, ok := r.Action.(*apiv3_route.Route_Route)
 
 		if ok {
 			return predicate(routeAction.Route)
@@ -119,12 +119,12 @@ func findRouteAction(listener *v3listener.Listener, predicate func(*route.RouteA
 		return nil
 	}
 
-	return routes[0].Action.(*route.Route_Route).Route
+	return routes[0].Action.(*apiv3_route.Route_Route).Route
 }
 
 // mustFindRouteAction wraps findVirtualHostRouteAction, and asserts that a
 // match is found.
-func mustFindRouteAction(t *testing.T, listener *v3listener.Listener, predicate func(*route.RouteAction) bool) *route.RouteAction {
+func mustFindRouteAction(t *testing.T, listener *apiv3_listener.Listener, predicate func(*apiv3_route.RouteAction) bool) *apiv3_route.RouteAction {
 	routeAction := findRouteAction(listener, predicate)
 	assert.NotNil(t, routeAction)
 	return routeAction
@@ -132,8 +132,8 @@ func mustFindRouteAction(t *testing.T, listener *v3listener.Listener, predicate 
 
 // mustFindRouteActionToCluster uses mustFindVirtualHostRouteAction to find a
 // route whose action routes to a given cluster name, and asserts that a match is found.
-func mustFindRouteActionToCluster(t *testing.T, listener *v3listener.Listener, clusterName string) *route.RouteAction {
-	routeAction := mustFindRouteAction(t, listener, func(ra *route.RouteAction) bool {
+func mustFindRouteActionToCluster(t *testing.T, listener *apiv3_listener.Listener, clusterName string) *apiv3_route.RouteAction {
+	routeAction := mustFindRouteAction(t, listener, func(ra *apiv3_route.RouteAction) bool {
 		return ra.GetCluster() == clusterName
 	})
 	return routeAction

--- a/cmd/entrypoint/testutil_fake_mapping_cors_test.go
+++ b/cmd/entrypoint/testutil_fake_mapping_cors_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/emissary-ingress/emissary/v3/cmd/entrypoint"
-	bootstrap "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/bootstrap/v3"
+	apiv3_bootstrap "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/bootstrap/v3"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -61,7 +61,7 @@ spec:
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
 
-	config, err := f.GetEnvoyConfig(func(config *bootstrap.Bootstrap) bool {
+	config, err := f.GetEnvoyConfig(func(config *apiv3_bootstrap.Bootstrap) bool {
 		return FindCluster(config, ClusterNameContains("cluster_foo_default_default")) != nil
 	})
 

--- a/cmd/entrypoint/testutil_fake_notifier_test_test.go
+++ b/cmd/entrypoint/testutil_fake_notifier_test_test.go
@@ -6,8 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/emissary-ingress/emissary/v3/cmd/entrypoint"
 	"github.com/stretchr/testify/require"
+
+	"github.com/emissary-ingress/emissary/v3/cmd/entrypoint"
 )
 
 func TestFakeNotifier(t *testing.T) {

--- a/cmd/entrypoint/testutil_fake_syntheticauth_test.go
+++ b/cmd/entrypoint/testutil_fake_syntheticauth_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/emissary-ingress/emissary/v3/cmd/entrypoint"
-	v3bootstrap "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/bootstrap/v3"
-	v3cluster "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/cluster/v3"
+	apiv3_bootstrap "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/bootstrap/v3"
+	apiv3_cluster "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/cluster/v3"
 	"github.com/emissary-ingress/emissary/v3/pkg/snapshot/v1"
 )
 
@@ -67,13 +67,13 @@ spec:
 			// (Http_Filters are harder to check since they always have the same name).
 			// The namespace for this extauthz cluster should be foo (since that is the
 			// namespace of the valid AuthService above).
-			isAuthCluster := func(c *v3cluster.Cluster) bool {
+			isAuthCluster := func(c *apiv3_cluster.Cluster) bool {
 				return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_foo")
 			}
 
 			// Grab the next Envoy config that has an Edge Stack auth cluster on
 			// 127.0.0.1:8500
-			envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
+			envoyConfig, err := f.GetEnvoyConfig(func(envoy *apiv3_bootstrap.Bootstrap) bool {
 				return FindCluster(envoy, isAuthCluster) != nil
 			})
 			require.NoError(t, err)
@@ -126,13 +126,13 @@ spec:
 			// (Http_Filters are harder to check since they always have the same name).
 			// The namespace for this extauthz cluster should be "foo" (since that is
 			// the namespace of the AuthService).
-			isAuthCluster := func(c *v3cluster.Cluster) bool {
+			isAuthCluster := func(c *apiv3_cluster.Cluster) bool {
 				return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_foo")
 			}
 
 			// Grab the next Envoy config that has an Edge Stack auth cluster on
 			// 127.0.0.1:8500
-			envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
+			envoyConfig, err := f.GetEnvoyConfig(func(envoy *apiv3_bootstrap.Bootstrap) bool {
 				return FindCluster(envoy, isAuthCluster) != nil
 			})
 			require.NoError(t, err)
@@ -188,13 +188,13 @@ spec:
 			// (Http_Filters are harder to check since they always have the same name).
 			// The namespace for this extauthz cluster should be "foo" (since that is
 			// the namespace of the valid AuthService above).
-			isAuthCluster := func(c *v3cluster.Cluster) bool {
+			isAuthCluster := func(c *apiv3_cluster.Cluster) bool {
 				return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_foo")
 			}
 
 			// Grab the next Envoy config that has an Edge Stack auth cluster on
 			// 127.0.0.1:8500
-			envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
+			envoyConfig, err := f.GetEnvoyConfig(func(envoy *apiv3_bootstrap.Bootstrap) bool {
 				return FindCluster(envoy, isAuthCluster) != nil
 			})
 			require.NoError(t, err)
@@ -245,12 +245,12 @@ spec:
 	// Check for an ext_authz cluster name matching the synthetic AuthService.  The namespace
 	// for this extauthz cluster should be default (since that is the namespace of the synthetic
 	// AuthService).
-	isAuthCluster := func(c *v3cluster.Cluster) bool {
+	isAuthCluster := func(c *apiv3_cluster.Cluster) bool {
 		return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_default")
 	}
 
 	// Grab the next Envoy config that has an Edge Stack auth cluster on 127.0.0.1:8500
-	envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
+	envoyConfig, err := f.GetEnvoyConfig(func(envoy *apiv3_bootstrap.Bootstrap) bool {
 		return FindCluster(envoy, isAuthCluster) != nil
 	})
 	require.NoError(t, err)
@@ -337,12 +337,12 @@ spec:
 	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are
 	// harder to check since they always have the same name).  The namespace for this extauthz
 	// cluster should be foo (since that is the namespace of the valid AuthService above)
-	isAuthCluster := func(c *v3cluster.Cluster) bool {
+	isAuthCluster := func(c *apiv3_cluster.Cluster) bool {
 		return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_foo")
 	}
 
 	// Grab the next Envoy config that has an Edge Stack auth cluster on 127.0.0.1:8500
-	envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
+	envoyConfig, err := f.GetEnvoyConfig(func(envoy *apiv3_bootstrap.Bootstrap) bool {
 		return FindCluster(envoy, isAuthCluster) != nil
 	})
 	require.NoError(t, err)
@@ -390,12 +390,12 @@ spec:
 	// Check for an ext_authz cluster name matching the synthetic AuthService.  The namespace
 	// for this extauthz cluster should be default (since that is the namespace of the synthetic
 	// AuthService).
-	isAuthCluster := func(c *v3cluster.Cluster) bool {
+	isAuthCluster := func(c *apiv3_cluster.Cluster) bool {
 		return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_default")
 	}
 
 	// Grab the next Envoy config that has an Edge Stack auth cluster on 127.0.0.1:8500
-	envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
+	envoyConfig, err := f.GetEnvoyConfig(func(envoy *apiv3_bootstrap.Bootstrap) bool {
 		return FindCluster(envoy, isAuthCluster) != nil
 	})
 	require.NoError(t, err)
@@ -435,12 +435,12 @@ spec:
 	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are
 	// harder to check since they always have the same name).  The namespace for this extauthz
 	// cluster should be foo (since that is the namespace of the valid AuthService above).
-	isAuthCluster = func(c *v3cluster.Cluster) bool {
+	isAuthCluster = func(c *apiv3_cluster.Cluster) bool {
 		return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_foo")
 	}
 
 	// Grab the next Envoy config that has an Edge Stack auth cluster on 127.0.0.1:8500
-	envoyConfig, err = f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
+	envoyConfig, err = f.GetEnvoyConfig(func(envoy *apiv3_bootstrap.Bootstrap) bool {
 		return FindCluster(envoy, isAuthCluster) != nil
 	})
 	require.NoError(t, err)
@@ -490,12 +490,12 @@ spec:
 	// Check for an ext_authz cluster name matching the synthetic AuthService.  The namespace
 	// for this extauthz cluster should be default (since that is the namespace of the synthetic
 	// AuthService).
-	isAuthCluster := func(c *v3cluster.Cluster) bool {
+	isAuthCluster := func(c *apiv3_cluster.Cluster) bool {
 		return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_foo")
 	}
 
 	// Grab the next Envoy config that has an Edge Stack auth cluster on 127.0.0.1:8500
-	envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
+	envoyConfig, err := f.GetEnvoyConfig(func(envoy *apiv3_bootstrap.Bootstrap) bool {
 		return FindCluster(envoy, isAuthCluster) != nil
 	})
 	require.NoError(t, err)
@@ -546,12 +546,12 @@ spec:
 	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are
 	// harder to check since they always have the same name).  the namespace for this extauthz
 	// cluster should be foo (since that is the namespace of the valid AuthService above).
-	isAuthCluster := func(c *v3cluster.Cluster) bool {
+	isAuthCluster := func(c *apiv3_cluster.Cluster) bool {
 		return strings.Contains(c.Name, "cluster_extauth_dummy_service_foo")
 	}
 
 	// Grab the next Envoy config that has an Edge Stack auth cluster on 127.0.0.1:8500
-	envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
+	envoyConfig, err := f.GetEnvoyConfig(func(envoy *apiv3_bootstrap.Bootstrap) bool {
 		return FindCluster(envoy, isAuthCluster) != nil
 	})
 	require.NoError(t, err)

--- a/cmd/entrypoint/testutil_fake_syntheticratelimit_test.go
+++ b/cmd/entrypoint/testutil_fake_syntheticratelimit_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/emissary-ingress/emissary/v3/cmd/entrypoint"
-	v3bootstrap "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/bootstrap/v3"
-	v3cluster "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/cluster/v3"
+	apiv3_bootstrap "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/bootstrap/v3"
+	apiv3_cluster "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/cluster/v3"
 	"github.com/emissary-ingress/emissary/v3/pkg/snapshot/v1"
 )
 
@@ -63,13 +63,13 @@ spec:
 			assert.Equal(t, "edge-stack-ratelimit-test", snap.Kubernetes.RateLimitServices[0].Name)
 
 			// Check for a cluster name matching the provided RateLimitService
-			isRateLimitCluster := func(c *v3cluster.Cluster) bool {
+			isRateLimitCluster := func(c *apiv3_cluster.Cluster) bool {
 				return strings.Contains(c.Name, "cluster_127_0_0_1_8500_foo")
 			}
 
 			// Grab the next Envoy config that has an Edge Stack ratelimit cluster on
 			// 127.0.0.1:8500
-			envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
+			envoyConfig, err := f.GetEnvoyConfig(func(envoy *apiv3_bootstrap.Bootstrap) bool {
 				return FindCluster(envoy, isRateLimitCluster) != nil
 			})
 			require.NoError(t, err)
@@ -118,13 +118,13 @@ spec:
 			assert.Equal(t, "v3", snap.Kubernetes.RateLimitServices[0].Spec.ProtocolVersion)
 
 			// Check for a cluster name matching the provided RateLimitService
-			isRateLimitCluster := func(c *v3cluster.Cluster) bool {
+			isRateLimitCluster := func(c *apiv3_cluster.Cluster) bool {
 				return strings.Contains(c.Name, "cluster_127_0_0_1_8500_foo")
 			}
 
 			// Grab the next Envoy config that has an Edge Stack rateLimit cluster on
 			// 127.0.0.1:8500
-			envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
+			envoyConfig, err := f.GetEnvoyConfig(func(envoy *apiv3_bootstrap.Bootstrap) bool {
 				return FindCluster(envoy, isRateLimitCluster) != nil
 			})
 			require.NoError(t, err)
@@ -175,13 +175,13 @@ spec:
 			assert.Equal(t, "edge-stack-ratelimit-test", snap.Kubernetes.RateLimitServices[0].Name)
 
 			// Check for a cluster name matching the provided RateLimitService
-			isRateLimitCluster := func(c *v3cluster.Cluster) bool {
+			isRateLimitCluster := func(c *apiv3_cluster.Cluster) bool {
 				return strings.Contains(c.Name, "cluster_127_0_0_1_8500_foo")
 			}
 
 			// Grab the next Envoy config that has an Edge Stack rateLimit cluster on
 			// 127.0.0.1:8500
-			envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
+			envoyConfig, err := f.GetEnvoyConfig(func(envoy *apiv3_bootstrap.Bootstrap) bool {
 				return FindCluster(envoy, isRateLimitCluster) != nil
 			})
 			require.NoError(t, err)
@@ -228,13 +228,13 @@ spec:
 	assert.Equal(t, "synthetic_edge_stack_rate_limit", snap.Kubernetes.RateLimitServices[0].Name)
 
 	// Check for a cluster name matching the provided RateLimitService
-	isRateLimitCluster := func(c *v3cluster.Cluster) bool {
+	isRateLimitCluster := func(c *apiv3_cluster.Cluster) bool {
 		return strings.Contains(c.Name, "cluster_127_0_0_1_8500_default")
 	}
 
 	// Grab the next Envoy config that has an Edge Stack rateLimit cluster on
 	// 127.0.0.1:8500
-	envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
+	envoyConfig, err := f.GetEnvoyConfig(func(envoy *apiv3_bootstrap.Bootstrap) bool {
 		return FindCluster(envoy, isRateLimitCluster) != nil
 	})
 	require.NoError(t, err)
@@ -315,13 +315,13 @@ spec:
 	assert.Equal(t, "edge-stack-ratelimit-test", snap.Kubernetes.RateLimitServices[0].Name)
 
 	// Check for a cluster name matching the provided RateLimitService
-	isRateLimitCluster := func(c *v3cluster.Cluster) bool {
+	isRateLimitCluster := func(c *apiv3_cluster.Cluster) bool {
 		return strings.Contains(c.Name, "cluster_127_0_0_1_8500_foo")
 	}
 
 	// Grab the next Envoy config that has an Edge Stack rateLimit cluster on
 	// 127.0.0.1:8500
-	envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
+	envoyConfig, err := f.GetEnvoyConfig(func(envoy *apiv3_bootstrap.Bootstrap) bool {
 		return FindCluster(envoy, isRateLimitCluster) != nil
 	})
 	require.NoError(t, err)
@@ -367,13 +367,13 @@ spec:
 	assert.Equal(t, "synthetic_edge_stack_rate_limit", snap.Kubernetes.RateLimitServices[0].Name)
 
 	// Check for a cluster name matching the provided RateLimitService
-	isRateLimitCluster := func(c *v3cluster.Cluster) bool {
+	isRateLimitCluster := func(c *apiv3_cluster.Cluster) bool {
 		return strings.Contains(c.Name, "cluster_127_0_0_1_8500_default")
 	}
 
 	// Grab the next Envoy config that has an Edge Stack rateLimit cluster on
 	// 127.0.0.1:8500
-	envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
+	envoyConfig, err := f.GetEnvoyConfig(func(envoy *apiv3_bootstrap.Bootstrap) bool {
 		return FindCluster(envoy, isRateLimitCluster) != nil
 	})
 	require.NoError(t, err)
@@ -410,13 +410,13 @@ spec:
 	assert.Equal(t, "edge-stack-ratelimit-test", snap.Kubernetes.RateLimitServices[0].Name)
 
 	// Check for a cluster name matching the provided RateLimitService
-	isRateLimitCluster = func(c *v3cluster.Cluster) bool {
+	isRateLimitCluster = func(c *apiv3_cluster.Cluster) bool {
 		return strings.Contains(c.Name, "cluster_127_0_0_1_8500_foo")
 	}
 
 	// Grab the next Envoy config that has an Edge Stack rateLimit cluster on
 	// 127.0.0.1:8500
-	envoyConfig, err = f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
+	envoyConfig, err = f.GetEnvoyConfig(func(envoy *apiv3_bootstrap.Bootstrap) bool {
 		return FindCluster(envoy, isRateLimitCluster) != nil
 	})
 	require.NoError(t, err)
@@ -462,13 +462,13 @@ spec:
 	assert.Equal(t, "v3", snap.Kubernetes.RateLimitServices[0].Spec.ProtocolVersion)
 
 	// Check for a cluster name matching the provided RateLimitService
-	isRateLimitCluster := func(c *v3cluster.Cluster) bool {
+	isRateLimitCluster := func(c *apiv3_cluster.Cluster) bool {
 		return strings.Contains(c.Name, "cluster_127_0_0_1_8500_foo")
 	}
 
 	// Grab the next Envoy config that has an Edge Stack rateLimit cluster on
 	// 127.0.0.1:8500
-	envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
+	envoyConfig, err := f.GetEnvoyConfig(func(envoy *apiv3_bootstrap.Bootstrap) bool {
 		return FindCluster(envoy, isRateLimitCluster) != nil
 	})
 	require.NoError(t, err)

--- a/cmd/entrypoint/testutil_fake_test.go
+++ b/cmd/entrypoint/testutil_fake_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/datawire/dlib/dlog"
 	"github.com/emissary-ingress/emissary/v3/cmd/entrypoint/internal/testqueue"
 	"github.com/emissary-ingress/emissary/v3/pkg/ambex"
-	v3bootstrap "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/bootstrap/v3"
+	apiv3_bootstrap "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/bootstrap/v3"
 	amb "github.com/emissary-ingress/emissary/v3/pkg/api/getambassador.io/v3alpha1"
 	"github.com/emissary-ingress/emissary/v3/pkg/consulwatch"
 	"github.com/emissary-ingress/emissary/v3/pkg/kates"
@@ -360,20 +360,20 @@ func (f *Fake) appendEnvoyConfig(ctx context.Context) {
 	if err != nil {
 		f.T.Fatalf("error decoding envoy.json after sending snapshot to python: %+v", err)
 	}
-	bs := msg.(*v3bootstrap.Bootstrap)
+	bs := msg.(*apiv3_bootstrap.Bootstrap)
 	f.envoyConfigs.Add(f.T, bs)
 }
 
 // GetEnvoyConfig will return the next envoy config that satisfies the supplied predicate.
-func (f *Fake) GetEnvoyConfig(predicate func(*v3bootstrap.Bootstrap) bool) (*v3bootstrap.Bootstrap, error) {
+func (f *Fake) GetEnvoyConfig(predicate func(*apiv3_bootstrap.Bootstrap) bool) (*apiv3_bootstrap.Bootstrap, error) {
 	f.T.Helper()
 	untyped, err := f.envoyConfigs.Get(f.T, func(obj interface{}) bool {
-		return predicate(obj.(*v3bootstrap.Bootstrap))
+		return predicate(obj.(*apiv3_bootstrap.Bootstrap))
 	})
 	if err != nil {
 		return nil, err
 	}
-	return untyped.(*v3bootstrap.Bootstrap), nil
+	return untyped.(*apiv3_bootstrap.Bootstrap), nil
 }
 
 // AutoFlush will cause a flush whenever any inputs are modified.

--- a/cmd/entrypoint/testutil_fake_test_test.go
+++ b/cmd/entrypoint/testutil_fake_test_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/emissary-ingress/emissary/v3/cmd/entrypoint"
-	v3bootstrap "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/bootstrap/v3"
-	v3 "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/type/v3"
+	apiv3_bootstrap "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/bootstrap/v3"
+	apiv3_type "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/type/v3"
 	"github.com/emissary-ingress/emissary/v3/pkg/kates"
 	"github.com/emissary-ingress/emissary/v3/pkg/snapshot/v1"
 )
@@ -18,7 +18,7 @@ func AnySnapshot(_ *snapshot.Snapshot) bool {
 	return true
 }
 
-func AnyConfig(_ *v3bootstrap.Bootstrap) bool {
+func AnyConfig(_ *apiv3_bootstrap.Bootstrap) bool {
 	return true
 }
 
@@ -60,7 +60,7 @@ func TestFake(t *testing.T) {
 
 }
 
-func assertRoutePresent(t *testing.T, envoyConfig *v3bootstrap.Bootstrap, cluster string, weight int) {
+func assertRoutePresent(t *testing.T, envoyConfig *apiv3_bootstrap.Bootstrap, cluster string, weight int) {
 	t.Helper()
 
 	listener := mustFindListenerByName(t, envoyConfig, "ambassador-listener-8080")
@@ -68,11 +68,11 @@ func assertRoutePresent(t *testing.T, envoyConfig *v3bootstrap.Bootstrap, cluste
 
 	for _, r := range routes {
 		assert.Equal(t, uint32(weight), r.Match.RuntimeFraction.DefaultValue.Numerator)
-		assert.Equal(t, v3.FractionalPercent_HUNDRED, r.Match.RuntimeFraction.DefaultValue.Denominator)
+		assert.Equal(t, apiv3_type.FractionalPercent_HUNDRED, r.Match.RuntimeFraction.DefaultValue.Denominator)
 	}
 }
 
-func assertRouteNotPresent(t *testing.T, envoyConfig *v3bootstrap.Bootstrap, cluster string) {
+func assertRouteNotPresent(t *testing.T, envoyConfig *apiv3_bootstrap.Bootstrap, cluster string) {
 	t.Helper()
 
 	listener := mustFindListenerByName(t, envoyConfig, "ambassador-listener-8080")
@@ -82,8 +82,8 @@ func assertRouteNotPresent(t *testing.T, envoyConfig *v3bootstrap.Bootstrap, clu
 }
 
 func TestWeightWithCache(t *testing.T) {
-	get_envoy_config := func(f *entrypoint.Fake, want_foo bool, want_bar bool) (*v3bootstrap.Bootstrap, error) {
-		return f.GetEnvoyConfig(func(config *v3bootstrap.Bootstrap) bool {
+	get_envoy_config := func(f *entrypoint.Fake, want_foo bool, want_bar bool) (*apiv3_bootstrap.Bootstrap, error) {
+		return f.GetEnvoyConfig(func(config *apiv3_bootstrap.Bootstrap) bool {
 			c_foo := FindCluster(config, ClusterNameContains("cluster_foo_"))
 			c_bar := FindCluster(config, ClusterNameContains("cluster_bar_"))
 

--- a/cmd/example-envoy-metrics-sink/main.go
+++ b/cmd/example-envoy-metrics-sink/main.go
@@ -5,10 +5,11 @@ import (
 	"io"
 	"os"
 
-	"github.com/datawire/dlib/dhttp"
-	"github.com/datawire/dlib/dlog"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/encoding/protojson"
+
+	"github.com/datawire/dlib/dhttp"
+	"github.com/datawire/dlib/dlog"
 
 	v2_metrics "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/service/metrics/v2"
 )

--- a/cmd/example-envoy-metrics-sink/main.go
+++ b/cmd/example-envoy-metrics-sink/main.go
@@ -11,18 +11,18 @@ import (
 	"github.com/datawire/dlib/dhttp"
 	"github.com/datawire/dlib/dlog"
 
-	v2_metrics "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/service/metrics/v2"
+	apiv2_svc_metrics "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/service/metrics/v2"
 )
 
 type server struct{}
 
-var _ v2_metrics.MetricsServiceServer = &server{}
+var _ apiv2_svc_metrics.MetricsServiceServer = &server{}
 
 func main() {
 	ctx := context.Background()
 
 	grpcMux := grpc.NewServer()
-	v2_metrics.RegisterMetricsServiceServer(grpcMux, &server{})
+	apiv2_svc_metrics.RegisterMetricsServiceServer(grpcMux, &server{})
 
 	sc := &dhttp.ServerConfig{
 		Handler: grpcMux,
@@ -38,7 +38,7 @@ func main() {
 	dlog.Print(ctx, "shut down without error")
 }
 
-func (s *server) StreamMetrics(stream v2_metrics.MetricsService_StreamMetricsServer) error {
+func (s *server) StreamMetrics(stream apiv2_svc_metrics.MetricsService_StreamMetricsServer) error {
 	dlog.Println(stream.Context(), "Started stream")
 	for {
 		in, err := stream.Recv()

--- a/cmd/kat-server/services/grpc-auth-v2.go
+++ b/cmd/kat-server/services/grpc-auth-v2.go
@@ -17,9 +17,9 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	// first party (protobuf)
-	core "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/api/v2/core"
-	pb "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/service/auth/v2"
-	envoy_type "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/type"
+	apiv2_core "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/api/v2/core"
+	apiv2_svc_auth "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/service/auth/v2"
+	apiv2_type "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/type"
 
 	// first party
 	"github.com/datawire/dlib/dgroup"
@@ -44,7 +44,7 @@ func (g *GRPCAuthV2) Start(ctx context.Context) <-chan bool {
 
 	grpcHandler := grpc.NewServer()
 	dlog.Printf(ctx, "registering v2 service")
-	pb.RegisterAuthorizationServer(grpcHandler, g)
+	apiv2_svc_auth.RegisterAuthorizationServer(grpcHandler, g)
 
 	cer, err := tls.LoadX509KeyPair(g.Cert, g.Key)
 	if err != nil {
@@ -81,7 +81,7 @@ func (g *GRPCAuthV2) Start(ctx context.Context) <-chan bool {
 }
 
 // Check checks the request object.
-func (g *GRPCAuthV2) Check(ctx context.Context, r *pb.CheckRequest) (*pb.CheckResponse, error) {
+func (g *GRPCAuthV2) Check(ctx context.Context, r *apiv2_svc_auth.CheckRequest) (*apiv2_svc_auth.CheckResponse, error) {
 	rs := &ResponseV2{}
 
 	rheader := r.GetAttributes().GetRequest().GetHttp().GetHeaders()
@@ -106,7 +106,7 @@ func (g *GRPCAuthV2) Check(ctx context.Context, r *pb.CheckRequest) (*pb.CheckRe
 	rs.AddHeader(false, "kat-resp-extauth-protocol-version", g.ProtocolVersion)
 
 	// Sets requested headers.
-	// Don't bother if we'll be returning a pb.CheckResponse_OkResponse; it'd be a no-op in that case.
+	// Don't bother if we'll be returning a apiv2_svc_auth.CheckResponse_OkResponse; it'd be a no-op in that case.
 	if rs.status != http.StatusOK && rs.status != 0 {
 		for _, key := range strings.Split(strings.ToLower(rheader["kat-req-extauth-requested-header"]), ",") {
 			if val := rheader[key]; val != "" {
@@ -185,7 +185,7 @@ func (g *GRPCAuthV2) Check(ctx context.Context, r *pb.CheckRequest) (*pb.CheckRe
 
 // ResponseV2 constructs an authorization response object.
 type ResponseV2 struct {
-	headers []*core.HeaderValueOption
+	headers []*apiv2_core.HeaderValueOption
 	body    string
 	status  uint32
 }
@@ -193,8 +193,8 @@ type ResponseV2 struct {
 // AddHeader adds a header to the response. When append param is true, Envoy will
 // append the value to an existent request header instead of overriding it.
 func (r *ResponseV2) AddHeader(a bool, k, v string) {
-	val := &core.HeaderValueOption{
-		Header: &core.HeaderValue{
+	val := &apiv2_core.HeaderValueOption{
+		Header: &apiv2_core.HeaderValue{
 			Key:   k,
 			Value: v,
 		},
@@ -239,14 +239,14 @@ func (r *ResponseV2) GetStatus() uint32 {
 }
 
 // GetResponse returns the gRPC authorization response object.
-func (r *ResponseV2) GetResponse() *pb.CheckResponse {
-	rs := &pb.CheckResponse{}
+func (r *ResponseV2) GetResponse() *apiv2_svc_auth.CheckResponse {
+	rs := &apiv2_svc_auth.CheckResponse{}
 	switch {
 	// Ok respose.
 	case r.status == http.StatusOK || r.status == 0:
 		rs.Status = &status.Status{Code: int32(code.Code_OK)}
-		rs.HttpResponse = &pb.CheckResponse_OkResponse{
-			OkResponse: &pb.OkHttpResponse{
+		rs.HttpResponse = &apiv2_svc_auth.CheckResponse_OkResponse{
+			OkResponse: &apiv2_svc_auth.OkHttpResponse{
 				Headers: r.headers,
 			},
 		}
@@ -254,10 +254,10 @@ func (r *ResponseV2) GetResponse() *pb.CheckResponse {
 	// Denied response.
 	default:
 		rs.Status = &status.Status{Code: int32(code.Code_UNAUTHENTICATED)}
-		rs.HttpResponse = &pb.CheckResponse_DeniedResponse{
-			DeniedResponse: &pb.DeniedHttpResponse{
-				Status: &envoy_type.HttpStatus{
-					Code: envoy_type.StatusCode(r.status),
+		rs.HttpResponse = &apiv2_svc_auth.CheckResponse_DeniedResponse{
+			DeniedResponse: &apiv2_svc_auth.DeniedHttpResponse{
+				Status: &apiv2_type.HttpStatus{
+					Code: apiv2_type.StatusCode(r.status),
 				},
 				Headers: r.headers,
 				Body:    r.body,

--- a/cmd/kat-server/services/grpc-rls-v3.go
+++ b/cmd/kat-server/services/grpc-rls-v3.go
@@ -14,8 +14,8 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	// first party (protobuf)
-	core "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/core/v3"
-	pb "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/service/ratelimit/v3"
+	apiv3_core "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/core/v3"
+	apiv3_svc_ratelimit "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/service/ratelimit/v3"
 
 	// first party
 	"github.com/datawire/dlib/dgroup"
@@ -40,7 +40,7 @@ func (g *GRPCRLSV3) Start(ctx context.Context) <-chan bool {
 
 	grpcHandler := grpc.NewServer()
 	dlog.Printf(ctx, "registering v3 service")
-	pb.RegisterRateLimitServiceServer(grpcHandler, g)
+	apiv3_svc_ratelimit.RegisterRateLimitServiceServer(grpcHandler, g)
 
 	cer, err := tls.LoadX509KeyPair(g.Cert, g.Key)
 	if err != nil {
@@ -77,7 +77,7 @@ func (g *GRPCRLSV3) Start(ctx context.Context) <-chan bool {
 }
 
 // Check checks the request object.
-func (g *GRPCRLSV3) ShouldRateLimit(ctx context.Context, r *pb.RateLimitRequest) (*pb.RateLimitResponse, error) {
+func (g *GRPCRLSV3) ShouldRateLimit(ctx context.Context, r *apiv3_svc_ratelimit.RateLimitRequest) (*apiv3_svc_ratelimit.RateLimitResponse, error) {
 	rs := &RLSResponseV3{}
 
 	dlog.Printf(ctx, "shouldRateLimit descriptors: %v\n", r.Descriptors)
@@ -92,9 +92,9 @@ func (g *GRPCRLSV3) ShouldRateLimit(ctx context.Context, r *pb.RateLimitRequest)
 	// Sets overallCode. If x-ambassador-test-allow is present and has value "true", then
 	// respond with OK. In any other case, respond with OVER_LIMIT.
 	if allowValue := descEntries["kat-req-rls-allow"]; allowValue == "true" {
-		rs.SetOverallCode(pb.RateLimitResponse_OK)
+		rs.SetOverallCode(apiv3_svc_ratelimit.RateLimitResponse_OK)
 	} else {
-		rs.SetOverallCode(pb.RateLimitResponse_OVER_LIMIT)
+		rs.SetOverallCode(apiv3_svc_ratelimit.RateLimitResponse_OVER_LIMIT)
 
 		// Response headers and body only make sense when the overall code is not OK,
 		// so we append them here, if they exist.
@@ -136,16 +136,16 @@ func (g *GRPCRLSV3) ShouldRateLimit(ctx context.Context, r *pb.RateLimitRequest)
 
 // RLSResponseV3 constructs an rls response object.
 type RLSResponseV3 struct {
-	headers     []*core.HeaderValueOption
+	headers     []*apiv3_core.HeaderValueOption
 	body        string
-	overallCode pb.RateLimitResponse_Code
+	overallCode apiv3_svc_ratelimit.RateLimitResponse_Code
 }
 
 // AddHeader adds a header to the response. When append param is true, Envoy will
 // append the value to an existent request header instead of overriding it.
 func (r *RLSResponseV3) AddHeader(a bool, k, v string) {
-	val := &core.HeaderValueOption{
-		Header: &core.HeaderValue{
+	val := &apiv3_core.HeaderValueOption{
+		Header: &apiv3_core.HeaderValue{
 			Key:   k,
 			Value: v,
 		},
@@ -169,25 +169,25 @@ func (r *RLSResponseV3) SetBody(s string) {
 }
 
 // SetOverallCode sets the rls response HTTP status code.
-func (r *RLSResponseV3) SetOverallCode(code pb.RateLimitResponse_Code) {
+func (r *RLSResponseV3) SetOverallCode(code apiv3_svc_ratelimit.RateLimitResponse_Code) {
 	r.overallCode = code
 }
 
 // GetOverallCode returns the rls response HTTP status code.
-func (r *RLSResponseV3) GetOverallCode() pb.RateLimitResponse_Code {
+func (r *RLSResponseV3) GetOverallCode() apiv3_svc_ratelimit.RateLimitResponse_Code {
 	return r.overallCode
 }
 
 // GetResponse returns the gRPC rls response object.
-func (r *RLSResponseV3) GetResponse() *pb.RateLimitResponse {
-	rs := &pb.RateLimitResponse{}
+func (r *RLSResponseV3) GetResponse() *apiv3_svc_ratelimit.RateLimitResponse {
+	rs := &apiv3_svc_ratelimit.RateLimitResponse{}
 	rs.OverallCode = r.overallCode
 	rs.RawBody = []byte(r.body)
 	for _, h := range r.headers {
 		hdr := h.Header
 		if hdr != nil {
 			rs.ResponseHeadersToAdd = append(rs.ResponseHeadersToAdd,
-				&core.HeaderValue{
+				&apiv3_core.HeaderValue{
 					Key:   hdr.Key,
 					Value: hdr.Value,
 				},

--- a/cmd/reproducer/manifests.go
+++ b/cmd/reproducer/manifests.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/emissary-ingress/emissary/v3/pkg/kates"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/yaml"
+
+	"github.com/emissary-ingress/emissary/v3/pkg/kates"
 )
 
 func marshalManifests(manifests []*kates.Unstructured) ([]byte, error) {

--- a/pkg/ambex/endpoint.go
+++ b/pkg/ambex/endpoint.go
@@ -5,8 +5,8 @@ import (
 	"sort"
 	"strings"
 
-	v3core "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/core/v3"
-	v3endpoint "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/endpoint/v3"
+	apiv3_core "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/core/v3"
+	apiv3_endpoint "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/endpoint/v3"
 )
 
 // The Endpoints struct is how Endpoint data gets communicated to ambex. This is a bit simpler than
@@ -32,16 +32,16 @@ func (e *Endpoints) RoutesString() string {
 }
 
 // ToMap_v3 produces a map with the envoy v3 friendly forms of all the endpoint data.
-func (e *Endpoints) ToMap_v3() map[string]*v3endpoint.ClusterLoadAssignment {
-	result := map[string]*v3endpoint.ClusterLoadAssignment{}
+func (e *Endpoints) ToMap_v3() map[string]*apiv3_endpoint.ClusterLoadAssignment {
+	result := map[string]*apiv3_endpoint.ClusterLoadAssignment{}
 	for name, eps := range e.Entries {
-		var endpoints []*v3endpoint.LbEndpoint
+		var endpoints []*apiv3_endpoint.LbEndpoint
 		for _, ep := range eps {
 			endpoints = append(endpoints, ep.ToLbEndpoint_v3())
 		}
-		loadAssignment := &v3endpoint.ClusterLoadAssignment{
+		loadAssignment := &apiv3_endpoint.ClusterLoadAssignment{
 			ClusterName: name,
-			Endpoints:   []*v3endpoint.LocalityLbEndpoints{{LbEndpoints: endpoints}},
+			Endpoints:   []*apiv3_endpoint.LocalityLbEndpoints{{LbEndpoints: endpoints}},
 		}
 		result[name] = loadAssignment
 	}
@@ -57,16 +57,16 @@ type Endpoint struct {
 }
 
 // ToLBEndpoint_v3 translates to envoy v3 frinedly form of the Endpoint data.
-func (e *Endpoint) ToLbEndpoint_v3() *v3endpoint.LbEndpoint {
-	return &v3endpoint.LbEndpoint{
-		HostIdentifier: &v3endpoint.LbEndpoint_Endpoint{
-			Endpoint: &v3endpoint.Endpoint{
-				Address: &v3core.Address{
-					Address: &v3core.Address_SocketAddress{
-						SocketAddress: &v3core.SocketAddress{
-							Protocol: v3core.SocketAddress_Protocol(v3core.SocketAddress_Protocol_value[e.Protocol]),
+func (e *Endpoint) ToLbEndpoint_v3() *apiv3_endpoint.LbEndpoint {
+	return &apiv3_endpoint.LbEndpoint{
+		HostIdentifier: &apiv3_endpoint.LbEndpoint_Endpoint{
+			Endpoint: &apiv3_endpoint.Endpoint{
+				Address: &apiv3_core.Address{
+					Address: &apiv3_core.Address_SocketAddress{
+						SocketAddress: &apiv3_core.SocketAddress{
+							Protocol: apiv3_core.SocketAddress_Protocol(apiv3_core.SocketAddress_Protocol_value[e.Protocol]),
 							Address:  e.Ip,
-							PortSpecifier: &v3core.SocketAddress_PortValue{
+							PortSpecifier: &apiv3_core.SocketAddress_PortValue{
 								PortValue: e.Port,
 							},
 							Ipv4Compat: true,

--- a/pkg/ambex/main.go
+++ b/pkg/ambex/main.go
@@ -74,12 +74,12 @@ import (
 	// generated Envoy config, even if that package is otherwise not used by ambex.
 
 	_ "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/accesslog/v3"
-	v3bootstrap "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/bootstrap/v3"
-	v3clusterconfig "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/cluster/v3"
-	v3core "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/core/v3"
-	v3endpointconfig "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/endpoint/v3"
-	v3listenerconfig "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/listener/v3"
-	v3routeconfig "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/route/v3"
+	apiv3_bootstrap "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/bootstrap/v3"
+	apiv3_cluster "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/cluster/v3"
+	apiv3_core "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/core/v3"
+	apiv3_endpoint "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/endpoint/v3"
+	apiv3_listener "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/listener/v3"
+	apiv3_route "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/route/v3"
 	_ "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/extensions/access_loggers/file/v3"
 	_ "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/extensions/access_loggers/grpc/v3"
 	_ "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/extensions/compression/gzip/compressor/v3"
@@ -97,12 +97,12 @@ import (
 	_ "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/extensions/filters/network/http_connection_manager/v3"
 	_ "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/extensions/filters/network/tcp_proxy/v3"
 	_ "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/extensions/transport_sockets/quic/v3"
-	v3cluster "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/service/cluster/v3"
-	v3discovery "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/service/discovery/v3"
-	v3endpoint "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/service/endpoint/v3"
-	v3listener "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/service/listener/v3"
-	v3route "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/service/route/v3"
-	v3runtime "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/service/runtime/v3"
+	apiv3_svc_cluster "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/service/cluster/v3"
+	apiv3_svc_discovery "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/service/discovery/v3"
+	apiv3_svc_endpoint "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/service/endpoint/v3"
+	apiv3_svc_listener "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/service/listener/v3"
+	apiv3_svc_route "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/service/route/v3"
+	apiv3_svc_runtime "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/service/runtime/v3"
 
 	// first-party libraries
 	"github.com/datawire/dlib/dgroup"
@@ -195,7 +195,7 @@ type HasherV3 struct {
 }
 
 // ID function
-func (h HasherV3) ID(node *v3core.Node) string {
+func (h HasherV3) ID(node *apiv3_core.Node) string {
 	if node == nil {
 		return "unknown"
 	}
@@ -215,11 +215,11 @@ func runManagementServer(ctx context.Context, serverv3 ecp_v3_server.Server, ads
 	}
 
 	// register services
-	v3discovery.RegisterAggregatedDiscoveryServiceServer(grpcServer, serverv3)
-	v3endpoint.RegisterEndpointDiscoveryServiceServer(grpcServer, serverv3)
-	v3cluster.RegisterClusterDiscoveryServiceServer(grpcServer, serverv3)
-	v3route.RegisterRouteDiscoveryServiceServer(grpcServer, serverv3)
-	v3listener.RegisterListenerDiscoveryServiceServer(grpcServer, serverv3)
+	apiv3_svc_discovery.RegisterAggregatedDiscoveryServiceServer(grpcServer, serverv3)
+	apiv3_svc_endpoint.RegisterEndpointDiscoveryServiceServer(grpcServer, serverv3)
+	apiv3_svc_cluster.RegisterClusterDiscoveryServiceServer(grpcServer, serverv3)
+	apiv3_svc_route.RegisterRouteDiscoveryServiceServer(grpcServer, serverv3)
+	apiv3_svc_listener.RegisterListenerDiscoveryServiceServer(grpcServer, serverv3)
 
 	dlog.Infof(ctx, "Listening on %s:%s", adsNetwork, adsAddress)
 
@@ -374,7 +374,7 @@ func update(
 	configv3 ecp_v3_cache.SnapshotCache,
 	generation *int,
 	dirs []string,
-	edsEndpointsV3 map[string]*v3endpointconfig.ClusterLoadAssignment,
+	edsEndpointsV3 map[string]*apiv3_endpoint.ClusterLoadAssignment,
 	fastpathSnapshot *FastpathSnapshot,
 	updates chan<- Update,
 ) error {
@@ -408,16 +408,16 @@ func update(
 		}
 		var dst *[]ecp_cache_types.Resource
 		switch m.(type) {
-		case *v3clusterconfig.Cluster:
+		case *apiv3_cluster.Cluster:
 			dst = &clustersv3
-		case *v3routeconfig.RouteConfiguration:
+		case *apiv3_route.RouteConfiguration:
 			dst = &routesv3
-		case *v3listenerconfig.Listener:
+		case *apiv3_listener.Listener:
 			dst = &listenersv3
-		case *v3runtime.Runtime:
+		case *apiv3_svc_runtime.Runtime:
 			dst = &runtimesv3
-		case *v3bootstrap.Bootstrap:
-			bs := m.(*v3bootstrap.Bootstrap)
+		case *apiv3_bootstrap.Bootstrap:
+			bs := m.(*apiv3_bootstrap.Bootstrap)
 			sr := bs.StaticResources
 			for _, lst := range sr.Listeners {
 				// When the RouteConfiguration is embedded in the listener, it will cause envoy to
@@ -579,19 +579,19 @@ func (l logAdapterBase) OnStreamOpen(ctx context.Context, sid int64, stype strin
 }
 
 // OnStreamClosed implements ecp_v3_server.Callbacks.
-func (l logAdapterBase) OnStreamClosed(sid int64, node *v3core.Node) {
+func (l logAdapterBase) OnStreamClosed(sid int64, node *apiv3_core.Node) {
 	dlog.Debugf(context.TODO(), "%v Stream closed[%v]", l.prefix, sid)
 }
 
 // OnStreamRequest implements ecp_v3_server.Callbacks.
-func (l logAdapterV3) OnStreamRequest(sid int64, req *v3discovery.DiscoveryRequest) error {
+func (l logAdapterV3) OnStreamRequest(sid int64, req *apiv3_svc_discovery.DiscoveryRequest) error {
 	dlog.Debugf(context.TODO(), "V3 Stream request[%v] for type %s: requesting %d resources", sid, req.TypeUrl, len(req.ResourceNames))
 	dlog.Debugf(context.TODO(), "V3 Stream request[%v] dump: %v", sid, req)
 	return nil
 }
 
 // OnStreamResponse implements ecp_v3_server.Callbacks.
-func (l logAdapterV3) OnStreamResponse(ctx context.Context, sid int64, req *v3discovery.DiscoveryRequest, res *v3discovery.DiscoveryResponse) {
+func (l logAdapterV3) OnStreamResponse(ctx context.Context, sid int64, req *apiv3_svc_discovery.DiscoveryRequest, res *apiv3_svc_discovery.DiscoveryResponse) {
 	dlog.Debugf(ctx, "V3 Stream response[%v] for type %s: returning %d resources", sid, res.TypeUrl, len(res.Resources))
 	dlog.Debugf(ctx, "V3 Stream dump response[%v]: %v -> %v", sid, req, res)
 }
@@ -603,31 +603,31 @@ func (l logAdapterV3) OnDeltaStreamOpen(ctx context.Context, sid int64, stype st
 }
 
 // OnDeltaStreamClosed implements ecp_v3_server.Callbacks.
-func (l logAdapterV3) OnDeltaStreamClosed(sid int64, node *v3core.Node) {
+func (l logAdapterV3) OnDeltaStreamClosed(sid int64, node *apiv3_core.Node) {
 	dlog.Debugf(context.TODO(), "%v DeltaStream closed[%v]", l.prefix, sid)
 }
 
 // OnStreamDeltaRequest implements ecp_v3_server.Callbacks.
-func (l logAdapterV3) OnStreamDeltaRequest(sid int64, req *v3discovery.DeltaDiscoveryRequest) error {
+func (l logAdapterV3) OnStreamDeltaRequest(sid int64, req *apiv3_svc_discovery.DeltaDiscoveryRequest) error {
 	dlog.Debugf(context.TODO(), "V3 Stream DeltaRequest[%v] for type %s: subscribing for %d resources", sid, req.TypeUrl, len(req.ResourceNamesSubscribe))
 	dlog.Debugf(context.TODO(), "V3 Stream DeltaRequest[%v] dump: %v", sid, req)
 	return nil
 }
 
 // OnStreamDelatResponse implements ecp_v3_server.Callbacks.
-func (l logAdapterV3) OnStreamDeltaResponse(sid int64, req *v3discovery.DeltaDiscoveryRequest, res *v3discovery.DeltaDiscoveryResponse) {
+func (l logAdapterV3) OnStreamDeltaResponse(sid int64, req *apiv3_svc_discovery.DeltaDiscoveryRequest, res *apiv3_svc_discovery.DeltaDiscoveryResponse) {
 	dlog.Debugf(context.TODO(), "V3 Stream dump DeltaResponse[%v] for type %s: returning %d resources", sid, res.TypeUrl, len(res.Resources))
 	dlog.Debugf(context.TODO(), "V3 Stream dump DeltaResponse[%v]: %v -> %v", sid, req, res)
 }
 
 // OnFetchRequest implements ecp_v3_server.Callbacks.
-func (l logAdapterV3) OnFetchRequest(ctx context.Context, r *v3discovery.DiscoveryRequest) error {
+func (l logAdapterV3) OnFetchRequest(ctx context.Context, r *apiv3_svc_discovery.DiscoveryRequest) error {
 	dlog.Debugf(ctx, "V3 Fetch request: %v", r)
 	return nil
 }
 
 // OnFetchResponse implements ecp_v3_server.Callbacks.
-func (l logAdapterV3) OnFetchResponse(req *v3discovery.DiscoveryRequest, res *v3discovery.DiscoveryResponse) {
+func (l logAdapterV3) OnFetchResponse(req *apiv3_svc_discovery.DiscoveryRequest, res *apiv3_svc_discovery.DiscoveryResponse) {
 	dlog.Debugf(context.TODO(), "V3 Fetch response: %v -> %v", req, res)
 }
 
@@ -697,7 +697,7 @@ func Main(
 	grp.Go("main-loop", func(ctx context.Context) error {
 		generation := 0
 		var fastpathSnapshot *FastpathSnapshot
-		edsEndpointsV3 := map[string]*v3endpointconfig.ClusterLoadAssignment{}
+		edsEndpointsV3 := map[string]*apiv3_endpoint.ClusterLoadAssignment{}
 
 		// We always start by updating with a totally empty snapshot.
 		//

--- a/pkg/ambex/transforms.go
+++ b/pkg/ambex/transforms.go
@@ -26,7 +26,7 @@ import (
 	"github.com/datawire/dlib/dlog"
 )
 
-// ListenerToRdsListener will take a listener definition and extract any inline RouteConfigurations
+// V3ListenerToRdsListener will take a listener definition and extract any inline RouteConfigurations
 // replacing them with a reference to an RDS supplied route configuration. It does not modify the
 // supplied listener, any configuration included in the result is copied from the input.
 //
@@ -34,84 +34,84 @@ import (
 // identity transform for any inputs not matching the expected form.
 //
 // Example Input (that will get transformed in a non-identity way):
-//   - a listener configured with an http connection manager
-//   - that specifies an http router
-//   - that supplies its RouteConfiguration inline via the route_config field
 //
-//   {
-//     "name": "...",
-//     ...,
-//     "filter_chains": [
-//       {
-//         "filter_chain_match": {...},
-//         "filters": [
-//           {
-//             "name": "envoy.filters.network.http_connection_manager",
-//             "typed_config": {
-//               "@type": "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager",
-//               "http_filters": [...],
-//               "route_config": {
-//                 "virtual_hosts": [
-//                   {
-//                     "name": "ambassador-listener-8443-*",
-//                     "domains": ["*"],
-//                     "routes": [...],
-//                   }
-//                 ]
-//               }
-//             }
-//           }
-//         ]
-//       }
-//     ]
-//   }
+//	// - a listener configured with an http connection manager
+//	// - that specifies an http router
+//	// - that supplies its RouteConfiguration inline via the route_config field
+//
+//	{
+//	  "name": "...",
+//	  ...,
+//	  "filter_chains": [
+//	    {
+//	      "filter_chain_match": {...},
+//	      "filters": [
+//	        {
+//	          "name": "envoy.filters.network.http_connection_manager",
+//	          "typed_config": {
+//	            "@type": "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager",
+//	            "http_filters": [...],
+//	            "route_config": {
+//	              "virtual_hosts": [
+//	                {
+//	                  "name": "ambassador-listener-8443-*",
+//	                  "domains": ["*"],
+//	                  "routes": [...],
+//	                }
+//	              ]
+//	            }
+//	          }
+//	        }
+//	      ]
+//	    }
+//	  ]
+//	}
 //
 // Example Output:
-//   - a duplicate listener that defines the "rds" field instead of the "route_config" field
-//   - and a list of route configurations
-//   - with route_config_name supplied in such a way as to correlate the two together
 //
-//   lnr, routes, err := ListenerToRdsListener(...)
+//	// - a duplicate listener that defines the "rds" field instead of the "route_config" field
+//	// - and a list of route configurations
+//	// - with route_config_name supplied in such a way as to correlate the two together
 //
-//   lnr = {
-//     "name": "...",
-//     ...,
-//     "filter_chains": [
-//       {
-//         "filter_chain_match": {...},
-//         "filters": [
-//           {
-//             "name": "envoy.filters.network.http_connection_manager",
-//             "typed_config": {
-//               "@type": "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager",
-//               "http_filters": [...],
-//               "rds": {
-//                 "config_source": {
-//                   "ads": {}
-//                 },
-//                 "route_config_name": "ambassador-listener-8443-routeconfig-0"
-//               }
-//             }
-//           }
-//         ]
-//       }
-//     ]
-//   }
+//	lnr, routes, err := ListenerToRdsListener(...)
 //
-//  routes = [
-//    {
-//      "name": "ambassador-listener-8443-routeconfig-0",
-//      "virtual_hosts": [
-//        {
-//          "name": "ambassador-listener-8443-*",
-//          "domains": ["*"],
-//          "routes": [...],
-//        }
-//      ]
-//    }
-//  ]
-
-// V3ListenerToRdsListener is the v3 variety of ListnerToRdsListener
+//	lnr = {
+//	  "name": "...",
+//	  ...,
+//	  "filter_chains": [
+//	    {
+//	      "filter_chain_match": {...},
+//	      "filters": [
+//	        {
+//	          "name": "envoy.filters.network.http_connection_manager",
+//	          "typed_config": {
+//	            "@type": "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager",
+//	            "http_filters": [...],
+//	            "rds": {
+//	              "config_source": {
+//	                "ads": {}
+//	              },
+//	              "route_config_name": "ambassador-listener-8443-routeconfig-0"
+//	            }
+//	          }
+//	        }
+//	      ]
+//	    }
+//	  ]
+//	}
+//
+//	routes = [
+//	  {
+//	    "name": "ambassador-listener-8443-routeconfig-0",
+//	    "virtual_hosts": [
+//	      {
+//	        "name": "ambassador-listener-8443-*",
+//	        "domains": ["*"],
+//	        "routes": [...],
+//	      }
+//	    ]
+//	  }
+//	]
 func V3ListenerToRdsListener(lnr *apiv3_listener.Listener) (*apiv3_listener.Listener, []*apiv3_route.RouteConfiguration, error) {
 	l := proto.Clone(lnr).(*apiv3_listener.Listener)
 	var routes []*apiv3_route.RouteConfiguration

--- a/pkg/api/getambassador.io/everything.go
+++ b/pkg/api/getambassador.io/everything.go
@@ -6,7 +6,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	runtimeutil "k8s.io/apimachinery/pkg/util/runtime"
 
-	"github.com/emissary-ingress/emissary/v3/pkg/api/getambassador.io/v2"
+	v2 "github.com/emissary-ingress/emissary/v3/pkg/api/getambassador.io/v2"
 	"github.com/emissary-ingress/emissary/v3/pkg/api/getambassador.io/v3alpha1"
 	"github.com/emissary-ingress/emissary/v3/pkg/kates"
 )

--- a/pkg/api/getambassador.io/v2/crd_tracingservice.go
+++ b/pkg/api/getambassador.io/v2/crd_tracingservice.go
@@ -20,8 +20,9 @@
 package v2
 
 import (
-	"github.com/emissary-ingress/emissary/v3/pkg/api/getambassador.io/v3alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/emissary-ingress/emissary/v3/pkg/api/getambassador.io/v3alpha1"
 )
 
 type TraceSampling struct {

--- a/pkg/diagnostics/v1/types_test.go
+++ b/pkg/diagnostics/v1/types_test.go
@@ -2,10 +2,11 @@ package diagnostics
 
 import (
 	"encoding/json"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestUnmarshal(t *testing.T) {

--- a/pkg/envoytest/controller.go
+++ b/pkg/envoytest/controller.go
@@ -11,12 +11,12 @@ import (
 	"google.golang.org/grpc"
 
 	// envoy api v3
-	v3core "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/core/v3"
-	v3cluster "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/service/cluster/v3"
-	v3discovery "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/service/discovery/v3"
-	v3endpoint "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/service/endpoint/v3"
-	v3listener "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/service/listener/v3"
-	v3route "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/service/route/v3"
+	apiv3_core "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/core/v3"
+	apiv3_svc_cluster "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/service/cluster/v3"
+	apiv3_svc_discovery "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/service/discovery/v3"
+	apiv3_svc_endpoint "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/service/endpoint/v3"
+	apiv3_svc_listener "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/service/listener/v3"
+	apiv3_svc_route "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/service/route/v3"
 
 	// envoy control plane
 	ecp_v3_cache "github.com/emissary-ingress/emissary/v3/pkg/envoy-control-plane/cache/v3"
@@ -186,11 +186,11 @@ func (e *EnvoyController) Run(ctx context.Context) error {
 	)
 
 	grpcMux := grpc.NewServer()
-	v3discovery.RegisterAggregatedDiscoveryServiceServer(grpcMux, srv)
-	v3endpoint.RegisterEndpointDiscoveryServiceServer(grpcMux, srv)
-	v3cluster.RegisterClusterDiscoveryServiceServer(grpcMux, srv)
-	v3route.RegisterRouteDiscoveryServiceServer(grpcMux, srv)
-	v3listener.RegisterListenerDiscoveryServiceServer(grpcMux, srv)
+	apiv3_svc_discovery.RegisterAggregatedDiscoveryServiceServer(grpcMux, srv)
+	apiv3_svc_endpoint.RegisterEndpointDiscoveryServiceServer(grpcMux, srv)
+	apiv3_svc_cluster.RegisterClusterDiscoveryServiceServer(grpcMux, srv)
+	apiv3_svc_route.RegisterRouteDiscoveryServiceServer(grpcMux, srv)
+	apiv3_svc_listener.RegisterListenerDiscoveryServiceServer(grpcMux, srv)
 
 	sc := &dhttp.ServerConfig{
 		Handler: grpcMux,
@@ -205,7 +205,7 @@ type ecNodeHash struct{}
 var _ ecp_v3_cache.NodeHash = ecNodeHash{}
 
 // ID implements ecp_v3_cache.NodeHash.
-func (ecNodeHash) ID(node *v3core.Node) string {
+func (ecNodeHash) ID(node *apiv3_core.Node) string {
 	if node == nil {
 		return "unknown"
 	}
@@ -227,12 +227,12 @@ func (ecc ecCallbacks) OnStreamOpen(_ context.Context, sid int64, stype string) 
 }
 
 // OnStreamClosed implements ecp_v3_server.Callbacks.
-func (ecc ecCallbacks) OnStreamClosed(sid int64, node *v3core.Node) {
+func (ecc ecCallbacks) OnStreamClosed(sid int64, node *apiv3_core.Node) {
 	//e.Infof("Stream closed[%v]", sid)
 }
 
 // OnStreamRequest implements ecp_v2_server.Callbacks.
-func (ecc ecCallbacks) OnStreamRequest(sid int64, req *v3discovery.DiscoveryRequest) error {
+func (ecc ecCallbacks) OnStreamRequest(sid int64, req *apiv3_svc_discovery.DiscoveryRequest) error {
 	//e.Infof("Stream request[%v]: %v", sid, req.TypeURL)
 
 	ecc.ec.cond.L.Lock()
@@ -253,7 +253,7 @@ func (ecc ecCallbacks) OnStreamRequest(sid int64, req *v3discovery.DiscoveryRequ
 }
 
 // OnStreamResponse implements ecp_v3_server.Callbacks.
-func (ecc ecCallbacks) OnStreamResponse(ctx context.Context, sid int64, req *v3discovery.DiscoveryRequest, res *v3discovery.DiscoveryResponse) {
+func (ecc ecCallbacks) OnStreamResponse(ctx context.Context, sid int64, req *apiv3_svc_discovery.DiscoveryRequest, res *apiv3_svc_discovery.DiscoveryResponse) {
 	//e.Infof("Stream response[%v]: %v -> %v", sid, req.TypeURL, res.Nonce)
 
 	ecc.ec.cond.L.Lock()
@@ -265,13 +265,13 @@ func (ecc ecCallbacks) OnStreamResponse(ctx context.Context, sid int64, req *v3d
 }
 
 // OnFetchRequest implements ecp_v3_server.Callbacks.
-func (ecc ecCallbacks) OnFetchRequest(_ context.Context, r *v3discovery.DiscoveryRequest) error {
+func (ecc ecCallbacks) OnFetchRequest(_ context.Context, r *apiv3_svc_discovery.DiscoveryRequest) error {
 	//e.Infof("Fetch request: %v", r)
 	return nil
 }
 
 // OnFetchResponse implements ecp_v3_server.Callbacks.
-func (ecc ecCallbacks) OnFetchResponse(req *v3discovery.DiscoveryRequest, res *v3discovery.DiscoveryResponse) {
+func (ecc ecCallbacks) OnFetchResponse(req *apiv3_svc_discovery.DiscoveryRequest, res *apiv3_svc_discovery.DiscoveryResponse) {
 	//e.Infof("Fetch response: %v -> %v", req, res)
 }
 
@@ -281,16 +281,16 @@ func (ecc ecCallbacks) OnDeltaStreamOpen(ctx context.Context, sid int64, stype s
 }
 
 // OnDeltaStreamClosed implements ecp_v3_server.Callbacks.
-func (ecc ecCallbacks) OnDeltaStreamClosed(sid int64, node *v3core.Node) {
+func (ecc ecCallbacks) OnDeltaStreamClosed(sid int64, node *apiv3_core.Node) {
 }
 
 // OnStreamDeltaRequest implements ecp_v3_server.Callbacks.
-func (ecc ecCallbacks) OnStreamDeltaRequest(sid int64, req *v3discovery.DeltaDiscoveryRequest) error {
+func (ecc ecCallbacks) OnStreamDeltaRequest(sid int64, req *apiv3_svc_discovery.DeltaDiscoveryRequest) error {
 	return nil
 }
 
 // OnStreamDelatResponse implements ecp_v3_server.Callbacks.
-func (ecc ecCallbacks) OnStreamDeltaResponse(sid int64, req *v3discovery.DeltaDiscoveryRequest, res *v3discovery.DeltaDiscoveryResponse) {
+func (ecc ecCallbacks) OnStreamDeltaResponse(sid int64, req *apiv3_svc_discovery.DeltaDiscoveryRequest, res *apiv3_svc_discovery.DeltaDiscoveryResponse) {
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/pkg/gateway/common_transforms.go
+++ b/pkg/gateway/common_transforms.go
@@ -3,36 +3,36 @@ package gateway
 import (
 	"fmt"
 
-	v3core "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/core/v3"
-	v3endpoint "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/endpoint/v3"
+	apiv3_core "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/core/v3"
+	apiv3_endpoint "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/endpoint/v3"
 	"github.com/emissary-ingress/emissary/v3/pkg/kates"
 )
 
-// Compile_Endpoints transforms a kubernetes endpoints resource into a v3endpoint.ClusterLoadAssignment
+// Compile_Endpoints transforms a kubernetes endpoints resource into a apiv3_endpoint.ClusterLoadAssignment
 func Compile_Endpoints(endpoints *kates.Endpoints) (*CompiledConfig, error) {
 	var clas []*CompiledLoadAssignment
 
 	for _, subset := range endpoints.Subsets {
 		for _, port := range subset.Ports {
-			var lbEndpoints []*v3endpoint.LbEndpoint
+			var lbEndpoints []*apiv3_endpoint.LbEndpoint
 			for _, addr := range subset.Addresses {
 				lbEndpoints = append(lbEndpoints, makeLbEndpoint("TCP", addr.IP, int(port.Port)))
 			}
 			path := fmt.Sprintf("k8s/%s/%s/%d", endpoints.Namespace, endpoints.Name, port.Port)
 			clas = append(clas, &CompiledLoadAssignment{
 				CompiledItem: NewCompiledItem(SourceFromResource(endpoints)),
-				LoadAssignment: &v3endpoint.ClusterLoadAssignment{
+				LoadAssignment: &apiv3_endpoint.ClusterLoadAssignment{
 					ClusterName: path,
-					Endpoints:   []*v3endpoint.LocalityLbEndpoints{{LbEndpoints: lbEndpoints}},
+					Endpoints:   []*apiv3_endpoint.LocalityLbEndpoints{{LbEndpoints: lbEndpoints}},
 				},
 			})
 			if len(subset.Ports) == 1 {
 				path := fmt.Sprintf("k8s/%s/%s", endpoints.Namespace, endpoints.Name)
 				clas = append(clas, &CompiledLoadAssignment{
 					CompiledItem: NewCompiledItem(SourceFromResource(endpoints)),
-					LoadAssignment: &v3endpoint.ClusterLoadAssignment{
+					LoadAssignment: &apiv3_endpoint.ClusterLoadAssignment{
 						ClusterName: path,
-						Endpoints:   []*v3endpoint.LocalityLbEndpoints{{LbEndpoints: lbEndpoints}},
+						Endpoints:   []*apiv3_endpoint.LocalityLbEndpoints{{LbEndpoints: lbEndpoints}},
 					},
 				})
 			}
@@ -46,16 +46,16 @@ func Compile_Endpoints(endpoints *kates.Endpoints) (*CompiledConfig, error) {
 }
 
 // makeLbEndpoint takes a protocol, ip, and port and makes an envoy LbEndpoint.
-func makeLbEndpoint(protocol, ip string, port int) *v3endpoint.LbEndpoint {
-	return &v3endpoint.LbEndpoint{
-		HostIdentifier: &v3endpoint.LbEndpoint_Endpoint{
-			Endpoint: &v3endpoint.Endpoint{
-				Address: &v3core.Address{
-					Address: &v3core.Address_SocketAddress{
-						SocketAddress: &v3core.SocketAddress{
-							Protocol:      v3core.SocketAddress_Protocol(v3core.SocketAddress_Protocol_value[protocol]),
+func makeLbEndpoint(protocol, ip string, port int) *apiv3_endpoint.LbEndpoint {
+	return &apiv3_endpoint.LbEndpoint{
+		HostIdentifier: &apiv3_endpoint.LbEndpoint_Endpoint{
+			Endpoint: &apiv3_endpoint.Endpoint{
+				Address: &apiv3_core.Address{
+					Address: &apiv3_core.Address_SocketAddress{
+						SocketAddress: &apiv3_core.SocketAddress{
+							Protocol:      apiv3_core.SocketAddress_Protocol(apiv3_core.SocketAddress_Protocol_value[protocol]),
 							Address:       ip,
-							PortSpecifier: &v3core.SocketAddress_PortValue{PortValue: uint32(port)},
+							PortSpecifier: &apiv3_core.SocketAddress_PortValue{PortValue: uint32(port)},
 							Ipv4Compat:    true,
 						},
 					},

--- a/pkg/gateway/compilation_units.go
+++ b/pkg/gateway/compilation_units.go
@@ -3,10 +3,10 @@ package gateway
 import (
 	gw "sigs.k8s.io/gateway-api/apis/v1alpha1"
 
-	v3cluster "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/cluster/v3"
-	v3endpoint "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/endpoint/v3"
-	v3listener "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/listener/v3"
-	v3route "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/route/v3"
+	apiv3_cluster "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/cluster/v3"
+	apiv3_endpoint "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/endpoint/v3"
+	apiv3_listener "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/listener/v3"
+	apiv3_route "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/route/v3"
 )
 
 // The types in this file primarily decorate envoy configuration with pointers back to Sources
@@ -42,7 +42,7 @@ type CompiledConfig struct {
 // which routes to supply to the listener.
 type CompiledListener struct {
 	CompiledItem
-	Listener *v3listener.Listener
+	Listener *apiv3_listener.Listener
 
 	// The predicate determines which routes belong to which listeners. If the listener specifies
 	// and Rds configuration, this Predicate and the Domains below will be used to construct a
@@ -59,7 +59,7 @@ type CompiledRoute struct {
 	// source such as labels kind, namespace, name, etc.
 	HTTPRoute *gw.HTTPRoute
 
-	Routes      []*v3route.Route
+	Routes      []*apiv3_route.Route
 	ClusterRefs []*ClusterRef
 }
 
@@ -76,11 +76,11 @@ type ClusterRef struct {
 // CompiledCluster decorates an envoy v2.Cluster.
 type CompiledCluster struct {
 	CompiledItem
-	Cluster *v3cluster.Cluster
+	Cluster *apiv3_cluster.Cluster
 }
 
 // CompiledLoadAssignment decorates an envoy v2.ClusterLoadAssignment.
 type CompiledLoadAssignment struct {
 	CompiledItem
-	LoadAssignment *v3endpoint.ClusterLoadAssignment
+	LoadAssignment *apiv3_endpoint.ClusterLoadAssignment
 }

--- a/pkg/gateway/compilation_units.go
+++ b/pkg/gateway/compilation_units.go
@@ -1,11 +1,12 @@
 package gateway
 
 import (
+	gw "sigs.k8s.io/gateway-api/apis/v1alpha1"
+
 	v3cluster "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/cluster/v3"
 	v3endpoint "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/endpoint/v3"
 	v3listener "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/listener/v3"
 	v3route "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/route/v3"
-	gw "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )
 
 // The types in this file primarily decorate envoy configuration with pointers back to Sources

--- a/pkg/gateway/dispatcher_test.go
+++ b/pkg/gateway/dispatcher_test.go
@@ -12,10 +12,10 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 
 	// envoy api v3
-	v3core "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/core/v3"
-	v3endpoint "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/endpoint/v3"
-	v3listener "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/listener/v3"
-	v3httpman "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/extensions/filters/network/http_connection_manager/v3"
+	apiv3_core "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/core/v3"
+	apiv3_endpoint "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/endpoint/v3"
+	apiv3_listener "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/listener/v3"
+	apiv3_httpman "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/extensions/filters/network/http_connection_manager/v3"
 
 	// envoy control plane
 	ecp_cache_types "github.com/emissary-ingress/emissary/v3/pkg/envoy-control-plane/cache/types"
@@ -190,7 +190,7 @@ func compile_Foo(f *Foo) (*gateway.CompiledConfig, error) {
 		CompiledItem: gateway.NewCompiledItem(gateway.SourceFromResource(f)),
 		Listeners: []*gateway.CompiledListener{
 			{
-				Listener: &v3listener.Listener{Name: f.Spec.Value},
+				Listener: &apiv3_listener.Listener{Name: f.Spec.Value},
 			},
 		},
 	}, nil
@@ -239,17 +239,17 @@ func compile_FooWithRouteConfigName(f *Foo) (*gateway.CompiledConfig, error) {
 	name := f.Spec.Value
 	rcName := fmt.Sprintf("%s-routeconfig", name)
 
-	hcm := &v3httpman.HttpConnectionManager{
+	hcm := &apiv3_httpman.HttpConnectionManager{
 		StatPrefix: name,
-		HttpFilters: []*v3httpman.HttpFilter{
+		HttpFilters: []*apiv3_httpman.HttpFilter{
 			{Name: ecp_wellknown.CORS},
 			{Name: ecp_wellknown.Router},
 		},
-		RouteSpecifier: &v3httpman.HttpConnectionManager_Rds{
-			Rds: &v3httpman.Rds{
-				ConfigSource: &v3core.ConfigSource{
-					ConfigSourceSpecifier: &v3core.ConfigSource_Ads{
-						Ads: &v3core.AggregatedConfigSource{},
+		RouteSpecifier: &apiv3_httpman.HttpConnectionManager_Rds{
+			Rds: &apiv3_httpman.Rds{
+				ConfigSource: &apiv3_core.ConfigSource{
+					ConfigSourceSpecifier: &apiv3_core.ConfigSource_Ads{
+						Ads: &apiv3_core.AggregatedConfigSource{},
 					},
 				},
 				RouteConfigName: rcName,
@@ -261,14 +261,14 @@ func compile_FooWithRouteConfigName(f *Foo) (*gateway.CompiledConfig, error) {
 		return nil, err
 	}
 
-	l := &v3listener.Listener{
+	l := &apiv3_listener.Listener{
 		Name: name,
-		FilterChains: []*v3listener.FilterChain{
+		FilterChains: []*apiv3_listener.FilterChain{
 			{
-				Filters: []*v3listener.Filter{
+				Filters: []*apiv3_listener.Filter{
 					{
 						Name:       ecp_wellknown.HTTPConnectionManager,
-						ConfigType: &v3listener.Filter_TypedConfig{TypedConfig: hcmAny},
+						ConfigType: &apiv3_listener.Filter_TypedConfig{TypedConfig: hcmAny},
 					},
 				},
 			},
@@ -306,18 +306,18 @@ func TestDispatcherAssemblyWithEmptyRouteConfigName(t *testing.T) {
 func compileFooWithEmptyRouteConfigName(f *Foo) (*gateway.CompiledConfig, error) {
 	name := f.Spec.Value
 
-	hcm := &v3httpman.HttpConnectionManager{
+	hcm := &apiv3_httpman.HttpConnectionManager{
 		StatPrefix: name,
-		HttpFilters: []*v3httpman.HttpFilter{
+		HttpFilters: []*apiv3_httpman.HttpFilter{
 			{Name: ecp_wellknown.CORS},
 			{Name: ecp_wellknown.Router},
 		},
-		RouteSpecifier: &v3httpman.HttpConnectionManager_Rds{
-			Rds: &v3httpman.Rds{
+		RouteSpecifier: &apiv3_httpman.HttpConnectionManager_Rds{
+			Rds: &apiv3_httpman.Rds{
 				// explicitly adding RDS Config with no name to trigger snapshot Consistency to fail
-				ConfigSource: &v3core.ConfigSource{
-					ConfigSourceSpecifier: &v3core.ConfigSource_Ads{
-						Ads: &v3core.AggregatedConfigSource{},
+				ConfigSource: &apiv3_core.ConfigSource{
+					ConfigSourceSpecifier: &apiv3_core.ConfigSource_Ads{
+						Ads: &apiv3_core.AggregatedConfigSource{},
 					},
 				},
 			},
@@ -328,14 +328,14 @@ func compileFooWithEmptyRouteConfigName(f *Foo) (*gateway.CompiledConfig, error)
 		return nil, err
 	}
 
-	l := &v3listener.Listener{
+	l := &apiv3_listener.Listener{
 		Name: name,
-		FilterChains: []*v3listener.FilterChain{
+		FilterChains: []*apiv3_listener.FilterChain{
 			{
-				Filters: []*v3listener.Filter{
+				Filters: []*apiv3_listener.Filter{
 					{
 						Name:       ecp_wellknown.HTTPConnectionManager,
-						ConfigType: &v3listener.Filter_TypedConfig{TypedConfig: hcmAny},
+						ConfigType: &apiv3_listener.Filter_TypedConfig{TypedConfig: hcmAny},
 					},
 				},
 			},
@@ -366,9 +366,9 @@ func TestDispatcherAssemblyWithoutRds(t *testing.T) {
 func compile_FooWithoutRds(f *Foo) (*gateway.CompiledConfig, error) {
 	name := f.Spec.Value
 
-	hcm := &v3httpman.HttpConnectionManager{
+	hcm := &apiv3_httpman.HttpConnectionManager{
 		StatPrefix: name,
-		HttpFilters: []*v3httpman.HttpFilter{
+		HttpFilters: []*apiv3_httpman.HttpFilter{
 			{Name: ecp_wellknown.CORS},
 			{Name: ecp_wellknown.Router},
 		},
@@ -378,17 +378,17 @@ func compile_FooWithoutRds(f *Foo) (*gateway.CompiledConfig, error) {
 		return nil, err
 	}
 
-	l := &v3listener.Listener{
+	l := &apiv3_listener.Listener{
 		Name: name,
-		FilterChains: []*v3listener.FilterChain{
+		FilterChains: []*apiv3_listener.FilterChain{
 			{
-				Filters: []*v3listener.Filter{
+				Filters: []*apiv3_listener.Filter{
 					{
 						Name: ecp_wellknown.RateLimit,
 					},
 					{
 						Name:       ecp_wellknown.HTTPConnectionManager,
-						ConfigType: &v3listener.Filter_TypedConfig{TypedConfig: hcmAny},
+						ConfigType: &apiv3_listener.Filter_TypedConfig{TypedConfig: hcmAny},
 					},
 				},
 			},
@@ -419,7 +419,7 @@ func TestDispatcherAssemblyEndpointDefaulting(t *testing.T) {
 
 	found := false
 	for _, r := range snapshot.Resources[ecp_cache_types.Endpoint].Items {
-		cla := r.Resource.(*v3endpoint.ClusterLoadAssignment)
+		cla := r.Resource.(*apiv3_endpoint.ClusterLoadAssignment)
 		if cla.ClusterName == "foo" && len(cla.Endpoints) == 0 {
 			found = true
 		}

--- a/pkg/gateway/gw_transforms.go
+++ b/pkg/gateway/gw_transforms.go
@@ -11,11 +11,11 @@ import (
 	gw "sigs.k8s.io/gateway-api/apis/v1alpha1"
 
 	// envoy api v3
-	v3core "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/core/v3"
-	v3listener "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/listener/v3"
-	v3route "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/route/v3"
-	v3httpman "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/extensions/filters/network/http_connection_manager/v3"
-	v3matcher "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/type/matcher/v3"
+	apiv3_core "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/core/v3"
+	apiv3_listener "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/listener/v3"
+	apiv3_route "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/config/route/v3"
+	apiv3_httpman "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/extensions/filters/network/http_connection_manager/v3"
+	apiv3_matcher "github.com/emissary-ingress/emissary/v3/pkg/api/envoy/type/matcher/v3"
 
 	// envoy control plane
 	ecp_wellknown "github.com/emissary-ingress/emissary/v3/pkg/envoy-control-plane/wellknown"
@@ -42,17 +42,17 @@ func Compile_Gateway(gateway *gw.Gateway) (*CompiledConfig, error) {
 }
 
 func Compile_Listener(parent Source, lst gw.Listener, name string) (*CompiledListener, error) {
-	hcm := &v3httpman.HttpConnectionManager{
+	hcm := &apiv3_httpman.HttpConnectionManager{
 		StatPrefix: name,
-		HttpFilters: []*v3httpman.HttpFilter{
+		HttpFilters: []*apiv3_httpman.HttpFilter{
 			{Name: ecp_wellknown.CORS},
 			{Name: ecp_wellknown.Router},
 		},
-		RouteSpecifier: &v3httpman.HttpConnectionManager_Rds{
-			Rds: &v3httpman.Rds{
-				ConfigSource: &v3core.ConfigSource{
-					ConfigSourceSpecifier: &v3core.ConfigSource_Ads{
-						Ads: &v3core.AggregatedConfigSource{},
+		RouteSpecifier: &apiv3_httpman.HttpConnectionManager_Rds{
+			Rds: &apiv3_httpman.Rds{
+				ConfigSource: &apiv3_core.ConfigSource{
+					ConfigSourceSpecifier: &apiv3_core.ConfigSource_Ads{
+						Ads: &apiv3_core.AggregatedConfigSource{},
 					},
 				},
 				RouteConfigName: name,
@@ -66,18 +66,18 @@ func Compile_Listener(parent Source, lst gw.Listener, name string) (*CompiledLis
 
 	return &CompiledListener{
 		CompiledItem: NewCompiledItem(Sourcef("listener %s", lst.Hostname)),
-		Listener: &v3listener.Listener{
+		Listener: &apiv3_listener.Listener{
 			Name: name,
-			Address: &v3core.Address{Address: &v3core.Address_SocketAddress{SocketAddress: &v3core.SocketAddress{
+			Address: &apiv3_core.Address{Address: &apiv3_core.Address_SocketAddress{SocketAddress: &apiv3_core.SocketAddress{
 				Address:       "0.0.0.0",
-				PortSpecifier: &v3core.SocketAddress_PortValue{PortValue: uint32(lst.Port)},
+				PortSpecifier: &apiv3_core.SocketAddress_PortValue{PortValue: uint32(lst.Port)},
 			}}},
-			FilterChains: []*v3listener.FilterChain{
+			FilterChains: []*apiv3_listener.FilterChain{
 				{
-					Filters: []*v3listener.Filter{
+					Filters: []*apiv3_listener.Filter{
 						{
 							Name:       ecp_wellknown.HTTPConnectionManager,
-							ConfigType: &v3listener.Filter_TypedConfig{TypedConfig: hcmAny},
+							ConfigType: &apiv3_listener.Filter_TypedConfig{TypedConfig: hcmAny},
 						},
 					},
 				},
@@ -94,7 +94,7 @@ func Compile_Listener(parent Source, lst gw.Listener, name string) (*CompiledLis
 func Compile_HTTPRoute(httpRoute *gw.HTTPRoute) (*CompiledConfig, error) {
 	src := SourceFromResource(httpRoute)
 	clusterRefs := []*ClusterRef{}
-	var routes []*v3route.Route
+	var routes []*apiv3_route.Route
 	for idx, rule := range httpRoute.Spec.Rules {
 		s := Sourcef("rule %d in %s", idx, src)
 		_routes, err := Compile_HTTPRouteRule(s, rule, httpRoute.Namespace, &clusterRefs)
@@ -116,25 +116,25 @@ func Compile_HTTPRoute(httpRoute *gw.HTTPRoute) (*CompiledConfig, error) {
 	}, nil
 }
 
-func Compile_HTTPRouteRule(src Source, rule gw.HTTPRouteRule, namespace string, clusterRefs *[]*ClusterRef) ([]*v3route.Route, error) {
-	var clusters []*v3route.WeightedCluster_ClusterWeight
+func Compile_HTTPRouteRule(src Source, rule gw.HTTPRouteRule, namespace string, clusterRefs *[]*ClusterRef) ([]*apiv3_route.Route, error) {
+	var clusters []*apiv3_route.WeightedCluster_ClusterWeight
 	for idx, fwd := range rule.ForwardTo {
 		s := Sourcef("forwardTo %d in %s", idx, src)
 		clusters = append(clusters, Compile_HTTPRouteForwardTo(s, fwd, namespace, clusterRefs))
 	}
 
-	wc := &v3route.WeightedCluster{Clusters: clusters}
+	wc := &apiv3_route.WeightedCluster{Clusters: clusters}
 
 	matches, err := Compile_HTTPRouteMatches(rule.Matches)
 	if err != nil {
 		return nil, err
 	}
-	var result []*v3route.Route
+	var result []*apiv3_route.Route
 	for _, match := range matches {
-		result = append(result, &v3route.Route{
+		result = append(result, &apiv3_route.Route{
 			Match: match,
-			Action: &v3route.Route_Route{Route: &v3route.RouteAction{
-				ClusterSpecifier: &v3route.RouteAction_WeightedClusters{WeightedClusters: wc},
+			Action: &apiv3_route.Route_Route{Route: &apiv3_route.RouteAction{
+				ClusterSpecifier: &apiv3_route.RouteAction_WeightedClusters{WeightedClusters: wc},
 			}},
 		})
 	}
@@ -142,7 +142,7 @@ func Compile_HTTPRouteRule(src Source, rule gw.HTTPRouteRule, namespace string, 
 	return result, err
 }
 
-func Compile_HTTPRouteForwardTo(src Source, forward gw.HTTPRouteForwardTo, namespace string, clusterRefs *[]*ClusterRef) *v3route.WeightedCluster_ClusterWeight {
+func Compile_HTTPRouteForwardTo(src Source, forward gw.HTTPRouteForwardTo, namespace string, clusterRefs *[]*ClusterRef) *apiv3_route.WeightedCluster_ClusterWeight {
 	suffix := ""
 	clusterName := *forward.ServiceName
 	if forward.Port != nil {
@@ -155,14 +155,14 @@ func Compile_HTTPRouteForwardTo(src Source, forward gw.HTTPRouteForwardTo, names
 		Name:         clusterName,
 		EndpointPath: fmt.Sprintf("k8s/%s/%s%s", namespace, *forward.ServiceName, suffix),
 	})
-	return &v3route.WeightedCluster_ClusterWeight{
+	return &apiv3_route.WeightedCluster_ClusterWeight{
 		Name:   clusterName,
 		Weight: &wrapperspb.UInt32Value{Value: uint32(forward.Weight)},
 	}
 }
 
-func Compile_HTTPRouteMatches(matches []gw.HTTPRouteMatch) ([]*v3route.RouteMatch, error) {
-	var result []*v3route.RouteMatch
+func Compile_HTTPRouteMatches(matches []gw.HTTPRouteMatch) ([]*apiv3_route.RouteMatch, error) {
+	var result []*apiv3_route.RouteMatch
 	for _, match := range matches {
 		item, err := Compile_HTTPRouteMatch(match)
 		if err != nil {
@@ -173,25 +173,25 @@ func Compile_HTTPRouteMatches(matches []gw.HTTPRouteMatch) ([]*v3route.RouteMatc
 	return result, nil
 }
 
-func Compile_HTTPRouteMatch(match gw.HTTPRouteMatch) (*v3route.RouteMatch, error) {
+func Compile_HTTPRouteMatch(match gw.HTTPRouteMatch) (*apiv3_route.RouteMatch, error) {
 	headers, err := Compile_HTTPHeaderMatch(match.Headers)
 	if err != nil {
 		return nil, err
 	}
-	result := &v3route.RouteMatch{
+	result := &apiv3_route.RouteMatch{
 		Headers: headers,
 	}
 
 	switch match.Path.Type {
 	case gw.PathMatchExact:
-		result.PathSpecifier = &v3route.RouteMatch_Path{Path: match.Path.Value}
+		result.PathSpecifier = &apiv3_route.RouteMatch_Path{Path: match.Path.Value}
 	case gw.PathMatchPrefix:
-		result.PathSpecifier = &v3route.RouteMatch_Prefix{Prefix: match.Path.Value}
+		result.PathSpecifier = &apiv3_route.RouteMatch_Prefix{Prefix: match.Path.Value}
 	case gw.PathMatchRegularExpression:
-		result.PathSpecifier = &v3route.RouteMatch_SafeRegex{SafeRegex: regexMatcher(match.Path.Value)}
+		result.PathSpecifier = &apiv3_route.RouteMatch_SafeRegex{SafeRegex: regexMatcher(match.Path.Value)}
 	case "":
 		// no path match, but PathSpecifier is required
-		result.PathSpecifier = &v3route.RouteMatch_Prefix{}
+		result.PathSpecifier = &apiv3_route.RouteMatch_Prefix{}
 	default:
 		return nil, errors.Errorf("unknown path match type: %q", match.Path.Type)
 	}
@@ -199,23 +199,23 @@ func Compile_HTTPRouteMatch(match gw.HTTPRouteMatch) (*v3route.RouteMatch, error
 	return result, nil
 }
 
-func Compile_HTTPHeaderMatch(headerMatch *gw.HTTPHeaderMatch) ([]*v3route.HeaderMatcher, error) {
+func Compile_HTTPHeaderMatch(headerMatch *gw.HTTPHeaderMatch) ([]*apiv3_route.HeaderMatcher, error) {
 	if headerMatch == nil {
 		return nil, nil
 	}
 
-	var result []*v3route.HeaderMatcher
+	var result []*apiv3_route.HeaderMatcher
 	for hdr, pattern := range headerMatch.Values {
-		hm := &v3route.HeaderMatcher{
+		hm := &apiv3_route.HeaderMatcher{
 			Name:        hdr,
 			InvertMatch: false,
 		}
 
 		switch headerMatch.Type {
 		case gw.HeaderMatchExact:
-			hm.HeaderMatchSpecifier = &v3route.HeaderMatcher_ExactMatch{ExactMatch: pattern}
+			hm.HeaderMatchSpecifier = &apiv3_route.HeaderMatcher_ExactMatch{ExactMatch: pattern}
 		case gw.HeaderMatchRegularExpression:
-			hm.HeaderMatchSpecifier = &v3route.HeaderMatcher_SafeRegexMatch{SafeRegexMatch: regexMatcher(pattern)}
+			hm.HeaderMatchSpecifier = &apiv3_route.HeaderMatcher_SafeRegexMatch{SafeRegexMatch: regexMatcher(pattern)}
 		default:
 			return nil, errors.Errorf("unknown header match type: %s", headerMatch.Type)
 		}
@@ -225,9 +225,9 @@ func Compile_HTTPHeaderMatch(headerMatch *gw.HTTPHeaderMatch) ([]*v3route.Header
 	return result, nil
 }
 
-func regexMatcher(pattern string) *v3matcher.RegexMatcher {
-	return &v3matcher.RegexMatcher{
-		EngineType: &v3matcher.RegexMatcher_GoogleRe2{GoogleRe2: &v3matcher.RegexMatcher_GoogleRE2{}},
+func regexMatcher(pattern string) *apiv3_matcher.RegexMatcher {
+	return &apiv3_matcher.RegexMatcher{
+		EngineType: &apiv3_matcher.RegexMatcher_GoogleRe2{GoogleRe2: &apiv3_matcher.RegexMatcher_GoogleRE2{}},
 		Regex:      pattern,
 	}
 }

--- a/pkg/gateway/helpers_test.go
+++ b/pkg/gateway/helpers_test.go
@@ -1,8 +1,9 @@
 package gateway_test
 
 import (
-	"github.com/emissary-ingress/emissary/v3/pkg/kates"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/emissary-ingress/emissary/v3/pkg/kates"
 )
 
 // makeFoo, Foo, and FooSpec are all helpers for quickly/easily creating dummy resources for testing

--- a/pkg/kates/k8s_resource_types/ingress.go
+++ b/pkg/kates/k8s_resource_types/ingress.go
@@ -12,9 +12,10 @@ import (
 	conv_net_v1 "k8s.io/kubernetes/pkg/apis/networking/v1"
 	conv_net_v1beta1 "k8s.io/kubernetes/pkg/apis/networking/v1beta1"
 
-	kates_internal "github.com/emissary-ingress/emissary/v3/pkg/kates_internal"
 	k8s_metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8s_runtime "k8s.io/apimachinery/pkg/runtime"
+
+	kates_internal "github.com/emissary-ingress/emissary/v3/pkg/kates_internal"
 )
 
 // TODO: Update the consumers (mostly Python, unfortunately... weaker typechecking makes this hard)

--- a/pkg/snapshot/v1/sanitize.go
+++ b/pkg/snapshot/v1/sanitize.go
@@ -1,8 +1,9 @@
 package snapshot
 
 import (
-	"github.com/emissary-ingress/emissary/v3/pkg/kates"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/emissary-ingress/emissary/v3/pkg/kates"
 )
 
 // Currently, this only removes "sensitive" information, which, for now, is just Secrets.data and

--- a/pkg/snapshot/v1/types.go
+++ b/pkg/snapshot/v1/types.go
@@ -3,10 +3,11 @@ package snapshot
 import (
 	"encoding/json"
 
+	gw "sigs.k8s.io/gateway-api/apis/v1alpha1"
+
 	amb "github.com/emissary-ingress/emissary/v3/pkg/api/getambassador.io/v3alpha1"
 	"github.com/emissary-ingress/emissary/v3/pkg/consulwatch"
 	"github.com/emissary-ingress/emissary/v3/pkg/kates"
-	gw "sigs.k8s.io/gateway-api/apis/v1alpha1"
 )
 
 const ApiVersion = "v1"

--- a/tools/src/py-mkopensource/main_test.go
+++ b/tools/src/py-mkopensource/main_test.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"encoding/json"
-	"github.com/datawire/go-mkopensource/pkg/dependencies"
-	"github.com/stretchr/testify/require"
 	"io"
 	"os"
 	"path"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/datawire/go-mkopensource/pkg/dependencies"
 )
 
 func TestMarkdownOutput(t *testing.T) {


### PR DESCRIPTION
## Description

David asked me about merge conflicts in https://github.com/emissary-ingress/emissary/pull/4472; I responded that the conflicts were because import names had been changed in `ambex/transforms.go`.  That set me down a line: who had the bright idea to change the import names... is there a way I can get the linter to enforce consistent import names?

- The first 3 commits are about tightening up the linter's handling of imports
- The last commit is cleaning up a v2/v3 duplication comment in `ambex/transforms.go`
- There was a 5th commit de-duping `ambex/transforms.go`, but I dropped it in favor of #4473

As usual for me, I suggest a commit-by-commit review. There are some more details in the commit messages.

## Related Issues
- https://github.com/emissary-ingress/emissary/pull/4473

## Testing
I did some fiddling around to check that the `.golangci.yml` rules work how I want.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `CHANGELOG.md`. - no applicable changes

   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations

 - [x] This is unlikely to impact how Ambassador performs at scale. - just naming

   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability

 - [x] My change is adequately tested. - CI should cover it

   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points

 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently. - is `gofmt -r` worth mentioning?

 - [ ] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
