### PR TITLE
[v3.2] Fix label selectors Re: PRs #4499 & #4318

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,18 @@ refer both to Emissary-ingress and to the Ambassador Edge Stack.
 
 ## UPCOMING BREAKING CHANGES
 
-### Emissary 3.1.0
- - Changes to label matching will change how Hosts match Mappings. Hosts were matching any labels found in Mappings, now it's changed to match `all labels`. To avoid unexpected behaviour after the upgrade, add all labels that Hosts have in their mappingSelector to Mappings you want it to match.
+### Emissary 3.2.0 and 2.5.0
+
+ - Changes to label matching will change how `Hosts` are associated with `Mappings`. There
+   was a bug with label selectors that was causing `Hosts` to be incorrectly being associated with
+   more `Mappings` than intended. If any single label from the selector was matched then the `Host`
+   would be associated with the `Mapping`. Now it has been updated to correctly only associate a
+   `Host` with a `Mapping` if **all** labels required by the selector are present. This brings the
+   `mappingSelector` field in-line with how label selectors are used in Kubernetes. To avoid
+   unexpected behaviour after the upgrade, add all labels that Hosts have in their `mappingSelector`
+   to `Mappings` you want to associate with the `Host`. You can opt-out of the new behaviour by
+   setting the environment variable `DISABLE_STRICT_LABEL_SELECTORS` to `"true"`
+   (default: `"false"`).
 
 ### Emissary 3.0.0
 
@@ -84,6 +94,18 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
   patch release of 1.23. This provides Emissary-ingress with the latest security patches,
   performances enhancments, and features offered by the envoy proxy.
 
+- Change: Changes to label matching will change how `Hosts` are associated with `Mappings`. There
+  was a bug with label selectors that was causing `Hosts` to be incorrectly being associated with
+  more `Mappings` than intended. If any single label from the selector was matched then the `Host`
+  would be associated with the `Mapping`. Now it has been updated to correctly only associate a
+  `Host` with a `Mapping` if **all** labels required by the selector are present. This brings the
+  `mappingSelector` field in-line with how label selectors are used in Kubernetes. To avoid
+  unexpected behaviour after the upgrade, add all labels that Hosts have in their `mappingSelector`
+  to `Mappings` you want to associate with the `Host`. You can opt-out of the new behaviour by
+  setting the environment variable `DISABLE_STRICT_LABEL_SELECTORS` to `"true"` (default:
+  `"false"`). (Thanks to <a href="https://github.com/f-herceg">Filip Herceg</a> and <a
+  href="https://github.com/dynajoe">Joe Andaverde</a>!).
+
 - Feature: Previously the `Host` resource could only use secrets that are in the namespace as the
   Host. The `tlsSecret` field in the Host has a new subfield `namespace` that will allow the use of
   secrets from different namespaces.
@@ -96,19 +118,19 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
   longer be incorrectly mapped to the same cluster. ([#4354])
 
 - Feature: By default, when Envoy is unable to communicate with the configured RateLimitService then
-  it will allow traffic through. The  `RateLimitService` resource now exposes the  <a
+  it will allow traffic through. The `RateLimitService` resource now exposes the <a
   href="https://www.envoyproxy.io/docs/envoy/v1.23.0/configuration/http/http_filters/rate_limit_filter">failure_mode_deny</a>
-  option. Set `failure_mode_deny: true`, then Envoy will  deny traffic when it is unable to
-  communicate to the RateLimitService  returning a 500.
+  option. Set `failure_mode_deny: true`, then Envoy will deny traffic when it is unable to
+  communicate to the RateLimitService returning a 500.
 
-- Bugfix: Previously, setting the `stats_name` for the `TracingService`, `RateLimitService`  or the
+- Bugfix: Previously, setting the `stats_name` for the `TracingService`, `RateLimitService` or the
   `AuthService` would have no affect because it was not being properly passed to the Envoy cluster
   config. This has been fixed and the `alt_stats_name` field in the cluster config is now set
   correctly. (Thanks to <a href="https://github.com/psalaberria002">Paul</a>!)
 
 - Feature: The `AMBASSADOR_RECONFIG_MAX_DELAY` env var can be optionally set to batch changes for
-  the specified  non-negative window period in seconds before doing an Envoy reconfiguration.
-  Default is "1" if not set.
+  the specified non-negative window period in seconds before doing an Envoy reconfiguration. Default
+  is "1" if not set.
 
 [#4354]: https://github.com/emissary-ingress/emissary/issues/4354
 
@@ -244,7 +266,24 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
   HTTP/3 connections using QUIC and the UDP network protocol. It currently only supports for
   connections between downstream clients and Emissary-ingress.
 
-## [2.4.0] TBD
+## [2.5.0] TBD
+[2.5.0]: https://github.com/emissary-ingress/emissary/compare/v2.4.0...v2.5.0
+
+### Emissary-ingress and Ambassador Edge Stack
+
+- Change: Changes to label matching will change how `Hosts` are associated with `Mappings`. There
+  was a bug with label selectors that was causing `Hosts` to be incorrectly being associated with
+  more `Mappings` than intended. If any single label from the selector was matched then the `Host`
+  would be associated with the `Mapping`. Now it has been updated to correctly only associate a
+  `Host` with a `Mapping` if **all** labels required by the selector are present. This brings the
+  `mappingSelector` field in-line with how label selectors are used in Kubernetes. To avoid
+  unexpected behaviour after the upgrade, add all labels that Hosts have in their `mappingSelector`
+  to `Mappings` you want to associate with the `Host`. You can opt-out of the new behaviour by
+  setting the environment variable `DISABLE_STRICT_LABEL_SELECTORS` to `"true"` (default:
+  `"false"`). (Thanks to <a href="https://github.com/f-herceg">Filip Herceg</a> and <a
+  href="https://github.com/dynajoe">Joe Andaverde</a>!).
+
+## [2.4.0] September 19, 2022
 [2.4.0]: https://github.com/emissary-ingress/emissary/compare/v2.3.2...v2.4.0
 
 ### Emissary-ingress and Ambassador Edge Stack
@@ -257,14 +296,14 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
   endpoints be inserted to clusters manually. This can help resolve with `503 UH` caused by
   certification rotation relating to a delay between EDS + CDS. The default is `false`.
 
-- Bugfix: Previously, setting the `stats_name` for the `TracingService`, `RateLimitService`  or the
+- Bugfix: Previously, setting the `stats_name` for the `TracingService`, `RateLimitService` or the
   `AuthService` would have no affect because it was not being properly passed to the Envoy cluster
   config. This has been fixed and the `alt_stats_name` field in the cluster config is now set
   correctly. (Thanks to <a href="https://github.com/psalaberria002">Paul</a>!)
 
 - Feature: The `AMBASSADOR_RECONFIG_MAX_DELAY` env var can be optionally set to batch changes for
-  the specified  non-negative window period in seconds before doing an Envoy reconfiguration.
-  Default is "1" if not set.
+  the specified non-negative window period in seconds before doing an Envoy reconfiguration. Default
+  is "1" if not set.
 
 ## [1.14.5] TBD
 [1.14.5]: https://github.com/emissary-ingress/emissary/compare/v2.3.2...v1.14.5

--- a/docs/CHANGELOG.tpl
+++ b/docs/CHANGELOG.tpl
@@ -32,6 +32,19 @@ refer both to Emissary-ingress and to the Ambassador Edge Stack.
 
 ## UPCOMING BREAKING CHANGES
 
+### Emissary 3.2.0 and 2.5.0
+
+ - Changes to label matching will change how `Hosts` are associated with `Mappings`. There
+   was a bug with label selectors that was causing `Hosts` to be incorrectly being associated with
+   more `Mappings` than intended. If any single label from the selector was matched then the `Host`
+   would be associated with the `Mapping`. Now it has been updated to correctly only associate a
+   `Host` with a `Mapping` if **all** labels required by the selector are present. This brings the
+   `mappingSelector` field in-line with how label selectors are used in Kubernetes. To avoid
+   unexpected behaviour after the upgrade, add all labels that Hosts have in their `mappingSelector`
+   to `Mappings` you want to associate with the `Host`. You can opt-out of the new behaviour by
+   setting the environment variable `DISABLE_STRICT_LABEL_SELECTORS` to `"true"`
+   (default: `"false"`).
+
 ### Emissary 3.0.0
 
  - **No `protocol_version: v2`**: Support for specifying `protocol_version: v2` in `AuthService`,

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -43,6 +43,18 @@ items:
           release of 1.23. This provides $productName$ with the latest security patches, performances enhancments,
           and features offered by the envoy proxy.
         docs: https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.23/v1.23.0
+      - title: Fixed <code>mappingSelector</code> associating <code>Hosts</code> with <code>Mappings</code>
+        type: change
+        body: >-
+          Changes to label matching will change how <code>Hosts</code> are associated with <code>Mappings</code>. There was a bug with label
+          selectors that was causing <code>Hosts</code> to be incorrectly being associated with more <code>Mappings</code> than intended.
+          If any single label from the selector was matched then the <code>Host</code> would be associated with the <code>Mapping</code>.
+          Now it has been updated to correctly only associate a <code>Host</code> with a <code>Mapping</code> if <b>all</b> labels required by
+          the selector are present. This brings the <code>mappingSelector</code> field in-line with how label selectors are used
+          in Kubernetes. To avoid unexpected behaviour after the upgrade, add all labels that Hosts have in their
+          <code>mappingSelector</code> to <code>Mappings</code> you want to associate with the <code>Host</code>. You can opt-out of the new behaviour
+          by setting the environment variable <code>DISABLE_STRICT_LABEL_SELECTORS</code> to <code>"true"</code> (default: <code>"false"</code>).
+          (Thanks to <a href="https://github.com/f-herceg">Filip Herceg</a> and <a href="https://github.com/dynajoe">Joe Andaverde</a>!).
       - title: Add support for Host resources using secrets from different namespaces
         type: feature
         body: >-
@@ -67,24 +79,24 @@ items:
         type: feature
         body: >-
           By default, when Envoy is unable to communicate with the configured
-          RateLimitService then it will allow traffic through. The 
-          <code>RateLimitService</code> resource now exposes the 
-          <a href="https://www.envoyproxy.io/docs/envoy/v1.23.0/configuration/http/http_filters/rate_limit_filter">failure_mode_deny</a> 
-          option. Set <code>failure_mode_deny: true</code>, then Envoy will 
-          deny traffic when it is unable to communicate to the RateLimitService 
+          RateLimitService then it will allow traffic through. The
+          <code>RateLimitService</code> resource now exposes the
+          <a href="https://www.envoyproxy.io/docs/envoy/v1.23.0/configuration/http/http_filters/rate_limit_filter">failure_mode_deny</a>
+          option. Set <code>failure_mode_deny: true</code>, then Envoy will
+          deny traffic when it is unable to communicate to the RateLimitService
           returning a 500.
         docs: https://www.getambassador.io/docs/emissary/latest/topics/running/services/rate-limit-service/
       - title: Properly populate alt_state_name for Tracing, Auth and RateLimit Services
         type: bugfix
         body: >-
-          Previously, setting the <code>stats_name</code> for the <code>TracingService</code>, <code>RateLimitService</code> 
+          Previously, setting the <code>stats_name</code> for the <code>TracingService</code>, <code>RateLimitService</code>
           or the <code>AuthService</code> would have no affect because it was not being properly passed to the Envoy cluster
           config. This has been fixed and the <code>alt_stats_name</code> field in the cluster config is now set correctly.
           (Thanks to <a href="https://github.com/psalaberria002">Paul</a>!)
       - title: Add support for config change batch window before reconfiguring Envoy
         type: feature
         body: >-
-          The <code>AMBASSADOR_RECONFIG_MAX_DELAY</code> env var can be optionally set to batch changes for the specified 
+          The <code>AMBASSADOR_RECONFIG_MAX_DELAY</code> env var can be optionally set to batch changes for the specified
           non-negative window period in seconds before doing an Envoy reconfiguration. Default is "1" if not set.
 
   - version: 3.1.1
@@ -268,8 +280,25 @@ items:
           connections using QUIC and the UDP network protocol. It currently only supports for connections
           between downstream clients and $productName$.
 
-  - version: 2.4.0
+  - version: 2.5.0
     date: 'TBD'
+    prevVersion: 2.4.0
+    notes:
+      - title: Fixed <code>mappingSelector</code> associating <code>Hosts</code> with <code>Mappings</code>
+        type: change
+        body: >-
+          Changes to label matching will change how <code>Hosts</code> are associated with <code>Mappings</code>. There was a bug with label
+          selectors that was causing <code>Hosts</code> to be incorrectly being associated with more <code>Mappings</code> than intended.
+          If any single label from the selector was matched then the <code>Host</code> would be associated with the <code>Mapping</code>.
+          Now it has been updated to correctly only associate a <code>Host</code> with a <code>Mapping</code> if <b>all</b> labels required by
+          the selector are present. This brings the <code>mappingSelector</code> field in-line with how label selectors are used
+          in Kubernetes. To avoid unexpected behaviour after the upgrade, add all labels that Hosts have in their
+          <code>mappingSelector</code> to <code>Mappings</code> you want to associate with the <code>Host</code>. You can opt-out of the new behaviour
+          by setting the environment variable <code>DISABLE_STRICT_LABEL_SELECTORS</code> to <code>"true"</code> (default: <code>"false"</code>).
+          (Thanks to <a href="https://github.com/f-herceg">Filip Herceg</a> and <a href="https://github.com/dynajoe">Joe Andaverde</a>!).
+
+  - version: 2.4.0
+    date: '2022-09-19'
     prevVersion: 2.3.2
     notes:
       - title: Add support for Host resources using secrets from different namespaces
@@ -289,7 +318,7 @@ items:
       - title: Properly populate alt_state_name for Tracing, Auth and RateLimit Services
         type: bugfix
         body: >-
-          Previously, setting the <code>stats_name</code> for the <code>TracingService</code>, <code>RateLimitService</code> 
+          Previously, setting the <code>stats_name</code> for the <code>TracingService</code>, <code>RateLimitService</code>
           or the <code>AuthService</code> would have no affect because it was not being properly passed to the Envoy cluster
           config. This has been fixed and the <code>alt_stats_name</code> field in the cluster config is now set correctly.
           (Thanks to <a href="https://github.com/psalaberria002">Paul</a>!)
@@ -297,7 +326,7 @@ items:
       - title: Add support for config change batch window before reconfiguring Envoy
         type: feature
         body: >-
-          The <code>AMBASSADOR_RECONFIG_MAX_DELAY</code> env var can be optionally set to batch changes for the specified 
+          The <code>AMBASSADOR_RECONFIG_MAX_DELAY</code> env var can be optionally set to batch changes for the specified
           non-negative window period in seconds before doing an Envoy reconfiguration. Default is "1" if not set.
 
   - version: 1.14.5

--- a/python/ambassador/ir/irhost.py
+++ b/python/ambassador/ir/irhost.py
@@ -8,7 +8,7 @@ from ..config import Config
 from ..utils import SavedSecret, dump_json
 from .irresource import IRResource
 from .irtlscontext import IRTLSContext
-from .irutils import hostglob_matches, selector_matches
+from .irutils import disable_strict_selectors, hostglob_matches, selector_matches
 
 if TYPE_CHECKING:
     from .ir import IR  # pragma: no cover
@@ -489,14 +489,7 @@ class IRHost(IRResource):
         ]:
             return True
 
-        # Ambassador (2.0-2.3) & (3.0-3.1) consider a match on a single label as a "good enough" match.
-        # In versions 2.5+ and 3.2+ _ALL_ labels in a selector must be present for it to be considered a match.
-        # DISABLE_STRICT_LABEL_SELECTORS provides a way to restore the old unintended loose matching behaviour
-        # in the event that it is desired. The ability to disable strict label matching will be removed in a future version.
-        disable_strict_selectors = parse_bool(
-            os.environ.get("DISABLE_STRICT_LABEL_SELECTORS", "false")
-        )
-        if disable_strict_selectors:
+        if disable_strict_selectors():
             return host_match or sel_match
 
         if mapsel:

--- a/python/ambassador/ir/irhost.py
+++ b/python/ambassador/ir/irhost.py
@@ -2,6 +2,8 @@ import copy
 import os
 from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
+from ambassador.utils import parse_bool
+
 from ..config import Config
 from ..utils import SavedSecret, dump_json
 from .irresource import IRResource
@@ -437,6 +439,7 @@ class IRHost(IRResource):
         mappingSelector.
         """
 
+        has_hostname = False
         host_match = False
         sel_match = False
 
@@ -444,6 +447,7 @@ class IRHost(IRResource):
 
         if group_regex:
             # It matches.
+            has_hostname = True
             host_match = True
             self.logger.debug("-- hostname %s group regex => %s", self.hostname, host_match)
         else:
@@ -457,6 +461,7 @@ class IRHost(IRResource):
             group_glob = group.get("host") or host_redirect  # NOT A TYPO: see above.
 
             if group_glob:
+                has_hostname = True
                 host_match = hostglob_matches(self.hostname, group_glob)
                 self.logger.debug(
                     "-- hostname %s group glob %s => %s", self.hostname, group_glob, host_match
@@ -472,11 +477,31 @@ class IRHost(IRResource):
                 dump_json(group.get("metadata_labels")),
                 sel_match,
             )
-        else:
-            # if the host does not have a mapping selector it matches any label set
-            sel_match = True
 
-        return host_match and sel_match
+        # Ambassador (2.0-2.3) & (3.0-3.1) consider a match on a single label as a "good enough" match.
+        # In versions 2.5+ and 3.2+ _ALL_ labels in a selector must be present for it to be considered a match.
+        # DISABLE_STRICT_LABEL_SELECTORS provides a way to restore the old unintended loose matching behaviour
+        # in the event that it is desired. The ability to disable strict label matching will be removed in a future version.
+        disable_strict_selectors = parse_bool(
+            os.environ.get("DISABLE_STRICT_LABEL_SELECTORS", "false")
+        )
+        if disable_strict_selectors:
+            return host_match or sel_match
+
+        if mapsel:
+            if has_hostname:
+                # If both mappingSelector and hostname are present, then they must both be a match
+                return host_match and sel_match
+            else:
+                # If the Mapping does not provide a hostname, then only the mappingSelector must match
+                return sel_match
+        else:
+            if has_hostname:
+                # If there is no mappingSelector then it must only match the provided hostname
+                return host_match
+            else:
+                # If there is no mappingSelector or hostname then it cannot match anything
+                return False
 
     def __str__(self) -> str:
         request_policy = self.get("requestPolicy", {})

--- a/python/ambassador/ir/irhost.py
+++ b/python/ambassador/ir/irhost.py
@@ -478,6 +478,17 @@ class IRHost(IRResource):
                 sel_match,
             )
 
+        groupName = group.get("name") or "None"
+
+        # The synthetic Mappings for diagnostics, readiness, and liveness probes always match all Hosts.
+        # They can all still be disabled if desired via the Ambassador Module resource
+        if groupName in [
+            "GROUP: internal_readiness_probe_mapping",
+            "GROUP: internal_liveness_probe_mapping",
+            "GROUP: internal_diagnostics_probe_mapping",
+        ]:
+            return True
+
         # Ambassador (2.0-2.3) & (3.0-3.1) consider a match on a single label as a "good enough" match.
         # In versions 2.5+ and 3.2+ _ALL_ labels in a selector must be present for it to be considered a match.
         # DISABLE_STRICT_LABEL_SELECTORS provides a way to restore the old unintended loose matching behaviour

--- a/python/ambassador/ir/irutils.py
+++ b/python/ambassador/ir/irutils.py
@@ -165,6 +165,20 @@ def hostglob_matches(g1: str, g2: str) -> bool:
 
 
 ################
+## disable_strict_selectors is a utility function to control the behaviour of label selectors for Host/Mapping association
+## and serves to provide a single place where the default value can be updated.
+##
+## Ambassador (2.0-2.3) & (3.0-3.1) consider a match on a single label as a "good enough" match.
+## In versions 2.5+ and 3.2+ _ALL_ labels in a selector must be present for it to be considered a match.
+## DISABLE_STRICT_LABEL_SELECTORS provides a way to restore the old unintended loose matching behaviour
+## in the event that it is desired. The ability to disable strict label matching will be removed in a future version
+
+
+def disable_strict_selectors() -> bool:
+    return parse_bool(os.environ.get("DISABLE_STRICT_LABEL_SELECTORS", "false"))
+
+
+################
 ## selector_matches is a utility for doing K8s label selector matching.
 
 
@@ -184,13 +198,7 @@ def selector_matches(
         logger.debug("    no incoming labels => False")
         return False
 
-    # Ambassador (2.0-2.3) & (3.0-3.1) consider a match on a single label as a "good enough" match.
-    # In versions 2.5+ and 3.2+ _ALL_ labels in a selector must be present for it to be considered a match.
-    # DISABLE_STRICT_LABEL_SELECTORS provides a way to restore the old unintended loose matching behaviour
-    # in the event that it is desired. The ability to disable strict label matching will be removed in a future version.
-    disable_strict_selectors = parse_bool(os.environ.get("DISABLE_STRICT_LABEL_SELECTORS", "false"))
-
-    if disable_strict_selectors:
+    if disable_strict_selectors():
         for k, v in match.items():
             if labels.get(k) == v:
                 logger.debug("    selector match for %s=%s => True", k, v)

--- a/python/ambassador/ir/irutils.py
+++ b/python/ambassador/ir/irutils.py
@@ -185,20 +185,29 @@ def selector_matches(
         return False
 
     # Ambassador (2.0-2.3) & (3.0-3.1) consider a match on a single label as a "good enough" match.
-    # In versions 2.4+ and 3.2+ _ALL_ labels in a selector must be present for it to be considered a match.
+    # In versions 2.5+ and 3.2+ _ALL_ labels in a selector must be present for it to be considered a match.
     # DISABLE_STRICT_LABEL_SELECTORS provides a way to restore the old unintended loose matching behaviour
     # in the event that it is desired. The ability to disable strict label matching will be removed in a future version.
     disable_strict_selectors = parse_bool(os.environ.get("DISABLE_STRICT_LABEL_SELECTORS", "false"))
 
-    # For every label in mappingSelector, there must be a label with same value in Mapping itself.
-    for k, v in match.items():
-        if labels.get(k) == v:
-            logger.debug("    selector match for %s=%s => True", k, v)
-            if disable_strict_selectors:
+    if disable_strict_selectors:
+        for k, v in match.items():
+            if labels.get(k) == v:
+                logger.debug("    selector match for %s=%s => True", k, v)
                 return True
-        elif not disable_strict_selectors:
-            logger.debug("    selector miss for %s=%s => False", k, v)
-            return False
 
-    logger.debug(f"    all selectors match => True")
-    return True
+            logger.debug("    selector miss on %s=%s", k, v)
+
+        logger.debug("    all selectors miss => False")
+        return False
+    else:
+        # For every label in mappingSelector, there must be a label with same value in the Mapping itself.
+        for k, v in match.items():
+            if labels.get(k) == v:
+                logger.debug("    selector match for %s=%s => True", k, v)
+            else:
+                logger.debug("    selector miss for %s=%s => False", k, v)
+                return False
+
+        logger.debug("    all selectors match => True")
+        return True

--- a/python/ambassador/ir/irutils.py
+++ b/python/ambassador/ir/irutils.py
@@ -13,7 +13,10 @@
 # limitations under the License
 
 import logging
+import os
 from typing import Any, Dict
+
+from ambassador.utils import parse_bool
 
 ######
 # Utilities for hostglob_matches
@@ -181,11 +184,19 @@ def selector_matches(
         logger.debug("    no incoming labels => False")
         return False
 
+    # Ambassador (2.0-2.3) & (3.0-3.1) consider a match on a single label as a "good enough" match.
+    # In versions 2.4+ and 3.2+ _ALL_ labels in a selector must be present for it to be considered a match.
+    # DISABLE_STRICT_LABEL_SELECTORS provides a way to restore the old unintended loose matching behaviour
+    # in the event that it is desired. The ability to disable strict label matching will be removed in a future version.
+    disable_strict_selectors = parse_bool(os.environ.get("DISABLE_STRICT_LABEL_SELECTORS", "false"))
+
     # For every label in mappingSelector, there must be a label with same value in Mapping itself.
     for k, v in match.items():
         if labels.get(k) == v:
             logger.debug("    selector match for %s=%s => True", k, v)
-        else:
+            if disable_strict_selectors:
+                return True
+        elif not disable_strict_selectors:
             logger.debug("    selector miss for %s=%s => False", k, v)
             return False
 

--- a/python/tests/kat/t_hosts.py
+++ b/python/tests/kat/t_hosts.py
@@ -716,7 +716,7 @@ spec:
     authority: none
   mappingSelector:
     matchLabels:
-      hostname: tls-context-host-1
+      host-one: tls-context-host-1
   tlsSecret:
     name: {self.path.k8s}-test-tlscontext-secret-1
   requestPolicy:
@@ -743,7 +743,7 @@ kind: Mapping
 metadata:
   name: {self.path.k8s}-host-1-mapping
   labels:
-    hostname: tls-context-host-1
+    host-one: tls-context-host-1
     kat-ambassador-id: {self.ambassador_id}
 spec:
   ambassador_id: [ {self.ambassador_id} ]
@@ -868,6 +868,8 @@ metadata:
   name: {self.path.k8s}-host-shared-mapping
   labels:
     kat-ambassador-id: {self.ambassador_id}
+    host-one: tls-context-host-1
+    hostname: ambassador.example.com
 spec:
   ambassador_id: [ {self.ambassador_id} ]
   hostname: "*"
@@ -912,6 +914,7 @@ spec:
             sni=True,
             expected=404,
         )
+        # host-shared-mapping must have the labels required by each Host even though it specifies `hostname: "*"`
         yield Query(
             self.url("target-shared/", scheme="https"),
             headers={"Host": "tls-context-host-1"},
@@ -1077,6 +1080,624 @@ spec:
             self.url(".well-known/acme-challenge/foo", scheme="http"),
             headers={"Host": "ambassador.example.com"},
             expected=200,
+        )
+
+    def check(self):
+        # XXX Ew. If self.results[0].json is empty, the harness won't convert it to a response.
+        errors = self.results[0].json or []
+        num_errors = len(errors)
+        assert num_errors == 0, "expected 0 errors, got {} -\n{}".format(num_errors, errors)
+
+        idx = 0
+
+        for result in self.results:
+            if result.status == 200 and result.query.headers and result.tls:
+                host_header = result.query.headers["Host"]
+                tls_common_name = result.tls[0]["Subject"]["CommonName"]
+
+                assert host_header == tls_common_name, "test %d wanted CN %s, but got %s" % (
+                    idx,
+                    host_header,
+                    tls_common_name,
+                )
+
+            idx += 1
+
+    def requirements(self):
+        # We're replacing super()'s requirements deliberately here. Without a Host header they can't work.
+        yield (
+            "url",
+            Query(
+                self.url("ambassador/v0/check_ready"),
+                headers={"Host": "tls-context-host-1"},
+                insecure=True,
+                sni=True,
+            ),
+        )
+        yield (
+            "url",
+            Query(
+                self.url("ambassador/v0/check_alive"),
+                headers={"Host": "tls-context-host-1"},
+                insecure=True,
+                sni=True,
+            ),
+        )
+        yield (
+            "url",
+            Query(
+                self.url("ambassador/v0/check_ready"),
+                headers={"Host": "tls-context-host-2"},
+                insecure=True,
+                sni=True,
+            ),
+        )
+        yield (
+            "url",
+            Query(
+                self.url("ambassador/v0/check_alive"),
+                headers={"Host": "tls-context-host-2"},
+                insecure=True,
+                sni=True,
+            ),
+        )
+
+
+class HostCRDLooseLabelSelector(AmbassadorTest):
+    """
+    Ambassador (2.0-2.3) & (3.0-3.1) consider a match on a single label as a "good enough" match.
+    In versions 2.4+ and 3.2+ _ALL_ labels in a selector must be present for it to be considered a match.
+    DISABLE_STRICT_LABEL_SELECTORS provides a way to restore the old unintended loose matching behaviour
+    in the event that it is desired. The ability to disable strict label matching will be removed in a future version.
+
+    When DISABLE_STRICT_LABEL_SELECTORS is "true", a Host should be associated with a Mapping if any of the labels in the
+    mappingSelector matches rather than requiring them all to match. Aditionally, even if the mappingSelector fails to match,
+    the Mapping should be associated with the Host if the hostname of the Mapping matches the Hostname of the Host
+    """
+
+    target: ServiceType
+
+    def init(self):
+        self.edge_stack_cleartext_host = False
+        self.target = HTTP(name="target")
+        self.manifest_envs += """
+    - name: DISABLE_STRICT_LABEL_SELECTORS
+      value: "true"
+"""
+
+    def manifests(self) -> str:
+        return (
+            self.format(
+                """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: {self.path.k8s}-host-1
+  labels:
+    kat-ambassador-id: {self.ambassador_id}
+spec:
+  ambassador_id: [ {self.ambassador_id} ]
+  hostname: tls-context-host-1
+  acmeProvider:
+    authority: none
+  mappingSelector:
+    matchLabels:
+      host-one: tls-context-host-1
+      h: foo
+  tlsSecret:
+    name: {self.path.k8s}-test-tlscontext-secret-1
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {self.path.k8s}-test-tlscontext-secret-1
+  labels:
+    kat-ambassador-id: {self.ambassador_id}
+type: kubernetes.io/tls
+data:
+  tls.crt: """
+                + TLSCerts["tls-context-host-1"].k8s_crt
+                + """
+  tls.key: """
+                + TLSCerts["tls-context-host-1"].k8s_key
+                + """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: {self.path.k8s}-host-1-mapping
+  labels:
+    host-one: tls-context-host-1
+    h: bar # This does not match the mappingSelector of the host but for loose matching the above label satisfies the requirement
+    kat-ambassador-id: {self.ambassador_id}
+spec:
+  ambassador_id: [ {self.ambassador_id} ]
+  hostname: "tls-context-host-1"
+  prefix: /target-1/
+  service: {self.target.path.fqdn}
+
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: {self.path.k8s}-host-2
+  labels:
+    kat-ambassador-id: {self.ambassador_id}
+spec:
+  ambassador_id: [ {self.ambassador_id} ]
+  hostname: tls-context-host-2
+  acmeProvider:
+    authority: none
+  mappingSelector:
+    matchLabels:
+      host-two: tls-context-host-2
+      h: foo # Hosts 1 and 2 share a requirement for this label/val combo
+  tlsSecret:
+    name: {self.path.k8s}-test-tlscontext-secret-2
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {self.path.k8s}-test-tlscontext-secret-2
+  labels:
+    kat-ambassador-id: {self.ambassador_id}
+type: kubernetes.io/tls
+data:
+  tls.crt: """
+                + TLSCerts["tls-context-host-2"].k8s_crt
+                + """
+  tls.key: """
+                + TLSCerts["tls-context-host-2"].k8s_key
+                + """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: {self.path.k8s}-host-2-mapping
+  labels:
+    host-two: tls-context-host-2
+    h: foo # Both of these labels match the requirement by the host's selector
+    kat-ambassador-id: {self.ambassador_id}
+spec:
+  ambassador_id: [ {self.ambassador_id} ]
+  host: "tls-context-host-2"
+  prefix: /target-2/
+  service: {self.target.path.fqdn}
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: {self.path.k8s}-host-shared-label-mapping-all
+  labels:
+    kat-ambassador-id: {self.ambassador_id}
+    host-one: tls-context-host-1
+    host-two: tls-context-host-2
+    h: foo
+spec:
+  ambassador_id: [ {self.ambassador_id} ]
+  prefix: /target-shared-labels-all/
+  service: {self.target.path.fqdn}
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: {self.path.k8s}-host-shared-label-mapping-one
+  labels:
+    kat-ambassador-id: {self.ambassador_id}
+    h: foo # This mapping only has this one label that is required by both hosts.
+    # With strict matching, neither should be associated, but with loose matching both should.
+spec:
+  ambassador_id: [ {self.ambassador_id} ]
+  prefix: /target-shared-labels-one/
+  service: {self.target.path.fqdn}
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: {self.path.k8s}-host-shared-hostname
+spec:
+  ambassador_id: [ {self.ambassador_id} ]
+  hostname: "*" # This Mapping does not have any of the required lables.
+  # With strict matching it should not work with either host, with loose matching it should work with both.
+  prefix: /target-shared-hostname/
+  service: {self.target.path.fqdn}
+"""
+            )
+            + super().manifests()
+        )
+
+    def scheme(self) -> str:
+        return "https"
+
+    def queries(self):
+        # 0: Get some info from diagd for self.check() to inspect
+        yield Query(
+            self.url("ambassador/v0/diag/?json=true&filter=errors"),
+            headers={"Host": "tls-context-host-1"},
+            insecure=True,
+            sni=True,
+        )
+
+        # 1-5: Host #1
+        yield Query(
+            self.url("target-1/", scheme="https"),
+            headers={"Host": "tls-context-host-1"},
+            insecure=True,
+            sni=True,
+            expected=200,
+        )
+        yield Query(
+            self.url("target-2/", scheme="https"),
+            headers={"Host": "tls-context-host-1"},
+            insecure=True,
+            sni=True,
+            expected=404,
+        )
+        yield Query(
+            self.url("target-shared-labels-all/", scheme="https"),
+            headers={"Host": "tls-context-host-1"},
+            insecure=True,
+            sni=True,
+            expected=200,
+        )
+        yield Query(
+            self.url("target-shared-labels-one/", scheme="https"),
+            headers={"Host": "tls-context-host-1"},
+            insecure=True,
+            sni=True,
+            expected=200,
+        )
+        yield Query(
+            self.url("target-shared-hostname/", scheme="https"),
+            headers={"Host": "tls-context-host-1"},
+            insecure=True,
+            sni=True,
+            expected=200,
+        )
+
+        # 11-15: Host #2
+        yield Query(
+            self.url("target-1/", scheme="https"),
+            headers={"Host": "tls-context-host-2"},
+            insecure=True,
+            sni=True,
+            expected=404,
+        )
+        yield Query(
+            self.url("target-2/", scheme="https"),
+            headers={"Host": "tls-context-host-2"},
+            insecure=True,
+            sni=True,
+            expected=200,
+        )
+        yield Query(
+            self.url("target-shared-labels-all/", scheme="https"),
+            headers={"Host": "tls-context-host-2"},
+            insecure=True,
+            sni=True,
+            expected=200,
+        )
+        yield Query(
+            self.url("target-shared-labels-one/", scheme="https"),
+            headers={"Host": "tls-context-host-2"},
+            insecure=True,
+            sni=True,
+            expected=200,
+        )
+        yield Query(
+            self.url("target-shared-hostname/", scheme="https"),
+            headers={"Host": "tls-context-host-2"},
+            insecure=True,
+            sni=True,
+            expected=200,
+        )
+
+    def check(self):
+        # XXX Ew. If self.results[0].json is empty, the harness won't convert it to a response.
+        errors = self.results[0].json or []
+        num_errors = len(errors)
+        assert num_errors == 0, "expected 0 errors, got {} -\n{}".format(num_errors, errors)
+
+        idx = 0
+
+        for result in self.results:
+            if result.status == 200 and result.query.headers and result.tls:
+                host_header = result.query.headers["Host"]
+                tls_common_name = result.tls[0]["Subject"]["CommonName"]
+
+                assert host_header == tls_common_name, "test %d wanted CN %s, but got %s" % (
+                    idx,
+                    host_header,
+                    tls_common_name,
+                )
+
+            idx += 1
+
+    def requirements(self):
+        # We're replacing super()'s requirements deliberately here. Without a Host header they can't work.
+        yield (
+            "url",
+            Query(
+                self.url("ambassador/v0/check_ready"),
+                headers={"Host": "tls-context-host-1"},
+                insecure=True,
+                sni=True,
+            ),
+        )
+        yield (
+            "url",
+            Query(
+                self.url("ambassador/v0/check_alive"),
+                headers={"Host": "tls-context-host-1"},
+                insecure=True,
+                sni=True,
+            ),
+        )
+        yield (
+            "url",
+            Query(
+                self.url("ambassador/v0/check_ready"),
+                headers={"Host": "tls-context-host-2"},
+                insecure=True,
+                sni=True,
+            ),
+        )
+        yield (
+            "url",
+            Query(
+                self.url("ambassador/v0/check_alive"),
+                headers={"Host": "tls-context-host-2"},
+                insecure=True,
+                sni=True,
+            ),
+        )
+
+
+class HostCRDStrictLabelSelector(AmbassadorTest):
+    """
+    Ambassador (2.0-2.3) & (3.0-3.1) consider a match on a single label as a "good enough" match.
+    In versions 2.4+ and 3.2+ _ALL_ labels in a selector must be present for it to be considered a match.
+    DISABLE_STRICT_LABEL_SELECTORS provides a way to restore the old unintended loose matching behaviour
+    in the event that it is desired. The ability to disable strict label matching will be removed in a future version.
+
+    When DISABLE_STRICT_LABEL_SELECTORS is "true", a Host should be associated with a Mapping if any of the labels in the
+    mappingSelector matches rather than requiring them all to match. Aditionally, even if the mappingSelector fails to match,
+    the Mapping should be associated with the Host if the hostname of the Mapping matches the Hostname of the Host
+    """
+
+    target: ServiceType
+
+    def init(self):
+        self.edge_stack_cleartext_host = False
+        self.target = HTTP(name="target")
+
+    def manifests(self) -> str:
+        return (
+            self.format(
+                """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: {self.path.k8s}-host-1
+  labels:
+    kat-ambassador-id: {self.ambassador_id}
+spec:
+  ambassador_id: [ {self.ambassador_id} ]
+  hostname: tls-context-host-1
+  acmeProvider:
+    authority: none
+  mappingSelector:
+    matchLabels:
+      host-one: tls-context-host-1
+      h: foo
+  tlsSecret:
+    name: {self.path.k8s}-test-tlscontext-secret-1
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {self.path.k8s}-test-tlscontext-secret-1
+  labels:
+    kat-ambassador-id: {self.ambassador_id}
+type: kubernetes.io/tls
+data:
+  tls.crt: """
+                + TLSCerts["tls-context-host-1"].k8s_crt
+                + """
+  tls.key: """
+                + TLSCerts["tls-context-host-1"].k8s_key
+                + """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: {self.path.k8s}-host-1-mapping
+  labels:
+    host-one: tls-context-host-1
+    h: bar # This does not match the mappingSelector of the host but for loose matching the above label satisfies the requirement
+    kat-ambassador-id: {self.ambassador_id}
+spec:
+  ambassador_id: [ {self.ambassador_id} ]
+  hostname: "tls-context-host-1"
+  prefix: /target-1/
+  service: {self.target.path.fqdn}
+
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: {self.path.k8s}-host-2
+  labels:
+    kat-ambassador-id: {self.ambassador_id}
+spec:
+  ambassador_id: [ {self.ambassador_id} ]
+  hostname: tls-context-host-2
+  acmeProvider:
+    authority: none
+  mappingSelector:
+    matchLabels:
+      host-two: tls-context-host-2
+      h: foo # Hosts 1 and 2 share a requirement for this label/val combo
+  tlsSecret:
+    name: {self.path.k8s}-test-tlscontext-secret-2
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {self.path.k8s}-test-tlscontext-secret-2
+  labels:
+    kat-ambassador-id: {self.ambassador_id}
+type: kubernetes.io/tls
+data:
+  tls.crt: """
+                + TLSCerts["tls-context-host-2"].k8s_crt
+                + """
+  tls.key: """
+                + TLSCerts["tls-context-host-2"].k8s_key
+                + """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: {self.path.k8s}-host-2-mapping
+  labels:
+    host-two: tls-context-host-2
+    h: foo # Both of these labels match the requirement by the host's selector
+    kat-ambassador-id: {self.ambassador_id}
+spec:
+  ambassador_id: [ {self.ambassador_id} ]
+  host: "tls-context-host-2"
+  prefix: /target-2/
+  service: {self.target.path.fqdn}
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: {self.path.k8s}-host-shared-label-mapping-all
+  labels:
+    kat-ambassador-id: {self.ambassador_id}
+    host-one: tls-context-host-1
+    host-two: tls-context-host-2
+    h: foo
+spec:
+  ambassador_id: [ {self.ambassador_id} ]
+  prefix: /target-shared-labels-all/
+  service: {self.target.path.fqdn}
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: {self.path.k8s}-host-shared-label-mapping-one
+  labels:
+    kat-ambassador-id: {self.ambassador_id}
+    h: foo # This mapping only has this one label that is required by both hosts.
+    # With strict matching, neither should be associated, but with loose matching both should.
+spec:
+  ambassador_id: [ {self.ambassador_id} ]
+  prefix: /target-shared-labels-one/
+  service: {self.target.path.fqdn}
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: {self.path.k8s}-host-shared-hostname
+spec:
+  ambassador_id: [ {self.ambassador_id} ]
+  hostname: "*" # This Mapping does not have any of the required lables.
+  # With strict matching it should not work with either host, with loose matching it should work with both.
+  prefix: /target-shared-hostname/
+  service: {self.target.path.fqdn}
+"""
+            )
+            + super().manifests()
+        )
+
+    def scheme(self) -> str:
+        return "https"
+
+    def queries(self):
+        # 0: Get some info from diagd for self.check() to inspect
+        yield Query(
+            self.url("ambassador/v0/diag/?json=true&filter=errors"),
+            headers={"Host": "tls-context-host-1"},
+            insecure=True,
+            sni=True,
+        )
+
+        # 1-5: Host #1
+        yield Query(
+            self.url("target-1/", scheme="https"),
+            headers={"Host": "tls-context-host-1"},
+            insecure=True,
+            sni=True,
+            expected=404,
+        )
+        yield Query(
+            self.url("target-2/", scheme="https"),
+            headers={"Host": "tls-context-host-1"},
+            insecure=True,
+            sni=True,
+            expected=404,
+        )
+        yield Query(
+            self.url("target-shared-labels-all/", scheme="https"),
+            headers={"Host": "tls-context-host-1"},
+            insecure=True,
+            sni=True,
+            expected=200,
+        )
+        yield Query(
+            self.url("target-shared-labels-one/", scheme="https"),
+            headers={"Host": "tls-context-host-1"},
+            insecure=True,
+            sni=True,
+            expected=404,
+        )
+        yield Query(
+            self.url("target-shared-hostname/", scheme="https"),
+            headers={"Host": "tls-context-host-1"},
+            insecure=True,
+            sni=True,
+            expected=404,
+        )
+
+        # 11-15: Host #2
+        yield Query(
+            self.url("target-1/", scheme="https"),
+            headers={"Host": "tls-context-host-2"},
+            insecure=True,
+            sni=True,
+            expected=404,
+        )
+        yield Query(
+            self.url("target-2/", scheme="https"),
+            headers={"Host": "tls-context-host-2"},
+            insecure=True,
+            sni=True,
+            expected=200,
+        )
+        yield Query(
+            self.url("target-shared-labels-all/", scheme="https"),
+            headers={"Host": "tls-context-host-2"},
+            insecure=True,
+            sni=True,
+            expected=200,
+        )
+        yield Query(
+            self.url("target-shared-labels-one/", scheme="https"),
+            headers={"Host": "tls-context-host-2"},
+            insecure=True,
+            sni=True,
+            expected=404,
+        )
+        yield Query(
+            self.url("target-shared-hostname/", scheme="https"),
+            headers={"Host": "tls-context-host-2"},
+            insecure=True,
+            sni=True,
+            expected=404,
         )
 
     def check(self):


### PR DESCRIPTION
## Description
Pulls in the commits from #4499 and #4318. There was a little extra work needed on top of those commits. I also added a changelog entry and some test coverage for the new strict matching behaviour as well as the environment variable `DISABLE_STRICT_LABEL_SELECTORS` which restores the old (flawed) behaviour. 

Plan moving forward with this is to first merge #4499 and #4318 once this PR is approved, then merge this PR on top of them immediately afterwards. 

I'll also throw up a PR cherry-picking all of this stuff back into ~~`release/v2.4`~~ `release/v2.5` so we can have the fix in both the upcoming `3.2` and ~~`2.4`~~ `2.5`.

### Issue Context:
Currently there are some problems with `Host` association with `Mappings` particularly regarding `mappingSelector`. 

1. According to all of our documentation, when `mappingSelector` and `hostname` are both present on a Mapping, but the current code treats it as an OR relationship. This means that if a `mappingSelector` is configured that would exclude a `Mapping` from being associated with a `Host`, then the rules enforced by the `mappingSelector` will be disregarded if the `Mapping` has a `hostname` that matches the `hostname` of the Host. This is flat out a bug since it goes against everything we have docummented about their interaction.
2. There is a problem in the logic of `mappingSelector`. Currently, if a `mappingSelector` requires 3 different labels for example, then if only one of those labels is present on a `Mapping` then it will be associated with the `Host` despite the fact that the `mappingSelector` requires the 3 lables. This is also a bug and goes against how label selectors work everywhere else in Kubernetes.

## Related Issues
Sister PR for ~~`v2.4`~~ `v2.5` https://github.com/emissary-ingress/emissary/pull/4512

## Testing
Manual testing, we've already got a bunch of test-coverage for Hosts that are passing and I've also added new tests explicitly for this behaviour.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `CHANGELOG.md`.

   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations

 - [x] This is unlikely to impact how Ambassador performs at scale.

   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability

 - [x] My change is adequately tested.

   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points

 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.

 - [ ] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
