### PR TITLE
Service name fix, changed to use envoy name instead of the service name

### DIFF
--- a/python/ambassador/ir/ircluster.py
+++ b/python/ambassador/ir/ircluster.py
@@ -312,11 +312,10 @@ class IRCluster(IRResource):
         # If we have a stats_name, use it. If not, default it to the service to make life
         # easier for people trying to find stats later -- but translate unusual characters
         # to underscores, just in case.
-
         if stats_name:
             new_args["stats_name"] = stats_name
         else:
-            new_args["stats_name"] = re.sub(r"[^0-9A-Za-z_]", "_", service)
+            new_args["stats_name"] = re.sub(r"[^0-9A-Za-z_]", "_", name)
 
         if grpc:
             new_args["grpc"] = True


### PR DESCRIPTION
## Description
Envoy stats are being sent and build with the incorrect name inside the snapshot, this one being formatted as `<name>`, instead of using the envoy name `<cluster>_<name>_<namespace>`. 

This change sends it with the correct envoy name, so that we are able to send the hmetric and other health stats that were not set because we were sending the envoy name to match only to cluster_stats inside envoy_stats.py when it was called from diagnostics.py. 

## Related Issues
List related issues.

## Testing
Manual, built a kubeception cluster, then make a couple of requests and trigger a 5xx error to see the health percent change.  

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `CHANGELOG.md`.

   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations

 - [x] This is unlikely to impact how Ambassador performs at scale.

   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability

 - [x] My change is adequately tested.

   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points

 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.

 - [ ] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
