### PR TITLE
[v2.5] Fix label selectors Re: PRs #4499 & #4318

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,18 @@ refer both to Emissary-ingress and to the Ambassador Edge Stack.
 
 ## UPCOMING BREAKING CHANGES
 
-### Emissary 3.1.0
- - Changes to label matching will change how Hosts match Mappings. Hosts were matching any labels found in Mappings, now it's changed to match `all labels`. To avoid unexpected behaviour after the upgrade, add all labels that Hosts have in their mappingSelector to Mappings you want it to match.
+### Emissary 3.2.0 and 2.4.0
+
+ - Changes to label matching will change how `Hosts` are associated with `Mappings`. There
+   was a bug with label selectors that was causing `Hosts` to be incorrectly being associated with
+   more `Mappings` than intended. If any single label from the selector was matched then the `Host`
+   would be associated with the `Mapping`. Now it has been updated to correctly only associate a
+   `Host` with a `Mapping` if **all** labels required by the selector are present. This brings the
+   `mappingSelector` field in-line with how label selectors are used in Kubernetes. To avoid
+   unexpected behaviour after the upgrade, add all labels that Hosts have in their `mappingSelector`
+   to `Mappings` you want to associate with the `Host`. You can opt-out of the new behaviour by
+   setting the environment variable `DISABLE_STRICT_LABEL_SELECTORS` to `"true"`
+   (default: `"false"`).
 
 ### Emissary 3.0.0
 
@@ -98,7 +108,19 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
   endpoints be inserted to clusters manually. This can help resolve with `503 UH` caused by
   certification rotation relating to a delay between EDS + CDS. The default is `false`.
 
-- Bugfix: Previously, setting the `stats_name` for the `TracingService`, `RateLimitService`  or the
+- Change: Changes to label matching will change how `Hosts` are associated with `Mappings`. There
+  was a bug with label selectors that was causing `Hosts` to be incorrectly being associated with
+  more `Mappings` than intended. If any single label from the selector was matched then the `Host`
+  would be associated with the `Mapping`. Now it has been updated to correctly only associate a
+  `Host` with a `Mapping` if **all** labels required by the selector are present. This brings the
+  `mappingSelector` field in-line with how label selectors are used in Kubernetes. To avoid
+  unexpected behaviour after the upgrade, add all labels that Hosts have in their `mappingSelector`
+  to `Mappings` you want to associate with the `Host`. You can opt-out of the new behaviour by
+  setting the environment variable `DISABLE_STRICT_LABEL_SELECTORS` to `"true"`
+  (default: `"false"`). (Thanks to <a href="https://github.com/f-herceg">Filip Herceg</a> and
+  <a href="https://github.com/dynajoe">Joe Andaverde</a>!).
+
+- Bugfix: Previously, setting the `stats_name` for the `TracingService`, `RateLimitService` or the
   `AuthService` would have no affect because it was not being properly passed to the Envoy cluster
   config. This has been fixed and the `alt_stats_name` field in the cluster config is now set
   correctly. (Thanks to <a href="https://github.com/psalaberria002">Paul</a>!)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ refer both to Emissary-ingress and to the Ambassador Edge Stack.
 
 ## UPCOMING BREAKING CHANGES
 
+### Emissary 3.1.0
+ - Changes to label matching will change how Hosts match Mappings. Hosts were matching any labels found in Mappings, now it's changed to match `all labels`. To avoid unexpected behaviour after the upgrade, add all labels that Hosts have in their mappingSelector to Mappings you want it to match.
+
 ### Emissary 3.0.0
 
  - **No `protocol_version: v2`**: Support for specifying `protocol_version: v2` in `AuthService`,

--- a/docs/CHANGELOG.tpl
+++ b/docs/CHANGELOG.tpl
@@ -32,6 +32,19 @@ refer both to Emissary-ingress and to the Ambassador Edge Stack.
 
 ## UPCOMING BREAKING CHANGES
 
+### Emissary 3.2.0 and 2.4.0
+
+ - Changes to label matching will change how `Hosts` are associated with `Mappings`. There
+   was a bug with label selectors that was causing `Hosts` to be incorrectly being associated with
+   more `Mappings` than intended. If any single label from the selector was matched then the `Host`
+   would be associated with the `Mapping`. Now it has been updated to correctly only associate a
+   `Host` with a `Mapping` if **all** labels required by the selector are present. This brings the
+   `mappingSelector` field in-line with how label selectors are used in Kubernetes. To avoid
+   unexpected behaviour after the upgrade, add all labels that Hosts have in their `mappingSelector`
+   to `Mappings` you want to associate with the `Host`. You can opt-out of the new behaviour by
+   setting the environment variable `DISABLE_STRICT_LABEL_SELECTORS` to `"true"`
+   (default: `"false"`).
+
 ### Emissary 3.0.0
 
  - **No `protocol_version: v2`**: Support for specifying `protocol_version: v2` in `AuthService`,

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -50,10 +50,23 @@ items:
           inserted to clusters manually. This can help resolve with `503 UH` caused by certification rotation relating to
           a delay between EDS + CDS. The default is `false`.
 
+      - title: Fixed <code>mappingSelector</code> associating <code>Hosts</code> with <code>Mappings</code>
+        type: change
+        body: >-
+          Changes to label matching will change how <code>Hosts</code> are associated with <code>Mappings</code>. There was a bug with label
+          selectors that was causing <code>Hosts</code> to be incorrectly being associated with more <code>Mappings</code> than intended.
+          If any single label from the selector was matched then the <code>Host</code> would be associated with the <code>Mapping</code>.
+          Now it has been updated to correctly only associate a <code>Host</code> with a <code>Mapping</code> if **all** labels required by
+          the selector are present. This brings the <code>mappingSelector</code> field in-line with how label selectors are used
+          in Kubernetes. To avoid unexpected behaviour after the upgrade, add all labels that Hosts have in their
+          <code>mappingSelector</code> to <code>Mappings</code> you want to associate with the <code>Host</code>. You can opt-out of the new behaviour
+          by setting the environment variable <code>DISABLE_STRICT_LABEL_SELECTORS</code> to <code>"true"</code> (default: <code>"false"</code>).
+          (Thanks to <a href="https://github.com/f-herceg">Filip Herceg</a> and <a href="https://github.com/dynajoe">Joe Andaverde</a>!).
+
       - title: Properly populate alt_state_name for Tracing, Auth and RateLimit Services
         type: bugfix
         body: >-
-          Previously, setting the <code>stats_name</code> for the <code>TracingService</code>, <code>RateLimitService</code> 
+          Previously, setting the <code>stats_name</code> for the <code>TracingService</code>, <code>RateLimitService</code>
           or the <code>AuthService</code> would have no affect because it was not being properly passed to the Envoy cluster
           config. This has been fixed and the <code>alt_stats_name</code> field in the cluster config is now set correctly.
           (Thanks to <a href="https://github.com/psalaberria002">Paul</a>!)

--- a/python/ambassador/ir/irhost.py
+++ b/python/ambassador/ir/irhost.py
@@ -436,6 +436,17 @@ class IRHost(IRResource):
                 sel_match,
             )
 
+        groupName = group.get("name") or "None"
+
+        # The synthetic Mappings for diagnostics, readiness, and liveness probes always match all Hosts.
+        # They can all still be disabled if desired via the Ambassador Module resource
+        if groupName in [
+            "GROUP: internal_readiness_probe_mapping",
+            "GROUP: internal_liveness_probe_mapping",
+            "GROUP: internal_diagnostics_probe_mapping",
+        ]:
+            return True
+
         # Ambassador (2.0-2.3) & (3.0-3.1) consider a match on a single label as a "good enough" match.
         # In versions 2.4+ and 3.2+ _ALL_ labels in a selector must be present for it to be considered a match.
         # DISABLE_STRICT_LABEL_SELECTORS provides a way to restore the old unintended loose matching behaviour

--- a/python/ambassador/ir/irhost.py
+++ b/python/ambassador/ir/irhost.py
@@ -422,11 +422,18 @@ class IRHost(IRResource):
         mapsel = self.get('mappingSelector')
 
         if mapsel:
-            sel_match = selector_matches(self.logger, mapsel, group.get('metadata_labels', {}))
-            self.logger.debug("-- host sel %s group labels %s => %s",
-                             dump_json(mapsel), dump_json(group.get('metadata_labels')), sel_match)
+            sel_match = selector_matches(self.logger, mapsel, group.get("metadata_labels", {}))
+            self.logger.debug(
+                "-- host sel %s group labels %s => %s",
+                dump_json(mapsel),
+                dump_json(group.get("metadata_labels")),
+                sel_match,
+            )
+        else:
+            # if the host does not have a mapping selector it matches any label set
+            sel_match = True
 
-        return host_match or sel_match
+        return host_match and sel_match
 
     def __str__(self) -> str:
         request_policy = self.get('requestPolicy', {})

--- a/python/ambassador/ir/irutils.py
+++ b/python/ambassador/ir/irutils.py
@@ -122,8 +122,8 @@ def hostglob_matches(g1: str, g2: str) -> bool:
         return False
 
     # OK, if we're here, we have a wildcard to check. There are a few cases
-    # here, so we'll start with the easy one: one value starts with "*" and 
-    # the other ends with "*", because those can always overlap as long as 
+    # here, so we'll start with the easy one: one value starts with "*" and
+    # the other ends with "*", because those can always overlap as long as
     # the overlap between isn't empty -- and in this method, we only need to
     # concern ourselves with being sure that there is a possibility of a match
     # to both.
@@ -132,13 +132,13 @@ def hostglob_matches(g1: str, g2: str) -> bool:
         return True
 
     # OK, now we have to actually do some work. Again, we really only have to
-    # be convinced that it's possible for something to match, so e.g. 
+    # be convinced that it's possible for something to match, so e.g.
     #
     # *example.com, example.com
     #
     # is not a valid pair, because that "*" must never match an empty string.
     # However,
-    #  
+    #
     # *example.com, *.example.com
     #
     # is fine, because e.g. "foo.example.com" matches both.
@@ -176,11 +176,13 @@ def selector_matches(logger: logging.Logger, selector: Dict[str, Any], labels: D
         logger.debug("    no incoming labels => False")
         return False
 
-    # every selector label must exist and be equal
+    # For every label in mappingSelector, there must be a label with same value in Mapping itself.
     for k, v in match.items():
-        if labels.get(k) != v:
-            logger.debug("    selector match for %s=%s => False", k, v)
+        if labels.get(k) == v:
+            logger.debug("    selector match for %s=%s => True", k, v)
+        else:
+            logger.debug("    selector miss for %s=%s => False", k, v)
             return False
 
-    logger.debug("    all selectors match => True")
+    logger.debug(f"    all selectors match => True")
     return True

--- a/python/ambassador/ir/irutils.py
+++ b/python/ambassador/ir/irutils.py
@@ -176,14 +176,11 @@ def selector_matches(logger: logging.Logger, selector: Dict[str, Any], labels: D
         logger.debug("    no incoming labels => False")
         return False
 
-    selmatch = False
-
+    # every selector label must exist and be equal
     for k, v in match.items():
-        if labels.get(k) == v:
-            logger.debug("    selector match for %s=%s => True", k, v)
-            return True
+        if labels.get(k) != v:
+            logger.debug("    selector match for %s=%s => False", k, v)
+            return False
 
-        logger.debug("    selector miss on %s=%s", k, v)
-
-    logger.debug("    all selectors miss => False")
-    return False
+    logger.debug("    all selectors match => True")
+    return True


### PR DESCRIPTION
## Description
Pulls in the commits from #4499 and #4318. There was a little extra work needed on top of those commits. I also added a changelog entry and some test coverage for the new strict matching behaviour as well as the environment variable `DISABLE_STRICT_LABEL_SELECTORS` which restores the old (flawed) behaviour. 

Plan moving forward with this is to first merge #4499 and #4318 once this PR is approved, then merge this PR on top of them immediately afterwards. 

I'll also throw up a PR cherry-picking all of this stuff back into ~~`release/v2.4`~~ `release/v2.5` so we can have the fix in both the upcoming `3.2` and ~~`2.4`~~ `2.5`.


### Issue Context:
Currently there are some problems with `Host` association with `Mappings` particularly regarding `mappingSelector`. 

1. According to all of our documentation, when `mappingSelector` and `hostname` are both present on a Mapping, but the current code treats it as an OR relationship. This means that if a `mappingSelector` is configured that would exclude a `Mapping` from being associated with a `Host`, then the rules enforced by the `mappingSelector` will be disregarded if the `Mapping` has a `hostname` that matches the `hostname` of the Host. This is flat out a bug since it goes against everything we have docummented about their interaction.
2. There is a problem in the logic of `mappingSelector`. Currently, if a `mappingSelector` requires 3 different labels for example, then if only one of those labels is present on a `Mapping` then it will be associated with the `Host` despite the fact that the `mappingSelector` requires the 3 lables. This is also a bug and goes against how label selectors work everywhere else in Kubernetes.

## Related Issues
Sister PR for `v3.2` https://github.com/emissary-ingress/emissary/pull/4506

## Testing
Manual testing, we've already got a bunch of test-coverage for Hosts that are passing and I've also added new tests explicitly for this behaviour.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `CHANGELOG.md`.

   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations

 - [x] This is unlikely to impact how Ambassador performs at scale.

   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability

 - [x] My change is adequately tested.

   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points

 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.

 - [ ] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
