### PR TITLE
[v2.4] Remove IHA xfails; fix the resulting failures

### DIFF
--- a/python/ambassador/ir/irhost.py
+++ b/python/ambassador/ir/irhost.py
@@ -339,7 +339,7 @@ class IRHost(IRResource):
             # This is a little weird. Basically we're going to resolve the secret (which should just
             # be a cache lookup here) so that we can use SavedSecret.__str__() as a serializer to
             # compare the configurations.
-            context_ss = self.resolve(ir, secret_name, None)
+            context_ss = ctx.resolve_secret(secret_name)
 
             self.logger.debug(f"Host {self.name}, ctx {ctx.name}, secret {secret_name}, resolved {context_ss}")
 

--- a/python/tests/kat/t_mappingtests_plain.py
+++ b/python/tests/kat/t_mappingtests_plain.py
@@ -91,8 +91,8 @@ spec:
 """
 
     def queries(self):
-        yield Query(self.parent.url(self.name + "/"))    # , xfail="IHA hostglob")
-        yield Query(self.parent.url(f'need-normalization/../{self.name}/'))    # , xfail="IHA hostglob")
+        yield Query(self.parent.url(self.name + "/"))
+        yield Query(self.parent.url(f'need-normalization/../{self.name}/'))
 
     def check(self):
         for r in self.results:
@@ -181,10 +181,10 @@ spec:
 """
 
     def queries(self):
-        yield Query(self.parent.url(self.name + "/")) # , xfail="IHA hostglob")
-        yield Query(self.parent.url(f'need-normalization/../{self.name}/')) # , xfail="IHA hostglob")
-        yield Query(self.parent.url(self.name + "-nested/")) # , xfail="IHA hostglob")
-        yield Query(self.parent.url(self.name + "-non-existent/"), expected=404) # , xfail="IHA hostglob")
+        yield Query(self.parent.url(self.name + "/"))
+        yield Query(self.parent.url(f'need-normalization/../{self.name}/'))
+        yield Query(self.parent.url(self.name + "-nested/"))
+        yield Query(self.parent.url(self.name + "-non-existent/"), expected=404)
 
     def check(self):
         for r in self.results:

--- a/python/tests/kat/t_redirect.py
+++ b/python/tests/kat/t_redirect.py
@@ -52,6 +52,16 @@ type: kubernetes.io/tls
 data:
   tls.crt: {TLSCerts["localhost"].k8s_crt}
   tls.key: {TLSCerts["localhost"].k8s_key}
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: {self.path.k8s}
+spec:
+  ambassador_id: [ {self.ambassador_id} ]
+  hostname: "*"
+  tlsSecret:
+    name: redirect-cert
 """ + super().manifests()
 
     def config(self) -> Generator[Union[str, Tuple[Node, str]], None, None]:

--- a/python/tests/kat/t_redirect.py
+++ b/python/tests/kat/t_redirect.py
@@ -115,6 +115,7 @@ class RedirectTestsWithProxyProto(AmbassadorTest):
     target: ServiceType
 
     def init(self):
+        self.xfail = "2.0.0-ea dropped Module.spec.config.use_proxy_proto in favor of Listeners... this test needs re-thought in that world, and also needs to check more things, it's too anemic to be useful as-is"
         self.target = HTTP()
 
     def requirements(self):
@@ -173,9 +174,7 @@ class RedirectTestsInvalidSecret(AmbassadorTest):
     target: ServiceType
 
     def init(self):
-        if EDGE_STACK:
-            self.xfail = "Not yet supported in Edge Stack"
-
+        self.xfail = "this is an invalid config, anything is allowed to happen"
         self.target = HTTP()
 
     def requirements(self):

--- a/python/tests/kat/t_redirect.py
+++ b/python/tests/kat/t_redirect.py
@@ -25,8 +25,6 @@ class RedirectTests(AmbassadorTest):
         if EDGE_STACK:
             self.xfail = "Not yet supported in Edge Stack"
 
-        self.xfail = "FIXME: IHA"
-
         self.target = HTTP()
 
     def requirements(self):
@@ -107,7 +105,6 @@ class RedirectTestsWithProxyProto(AmbassadorTest):
     target: ServiceType
 
     def init(self):
-        self.xfail = "FIXME: IHA"
         self.target = HTTP()
 
     def requirements(self):
@@ -169,7 +166,6 @@ class RedirectTestsInvalidSecret(AmbassadorTest):
         if EDGE_STACK:
             self.xfail = "Not yet supported in Edge Stack"
 
-        self.xfail = "FIXME: IHA"
         self.target = HTTP()
 
     def requirements(self):

--- a/python/tests/kat/t_tls.py
+++ b/python/tests/kat/t_tls.py
@@ -23,8 +23,6 @@ class TLSContextsTest(AmbassadorTest):
         if EDGE_STACK:
             self.xfail = "Not yet supported in Edge Stack"
 
-        self.xfail = "FIXME: IHA"
-
     def manifests(self) -> str:
         return f"""
 ---
@@ -74,7 +72,6 @@ service: {self.target.path.fqdn}
 class ClientCertificateAuthentication(AmbassadorTest):
 
     def init(self):
-        self.xfail = "FIXME: IHA"
         self.target = HTTP()
 
     def manifests(self) -> str:
@@ -190,7 +187,6 @@ add_request_headers:
 class ClientCertificateAuthenticationContext(AmbassadorTest):
 
     def init(self):
-        self.xfail = "FIXME: IHA"
         self.target = HTTP()
 
     def manifests(self) -> str:
@@ -277,7 +273,6 @@ service: {self.target.path.fqdn}
 class ClientCertificateAuthenticationContextCRL(AmbassadorTest):
 
     def init(self):
-        self.xfail = "FIXME: IHA"  # This test should cover TLSContext with a crl_secret
         self.target = HTTP()
 
     def manifests(self) -> str:
@@ -358,7 +353,6 @@ hostname: "*"
 class TLSOriginationSecret(AmbassadorTest):
 
     def init(self):
-        self.xfail = "FIXME: IHA"
         self.target = HTTP()
 
     def manifests(self) -> str:
@@ -425,7 +419,6 @@ class TLS(AmbassadorTest):
     target: ServiceType
 
     def init(self):
-        self.xfail = "FIXME: IHA"
         self.target = HTTP()
 
     def manifests(self) -> str:
@@ -512,7 +505,6 @@ class TLSInvalidSecret(AmbassadorTest):
     target: ServiceType
 
     def init(self):
-        self.xfail = "FIXME: IHA"
         self.target = HTTP()
 
     def config(self) -> Generator[Union[str, Tuple[Node, str]], None, None]:
@@ -576,7 +568,6 @@ class TLSContextTest(AmbassadorTest):
     # debug = True
 
     def init(self):
-        self.xfail = "FIXME: IHA"
         self.target = HTTP()
 
         if EDGE_STACK:
@@ -851,7 +842,6 @@ redirect_cleartext_from: 8081
 class TLSIngressTest(AmbassadorTest):
 
     def init(self):
-        self.xfail = "FIXME: IHA"
         self.target = HTTP()
 
     def manifests(self) -> str:
@@ -1094,8 +1084,6 @@ class TLSContextProtocolMaxVersion(AmbassadorTest):
         if EDGE_STACK:
             self.xfail = "Not yet supported in Edge Stack"
 
-        self.xfail = "FIXME: IHA"
-
     def manifests(self) -> str:
         return f"""
 ---
@@ -1212,7 +1200,6 @@ class TLSContextProtocolMinVersion(AmbassadorTest):
     # debug = True
 
     def init(self):
-        self.xfail = "FIXME: IHA"
         self.target = HTTP()
 
     def manifests(self) -> str:
@@ -1311,7 +1298,6 @@ class TLSContextCipherSuites(AmbassadorTest):
     # debug = True
 
     def init(self):
-        self.xfail = "FIXME: IHA"
         self.target = HTTP()
 
     def manifests(self) -> str:
@@ -1464,8 +1450,6 @@ class TLSCoalescing(AmbassadorTest):
         if EDGE_STACK:
             self.xfail = "Not yet supported in Edge Stack"
 
-        self.xfail = "FIXME: IHA"
-
     def manifests(self) -> str:
         return f"""
 ---
@@ -1523,7 +1507,6 @@ class TLSInheritFromModule(AmbassadorTest):
     target: ServiceType
 
     def init(self):
-        self.xfail = "FIXME: IHA"
         self.edge_stack_cleartext_host = False
         self.target = HTTP()
 

--- a/python/tests/kat/t_tls.py
+++ b/python/tests/kat/t_tls.py
@@ -35,6 +35,15 @@ data:
   tls.crt: {TLSCerts["master.datawire.io"].k8s_crt}
 kind: Secret
 type: Opaque
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: {self.path.k8s}
+spec:
+  ambassador_id: [ {self.ambassador_id} ]
+  tlsSecret:
+    name: test-tlscontexts-secret
 """ + super().manifests()
 
     def config(self) -> Generator[Union[str, Tuple[Node, str]], None, None]:
@@ -97,6 +106,17 @@ type: kubernetes.io/tls
 data:
   tls.crt: {TLSCerts["ambassador.example.com"].k8s_crt}
   tls.key: {TLSCerts["ambassador.example.com"].k8s_key}
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: {self.path.k8s}
+spec:
+  ambassador_id: [ {self.ambassador_id} ]
+  tlsSecret:
+    name: test-clientcert-server-secret
+  tls:
+    cert_required: True
 """ + super().manifests()
 
     def config(self) -> Generator[Union[str, Tuple[Node, str]], None, None]:
@@ -225,6 +245,18 @@ spec:
   secret: ccauthctx-server-secret
   ca_secret: ccauthctx-client-secret
   cert_required: True
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: {self.path.k8s}
+spec:
+  ambassador_id: [ {self.ambassador_id} ]
+  hostname: "*"
+  tlsSecret:
+    name: ccauthctx-server-secret
+  tlsContext:
+    name: ccauthctx-tls
 """) + super().manifests()
 
     def config(self) -> Generator[Union[str, Tuple[Node, str]], None, None]:
@@ -322,6 +354,18 @@ spec:
   ca_secret: ccauthctxcrl-client-secret
   crl_secret: ccauthctxcrl-crl-secret
   cert_required: True
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: {self.path.k8s}
+spec:
+  ambassador_id: [ {self.ambassador_id} ]
+  hostname: "*"
+  tlsSecret:
+    name: ccauthctxcrl-server-secret
+  tlsContext:
+    name: ccauthctxcrl-tls
 """) + super().manifests()
 
     def config(self) -> Generator[Union[str, Tuple[Node, str]], None, None]:
@@ -609,6 +653,60 @@ metadata:
   labels:
     kat-ambassador-id: tlscontexttest
 type: kubernetes.io/tls
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: {self.path.k8s}-1
+spec:
+  ambassador_id: [ {self.ambassador_id} ]
+  hostname: tls-context-host-1
+  tlsSecret:
+    name: test-tlscontext-secret-1
+    namespace: secret-namespace
+  tlsContext:
+    name: {self.name}-same-context-1
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: {self.path.k8s}-2
+spec:
+  ambassador_id: [ {self.ambassador_id} ]
+  hostname: tls-context-host-2
+  tlsSecret:
+    name: test-tlscontext-secret-2
+  tlsContext:
+    name: {self.name}-same-context-2
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: {self.path.k8s}-no-secret
+spec:
+  ambassador_id: [ {self.ambassador_id} ]
+  tlsContext:
+    name: {self.name}-no-secret
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: {self.path.k8s}-same-context-error
+spec:
+  ambassador_id: [ {self.ambassador_id} ]
+  hostname: tls-context-host-1
+  tlsContext:
+    name: {self.name}-same-context-error
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: {self.path.k8s}-rcf-error
+spec:
+  ambassador_id: [ {self.ambassador_id} ]
+  hostname: tls-context-host-1
+  tlsContext:
+    name: {self.name}-rcf-error
 """ + super().manifests()
 
     def config(self) -> Generator[Union[str, Tuple[Node, str]], None, None]:
@@ -933,6 +1031,16 @@ spec:
               number: 80
         path: /tls-context-same/
         pathType: Prefix
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: {self.path.k8s}
+spec:
+  ambassador_id: [ {self.ambassador_id} ]
+  hostname: "*"
+  tlsSecret:
+    name: test-tlscontext-secret-ingress-0
 """ + super().manifests()
 
     def config(self) -> Generator[Union[str, Tuple[Node, str]], None, None]:
@@ -1097,6 +1205,18 @@ metadata:
   labels:
     kat-ambassador-id: tlscontextprotocolmaxversion
 type: kubernetes.io/tls
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: {self.path.k8s}
+spec:
+  ambassador_id: [ {self.ambassador_id} ]
+  hostname: tls-context-host-1
+  tlsSecret:
+    name: secret.max-version
+  tlsContext:
+    name: {self.name}-same-context-1
 """ + super().manifests()
 
     def config(self) -> Generator[Union[str, Tuple[Node, str]], None, None]:
@@ -1215,6 +1335,18 @@ metadata:
   labels:
     kat-ambassador-id: tlscontextprotocolminversion
 type: kubernetes.io/tls
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: {self.path.k8s}
+spec:
+  ambassador_id: [ {self.ambassador_id} ]
+  hostname: tls-context-host-1
+  tlsSecret:
+    name: secret.min-version
+  tlsContext:
+    name: {self.name}-same-context-1
 """ + super().manifests()
 
     def config(self) -> Generator[Union[str, Tuple[Node, str]], None, None]:
@@ -1313,6 +1445,18 @@ metadata:
   labels:
     kat-ambassador-id: tlscontextciphersuites
 type: kubernetes.io/tls
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: {self.path.k8s}
+spec:
+  ambassador_id: [ {self.ambassador_id} ]
+  hostname: tls-context-host-1
+  tlsSecret:
+    name: secret.cipher-suites
+  tlsContext:
+    name: {self.name}-same-context-1
 """ + super().manifests()
 
     def config(self) -> Generator[Union[str, Tuple[Node, str]], None, None]:
@@ -1463,6 +1607,42 @@ data:
   tls.key: {TLSCerts["*.domain.com"].k8s_key}
 kind: Secret
 type: kubernetes.io/tls
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: {self.path.k8s}-apex
+spec:
+  ambassador_id: [ {self.ambassador_id} ]
+  hostname: domain.com
+  tlsSecret:
+    name: tlscoalescing-certs
+  tlsContext:
+    name: tlscoalescing-context
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: {self.path.k8s}-a
+spec:
+  ambassador_id: [ {self.ambassador_id} ]
+  hostname: a.domain.com
+  tlsSecret:
+    name: tlscoalescing-certs
+  tlsContext:
+    name: tlscoalescing-context
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: {self.path.k8s}-b
+spec:
+  ambassador_id: [ {self.ambassador_id} ]
+  hostname: b.domain.com
+  tlsSecret:
+    name: tlscoalescing-certs
+  tlsContext:
+    name: tlscoalescing-context
 """ + super().manifests()
 
     def config(self) -> Generator[Union[str, Tuple[Node, str]], None, None]:
@@ -1526,6 +1706,22 @@ config:
 
     def manifests(self) -> str:
         return self.format('''
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: {self.path.k8s}
+spec:
+  ambassador_id: [ {self.ambassador_id} ]
+  hostname: a.domain.com
+  tlsSecret:
+    name: {self.name.k8s}
+  tlsContext:
+    name: {self.name.k8s}
+  requestPolicy:
+    insecure:
+      action: Redirect
+      additionalPort: 8080
 ---
 apiVersion: getambassador.io/v3alpha1
 kind: TLSContext


### PR DESCRIPTION
## Description

This PR un-xfails some tests, and attempts to deal with the resulting failures.  This is tricky because failures may be due to the test needing updated, or may be due to the code-under-test actually being broken.

So far, code-under-test that has been fixed:
 - Found a bug where @AliceProxy's `Host`-with-cross-namespace-secrets code doesn't work when the `Host` is referencing a `TLSContext` rather than including the `tls` config in-line.

Test issues:
- A bunch of the tests use `tls` `Modules`.  `tls` `Modules` were (allegedly) dropped in 2.0.0-ea. I've started adding `Hosts` to do what these should-be-ignored `Modules` were doing. However, if I'm reading the logs right (which is a *big* if in my current mental state), it looks like it's actually synthesizing `TLSContexts` from the `Modules`, which it totally should not be doing if we dropped them.  So maybe we just said we dropped them but didn't really drop them some of our users are still relying on them?

## Related Issues
List related issues.

## Testing
A few sentences describing what testing you've done, e.g., manual tests, automated tests, deployed in production, etc.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `CHANGELOG.md`.

   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations

 - [ ] This is unlikely to impact how Ambassador performs at scale.

   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability

 - [ ] My change is adequately tested.

   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points

 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.

 - [ ] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
