### PR TITLE
[v2.4] fix: make stats_name work in tracing, ratelimit and auth services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,11 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
   endpoints be inserted to clusters manually. This can help resolve with `503 UH` caused by
   certification rotation relating to a delay between EDS + CDS. The default is `false`.
 
+- Bugfix: Previously, setting the `stats_name` for the `TracingService`, `RateLimitService`  or the
+  `AuthService` would have no affect because it was not being properly passed to the Envoy cluster
+  config. This has been fixed and the `alt_stats_name` field in the cluster config is now set
+  correctly. (Thanks to <a href="https://github.com/psalaberria002">Paul</a>!)
+
 ## [1.14.5] TBD
 [1.14.5]: https://github.com/emissary-ingress/emissary/compare/v2.3.2...v1.14.5
 

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -50,6 +50,14 @@ items:
           inserted to clusters manually. This can help resolve with `503 UH` caused by certification rotation relating to
           a delay between EDS + CDS. The default is `false`.
 
+      - title: Properly populate alt_state_name for Tracing, Auth and RateLimit Services
+        type: bugfix
+        body: >-
+          Previously, setting the <code>stats_name</code> for the <code>TracingService</code>, <code>RateLimitService</code> 
+          or the <code>AuthService</code> would have no affect because it was not being properly passed to the Envoy cluster
+          config. This has been fixed and the <code>alt_stats_name</code> field in the cluster config is now set correctly.
+          (Thanks to <a href="https://github.com/psalaberria002">Paul</a>!)
+
   - version: 1.14.5
     date: 'TBD'
     notes:

--- a/python/ambassador/ir/irauth.py
+++ b/python/ambassador/ir/irauth.py
@@ -149,6 +149,8 @@ class IRAuth (IRFilter):
         self.__to_header_list('allowed_request_headers', module)
         self.__to_header_list('allowed_authorization_headers', module)
 
+        self["stats_name"] = module.get("stats_name", None)
+
         status_on_error = module.get('status_on_error', None)
         if status_on_error:
             self['status_on_error'] = status_on_error

--- a/python/ambassador/ir/irratelimit.py
+++ b/python/ambassador/ir/irratelimit.py
@@ -57,6 +57,8 @@ class IRRateLimit (IRFilter):
         self.domain = config.get('domain', ir.ambassador_module.default_label_domain)
         self.protocol_version = config.get("protocol_version", "v2")
 
+        self.stats_name = config.get("stats_name", None)
+
         # XXX host_rewrite actually isn't in the schema right now.
         self.host_rewrite = config.get('host_rewrite', None)
 

--- a/python/ambassador/ir/irtracing.py
+++ b/python/ambassador/ir/irtracing.py
@@ -106,6 +106,8 @@ class IRTracing(IRResource):
         self.tag_headers = config.get('tag_headers', [])
         self.sampling = config.get('sampling', {})
 
+        self.stats_name = config.get("stats_name", None)
+
         # XXX host_rewrite actually isn't in the schema right now.
         self.host_rewrite = config.get('host_rewrite', None)
 

--- a/python/tests/unit/test_irauth.py
+++ b/python/tests/unit/test_irauth.py
@@ -4,6 +4,7 @@ import sys
 
 import pytest
 from kat.harness import EDGE_STACK
+from tests.utils import econf_foreach_cluster
 
 logging.basicConfig(
     level=logging.INFO,
@@ -95,6 +96,40 @@ spec:
 
     assert ext_auth_config['typed_config']['grpc_service']['envoy_grpc']['cluster_name'] == 'cluster_extauth_someservice_default'
     assert ext_auth_config['typed_config']['transport_api_version'] == 'V3'
+
+
+def test_cluster_fields():
+    yaml = """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: AuthService
+metadata:
+  name:  mycoolauthservice
+  namespace: default
+spec:
+  auth_service: someservice
+  protocol_version: "v3"
+  proto: grpc
+  stats_name: authservice
+"""
+
+    econf = _get_envoy_config(yaml)
+
+    conf = econf.as_dict()
+    ext_auth_config = _get_ext_auth_config(conf)
+
+    cluster_name = "cluster_extauth_someservice_default"
+
+    assert ext_auth_config
+    assert (
+        ext_auth_config["typed_config"]["grpc_service"]["envoy_grpc"]["cluster_name"]
+        == cluster_name
+    )
+
+    def check_fields(cluster):
+        assert cluster["alt_stat_name"] == "authservice"
+
+    econf_foreach_cluster(econf.as_dict(), check_fields, name=cluster_name)
 
 
 @pytest.mark.compilertest

--- a/python/tests/unit/test_irratelimit.py
+++ b/python/tests/unit/test_irratelimit.py
@@ -4,6 +4,8 @@ import sys
 
 import pytest
 
+from tests.utils import econf_foreach_cluster
+
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s test %(levelname)s: %(message)s",
@@ -147,6 +149,42 @@ spec:
     assert conf
 
     assert conf.get('typed_config') == config
+
+
+@pytest.mark.compilertest
+def test_irratelimit_cluster_fields():
+
+    stats_name = "ratelimitservice"
+
+    yaml = """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: RateLimitService
+metadata:
+  name: myrls
+  namespace: default
+spec:
+  service: {}
+  protocol_version: "v3"
+  stats_name: {}
+""".format(
+        SERVICE_NAME, stats_name
+    )
+
+    econf = _get_envoy_config(yaml)
+    conf = _get_rl_config(econf.as_dict())
+
+    assert conf
+    assert conf.get("typed_config") == _get_ratelimit_default_conf()
+
+    assert "ir.ratelimit" not in econf.ir.aconf.errors
+
+    def check_fields(cluster):
+        assert cluster["alt_stat_name"] == stats_name
+
+    econf_foreach_cluster(
+        econf.as_dict(), check_fields, name="cluster_{}_default".format(SERVICE_NAME)
+    )
 
 
 @pytest.mark.compilertest

--- a/python/tests/unit/test_tracing.py
+++ b/python/tests/unit/test_tracing.py
@@ -4,12 +4,16 @@ import logging
 import pytest
 
 from tests.selfsigned import TLSCerts
-from tests.utils import assert_valid_envoy_config, module_and_mapping_manifests
+from tests.utils import (
+    assert_valid_envoy_config,
+    econf_foreach_cluster,
+    module_and_mapping_manifests,
+)
 
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s test %(levelname)s: %(message)s",
-    datefmt='%Y-%m-%d %H:%M:%S'
+    datefmt='%Y-%m-%d %H:%M:%S',
 )
 
 logger = logging.getLogger("ambassador")
@@ -17,15 +21,33 @@ logger = logging.getLogger("ambassador")
 from ambassador import Config, IR
 from ambassador.envoy import EnvoyConfig
 from ambassador.fetch import ResourceFetcher
-from ambassador.utils import SecretHandler, SecretInfo
+from ambassador.utils import NullSecretHandler, SecretHandler, SecretInfo
+from tests.utils import default_listener_manifests
 
 if TYPE_CHECKING:
     from ambassador.ir.irresource import IRResource # pragma: no cover
 
+
 class MockSecretHandler(SecretHandler):
-    def load_secret(self, resource: 'IRResource', secret_name: str, namespace: str) -> Optional[SecretInfo]:
-            return SecretInfo('fallback-self-signed-cert', 'ambassador', "mocked-fallback-secret",
-                              TLSCerts["acook"].pubcert, TLSCerts["acook"].privkey, decode_b64=False)
+    def load_secret(self, resource: "IRResource", secret_name: str, namespace: str) -> Optional[SecretInfo]:
+        return SecretInfo('fallback-self-signed-cert', 'ambassador', "mocked-fallback-secret",
+            TLSCerts["acook"].pubcert, TLSCerts["acook"].privkey, decode_b64=False)
+
+
+def _get_envoy_config(yaml):
+
+    aconf = Config()
+    fetcher = ResourceFetcher(logger, aconf)
+    fetcher.parse_yaml(default_listener_manifests() + yaml, k8s=True)
+
+    aconf.load_all(fetcher.sorted())
+
+    secret_handler = NullSecretHandler(logger, None, None, "0")
+
+    ir = IR(aconf, file_checker=lambda path: True, secret_handler=secret_handler)
+
+    assert ir
+    return EnvoyConfig.generate(ir)
 
 
 def lightstep_tracing_service_manifest():
@@ -115,3 +137,76 @@ def test_tracing_config_v2():
     assert_valid_envoy_config(ads_config, v2=True)
     assert_valid_envoy_config(bootstrap_config, v2=True)
 
+@pytest.mark.compilertest
+def test_tracing_zipkin_defaults():
+
+    yaml = """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: TracingService
+metadata:
+    name: myts
+    namespace: default
+spec:
+    service: zipkin-test:9411
+    driver: zipkin
+"""
+
+    econf = _get_envoy_config(yaml)
+
+    bootstrap_config, _, _ = econf.split_config()
+    assert "tracing" in bootstrap_config
+
+    assert bootstrap_config["tracing"] == {
+        "http": {
+            "name": "envoy.zipkin",
+            "typed_config": {
+                "@type": "type.googleapis.com/envoy.config.trace.v3.ZipkinConfig",
+                "collector_endpoint": "/api/v2/spans",
+                "collector_endpoint_version": "HTTP_JSON",
+                "trace_id_128bit": True,
+                "collector_cluster": "cluster_tracing_zipkin_test_9411_default",
+            },
+        }
+    }
+
+
+@pytest.mark.compilertest
+def test_tracing_cluster_fields():
+
+    yaml = """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: TracingService
+metadata:
+    name: myts
+    namespace: default
+spec:
+    service: zipkin-test:9411
+    driver: zipkin
+    stats_name: tracingservice
+"""
+
+    econf = _get_envoy_config(yaml)
+
+    bootstrap_config, _, _ = econf.split_config()
+    assert "tracing" in bootstrap_config
+
+    cluster_name = "cluster_tracing_zipkin_test_9411_default"
+    assert bootstrap_config["tracing"] == {
+        "http": {
+            "name": "envoy.zipkin",
+            "typed_config": {
+                "@type": "type.googleapis.com/envoy.config.trace.v3.ZipkinConfig",
+                "collector_endpoint": "/api/v2/spans",
+                "collector_endpoint_version": "HTTP_JSON",
+                "trace_id_128bit": True,
+                "collector_cluster": cluster_name,
+            },
+        }
+    }
+
+    def check_fields(cluster):
+        assert cluster["alt_stat_name"] == "tracingservice"
+
+    econf_foreach_cluster(econf.as_dict(), check_fields, name=cluster_name)


### PR DESCRIPTION
## Description
This backports the fix for stats_name so that it is properly passed to the `alt_stat_name` field on the cluster for Tracing, RateLimit and Auth Services.


> **Note** : The only major change was to add test coverage to ensure that both envoy V2 and V3 configuration was working correctly since Emissary-ingress 3.y series only supports Envoy v3 configuration.

## Related Issues
See the existing PR here: https://github.com/emissary-ingress/emissary/pull/4266 that was landed on master

## Testing
Added additional test to ensure fix also works for V2 configuration.

## Checklist
 - [x] I made sure to update `CHANGELOG.md`.
 - [x] This is unlikely to impact how Ambassador performs at scale.
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
