### PR TITLE
pkg/kates: fix bug where Accumulator was not coalescing changes mid-watch 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,10 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
   config. This has been fixed and the `alt_stats_name` field in the cluster config is now set
   correctly. (Thanks to <a href="https://github.com/psalaberria002">Paul</a>!)
 
+- Feature: The `AMBASSADOR_RECONFIG_MAX_DELAY` env var can be optionally set to batch changes for
+  the specified  non-negative window period in seconds before doing an Envoy reconfiguration.
+  Default is "1" if not set.
+
 [#4354]: https://github.com/emissary-ingress/emissary/issues/4354
 
 ## [3.1.1] TBD

--- a/cmd/entrypoint/watcher.go
+++ b/cmd/entrypoint/watcher.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	gw "sigs.k8s.io/gateway-api/apis/v1alpha1"
 
@@ -33,6 +35,16 @@ func WatchAllTheThings(
 	if err != nil {
 		return err
 	}
+	intv, err := strconv.Atoi(env("AMBASSADOR_RECONFIG_MAX_DELAY", "1"))
+	if err != nil {
+		return err
+	}
+	maxInterval := time.Duration(intv) * time.Second
+	err = client.MaxAccumulatorInterval(maxInterval)
+	if err != nil {
+		return err
+	}
+	dlog.Infof(ctx, "AMBASSADOR_RECONFIG_MAX_DELAY set to %d", intv)
 
 	serverTypeList, err := client.ServerResources()
 	if err != nil {

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -74,7 +74,6 @@ items:
           deny traffic when it is unable to communicate to the RateLimitService 
           returning a 500.
         docs: https://www.getambassador.io/docs/emissary/latest/topics/running/services/rate-limit-service/
-
       - title: Properly populate alt_state_name for Tracing, Auth and RateLimit Services
         type: bugfix
         body: >-
@@ -82,6 +81,11 @@ items:
           or the <code>AuthService</code> would have no affect because it was not being properly passed to the Envoy cluster
           config. This has been fixed and the <code>alt_stats_name</code> field in the cluster config is now set correctly.
           (Thanks to <a href="https://github.com/psalaberria002">Paul</a>!)
+      - title: Add support for config change batch window before reconfiguring Envoy
+        type: feature
+        body: >-
+          The <code>AMBASSADOR_RECONFIG_MAX_DELAY</code> env var can be optionally set to batch changes for the specified 
+          non-negative window period in seconds before doing an Envoy reconfiguration. Default is "1" if not set.
 
   - version: 3.1.1
     prevVersion: 3.1.0

--- a/pkg/kates/accumulator_test.go
+++ b/pkg/kates/accumulator_test.go
@@ -1,7 +1,9 @@
 package kates
 
 import (
+	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -18,7 +20,7 @@ type Snap struct {
 func TestBootstrapNoNotifyBeforeSync(t *testing.T) {
 	// Create a set of 10 configmaps to give us some resources to watch.
 	ctx, cli := testClient(t, nil)
-	var cms [10]*ConfigMap 
+	var cms [10]*ConfigMap
 	for i := 0; i < 10; i++ {
 		cm := &ConfigMap{
 			TypeMeta: TypeMeta{
@@ -91,4 +93,227 @@ func TestBootstrapNotifyEvenOnEmptyWatch(t *testing.T) {
 	// When we are here the first notification will have happened, and since there were no resources
 	// that satisfy the selector, the ConfigMaps field should be empty.
 	assert.Equal(t, 0, len(snap.ConfigMaps))
+}
+
+// Make sure we coalesce raw changes before sending an update when a batch of resources
+// are created/modified in quick succession.
+func TestBatchChangesBeforeNotify(t *testing.T) {
+	ctx, cli := testClient(t, nil)
+	// Set a long enough interval to make sure all changes are batched before sending.
+	err := cli.MaxAccumulatorInterval(10 * time.Second)
+	require.NoError(t, err)
+	acc, err := cli.Watch(ctx, Query{Name: "ConfigMaps", Kind: "ConfigMap", LabelSelector: "test=test-batch"})
+	require.NoError(t, err)
+
+	snap := &Snap{}
+
+	// Listen for changes from the Accumulator. Here it will listen for only 2 updates
+	// The first update should be the one sent during bootstrap. No resources should have changed
+	// in this update. The second update should contain resource changes.
+	<-acc.Changed()
+	updated, err := acc.Update(ctx, snap)
+	require.NoError(t, err)
+	if !updated {
+		t.Error("Expected snapshot to be successfully updated after receiving first change event")
+	}
+	assert.Equal(t, 0, len(snap.ConfigMaps))
+
+	// Use a separate client to create resources to avoid any potential uses of the cache
+	_, cli2 := testClient(t, nil)
+
+	// Create a set of 10 Configmaps after the Accumulator is watching to simulate getting
+	// a bunch of resources at once mid-watch.
+	var cms [10]*ConfigMap
+	for i := 0; i < 10; i++ {
+		cm := &ConfigMap{
+			TypeMeta: TypeMeta{
+				Kind: "ConfigMap",
+			},
+			ObjectMeta: ObjectMeta{
+				Name: fmt.Sprintf("test-batch-%d", i),
+				Labels: map[string]string{
+					"test": "test-batch",
+				},
+			},
+		}
+		err := cli2.Upsert(ctx, cm, cm, &cm)
+		require.NoError(t, err)
+		cms[i] = cm
+	}
+
+	<-acc.Changed()
+	updated, err = acc.Update(ctx, snap)
+	require.NoError(t, err)
+	if !updated {
+		t.Error("Expected snapshot to be successfully updated after receiving second change event")
+	}
+
+	// After receiving 2 updates from the Accumulator, we should have 10 ConfigMaps
+	// in our Snapshot due to the Accumulator coalescing changes before sending an update.
+	assert.Equal(t, 10, len(snap.ConfigMaps))
+
+	t.Cleanup(func() {
+		for _, cm := range cms {
+			if err := cli.Delete(ctx, cm, nil); err != nil && !IsNotFound(err) {
+				t.Error(err)
+			}
+		}
+	})
+}
+
+// Make sure we send an update after the window period expires when we keep
+// sending changes less than the batch interval. This is to test against an edge case where a
+// a change event is never triggered due to constant changes.
+func TestNotifyNotInfinitelyBlocked(t *testing.T) {
+	ctx, cli := testClient(t, nil)
+	err := cli.MaxAccumulatorInterval(5 * time.Second)
+	require.NoError(t, err)
+	acc, err := cli.Watch(ctx, Query{Name: "ConfigMaps", Kind: "ConfigMap", LabelSelector: "test=test-batch-max"})
+	require.NoError(t, err)
+
+	snap := &Snap{}
+
+	<-acc.Changed()
+	updated, err := acc.Update(ctx, snap)
+	require.NoError(t, err)
+	if !updated {
+		t.Error("Expected snapshot to be successfully updated after receiving first change event")
+	}
+	assert.Equal(t, 0, len(snap.ConfigMaps))
+
+	var cms []*ConfigMap
+	ctx2, cli2 := testClient(t, nil)
+	ctx2, cancel := context.WithCancel(ctx2)
+	var wg sync.WaitGroup
+	// Create a new Configmap every 2 seconds < 5 second interval to simulate a constant changes
+	go func() {
+		wg.Add(1)
+		defer wg.Done()
+		var i int
+		ticker := time.NewTicker(2 * time.Second)
+		for {
+			select {
+			case <-ticker.C:
+				cm := &ConfigMap{
+					TypeMeta: TypeMeta{
+						Kind: "ConfigMap",
+					},
+					ObjectMeta: ObjectMeta{
+						Name: fmt.Sprintf("test-batch-%d", i),
+						Labels: map[string]string{
+							"test": "test-batch-max",
+						},
+					},
+				}
+				err := cli2.Upsert(ctx, cm, cm, &cm)
+				require.NoError(t, err)
+				cms = append(cms, cm)
+				i++
+			case <-ctx2.Done():
+				return
+			}
+		}
+	}()
+
+	// Watch for second change. Actually validating this is tricky. Idiosyncratic timing differences
+	// can cause the number of Configmaps in the change event to change across test runs resulting in a
+	// flakey test. We're just concerned that we got _a_ change when constant updates are being made
+	// less than the batch window interval so that we're not infinitely blocked. So we're just going to
+	// check that the snapshot is non-empty after we get the change. If we don't
+	// get a change after some time then we fail the test.
+	select {
+	case <-acc.Changed():
+		updated, err = acc.Update(ctx, snap)
+		require.NoError(t, err)
+		if !updated {
+			t.Error("Expected snapshot to be successfully updated after receiving second change event")
+		}
+		assert.Greater(t, len(snap.ConfigMaps), 0)
+		cancel()
+		wg.Wait()
+	case <-time.After(10 * time.Second):
+		cancel()
+		wg.Wait()
+		t.Error("Timeout after 10s listening for second change. It's possible it's infinitely blocked")
+	}
+
+	t.Cleanup(func() {
+		for _, cm := range cms {
+			if err := cli.Delete(ctx, cm, nil); err != nil && !IsNotFound(err) {
+				t.Error(err)
+			}
+		}
+	})
+}
+
+// Make sure we get single updates when changes are submitted after the batch interval has expired.
+func TestNotifyOnUpdate(t *testing.T) {
+	ctx, cli := testClient(t, nil)
+	err := cli.MaxAccumulatorInterval(2 * time.Second)
+	require.NoError(t, err)
+	acc, err := cli.Watch(ctx, Query{Name: "ConfigMaps", Kind: "ConfigMap", LabelSelector: "test=test-isolated"})
+	require.NoError(t, err)
+
+	snap := &Snap{}
+
+	waitForChange := func() {
+		<-acc.Changed()
+		updated, err := acc.Update(ctx, snap)
+		require.NoError(t, err)
+		if !updated {
+			t.Error("Expected snapshot to be successfully updated after receiving change event")
+		}
+	}
+
+	waitForChange()
+	assert.Equal(t, 0, len(snap.ConfigMaps))
+
+	var cms [2]*ConfigMap
+
+	cm := &ConfigMap{
+		TypeMeta: TypeMeta{
+			Kind: "ConfigMap",
+		},
+		ObjectMeta: ObjectMeta{
+			Name: "test-isolated-1",
+			Labels: map[string]string{
+				"test": "test-isolated",
+			},
+		},
+	}
+	err = cli.Upsert(ctx, cm, cm, &cm)
+	require.NoError(t, err)
+	cms[0] = cm
+
+	waitForChange()
+	assert.Equal(t, 1, len(snap.ConfigMaps))
+
+	// Send the next change after the 2 second batch interval
+	time.Sleep(3)
+
+	cm = &ConfigMap{
+		TypeMeta: TypeMeta{
+			Kind: "ConfigMap",
+		},
+		ObjectMeta: ObjectMeta{
+			Name: "test-isolated-2",
+			Labels: map[string]string{
+				"test": "test-isolated",
+			},
+		},
+	}
+	err = cli.Upsert(ctx, cm, cm, &cm)
+	require.NoError(t, err)
+	cms[1] = cm
+
+	waitForChange()
+	assert.Equal(t, 2, len(snap.ConfigMaps))
+
+	t.Cleanup(func() {
+		for _, cm := range cms {
+			if err := cli.Delete(ctx, cm, nil); err != nil && !IsNotFound(err) {
+				t.Error(err)
+			}
+		}
+	})
 }


### PR DESCRIPTION
## Description
The Accumulator struct attempts to coalesce changes into a single snapshot update as a way to do graceful load shedding.
However, while this was the behavior on bootstrap, it didn't always happen mid-watch - each event that was received turned into a single snapshot update, thus not really satisfying this requirement.

We add a new option to batch changes for a specified window interval before sending a snapshot update.
The batching behavior is as follows:
 - The Accumulator will receive raw changes up until the window period where it will then send a change, even if new updates are still coming in.
   This is to prevent the potential of a scenario where a change is never sent due to an extremely volatile cluster.
   While there may be a way to be more dynamic in how long to wait before sending this change, this approach is simpler and more predicable.

 - If an isolated updated comes in (e.g. last change was submitted an hour ago but the window period is set to 10s), it may not neccessarily wait until the window period before sending change, it can send immediately.

 - The default interval is set to 1s to be inline with current change velocity.

 - A snapshot update won't be sent until all resources are fully bootstrapped, regardless of what interval is set.
   This is the ensure that the other requirements for the Accumulator are still satisfied.

`AMBASSADOR_RECONFIG_MAX_DELAY` controls the interval to wait before sending snapshot updates when listening for K8s resources, especially when many resources are updated in quick succession.

## Related Issues
Issue is not in this repo.

## Testing
Add new test cases. 

For performance testing, ran a test that concurrently applies namespaces with each namespace applying 35 deployments, host, and mappings each. Each deployment has 2 replicas. We track the number of snapshot versions pushed. Prevously the number of snapshot versions created when applying 1 namespace was ~118. After setting a 10s interval, the snapshot version reduced to 16. For max concurrent namespaces it would previously start OOMing at 6 concurrent namespaces; with a 10 sec interval it's at least >15. Peak memory usage was 600MB so with a higher memory limit, it can likely support much higher.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `CHANGELOG.md`.

   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations

 - [ ] This is unlikely to impact how Ambassador performs at scale - load testing shows xxxx.
   

   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability

 - [x] My change is adequately tested.

   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points

 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently - N/A.

 - [ ] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
