### PR TITLE
Repatriate changelog updates from release/v2.4 to master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -259,6 +259,10 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
   config. This has been fixed and the `alt_stats_name` field in the cluster config is now set
   correctly. (Thanks to <a href="https://github.com/psalaberria002">Paul</a>!)
 
+- Feature: The `AMBASSADOR_RECONFIG_MAX_DELAY` env var can be optionally set to batch changes for
+  the specified  non-negative window period in seconds before doing an Envoy reconfiguration.
+  Default is "1" if not set.
+
 ## [1.14.5] TBD
 [1.14.5]: https://github.com/emissary-ingress/emissary/compare/v2.3.2...v1.14.5
 

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -294,6 +294,12 @@ items:
           config. This has been fixed and the <code>alt_stats_name</code> field in the cluster config is now set correctly.
           (Thanks to <a href="https://github.com/psalaberria002">Paul</a>!)
 
+      - title: Add support for config change batch window before reconfiguring Envoy
+        type: feature
+        body: >-
+          The <code>AMBASSADOR_RECONFIG_MAX_DELAY</code> env var can be optionally set to batch changes for the specified 
+          non-negative window period in seconds before doing an Envoy reconfiguration. Default is "1" if not set.
+
   - version: 1.14.5
     date: 'TBD'
     notes:


### PR DESCRIPTION
Cherry-pick 091be77 to pull forward changelog updates for v2.4 back into master.

Idk if it makes sense to also bring forward 12a0e77. That would certaintly cause a merge conflict and would need to undo changes since V2 doesn't exist on master anymore.