### PR TITLE
Fix label selector matching and host/mapping pairing

### DIFF
--- a/python/ambassador/ir/irhost.py
+++ b/python/ambassador/ir/irhost.py
@@ -472,8 +472,11 @@ class IRHost(IRResource):
                 dump_json(group.get("metadata_labels")),
                 sel_match,
             )
+        else:
+            # if the host does not have a mapping selector it matches any label set
+            sel_match = True
 
-        return host_match or sel_match
+        return host_match and sel_match
 
     def __str__(self) -> str:
         request_policy = self.get("requestPolicy", {})

--- a/python/ambassador/ir/irutils.py
+++ b/python/ambassador/ir/irutils.py
@@ -181,14 +181,11 @@ def selector_matches(
         logger.debug("    no incoming labels => False")
         return False
 
-    selmatch = False
-
+    # every selector label must exist and be equal
     for k, v in match.items():
-        if labels.get(k) == v:
-            logger.debug("    selector match for %s=%s => True", k, v)
-            return True
+        if labels.get(k) != v:
+            logger.debug("    selector match for %s=%s => False", k, v)
+            return False
 
-        logger.debug("    selector miss on %s=%s", k, v)
-
-    logger.debug("    all selectors miss => False")
-    return False
+    logger.debug("    all selectors match => True")
+    return True


### PR DESCRIPTION
Fix bug where label matching used OR instead of AND. Fix bug where a Mapping could be paired to a Host only on hostname when selector mappings are also present.

## Description
The logic for pairing hosts and mappings seems incorrect. We witnessed that two separate listeners on different ports but with the same hostname had combined routes. This has significant implication on security by exposing backend services through unintended ports.

## Related Issues
The 4th bullet point on this issue seems related: https://github.com/emissary-ingress/emissary/issues/4175
another pr https://github.com/emissary-ingress/emissary/pull/4318/files

## Testing

Two separate Hosts with the same hostname but different mapping selectors.
Multiple mappings that use the same hostname with labels.
