### PR TITLE
[v2.4] Fix TCPMappings

### DIFF
--- a/.github/actions/collect-logs/action.yml
+++ b/.github/actions/collect-logs/action.yml
@@ -40,13 +40,17 @@ runs:
         if test -f ~/.kube/config; then
           make tools/bin/kubectl
           mkdir /tmp/test-logs/cluster
+          tools/bin/kubectl get hosts --all-namespaces -o yaml >/tmp/test-logs/cluster/all-hosts.yaml || true
           tools/bin/kubectl get pods --all-namespaces      >/tmp/test-logs/cluster/all-pods.txt || true
           tools/bin/kubectl describe pods --all-namespaces >/tmp/test-logs/cluster/all-pods-described.txt || true
 
           tools/bin/kubectl get pods --all-namespaces -ocustom-columns="name:.metadata.name,namespace:.metadata.namespace" --no-headers | while read -r name namespace; do
             tools/bin/kubectl --namespace="$namespace" logs "$name" >"/tmp/test-logs/cluster/pod.${namespace}.${name}.log" || true
           done
+
+          tools/bin/kubectl cp xfpredirect:/tmp/ambassador/snapshots /tmp/test-logs/cluster/xfpredirect.snapshots || true
         fi
+        cp /tmp/*.yaml /tmp/test-logs || true
     - name: "Upload Logs"
       uses: actions/upload-artifact@v2
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,10 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
   endpoints be inserted to clusters manually. This can help resolve with `503 UH` caused by
   certification rotation relating to a delay between EDS + CDS. The default is `false`.
 
+- Bugfix: Emissary-ingress 2.0.0 introduced a bug where a `TCPMapping` that uses SNI, instead of
+  using the hostname glob in the `TCPMapping`, uses the hostname glob in the `Host` that the TLS
+  termination configuration comes from.
+
 ## [1.14.5] TBD
 [1.14.5]: https://github.com/emissary-ingress/emissary/compare/v2.3.2...v1.14.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,11 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
   using the hostname glob in the `TCPMapping`, uses the hostname glob in the `Host` that the TLS
   termination configuration comes from.
 
+- Bugfix: Emissary-ingress 2.0.0 introduced a bug where a `TCPMapping` that terminates TLS must have
+  a corresponding `Host` that it can take the TLS configuration from. This was semi-intentional, but
+  didn't make much sense.  You can now use a `TLSContext` without a `Host`as in Emissary-ingress 1.y
+  releases, or a `Host` with or without a `TLSContext` as in prior 2.y releases.
+
 ## [1.14.5] TBD
 [1.14.5]: https://github.com/emissary-ingress/emissary/compare/v2.3.2...v1.14.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,11 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
   didn't make much sense.  You can now use a `TLSContext` without a `Host`as in Emissary-ingress 1.y
   releases, or a `Host` with or without a `TLSContext` as in prior 2.y releases.
 
+- Bugfix: Prior releases of Emissary-ingress had the arbitrary limitation that a `TCPMapping` cannot
+  be used on the same port that HTTP is served on, even if TLS+SNI would make this possible. 
+  Emissary-ingress now allows `TCPMappings` to be used on the same `Listener` port as HTTP `Hosts`,
+  as long as that `Listener` terminates TLS.
+
 ## [1.14.5] TBD
 [1.14.5]: https://github.com/emissary-ingress/emissary/compare/v2.3.2...v1.14.5
 

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -57,6 +57,15 @@ items:
           instead of using the hostname glob in the <code>TCPMapping</code>, uses the hostname glob
           in the <code>Host</code> that the TLS termination configuration comes from.
 
+      - title: TCPMappings configure TLS termination without a Host resource
+        type: bugfix
+        body: >-
+          $productName$ 2.0.0 introduced a bug where a <code>TCPMapping</code> that terminates TLS
+          must have a corresponding <code>Host</code> that it can take the TLS configuration from.
+          This was semi-intentional, but didn't make much sense.  You can now use a
+          <code>TLSContext</code> without a <code>Host</code>as in $productName$ 1.y releases, or a
+          <code>Host</code> with or without a <code>TLSContext</code> as in prior 2.y releases.
+
   - version: 1.14.5
     date: 'TBD'
     notes:

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -50,6 +50,13 @@ items:
           inserted to clusters manually. This can help resolve with `503 UH` caused by certification rotation relating to
           a delay between EDS + CDS. The default is `false`.
 
+      - title: TCPMappings use correct SNI configuration
+        type: bugfix
+        body: >-
+          $productName$ 2.0.0 introduced a bug where a <code>TCPMapping</code> that uses SNI,
+          instead of using the hostname glob in the <code>TCPMapping</code>, uses the hostname glob
+          in the <code>Host</code> that the TLS termination configuration comes from.
+
   - version: 1.14.5
     date: 'TBD'
     notes:

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -66,6 +66,15 @@ items:
           <code>TLSContext</code> without a <code>Host</code>as in $productName$ 1.y releases, or a
           <code>Host</code> with or without a <code>TLSContext</code> as in prior 2.y releases.
 
+      - title: TCPMappings and HTTP Hosts can coexist on Listeners that terminate TLS
+        type: bugfix
+        body: >-
+          Prior releases of $productName$ had the arbitrary limitation that a
+          <code>TCPMapping</code> cannot be used on the same port that HTTP is served on, even if
+          TLS+SNI would make this possible.  $productName$ now allows <code>TCPMappings</code> to be
+          used on the same <code>Listener</code> port as HTTP <code>Hosts</code>, as long as that
+          <code>Listener</code> terminates TLS.
+
   - version: 1.14.5
     date: 'TBD'
     notes:

--- a/python/ambassador/envoy/v2/v2listener.py
+++ b/python/ambassador/envoy/v2/v2listener.py
@@ -541,15 +541,6 @@ class V2Listener(dict):
         if self._log_debug:
             self.config.ir.logger.debug(f"V2Listener: ==== finalize {self}")
 
-        # OK. Assemble the high-level stuff for Envoy.
-        self.address = {
-            "socket_address": {
-                "address": self.bind_address,
-                "port_value": self.port,
-                "protocol": "TCP"
-            }
-        }
-
         # Next, deal with HTTP stuff if this is an HTTP Listener.
         if self._base_http_config:
             self.compute_chains()
@@ -955,7 +946,13 @@ class V2Listener(dict):
     def as_dict(self) -> dict:
         listener = {
             "name": self.name,
-            "address": self.address,
+            "address": {
+                "socket_address": {
+                    "address": self.bind_address,
+                    "port_value": self.port,
+                    "protocol": "TCP"
+                }
+            },
             "filter_chains": self._filter_chains,
             "traffic_direction": self.traffic_direction
         }

--- a/python/ambassador/envoy/v2/v2listener.py
+++ b/python/ambassador/envoy/v2/v2listener.py
@@ -132,7 +132,6 @@ class V2Listener(dict):
         bindstr = f"-{self.bind_address}" if (self.bind_address != "0.0.0.0") else ""
         self.name = irlistener.name or f"ambassador-listener{bindstr}-{self.port}"
 
-        self.use_proxy_proto = False
         self.listener_filters: List[dict] = []
         self.traffic_direction: str = "UNSPECIFIED"
         self.per_connection_buffer_limit_bytes: Optional[int] = None
@@ -957,14 +956,6 @@ class V2Listener(dict):
             listener["listener_filters"] = self.listener_filters
 
         return listener
-
-    def pretty(self) -> dict:
-        return {
-            "name": self.name,
-            "bind_address": self.bind_address,
-            "port": self.port,
-            "chains": self._chains,
-        }
 
     def __str__(self) -> str:
         return "<V2Listener %s %s on %s:%d [%s]>" % (

--- a/python/ambassador/envoy/v2/v2listener.py
+++ b/python/ambassador/envoy/v2/v2listener.py
@@ -54,25 +54,33 @@ if TYPE_CHECKING:
 # on the same port. Possible near-future feature.)
 
 class V2Chain:
-    def __init__(self, config: 'V2Config', type: str, host: Optional[IRHost]) -> None:
+    _config: 'V2Config'
+    _logger: logging.Logger
+    _log_debug: bool
+
+    # We can have multiple hosts here, primarily so that HTTP chains can DTRT --
+    # but it would be fine to have multiple HTTPS hosts too, as long as they all
+    # share a TLSContext.
+    type: Literal['tcp', 'http', 'https']
+    context: Optional['IRTLSContext']
+    hosts: Dict[str, IRHost]
+    routes: List[DictifiedV2Route]
+    tcpmappings: List[IRTCPMappingGroup]
+
+    def __init__(self, config: 'V2Config', type: Literal['tcp', 'http', 'https'], host: Optional[IRHost]) -> None:
         self._config = config
         self._logger = self._config.ir.logger
         self._log_debug = self._logger.isEnabledFor(logging.DEBUG)
 
         self.type = type
-
-        # We can have multiple hosts here, primarily so that HTTP chains can DTRT --
-        # but it would be fine to have multiple HTTPS hosts too, as long as they all
-        # share a TLSContext.
-        self.context: Optional[IRTLSContext]= None
-        self.hosts: Dict[str, IRHost] = {}
+        self.context = None
+        self.hosts = {}
+        self.routes = []
+        self.tcpmappings = []
 
         # It's OK if an HTTP chain has no Host.
         if host:
             self.add_host(host)
-
-        self.routes: List[DictifiedV2Route] = []
-        self.tcpmappings: List[IRTCPMappingGroup] = []
 
     def add_host(self, host: IRHost) -> None:
         self.hosts[host.hostname] = host
@@ -198,7 +206,7 @@ class V2Listener:
                 # Nothing to do.
                 pass
 
-    def add_chain(self, chain_type: str, host: Optional[IRHost]) -> V2Chain:
+    def add_chain(self, chain_type: Literal['tcp', 'http', 'https'], host: Optional[IRHost]) -> V2Chain:
         # Add a chain for a specific Host to this listener, while dealing with the fundamental
         # asymmetry that filter_chain_match can - and should - use SNI whenever the chain has
         # TLS available, but that's simply not available for chains without TLS.
@@ -211,7 +219,7 @@ class V2Listener:
         # answer is just that it would needlessly add nesting to all our loops and such (this
         # is also why there's no vhost data structure).
 
-        chain_key = chain_type
+        chain_key: str = chain_type
         hoststr = host.hostname if host else '(no host)'
         hostname = (host.hostname if host else None) or '*'
 

--- a/python/ambassador/envoy/v2/v2listener.py
+++ b/python/ambassador/envoy/v2/v2listener.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License
-from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
+from typing import Any, Dict, List, Literal, Optional, Tuple, TYPE_CHECKING
 from typing import cast as typecast
 
 from os import environ
@@ -121,25 +121,45 @@ class V2Chain(dict):
 # here is all about constructing the Envoy configuration implied by the IRListener.
 
 class V2Listener(dict):
+    config: 'V2Config'
+    _irlistener: IRListener
+
+    @property
+    def bind_address(self) -> str:
+        return self._irlistener.bind_address
+    @property
+    def port(self) -> int:
+        return self._irlistener.port
+    @property
+    def bind_to(self) -> str:
+        return f"{self.bind_address}-{self.port}"
+    @property
+    def _stats_prefix(self) -> str:
+        return self._irlistener.statsPrefix
+    @property
+    def _security_model(self) -> Literal['XFP', 'SECURE', 'INSECURE']:
+        return self._irlistener.securityModel
+    @property
+    def _l7_depth(self) -> int:
+        return self._irlistener.get('l7Depth', 0)
+    @property
+    def _insecure_only(self) -> bool:
+        return self._irlistener.insecure_only
+    @property
+    def per_connection_buffer_limit_bytes(self) -> Optional[int]:
+        return self.config.ir.ambassador_module.get('buffer_limit_bytes', None)
+
     def __init__(self, config: 'V2Config', irlistener: IRListener) -> None:
         super().__init__()
 
         self.config = config
-        self.bind_address = irlistener.bind_address
-        self.port = irlistener.port
-        self.bind_to = f"{self.bind_address}-{self.port}"
+        self._irlistener = irlistener   # We cache the IRListener to use its match method later
 
         bindstr = f"-{self.bind_address}" if (self.bind_address != "0.0.0.0") else ""
         self.name = irlistener.name or f"ambassador-listener{bindstr}-{self.port}"
 
         self.listener_filters: List[dict] = []
         self.traffic_direction: str = "UNSPECIFIED"
-        self.per_connection_buffer_limit_bytes: Optional[int] = None
-        self._irlistener = irlistener   # We cache the IRListener to use its match method later
-        self._stats_prefix = irlistener.statsPrefix
-        self._security_model: str = irlistener.securityModel
-        self._l7_depth: int = irlistener.get('l7Depth', 0)
-        self._insecure_only: bool = False
         self._filter_chains: List[dict] = []
         self._base_http_config: Optional[Dict[str, Any]] = None
         self._chains: Dict[str, V2Chain] = {}
@@ -151,13 +171,6 @@ class V2Listener(dict):
         self._log_debug = self.config.ir.logger.isEnabledFor(logging.DEBUG)
         if self._log_debug:
             self.config.ir.logger.debug(f"V2Listener {self.name} created -- {self._security_model}, l7Depth {self._l7_depth}")
-
-        # If the IRListener is marked insecure-only, so are we.
-        self._insecure_only = irlistener.insecure_only
-
-        buffer_limit_bytes = self.config.ir.ambassador_module.get('buffer_limit_bytes', None)
-        if buffer_limit_bytes:
-            self.per_connection_buffer_limit_bytes = buffer_limit_bytes
 
         # Build out our listener filters, and figure out if we're an HTTP listener
         # in the process.

--- a/python/ambassador/envoy/v2/v2listener.py
+++ b/python/ambassador/envoy/v2/v2listener.py
@@ -236,42 +236,6 @@ class V2Listener(dict):
 
         return chain
 
-    def add_tcp_group(self, irgroup: IRTCPMappingGroup) -> None:
-        # The TCP analog of add_chain -- it adds a chain, too, but works with a TCP
-        # mapping group rather than a Host. Same deal applies with TLS: you can't do
-        # host-based matching without it.
-
-        group_host = irgroup.get('host', None)
-
-        if self._log_debug:
-            self.config.ir.logger.debug("V2Listener %s on %s: take TCPMappingGroup on %s (%s)",
-                                        self.name, self.bind_to, irgroup.bind_to(), group_host or "i'*'")
-
-        if not group_host:
-            # Special case. No Host in a TCPMapping means an unconditional forward,
-            # so just add this immediately as a "*" chain.
-            chain = self.add_chain("tcp", None)
-            chain.add_tcpmapping(irgroup)
-        else:
-            # What matching Hosts do we have?
-            for host in sorted(self.config.ir.get_hosts(), key=lambda h: h.hostname):
-                # They're asking for a hostname match here, which _cannot happen_ without
-                # SNI -- so don't take any hosts that don't have a TLSContext.
-
-                if not host.context:
-                    if self._log_debug:
-                        self.config.ir.logger.debug("V2Listener %s @ %s TCP %s: skip %s",
-                                                    self.name, self.bind_to, group_host, host)
-                    continue
-
-                if self._log_debug:
-                    self.config.ir.logger.debug("V2Listener %s @ %s TCP %s: consider %s",
-                                                self.name, self.bind_to, group_host, host)
-
-                if hostglob_matches(host.hostname, group_host):
-                    chain = self.add_chain("tcp", host)
-                    chain.add_tcpmapping(irgroup)
-
     # access_log constructs the access_log configuration for this V2Listener
     def access_log(self) -> List[dict]:
         access_log: List[dict] = []
@@ -615,8 +579,40 @@ class V2Listener(dict):
                 # self.config.ir.logger.debug("V2Listener %s: skip TCPMappingGroup on %s", self.bind_to, irgroup.bind_to())
                 continue
 
-            self.add_tcp_group(irgroup)
+            # Add a chain, same as we do in compute_httpchains, just for a 'TCPMappingGroup' rather
+            # than for a 'Host'.  Same deal applies with TLS: you can't do host-based matching
+            # without it.
 
+            group_host = irgroup.get('host', None)
+
+            if self._log_debug:
+                self.config.ir.logger.debug("V2Listener %s on %s: take TCPMappingGroup on %s (%s)",
+                                            self.name, self.bind_to, irgroup.bind_to(), group_host or "i'*'")
+
+            if not group_host:
+                # Special case. No Host in a TCPMapping means an unconditional forward,
+                # so just add this immediately as a "*" chain.
+                chain = self.add_chain("tcp", None)
+                chain.add_tcpmapping(irgroup)
+            else:
+                # What matching Hosts do we have?
+                for host in sorted(self.config.ir.get_hosts(), key=lambda h: h.hostname):
+                    # They're asking for a hostname match here, which _cannot happen_ without
+                    # SNI -- so don't take any hosts that don't have a TLSContext.
+
+                    if not host.context:
+                        if self._log_debug:
+                            self.config.ir.logger.debug("V2Listener %s @ %s TCP %s: skip %s",
+                                                        self.name, self.bind_to, group_host, host)
+                        continue
+
+                    if self._log_debug:
+                        self.config.ir.logger.debug("V2Listener %s @ %s TCP %s: consider %s",
+                                                    self.name, self.bind_to, group_host, host)
+
+                    if hostglob_matches(host.hostname, group_host):
+                        chain = self.add_chain("tcp", host)
+                        chain.add_tcpmapping(irgroup)
 
     def compute_httpchains(self) -> None:
         # Compute the set of chains we need, HTTP version. The core here is matching

--- a/python/ambassador/envoy/v2/v2listener.py
+++ b/python/ambassador/envoy/v2/v2listener.py
@@ -85,10 +85,10 @@ class V2Chain:
         else:
             return 'http'
 
-    def add_host(self, host: IRHost) -> None:
+    def add_host(self, host: IRHost, hostname: Optional[str]=None) -> None:
         if self._log_debug:
-            self._logger.debug(f"      CHAIN UPDATE: add HTTP host: hostname={repr(host.hostname)}")
-        self.hosts[host.hostname] = host
+            self._logger.debug(f"      CHAIN UPDATE: add HTTP host: hostname={repr(hostname or host.hostname)}")
+        self.hosts[hostname or host.hostname] = host
 
         # Don't mess with the context if we're a cleartext chain...
         if not self.context:
@@ -625,8 +625,8 @@ class V2Listener:
                                                     self.name, self.bind_to, group_host, host)
 
                     if hostglob_matches(host.hostname, group_host):
-                        chain = self.add_chain('tcp', host.context, host.hostname)
-                        chain.add_host(host)
+                        chain = self.add_chain('tcp', host.context, group_host)
+                        chain.add_host(host, hostname=group_host)
                         chain.add_tcpmapping(irgroup)
 
     def compute_httpchains(self) -> None:

--- a/python/ambassador/envoy/v2/v2listener.py
+++ b/python/ambassador/envoy/v2/v2listener.py
@@ -53,7 +53,7 @@ if TYPE_CHECKING:
 # be used. (And yes, that implies that at the moment, you can't mix HTTP Mappings and TCP Mappings
 # on the same port. Possible near-future feature.)
 
-class V2Chain(dict):
+class V2Chain:
     def __init__(self, config: 'V2Config', type: str, host: Optional[IRHost]) -> None:
         self._config = config
         self._logger = self._config.ir.logger
@@ -120,7 +120,7 @@ class V2Chain(dict):
 # There is a one-to-one correspondence between an IRListener and an Envoy listener: the logic
 # here is all about constructing the Envoy configuration implied by the IRListener.
 
-class V2Listener(dict):
+class V2Listener:
     config: 'V2Config'
     _irlistener: IRListener
 

--- a/python/ambassador/envoy/v2/v2listener.py
+++ b/python/ambassador/envoy/v2/v2listener.py
@@ -543,6 +543,7 @@ class V2Listener:
 
                 # OK. Basic filter chain entry next.
                 filter_chain: Dict[str, Any] = {
+                    'name': f"tcphost-{irgroup.name}",
                     'filters': [
                         tcp_filter
                     ]
@@ -834,6 +835,7 @@ class V2Listener:
                     if self._log_debug:
                         self._irlistener.logger.debug("FHTTP   create filter_chain %s / empty match", chain_key)
                     filter_chain = {
+                        "name": "httphost-shared",
                         "filter_chain_match": {},
                         "_vhosts": {}
                     }
@@ -847,6 +849,7 @@ class V2Listener:
                 # have a matching chain for this.
 
                 filter_chain = {
+                    "name": f"httpshost-{next(iter(chain.hosts.values())).name}",
                     "_vhosts": {}
                 }
                 filter_chain_match: Dict[str, Any] = {}

--- a/python/ambassador/envoy/v2/v2listener.py
+++ b/python/ambassador/envoy/v2/v2listener.py
@@ -61,41 +61,43 @@ class V2Chain:
     # We can have multiple hosts here, primarily so that HTTP chains can DTRT --
     # but it would be fine to have multiple HTTPS hosts too, as long as they all
     # share a TLSContext.
-    type: Literal['tcp', 'http', 'https']
     context: Optional['IRTLSContext']
     hosts: Dict[str, IRHost]
     routes: List[DictifiedV2Route]
     tcpmappings: List[IRTCPMappingGroup]
 
-    def __init__(self, config: 'V2Config', type: Literal['tcp', 'http', 'https'], host: Optional[IRHost]) -> None:
+    def __init__(self, config: 'V2Config', context: Optional['IRTLSContext']) -> None:
         self._config = config
         self._logger = self._config.ir.logger
         self._log_debug = self._logger.isEnabledFor(logging.DEBUG)
 
-        self.type = type
-        self.context = None
+        self.context = context
         self.hosts = {}
         self.routes = []
         self.tcpmappings = []
 
-        # It's OK if an HTTP chain has no Host.
-        if host:
-            self.add_host(host)
+    @property
+    def type(self) -> Literal['tcp', 'http', 'https']:
+        if len(self.tcpmappings) > 0:
+            return 'tcp'
+        elif self.context:
+            return 'https'
+        else:
+            return 'http'
 
     def add_host(self, host: IRHost) -> None:
+        if self._log_debug:
+            self._logger.debug(f"      CHAIN UPDATE: add HTTP host: hostname={repr(host.hostname)}")
         self.hosts[host.hostname] = host
 
-        # Don't mess with the context if we're an HTTP chain...
-        if self.type.lower() == "http":
+        # Don't mess with the context if we're a cleartext chain...
+        if not self.context:
             return
 
         # OK, we're some type where TLS makes sense. Do the thing.
-        if host.context:
-            if not self.context:
-                self.context = host.context
-            elif self.context != host.context:
-                self._config.ir.post_error("Chain context mismatch: Host %s cannot combine with %s" %
-                                           (host.name, ", ".join(sorted(self.hosts.keys()))))
+        if host.context and host.context != self.context:
+            self._config.ir.post_error("Chain context mismatch: Host %s cannot combine with %s" %
+                                       (host.name, ", ".join(sorted(self.hosts.keys()))))
 
     def hostglobs(self) -> List[str]:
         # Get a list of host globs currently set up for this chain.
@@ -111,6 +113,8 @@ class V2Chain:
         self.routes.append(route)
 
     def add_tcpmapping(self, tcpmapping: IRTCPMappingGroup) -> None:
+        if self._log_debug:
+            self._logger.debug(f"      CHAIN UPDATE: add TCP host: hostname={repr(tcpmapping.get('host'))}")
         self.tcpmappings.append(tcpmapping)
 
     def __str__(self) -> str:
@@ -206,7 +210,7 @@ class V2Listener:
                 # Nothing to do.
                 pass
 
-    def add_chain(self, chain_type: Literal['tcp', 'http', 'https'], host: Optional[IRHost]) -> V2Chain:
+    def add_chain(self, chain_type: Literal['tcp', 'http', 'https'], context: Optional['IRTLSContext'], hostname: str) -> V2Chain:
         # Add a chain for a specific Host to this listener, while dealing with the fundamental
         # asymmetry that filter_chain_match can - and should - use SNI whenever the chain has
         # TLS available, but that's simply not available for chains without TLS.
@@ -219,28 +223,30 @@ class V2Listener:
         # answer is just that it would needlessly add nesting to all our loops and such (this
         # is also why there's no vhost data structure).
 
-        chain_key: str = chain_type
-        hoststr = host.hostname if host else '(no host)'
-        hostname = (host.hostname if host else None) or '*'
+        if chain_type == 'http':
+            assert not context
+        if chain_type == 'https':
+            assert context
 
-        if host:
-            chain_key = "%s-%s" % (chain_type, hostname)
+        hostname = hostname or '*'
+
+        # I (LukeShu) can't really give an explanation of why `or chain_type == 'http'` belongs in
+        # this expression (it's what the above comment "we can - and do - separate HTTP chains into
+        # specific domains" is referring to), other than that it needs to be here in order for
+        # compute_routes() to work correctly.  Maybe that's bad and we should go fix
+        # compute_routes() and remove `or chain_type = 'http'`... I'd have to study compute_routes()
+        # a lot more in order to be able to answer that; but in the mean time, including it in the
+        # expression keeps things working.
+        separate_by_host = bool(context) or chain_type == 'http'
+        chain_key = f"{chain_type}-{hostname}" if separate_by_host else chain_type
 
         chain = self._chains.get(chain_key)
-
-        if chain is not None:
-            if host:
-                chain.add_host(host)
-                if self._log_debug:
-                    self.config.ir.logger.debug("      CHAIN ADD: host %s chain_key %s -- %s", hoststr, chain_key, chain)
-            else:
-                if self._log_debug:
-                    self.config.ir.logger.debug("      CHAIN NOOP: host %s chain_key %s -- %s", hoststr, chain_key, chain)
-        else:
-            chain = V2Chain(self.config, chain_type, host)
+        verb = "REUSED" if chain else "CREATE"
+        if chain is None:
+            chain = V2Chain(self.config, context)
             self._chains[chain_key] = chain
-            if self._log_debug:
-                self.config.ir.logger.debug("      CHAIN CREATE: host %s chain_key %s -- %s", hoststr, chain_key, chain)
+        if self._log_debug:
+            self.config.ir.logger.debug(f"      CHAIN {verb}: tls={bool(context)} host={repr(hostname)} => chains[{repr(chain_key)}]={chain}")
 
         return chain
 
@@ -598,12 +604,11 @@ class V2Listener:
                 self.config.ir.logger.debug("V2Listener %s on %s: take TCPMappingGroup on %s (%s)",
                                             self.name, self.bind_to, irgroup.bind_to(), group_host or "i'*'")
 
-            if not group_host:
+            if not group_host: # cleartext
                 # Special case. No Host in a TCPMapping means an unconditional forward,
                 # so just add this immediately as a "*" chain.
-                chain = self.add_chain("tcp", None)
-                chain.add_tcpmapping(irgroup)
-            else:
+                self.add_chain('tcp', None, '*').add_tcpmapping(irgroup)
+            else: # TLS/SNI
                 # What matching Hosts do we have?
                 for host in sorted(self.config.ir.get_hosts(), key=lambda h: h.hostname):
                     # They're asking for a hostname match here, which _cannot happen_ without
@@ -620,7 +625,8 @@ class V2Listener:
                                                     self.name, self.bind_to, group_host, host)
 
                     if hostglob_matches(host.hostname, group_host):
-                        chain = self.add_chain("tcp", host)
+                        chain = self.add_chain('tcp', host.context, host.hostname)
+                        chain.add_host(host)
                         chain.add_tcpmapping(irgroup)
 
     def compute_httpchains(self) -> None:
@@ -666,7 +672,7 @@ class V2Listener:
                 if self._log_debug:
                     self.config.ir.logger.debug("      take SECURE %s", host)
 
-                self.add_chain("https", host)
+                self.add_chain('https', host.context, host.hostname).add_host(host)
 
             # Same idea on the insecure side: only skip the Host if the Listener's securityModel
             # is INSECURE but the Host's insecure_action is Reject.
@@ -674,7 +680,7 @@ class V2Listener:
                 if self._log_debug:
                     self.config.ir.logger.debug("      take INSECURE %s", host)
 
-                self.add_chain("http", host)
+                self.add_chain('http', None, host.hostname).add_host(host)
 
     def compute_routes(self) -> None:
         # Compute the set of valid HTTP routes for _each chain_ in this Listener.

--- a/python/ambassador/envoy/v2/v2listener.py
+++ b/python/ambassador/envoy/v2/v2listener.py
@@ -662,7 +662,7 @@ class V2Listener:
             # Listener can ever produce will be rejected. In any other case, we'll set up an
             # HTTPS chain for this Host, as long as we think TLS is OK.
             host_will_reject_secure = ((not host.secure_action) or (host.secure_action == "Reject"))
-            if self._tls_ok and (not ((self._security_model == "SECURE") and host_will_reject_secure)):
+            if self._tls_ok and host.context and (not ((self._security_model == "SECURE") and host_will_reject_secure)):
                 if self._log_debug:
                     self.config.ir.logger.debug("      take SECURE %s", host)
 
@@ -870,11 +870,7 @@ class V2Listener:
                 # Likewise, an HTTPS chain will ask for TLS.
                 filter_chain_match["transport_protocol"] = "tls"
 
-                if chain.context:
-                    # ...uh. How could we not have a context if we're doing TLS?
-                    # Note that we're modifying the filter_chain itself here, not
-                    # filter_chain_match.
-                    filter_chain["tls_context"] = V2TLSContext(chain.context)
+                filter_chain["tls_context"] = V2TLSContext(chain.context)
 
                 # Finally, stash the match in the chain...
                 filter_chain["filter_chain_match"] = filter_chain_match

--- a/python/ambassador/envoy/v2/v2listener.py
+++ b/python/ambassador/envoy/v2/v2listener.py
@@ -657,17 +657,12 @@ class V2Listener:
 
             # OK, we can't drop it for that, so we need to check the actions.
 
-            security_model = self._security_model
-            secure_action = host.secure_action
-            insecure_action = host.insecure_action
-
             # If the Listener's securityModel is SECURE, but this host has a secure_action
             # of Reject (or empty), we'll skip this host, because the only requests this
             # Listener can ever produce will be rejected. In any other case, we'll set up an
             # HTTPS chain for this Host, as long as we think TLS is OK.
-
-            will_reject_secure = ((not secure_action) or (secure_action == "Reject"))
-            if self._tls_ok and (not ((security_model == "SECURE") and will_reject_secure)):
+            host_will_reject_secure = ((not host.secure_action) or (host.secure_action == "Reject"))
+            if self._tls_ok and (not ((self._security_model == "SECURE") and host_will_reject_secure)):
                 if self._log_debug:
                     self.config.ir.logger.debug("      take SECURE %s", host)
 
@@ -675,8 +670,7 @@ class V2Listener:
 
             # Same idea on the insecure side: only skip the Host if the Listener's securityModel
             # is INSECURE but the Host's insecure_action is Reject.
-
-            if not ((security_model == "INSECURE") and (insecure_action == "Reject")):
+            if not ((self._security_model == "INSECURE") and (host.insecure_action == "Reject")):
                 if self._log_debug:
                     self.config.ir.logger.debug("      take INSECURE %s", host)
 

--- a/python/ambassador/envoy/v3/v3listener.py
+++ b/python/ambassador/envoy/v3/v3listener.py
@@ -195,21 +195,8 @@ class V3Listener(dict):
                 })
 
             if proto == "TCP":
-                # TCP doesn't require any specific listener filters, but it
-                # does require stuff in the filter chains. We can go ahead and
-                # tackle that here.
-                for irgroup in self.config.ir.ordered_groups():
-                    # Only look at TCPMappingGroups here...
-                    if not isinstance(irgroup, IRTCPMappingGroup):
-                        continue
-
-                    # ...and make sure the group in question wants the same bind
-                    # address that we do.
-                    if irgroup.bind_to() != self.bind_to:
-                        # self.config.ir.logger.debug("V3Listener %s: skip TCPMappingGroup on %s", self.bind_to, irgroup.bind_to())
-                        continue
-
-                    self.add_tcp_group(irgroup)
+                # Nothing to do.
+                pass
 
     def add_chain(self, chain_type: str, host: Optional[IRHost]) -> V3Chain:
         # Add a chain for a specific Host to this listener, while dealing with the fundamental
@@ -560,11 +547,12 @@ class V3Listener(dict):
 
         # Next, deal with HTTP stuff if this is an HTTP Listener.
         if self._base_http_config:
-            self.compute_chains()
+            self.compute_httpchains()
             self.compute_routes()
             self.finalize_http()
         else:
             # TCP is a lot simpler.
+            self.compute_tcpchains()
             self.finalize_tcp()
 
     def finalize_tcp(self) -> None:
@@ -640,7 +628,22 @@ class V3Listener(dict):
                 # ...and stick this chain into our filter.
                 self._filter_chains.append(filter_chain)
 
-    def compute_chains(self) -> None:
+    def compute_tcpchains(self) -> None:
+        for irgroup in self.config.ir.ordered_groups():
+            # Only look at TCPMappingGroups here...
+            if not isinstance(irgroup, IRTCPMappingGroup):
+                continue
+
+            # ...and make sure the group in question wants the same bind
+            # address that we do.
+            if irgroup.bind_to() != self.bind_to:
+                # self.config.ir.logger.debug("V3Listener %s: skip TCPMappingGroup on %s", self.bind_to, irgroup.bind_to())
+                continue
+
+            self.add_tcp_group(irgroup)
+
+
+    def compute_httpchains(self) -> None:
         # Compute the set of chains we need, HTTP version. The core here is matching
         # up Hosts with this Listener, and creating a chain for each Host.
 

--- a/python/ambassador/envoy/v3/v3listener.py
+++ b/python/ambassador/envoy/v3/v3listener.py
@@ -85,10 +85,10 @@ class V3Chain:
         else:
             return 'http'
 
-    def add_host(self, host: IRHost) -> None:
+    def add_host(self, host: IRHost, hostname: Optional[str]=None) -> None:
         if self._log_debug:
-            self._logger.debug(f"      CHAIN UPDATE: add HTTP host: hostname={repr(host.hostname)}")
-        self.hosts[host.hostname] = host
+            self._logger.debug(f"      CHAIN UPDATE: add HTTP host: hostname={repr(hostname or host.hostname)}")
+        self.hosts[hostname or host.hostname] = host
 
         # Don't mess with the context if we're a cleartext chain...
         if not self.context:
@@ -650,8 +650,8 @@ class V3Listener:
                                                     self.name, self.bind_to, group_host, host)
 
                     if hostglob_matches(host.hostname, group_host):
-                        chain = self.add_chain('tcp', host.context, host.hostname)
-                        chain.add_host(host)
+                        chain = self.add_chain('tcp', host.context, group_host)
+                        chain.add_host(host, hostname=group_host)
                         chain.add_tcpmapping(irgroup)
 
     def compute_httpchains(self) -> None:

--- a/python/ambassador/envoy/v3/v3listener.py
+++ b/python/ambassador/envoy/v3/v3listener.py
@@ -211,7 +211,7 @@ class V3Listener:
         # representations) that won't get logged anyway.
         self._log_debug = self.config.ir.logger.isEnabledFor(logging.DEBUG)
         if self._log_debug:
-            self.config.ir.logger.debug(f"V3Listener {self.name} created -- {self._security_model}, l7Depth {self._l7_depth}")
+            self.config.ir.logger.debug(f"V3Listener {self.name}: created: port={self.port} security_model={self._security_model} l7depth={self._l7_depth}")
 
         # Build out our listener filters, and figure out if we're an HTTP listener
         # in the process.
@@ -551,7 +551,7 @@ class V3Listener:
 
     def finalize(self) -> None:
         if self._log_debug:
-            self.config.ir.logger.debug(f"V3Listener: ==== finalize {self}")
+            self.config.ir.logger.debug(f"V3Listener {self}: finalize ============================")
 
         # We do TCP chains before HTTP chains so that TCPMappings have precedence over Hosts.  This
         # is important because 2.x releases prior to 2.4 required you to create a Host for the
@@ -572,11 +572,12 @@ class V3Listener:
     def finalize_tcp(self) -> None:
         # Finalize a TCP listener, which amounts to walking all our TCP chains and
         # setting up Envoy configuration structures for them.
-        logger = self.config.ir.logger
+
+        self.config.ir.logger.debug("  finalize_tcp")
 
         for chain_key, chain in self._chains.items():
             if self._log_debug:
-                logger.debug("BUILD CHAIN %s - %s", chain_key, chain)
+                self.config.ir.logger.debug(f"    build chain[{repr(chain_key)}]={chain}")
 
             for irgroup in chain.hosts.values():
                 if not isinstance(irgroup, IRTCPMappingGroup):
@@ -644,27 +645,29 @@ class V3Listener:
                 self._filter_chains.append(filter_chain)
 
     def compute_tcpchains(self) -> None:
+        self.config.ir.logger.debug("  compute_tcpchains")
+
         for irgroup in self.config.ir.ordered_groups():
             # Only look at TCPMappingGroups here...
             if not isinstance(irgroup, IRTCPMappingGroup):
                 continue
 
+            if self._log_debug:
+                self.config.ir.logger.debug(f"    consider {irgroup}")
+
             # ...and make sure the group in question wants the same bind
             # address that we do.
             if irgroup.bind_to() != self.bind_to:
-                # self.config.ir.logger.debug("V3Listener %s: skip TCPMappingGroup on %s", self.bind_to, irgroup.bind_to())
+                self.config.ir.logger.debug("      reject")
                 continue
+
+            self.config.ir.logger.debug("      accept")
 
             # Add a chain, same as we do in compute_httpchains, just for a 'TCPMappingGroup' rather
             # than for a 'Host'.  Same deal applies with TLS: you can't do host-based matching
             # without it.
 
             group_host = irgroup.get('host', None)
-
-            if self._log_debug:
-                self.config.ir.logger.debug("V3Listener %s on %s: take TCPMappingGroup on %s (%s)",
-                                            self.name, self.bind_to, irgroup.bind_to(), group_host or "i'*'")
-
             if not group_host: # cleartext
                 # Special case. No Host in a TCPMapping means an unconditional forward,
                 # so just add this immediately as a "*" chain.
@@ -680,15 +683,15 @@ class V3Listener:
         # Compute the set of chains we need, HTTP version. The core here is matching
         # up Hosts with this Listener, and creating a chain for each Host.
 
-        self.config.ir.logger.debug("V3Listener %s: checking hosts for %s", self.name, self)
+        self.config.ir.logger.debug("  compute_httpchains")
 
         for host in sorted(self.config.ir.get_hosts(), key=lambda h: h.hostname):
             if self._log_debug:
-                self.config.ir.logger.debug("  consider %s", host)
+                self.config.ir.logger.debug(f"    consider {host}")
 
             # First up: drop this host if nothing matches at all.
             if not self._irlistener.matches_host(host):
-                # Bzzzt.
+                self.config.ir.logger.debug("      reject: hostglobs don't match")
                 continue
 
             # OK, if we're still here, then it's a question of matching the Listener's
@@ -703,9 +706,7 @@ class V3Listener:
             # here.)
 
             if self._insecure_only and (self.port != host.insecure_addl_port):
-                if self._log_debug:
-                    self.config.ir.logger.debug("      drop %s, insecure-only port mismatch", host.name)
-
+                self.config.ir.logger.debug("      reject: insecure-only port mismatch")
                 continue
 
             # OK, we can't drop it for that, so we need to check the actions.
@@ -716,17 +717,13 @@ class V3Listener:
             # HTTPS chain for this Host, as long as we think TLS is OK.
             host_will_reject_secure = ((not host.secure_action) or (host.secure_action == "Reject"))
             if self._tls_ok and host.context and (not ((self._security_model == "SECURE") and host_will_reject_secure)):
-                if self._log_debug:
-                    self.config.ir.logger.debug("      take SECURE %s", host)
-
+                self.config.ir.logger.debug("      accept SECURE")
                 self.add_chain('https', host.context, host.hostname).add_httphost(host)
 
             # Same idea on the insecure side: only skip the Host if the Listener's securityModel
             # is INSECURE but the Host's insecure_action is Reject.
             if not ((self._security_model == "INSECURE") and (host.insecure_action == "Reject")):
-                if self._log_debug:
-                    self.config.ir.logger.debug("      take INSECURE %s", host)
-
+                self.config.ir.logger.debug("      accept INSECURE")
                 self.add_chain('http', None, host.hostname).add_httphost(host)
 
     def compute_routes(self) -> None:
@@ -734,15 +731,16 @@ class V3Listener:
         #
         # Note that a route using XFP can match _any_ chain, whether HTTP or HTTPS.
 
-        logger = self.config.ir.logger
+        self.config.ir.logger.debug("  compute_routes")
 
         for chain_key, chain in self._chains.items():
+            if self._log_debug:
+                self.config.ir.logger.debug(f"    consider chain[{repr(chain_key)}]={chain}")
+
             # Only look at HTTP(S) chains.
             if not any(isinstance(h, IRHost) for h in chain.hosts.values()):
+                self.config.ir.logger.debug("      reject: is non-HTTP")
                 continue
-
-            if self._log_debug:
-                logger.debug("MATCH CHAIN %s - %s", chain_key, chain)
 
             # Remember whether we found an ACME route.
             found_acme = False
@@ -752,16 +750,16 @@ class V3Listener:
             # V3RouteVariants to lazily cache some of the work that we're doing across chains.
             for rv in self.config.route_variants:
                 if self._log_debug:
-                    logger.debug("  CHECK ROUTE: %s", v3prettyroute(dict(rv.route)))
+                    self.config.ir.logger.debug(f"        consider route {v3prettyroute(dict(rv.route))}")
 
                 matching_hosts = chain.matching_hosts(rv.route)
 
                 if self._log_debug:
-                    logger.debug("    = matching_hosts %s", ", ".join([ h.hostname for h in matching_hosts ]))
+                    self.config.ir.logger.debug(f"          matching_hosts={[h.hostname for h in matching_hosts]}")
 
                 if not matching_hosts:
                     if self._log_debug:
-                        logger.debug(f"    drop outright: no hosts match {sorted(rv.route['_host_constraints'])}")
+                        self.config.ir.logger.debug(f"          reject: no hosts match {sorted(rv.route['_host_constraints'])}")
                     continue
 
                 for host in matching_hosts:
@@ -772,6 +770,9 @@ class V3Listener:
                     # "candidates" is host, matcher, action, V3RouteVariants
                     candidates: List[Tuple[IRHost, str, str, V3RouteVariants]] = []
                     hostname = host.hostname
+
+                    if self._log_debug:
+                        self.config.ir.logger.debug(f"          host={hostname}")
 
                     if (host.secure_action is not None) and (self._security_model != "INSECURE"):
                         # We have a secure action, and we're willing to believe that at least some of
@@ -810,16 +811,14 @@ class V3Listener:
                             # really mean "redirect to HTTPS" specifically.
 
                             if self._log_debug:
-                                logger.debug("      %s - %s: accept on %s %s%s",
-                                             matcher, action, self.name, hostname, extra_info)
+                                self.config.ir.logger.debug(f"          route: accept matcher={matcher} action={action} {extra_info}")
 
                             variant = dict(rv.get_variant(matcher, action.lower()))
                             variant["_host_constraints"] = set([ hostname ])
                             chain.add_route(variant)
                         else:
                             if self._log_debug:
-                                logger.debug("      %s - %s: drop from %s %s%s",
-                                             matcher, action, self.name, hostname, extra_info)
+                                self.config.ir.logger.debug(f"          route: reject matcher={matcher} action={action} {extra_info}")
 
             # If we're on Edge Stack and we don't already have an ACME route, add one.
             if self.config.ir.edge_stack_allowed and not found_acme:
@@ -831,8 +830,7 @@ class V3Listener:
                     # Uh whut? how is Edge Stack running exactly?
                     raise Exception("Edge Stack claims to be running, but we have no sidecar cluster??")
 
-                if self._log_debug:
-                    logger.debug("      punching a hole for ACME")
+                self.config.ir.logger.debug("      punching a hole for ACME")
 
                 # Make sure to include _host_constraints in here for now.
                 #
@@ -853,7 +851,7 @@ class V3Listener:
 
             if self._log_debug:
                 for route in chain.routes:
-                    logger.debug("  CHAIN ROUTE: %s" % v3prettyroute(route))
+                    self.config.ir.logger.debug("  CHAIN ROUTE: %s" % v3prettyroute(route))
 
     def finalize_http(self) -> None:
         # Finalize everything HTTP. Like the TCP side of the world, this is about walking
@@ -862,6 +860,8 @@ class V3Listener:
         # All of our HTTP chains get collapsed into a single chain with (likely) multiple
         # domains here.
 
+        self.config.ir.logger.debug("  finalize_http")
+
         filter_chains: Dict[str, Dict[str, Any]] = {}
 
         for chain_key, chain in self._chains.items():
@@ -869,11 +869,13 @@ class V3Listener:
                 continue
 
             if self._log_debug:
-                self._irlistener.logger.debug("FHTTP %s / %s / %s", self, chain_key, chain)
+                self._irlistener.logger.debug(f"    build chain[{repr(chain_key)}]={chain}")
 
             filter_chain: Optional[Dict[str, Any]] = None
 
             if not chain.context: # cleartext
+                if self._log_debug:
+                    self._irlistener.logger.debug(f"      cleartext for hostglobs={chain.hostglobs()}")
                 # All HTTP chains get collapsed into one here, using domains to separate them.
                 # This works because we don't need to offer TLS certs (we can't anyway), and
                 # because of that, SNI (and thus filter server_names matches) aren't things.
@@ -905,6 +907,9 @@ class V3Listener:
                 filter_chain_match: Dict[str, Any] = {}
 
                 chain_hosts = chain.hostglobs()
+
+                if self._log_debug:
+                    self._irlistener.logger.debug(f"      tls for hostglobs={chain_hosts}")
 
                 # Set up the server_names part of the match, if we have any names.
                 #
@@ -947,6 +952,9 @@ class V3Listener:
             for host in chain.hosts.values():
                 if not isinstance(host, IRHost):
                     continue
+
+                if self._log_debug:
+                    self._irlistener.logger.debug(f"      adding vhost {repr(host.hostname)}")
 
                 # Make certain that no internal keys from the route make it into the Envoy
                 # configuration.
@@ -1040,22 +1048,20 @@ class V3Listener:
     @classmethod
     def generate(cls, config: 'V3Config') -> None:
         config.listeners = []
-        logger = config.ir.logger
 
         for key in config.ir.listeners.keys():
             irlistener = config.ir.listeners[key]
             v3listener = V3Listener(config, irlistener)
             v3listener.finalize()
 
-            config.ir.logger.info(f"V3Listener: ==== GENERATED {v3listener}")
-
-            if v3listener._log_debug:
-                for k in sorted(v3listener._chains.keys()):
-                    chain = v3listener._chains[k]
-                    config.ir.logger.debug("    %s", chain)
-
-                    for r in chain.routes:
-                        config.ir.logger.debug("      %s", v3prettyroute(r))
+            config.ir.logger.info(f"V3Listener {v3listener}: generated ===========================")
+            if config.ir.logger.isEnabledFor(logging.DEBUG):
+                if v3listener._log_debug:
+                    for k in sorted(v3listener._chains.keys()):
+                        chain = v3listener._chains[k]
+                        config.ir.logger.debug(f"  chain {chain}")
+                        for r in chain.routes:
+                            config.ir.logger.debug(f"    route {v3prettyroute(r)}")
 
             # Does this listener have any filter chains?
             if v3listener._filter_chains:

--- a/python/ambassador/envoy/v3/v3listener.py
+++ b/python/ambassador/envoy/v3/v3listener.py
@@ -687,7 +687,7 @@ class V3Listener:
             # Listener can ever produce will be rejected. In any other case, we'll set up an
             # HTTPS chain for this Host, as long as we think TLS is OK.
             host_will_reject_secure = ((not host.secure_action) or (host.secure_action == "Reject"))
-            if self._tls_ok and (not ((self._security_model == "SECURE") and host_will_reject_secure)):
+            if self._tls_ok and host.context and (not ((self._security_model == "SECURE") and host_will_reject_secure)):
                 if self._log_debug:
                     self.config.ir.logger.debug("      take SECURE %s", host)
 
@@ -895,19 +895,15 @@ class V3Listener:
                 # Likewise, an HTTPS chain will ask for TLS.
                 filter_chain_match["transport_protocol"] = "tls"
 
-                if chain.context:
-                    # ...uh. How could we not have a context if we're doing TLS?
-                    # Note that we're modifying the filter_chain itself here, not
-                    # filter_chain_match.
-                    envoy_ctx = V3TLSContext(chain.context)
+                envoy_ctx = V3TLSContext(chain.context)
 
-                    filter_chain['transport_socket'] = {
-                        'name': 'envoy.transport_sockets.tls',
-                        'typed_config': {
-                            '@type': 'type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext',
-                            **envoy_ctx
-                        }
+                filter_chain['transport_socket'] = {
+                    'name': 'envoy.transport_sockets.tls',
+                    'typed_config': {
+                        '@type': 'type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext',
+                        **envoy_ctx
                     }
+                }
 
                 # Finally, stash the match in the chain...
                 filter_chain["filter_chain_match"] = filter_chain_match

--- a/python/ambassador/envoy/v3/v3listener.py
+++ b/python/ambassador/envoy/v3/v3listener.py
@@ -682,17 +682,12 @@ class V3Listener:
 
             # OK, we can't drop it for that, so we need to check the actions.
 
-            security_model = self._security_model
-            secure_action = host.secure_action
-            insecure_action = host.insecure_action
-
             # If the Listener's securityModel is SECURE, but this host has a secure_action
             # of Reject (or empty), we'll skip this host, because the only requests this
             # Listener can ever produce will be rejected. In any other case, we'll set up an
             # HTTPS chain for this Host, as long as we think TLS is OK.
-
-            will_reject_secure = ((not secure_action) or (secure_action == "Reject"))
-            if self._tls_ok and (not ((security_model == "SECURE") and will_reject_secure)):
+            host_will_reject_secure = ((not host.secure_action) or (host.secure_action == "Reject"))
+            if self._tls_ok and (not ((self._security_model == "SECURE") and host_will_reject_secure)):
                 if self._log_debug:
                     self.config.ir.logger.debug("      take SECURE %s", host)
 
@@ -700,8 +695,7 @@ class V3Listener:
 
             # Same idea on the insecure side: only skip the Host if the Listener's securityModel
             # is INSECURE but the Host's insecure_action is Reject.
-
-            if not ((security_model == "INSECURE") and (insecure_action == "Reject")):
+            if not ((self._security_model == "INSECURE") and (host.insecure_action == "Reject")):
                 if self._log_debug:
                     self.config.ir.logger.debug("      take INSECURE %s", host)
 

--- a/python/ambassador/envoy/v3/v3listener.py
+++ b/python/ambassador/envoy/v3/v3listener.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License
-from typing import Any, Dict, List, Literal, Optional, Tuple, TYPE_CHECKING
+from typing import Any, Dict, List, Literal, Optional, Tuple, TYPE_CHECKING, Union
 from typing import cast as typecast
 
 from os import environ
@@ -46,25 +46,20 @@ if TYPE_CHECKING:
 # also can have a TLS context to say which certificate to serve if a connection is to be
 # processed by the chain.
 #
-# A basic asymmetry of the chain is that the filter_chain_match can only do hostname matching
-# if TLS (and thus SNI) is in play, which means for our purposes that a chain _with_ TLS enabled
-# is fundamentally different from a chain _without_ TLS enabled. We encapsulate that idea in
-# the "type" parameter, which can be "http", "https", or "tcp" depending on how the chain will
-# be used. (And yes, that implies that at the moment, you can't mix HTTP Mappings and TCP Mappings
-# on the same port. Possible near-future feature.)
+# A basic asymmetry of the chain is that the filter_chain_match can only do hostname matching if SNI
+# is available (i.e. we're terminating TLS), which means for our purposes that a chain _with_ TLS
+# enabled is fundamentally different from a chain _without_ TLS enabled.  Whether a chain has TLS
+# enabled can be checked with the truthiness of `chain.context`.
 
 class V3Chain:
     _config: 'V3Config'
     _logger: logging.Logger
     _log_debug: bool
 
-    # We can have multiple hosts here, primarily so that HTTP chains can DTRT --
-    # but it would be fine to have multiple HTTPS hosts too, as long as they all
-    # share a TLSContext.
+    # We can have multiple hosts here, primarily so that cleartext HTTP chains can DTRT.
     context: Optional['IRTLSContext']
-    hosts: Dict[str, IRHost]
+    hosts: Dict[str, Union[IRHost, IRTCPMappingGroup]]
     routes: List[DictifiedV3Route]
-    tcpmappings: List[IRTCPMappingGroup]
 
     def __init__(self, config: 'V3Config', context: Optional['IRTLSContext']) -> None:
         self._config = config
@@ -74,30 +69,42 @@ class V3Chain:
         self.context = context
         self.hosts = {}
         self.routes = []
-        self.tcpmappings = []
 
-    @property
-    def type(self) -> Literal['tcp', 'http', 'https']:
-        if len(self.tcpmappings) > 0:
-            return 'tcp'
-        elif self.context:
-            return 'https'
-        else:
-            return 'http'
-
-    def add_host(self, host: IRHost, hostname: Optional[str]=None) -> None:
+    def add_tcphost(self, tcpmapping: IRTCPMappingGroup) -> None:
         if self._log_debug:
-            self._logger.debug(f"      CHAIN UPDATE: add HTTP host: hostname={repr(hostname or host.hostname)}")
-        self.hosts[hostname or host.hostname] = host
+            self._logger.debug(f"      CHAIN UPDATE: add TCP host: hostname={repr(tcpmapping.get('host'))}")
 
-        # Don't mess with the context if we're a cleartext chain...
-        if not self.context:
+        if len(self.hosts) > 0:
+            # If we have SNI, then each host gets its own chain, so we should never have more than 1
+            # self.hosts; if we don't have SNI then a single TLSContext takes over the entire chain
+            # and so we shouldn't have more than 1 self.hosts then either.
+            other = next(iter(self.hosts.values()))
+            other_type = "TCPMapping" if isinstance(other, IRTCPMappingGroup) else "Host"
+            tcpmapping.post_error("TCPMapping {tcpmapping.name}: discarding because it conflicts with {other_type} {other.name}")
             return
 
-        # OK, we're some type where TLS makes sense. Do the thing.
-        if host.context and host.context != self.context:
-            self._config.ir.post_error("Chain context mismatch: Host %s cannot combine with %s" %
-                                       (host.name, ", ".join(sorted(self.hosts.keys()))))
+        self.hosts[tcpmapping.get('host') or '*'] = tcpmapping
+
+    def add_httphost(self, host: IRHost) -> None:
+        if self._log_debug:
+            self._logger.debug(f"      CHAIN UPDATE: add HTTP host: hostname={repr(host.hostname)}")
+
+        if self.context:
+            # If we have SNI, then each host gets its own chain, so we should never have more than 1
+            # self.hosts
+            if len(self.hosts) > 0:
+                other = next(iter(self.hosts.values()))
+                other_type = "TCPMapping" if isinstance(other, IRTCPMappingGroup) else "Host"
+                host.post_error("TLS Host {host.name}: discarding because it conflicts with {other_type} {other.name}")
+                return
+        else:
+            # If we don't have SNI then a single TLSContext takes over the entire chain.
+            for other in self.hosts.values():
+                if isinstance(other, IRTCPMappingGroup):
+                    host.post_error("Cleartext Host {host.name}: discarding because it conflicts with TCPMapping {other.name}")
+                    return
+
+        self.hosts[host.hostname] = host
 
     def hostglobs(self) -> List[str]:
         # Get a list of host globs currently set up for this chain.
@@ -105,23 +112,19 @@ class V3Chain:
 
     def matching_hosts(self, route: V3Route) -> List[IRHost]:
         # Get a list of _IRHosts_ that the given route should be matched with.
-        rv: List[IRHost] = [ host for host in self.hosts.values() if host.matches_httpgroup(route._group) ]
-
+        rv: List[IRHost] = []
+        for host in self.hosts.values():
+            if isinstance(host, IRHost) and host.matches_httpgroup(route._group):
+                rv.append(host)
         return rv
 
     def add_route(self, route: DictifiedV3Route) -> None:
         self.routes.append(route)
 
-    def add_tcpmapping(self, tcpmapping: IRTCPMappingGroup) -> None:
-        if self._log_debug:
-            self._logger.debug(f"      CHAIN UPDATE: add TCP host: hostname={repr(tcpmapping.get('host'))}")
-        self.tcpmappings.append(tcpmapping)
-
     def __str__(self) -> str:
         ctxstr = f" ctx {self.context.name}" if self.context else ""
 
-        return "CHAIN: %s%s [ %s ]" % \
-               (self.type.upper(), ctxstr, ", ".join(sorted(self.hostglobs())))
+        return f"CHAIN: tls={bool(self.context)} hostglobs={repr(sorted(self.hostglobs()))}"
 
 
 # Model an Envoy listener.
@@ -539,13 +542,13 @@ class V3Listener:
         logger = self.config.ir.logger
 
         for chain_key, chain in self._chains.items():
-            if chain.type != "tcp":
-                continue
-
             if self._log_debug:
                 logger.debug("BUILD CHAIN %s - %s", chain_key, chain)
 
-            for irgroup in chain.tcpmappings:
+            for irgroup in chain.hosts.values():
+                if not isinstance(irgroup, IRTCPMappingGroup):
+                    continue
+
                 # First up, which clusters do we need to talk to?
                 clusters = [{
                     'name': mapping.cluster.envoy_name,
@@ -598,7 +601,7 @@ class V3Listener:
                 # make sure that we don't have two chains with an empty filter_match
                 # criterion (since Envoy will reject such a configuration).
 
-                if len(chain_hosts) > 0:
+                if len(chain_hosts) > 0 and ("*" not in chain_hosts):
                     filter_chain_match['server_names'] = chain_hosts
 
                 # Once all of that is done, hook in the match...
@@ -632,7 +635,7 @@ class V3Listener:
             if not group_host: # cleartext
                 # Special case. No Host in a TCPMapping means an unconditional forward,
                 # so just add this immediately as a "*" chain.
-                self.add_chain('tcp', None, '*').add_tcpmapping(irgroup)
+                self.add_chain('tcp', None, '*').add_tcphost(irgroup)
             else: # TLS/SNI
                 # What matching Hosts do we have?
                 for host in sorted(self.config.ir.get_hosts(), key=lambda h: h.hostname):
@@ -650,9 +653,7 @@ class V3Listener:
                                                     self.name, self.bind_to, group_host, host)
 
                     if hostglob_matches(host.hostname, group_host):
-                        chain = self.add_chain('tcp', host.context, group_host)
-                        chain.add_host(host, hostname=group_host)
-                        chain.add_tcpmapping(irgroup)
+                        self.add_chain('tcp', host.context, group_host).add_tcphost(irgroup)
 
     def compute_httpchains(self) -> None:
         # Compute the set of chains we need, HTTP version. The core here is matching
@@ -697,7 +698,7 @@ class V3Listener:
                 if self._log_debug:
                     self.config.ir.logger.debug("      take SECURE %s", host)
 
-                self.add_chain('https', host.context, host.hostname).add_host(host)
+                self.add_chain('https', host.context, host.hostname).add_httphost(host)
 
             # Same idea on the insecure side: only skip the Host if the Listener's securityModel
             # is INSECURE but the Host's insecure_action is Reject.
@@ -705,7 +706,7 @@ class V3Listener:
                 if self._log_debug:
                     self.config.ir.logger.debug("      take INSECURE %s", host)
 
-                self.add_chain('http', None, host.hostname).add_host(host)
+                self.add_chain('http', None, host.hostname).add_httphost(host)
 
     def compute_routes(self) -> None:
         # Compute the set of valid HTTP routes for _each chain_ in this Listener.
@@ -716,7 +717,7 @@ class V3Listener:
 
         for chain_key, chain in self._chains.items():
             # Only look at HTTP(S) chains.
-            if (chain.type != "http") and (chain.type != "https"):
+            if not any(isinstance(h, IRHost) for h in chain.hosts.values()):
                 continue
 
             if self._log_debug:
@@ -843,12 +844,15 @@ class V3Listener:
         filter_chains: Dict[str, Dict[str, Any]] = {}
 
         for chain_key, chain in self._chains.items():
+            if not any(isinstance(h, IRHost) for h in chain.hosts.values()):
+                continue
+
             if self._log_debug:
                 self._irlistener.logger.debug("FHTTP %s / %s / %s", self, chain_key, chain)
 
             filter_chain: Optional[Dict[str, Any]] = None
 
-            if chain.type == "http":
+            if not chain.context: # cleartext
                 # All HTTP chains get collapsed into one here, using domains to separate them.
                 # This works because we don't need to offer TLS certs (we can't anyway), and
                 # because of that, SNI (and thus filter server_names matches) aren't things.
@@ -869,7 +873,7 @@ class V3Listener:
                 else:
                     if self._log_debug:
                         self._irlistener.logger.debug("FHTTP   use filter_chain %s: vhosts %d", chain_key, len(filter_chain["_vhosts"]))
-            elif chain.type == "https":
+            else: # TLS/SNI
                 # Since chain_key is a dictionary key in its own right, we can't already
                 # have a matching chain for this.
 
@@ -916,13 +920,13 @@ class V3Listener:
 
                 # ...and save it.
                 filter_chains[chain_key] = filter_chain
-            else:
-                # The chain type is neither HTTP nor HTTPS -- must be a TCP chain. Skip it.
-                continue
 
             # OK, we have the filter_chain variable set -- build the Envoy virtual_hosts for it.
 
             for host in chain.hosts.values():
+                if not isinstance(host, IRHost):
+                    continue
+
                 # Make certain that no internal keys from the route make it into the Envoy
                 # configuration.
                 routes = []
@@ -1036,4 +1040,4 @@ class V3Listener:
             if v3listener._filter_chains:
                 config.listeners.append(v3listener)
             else:
-                irlistener.post_error("No matching Hosts found, disabling!")
+                irlistener.post_error("No matching Hosts/TCPMappings found, disabling!")

--- a/python/ambassador/envoy/v3/v3listener.py
+++ b/python/ambassador/envoy/v3/v3listener.py
@@ -127,6 +127,32 @@ class V3Chain:
         return f"CHAIN: tls={bool(self.context)} hostglobs={repr(sorted(self.hostglobs()))}"
 
 
+def tlscontext_for_tcpmapping(irgroup: IRTCPMappingGroup, config: 'V3Config') -> Optional['IRTLSContext']:
+    group_host = irgroup.get('host')
+    if not group_host:
+        return None
+
+    # We can pair directly with a 'TLSContext', or get a TLS config through a 'Host'.
+    #
+    # Give 'Hosts' precedence.  Why?  IDK, it felt right.
+
+    # First, Hosts:
+
+    for irhost in sorted(config.ir.get_hosts(), key=lambda h: h.hostname):
+        if irhost.context and hostglob_matches(irhost.hostname, group_host):
+            return irhost.context
+
+    # Second, TLSContexts:
+
+    for context in config.ir.get_tls_contexts():
+        for context_host in context.get('hosts') or []:
+            # Note: this is *not* glob matching.
+            if context_host == group_host:
+                return context
+
+    return None
+
+
 # Model an Envoy listener.
 #
 # In Envoy, Listeners are the top-level configuration element defining a port on which we'll
@@ -637,23 +663,11 @@ class V3Listener:
                 # so just add this immediately as a "*" chain.
                 self.add_chain('tcp', None, '*').add_tcphost(irgroup)
             else: # TLS/SNI
-                # What matching Hosts do we have?
-                for host in sorted(self.config.ir.get_hosts(), key=lambda h: h.hostname):
-                    # They're asking for a hostname match here, which _cannot happen_ without
-                    # SNI -- so don't take any hosts that don't have a TLSContext.
-
-                    if not host.context:
-                        if self._log_debug:
-                            self.config.ir.logger.debug("V3Listener %s @ %s TCP %s: skip %s",
-                                                        self.name, self.bind_to, group_host, host)
-                        continue
-
-                    if self._log_debug:
-                        self.config.ir.logger.debug("V3Listener %s @ %s TCP %s: consider %s",
-                                                    self.name, self.bind_to, group_host, host)
-
-                    if hostglob_matches(host.hostname, group_host):
-                        self.add_chain('tcp', host.context, group_host).add_tcphost(irgroup)
+                context = tlscontext_for_tcpmapping(irgroup, self.config)
+                if not context:
+                    irgroup.post_error("No matching TLSContext found, disabling!")
+                    continue
+                self.add_chain('tcp', context, group_host).add_tcphost(irgroup)
 
     def compute_httpchains(self) -> None:
         # Compute the set of chains we need, HTTP version. The core here is matching

--- a/python/ambassador/envoy/v3/v3listener.py
+++ b/python/ambassador/envoy/v3/v3listener.py
@@ -53,7 +53,7 @@ if TYPE_CHECKING:
 # be used. (And yes, that implies that at the moment, you can't mix HTTP Mappings and TCP Mappings
 # on the same port. Possible near-future feature.)
 
-class V3Chain(dict):
+class V3Chain:
     def __init__(self, config: 'V3Config', type: str, host: Optional[IRHost]) -> None:
         self._config = config
         self._logger = self._config.ir.logger
@@ -120,7 +120,7 @@ class V3Chain(dict):
 # There is a one-to-one correspondence between an IRListener and an Envoy listener: the logic
 # here is all about constructing the Envoy configuration implied by the IRListener.
 
-class V3Listener(dict):
+class V3Listener:
     config: 'V3Config'
     _irlistener: IRListener
 

--- a/python/ambassador/envoy/v3/v3listener.py
+++ b/python/ambassador/envoy/v3/v3listener.py
@@ -132,7 +132,6 @@ class V3Listener(dict):
         bindstr = f"-{self.bind_address}" if (self.bind_address != "0.0.0.0") else ""
         self.name = irlistener.name or f"ambassador-listener{bindstr}-{self.port}"
 
-        self.use_proxy_proto = False
         self.listener_filters: List[dict] = []
         self.traffic_direction: str = "UNSPECIFIED"
         self.per_connection_buffer_limit_bytes: Optional[int] = None
@@ -990,14 +989,6 @@ class V3Listener(dict):
             listener["listener_filters"] = self.listener_filters
 
         return listener
-
-    def pretty(self) -> dict:
-        return {
-            "name": self.name,
-            "bind_address": self.bind_address,
-            "port": self.port,
-            "chains": self._chains,
-        }
 
     def __str__(self) -> str:
         return "<V3Listener %s %s on %s:%d [%s]>" % (

--- a/python/ambassador/envoy/v3/v3listener.py
+++ b/python/ambassador/envoy/v3/v3listener.py
@@ -259,6 +259,7 @@ class V3Listener:
 
         hostname = hostname or '*'
 
+        chain_key = "tls" if context else "cleartext"
         # I (LukeShu) can't really give an explanation of why `or chain_type == 'http'` belongs in
         # this expression (it's what the above comment "we can - and do - separate HTTP chains into
         # specific domains" is referring to), other than that it needs to be here in order for
@@ -266,8 +267,8 @@ class V3Listener:
         # compute_routes() and remove `or chain_type = 'http'`... I'd have to study compute_routes()
         # a lot more in order to be able to answer that; but in the mean time, including it in the
         # expression keeps things working.
-        separate_by_host = bool(context) or chain_type == 'http'
-        chain_key = f"{chain_type}-{hostname}" if separate_by_host else chain_type
+        if context or chain_type == 'http':
+            chain_key += f"-{hostname}"
 
         chain = self._chains.get(chain_key)
         verb = "REUSED" if chain else "CREATE"
@@ -552,15 +553,21 @@ class V3Listener:
         if self._log_debug:
             self.config.ir.logger.debug(f"V3Listener: ==== finalize {self}")
 
-        # Next, deal with HTTP stuff if this is an HTTP Listener.
+        # We do TCP chains before HTTP chains so that TCPMappings have precedence over Hosts.  This
+        # is important because 2.x releases prior to 2.4 required you to create a Host for the
+        # TCPMapping to steal the TLS termination config from (so TCPMapping users coming from 2.3
+        # will _very likely_ have "conflicting" Hosts and TCPMappings), and also didn't support
+        # TCPMappings and Hosts on the same Listener (so 2.3 didn't see these as "conflicts").  But
+        # now that we do support them together on the same Listener, we do see them as conflicts,
+        # and so we keep compatibility with 2.3 by saying "in the event of a conflict, TCPMappings
+        # have precedence over Hosts."
+        self.compute_tcpchains()
+        self.finalize_tcp()
+
         if self._base_http_config:
             self.compute_httpchains()
             self.compute_routes()
             self.finalize_http()
-        else:
-            # TCP is a lot simpler.
-            self.compute_tcpchains()
-            self.finalize_tcp()
 
     def finalize_tcp(self) -> None:
         # Finalize a TCP listener, which amounts to walking all our TCP chains and

--- a/python/ambassador/envoy/v3/v3listener.py
+++ b/python/ambassador/envoy/v3/v3listener.py
@@ -560,6 +560,7 @@ class V3Listener:
 
                 # OK. Basic filter chain entry next.
                 filter_chain: Dict[str, Any] = {
+                    'name': f"tcphost-{irgroup.name}",
                     'filters': [
                         tcp_filter
                     ]
@@ -859,6 +860,7 @@ class V3Listener:
                     if self._log_debug:
                         self._irlistener.logger.debug("FHTTP   create filter_chain %s / empty match", chain_key)
                     filter_chain = {
+                        "name": "httphost-shared",
                         "filter_chain_match": {},
                         "_vhosts": {}
                     }
@@ -872,6 +874,7 @@ class V3Listener:
                 # have a matching chain for this.
 
                 filter_chain = {
+                    "name": f"httpshost-{next(iter(chain.hosts.values())).name}",
                     "_vhosts": {}
                 }
                 filter_chain_match: Dict[str, Any] = {}

--- a/python/ambassador/envoy/v3/v3listener.py
+++ b/python/ambassador/envoy/v3/v3listener.py
@@ -558,15 +558,6 @@ class V3Listener(dict):
         if self._log_debug:
             self.config.ir.logger.debug(f"V3Listener: ==== finalize {self}")
 
-        # OK. Assemble the high-level stuff for Envoy.
-        self.address = {
-            "socket_address": {
-                "address": self.bind_address,
-                "port_value": self.port,
-                "protocol": "TCP"
-            }
-        }
-
         # Next, deal with HTTP stuff if this is an HTTP Listener.
         if self._base_http_config:
             self.compute_chains()
@@ -988,7 +979,13 @@ class V3Listener(dict):
     def as_dict(self) -> dict:
         listener = {
             "name": self.name,
-            "address": self.address,
+            "address": {
+                "socket_address": {
+                    "address": self.bind_address,
+                    "port_value": self.port,
+                    "protocol": "TCP"
+                }
+            },
             "filter_chains": self._filter_chains,
             "traffic_direction": self.traffic_direction
         }

--- a/python/ambassador/ir/irutils.py
+++ b/python/ambassador/ir/irutils.py
@@ -167,23 +167,23 @@ def selector_matches(logger: logging.Logger, selector: Dict[str, Any], labels: D
 
     if not match:
         # If there's no matchLabels to match, return True.
-        logger.debug("    no matchLabels in selector => True")
+        logger.debug("      no matchLabels in selector => True")
         return True
 
     # If we have stuff to match on, but no labels to actually match them, we
     # can short-circuit (and skip a weirder conditional down in the loop).
     if not labels:
-        logger.debug("    no incoming labels => False")
+        logger.debug("      no incoming labels => False")
         return False
 
     selmatch = False
 
     for k, v in match.items():
         if labels.get(k) == v:
-            logger.debug("    selector match for %s=%s => True", k, v)
+            logger.debug("      selector match for %s=%s => True", k, v)
             return True
 
-        logger.debug("    selector miss on %s=%s", k, v)
+        logger.debug("      selector miss on %s=%s", k, v)
 
-    logger.debug("    all selectors miss => False")
+    logger.debug("      all selectors miss => False")
     return False

--- a/python/tests/kat/t_redirect.py
+++ b/python/tests/kat/t_redirect.py
@@ -237,7 +237,7 @@ class XFPRedirect(AmbassadorTest):
 apiVersion: getambassador.io/v3alpha1
 kind: Listener
 metadata:
-  name: ambassador-listener-8080
+  name: {self.path.k8s}
 spec:
   ambassador_id: [{self.ambassador_id}]
   port: 8080
@@ -251,7 +251,7 @@ spec:
 apiVersion: getambassador.io/v3alpha1
 kind: Host
 metadata:
-  name: weird-xfp-test-host
+  name: {self.path.k8s}
 spec:
   ambassador_id: [{self.ambassador_id}]
   requestPolicy:

--- a/python/tests/kat/t_tcpmapping.py
+++ b/python/tests/kat/t_tcpmapping.py
@@ -942,7 +942,6 @@ class TCPMappingSNIWithHTTPTest(AmbassadorTest):
             yield cls(tls_src, name="{self.tls_src}")
 
     def init(self, tls_src: Literal['tlscontext', 'host']) -> None:
-        self.xfail = "bug (1.14): emits 2 Envoy listeners; one HTTP, one TLS; remarkably Envoy doesn't complain, it just lets the first one (HTTP) win"
         self.tls_src = tls_src
         self.target = HTTP()
 

--- a/python/tests/kat/t_tcpmapping.py
+++ b/python/tests/kat/t_tcpmapping.py
@@ -745,7 +745,6 @@ class TCPMappingSNISharedContextTest(TCPMappingTLSTerminationTest):
 
     def init(self, tls_src: Literal['tlscontext', 'host']) -> None:
         super().init(tls_src)
-        self.xfail = "bug (2.3): filter chains have identical (conflicting) matching rules"
         self.target_a = HTTP(name="target-a")
         self.target_b = HTTP(name="target-b")
 

--- a/python/tests/kat/t_tcpmapping.py
+++ b/python/tests/kat/t_tcpmapping.py
@@ -588,8 +588,6 @@ class TCPMappingTLSTerminationTest(AmbassadorTest):
             yield cls(tls_src, name="{self.tls_src}")
 
     def init(self, tls_src: Literal['tlscontext', 'host']) -> None:
-        if tls_src == 'tlscontext':
-            self.xfail = "bug (2.3): TCPMappings can't match directly with termination TLSContexts"
         self.tls_src = tls_src
 
     def manifests(self) -> str:


### PR DESCRIPTION
## Description

This PR addresses the xfail'ed tests introduced by https://github.com/emissary-ingress/emissary/pull/4493.

As usual for me, I suggest a commit-by-commit review.  Each commit is tagged as either `tidy` for minor tidy-ups that are mostly mechanical and you can probably skim, `refactor` for bigger tidy-ups that actually have logic changes and probably deserve a little more scrutiny, `fix` for the commits that actually contain fixes, or `enhance` for minor enhancements like better logging or diagnostics. As usual for me, the general scheme of that is that the early tidy-up commits line things up so that the "fix" commits can be short-and-sweet; you can see what's actually changing in them without a bunch of other tidy-up noise that is necessary to support them.

The last 2 commits are adding diagnostics trying to figure out why I was seeing `XFPRedirect` fail (because Emissary evidently doesn't see the test's `Host`?) fail with xDS v2.  However, now it turned green.  Oh well, if we see a later run turn red (which seems reasonably likely), at least then we'll have diagnostics about why.

There's a commit in there that I've tagged as co-authored-by @kflynn. It looks pretty different than his original commit, but the logic of the change is the same.

## Related Issues
- Motivating issue: https://github.com/datawire/apro/issues/3036
- Found issue while writing the tests: https://github.com/emissary-ingress/emissary/issues/4476 (not fixed in this PR)
- Base PR (1.14) https://github.com/emissary-ingress/emissary/pull/4477
- Base PR (2.4): https://github.com/emissary-ingress/emissary/pull/4493
- Old version of this PR: https://github.com/emissary-ingress/emissary/pull/4495

## Testing
- https://github.com/emissary-ingress/emissary/pull/4493

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `CHANGELOG.md`. - yes, I added 3 entries

   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations

 - [ ] This is unlikely to impact how Ambassador performs at scale.

   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability

 - [x] My change is adequately tested.

   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points

 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.

 - [ ] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
