### PR TITLE
Resolve mismatched clusters name on envoy_stats without overwriting

### DIFF
--- a/python/ambassador/diagnostics/diagnostics.py
+++ b/python/ambassador/diagnostics/diagnostics.py
@@ -558,7 +558,7 @@ class Diagnostics:
                     "type": type_name,
                     "_source": svc.location,
                     "name": url,
-                    "cluster": cluster.envoy_name,
+                    "cluster": cluster.name,
                     "_service_weight": svc_weight,
                 }
             )

--- a/python/ambassador/diagnostics/diagnostics.py
+++ b/python/ambassador/diagnostics/diagnostics.py
@@ -119,7 +119,7 @@ class DiagResult:
         # Go ahead and grab Envoy cluster stats for all possible clusters.
         # XXX This might be a bit silly.
         self.cstats = {
-            cluster.envoy_name: self.estat.cluster_stats(cluster.stats_name)
+            cluster.name: self.estat.cluster_stats(cluster.stats_name)
             for cluster in self.diag.clusters.values()
         }
 

--- a/python/ambassador/diagnostics/diagnostics.py
+++ b/python/ambassador/diagnostics/diagnostics.py
@@ -118,8 +118,10 @@ class DiagResult:
 
         # Go ahead and grab Envoy cluster stats for all possible clusters.
         # XXX This might be a bit silly.
-        self.cluster_names = [cluster.envoy_name for cluster in self.diag.clusters.values()]
-        self.cstats = {name: self.estat.cluster_stats(name) for name in self.cluster_names}
+        self.cstats = {
+            cluster.envoy_name: self.estat.cluster_stats(cluster.stats_name)
+            for cluster in self.diag.clusters.values()
+        }
 
         # Save the request host and scheme. We'll need them later.
         self.request_host = request.headers.get("Host", "*")


### PR DESCRIPTION
## Description
Envoy stats are being sent and built with the incorrect name inside the snapshot due to cluster name mismatches, this one being formatted as `<name>`, instead of using the envoy name `<cluster>_<name>_<namespace>`.

This change seeks to make both cluster names similar temporarily in order to check if the given cluster really exists in `envoy_stats`

#### Befere

The old logic creates an aux variable `self.cluster_names` which the only goal is to store the `envoy_name`s mapped from `self.diag.clusters`; then the `self.cstats` variable does a second map over `self.cluster_names` passing `envoy_name` to `self.estat.cluster_stats` and returns a Dict with key-cluster-name formatted as ` <cluster>_<name>_<namespace>`:

```python
self.cluster_names = [cluster.envoy_name for cluster in self.diag.clusters.values()]
self.cstats = {name: self.estat.cluster_stats(name) for name in self.cluster_names}
```

In the following pic, the routes are in orange color, meaning that the cluster names didn't match

<img width="1135" alt="Screen Shot 2022-09-16 at 3 10 33 PM" src="https://user-images.githubusercontent.com/103530646/190728822-d1d57a82-a832-4b2f-9cf1-b634124a772b.png">

So in consequence the `self.cstats` returns undefined cluster stats

<img width="1792" alt="Screen Shot 2022-09-16 at 3 12 28 PM" src="https://user-images.githubusercontent.com/103530646/190728831-f137e164-0d26-4080-b296-9b5f3be06724.png">


#### After

I removed the `self.cluster_names` aux variable in favor of directly using `cluster.stats_name` from `self.diag.clusters` as parameter for `self.estat.cluster_stats` because this one has the right format <cluster_name> accepted by the method

```python
self.cstats = {cluster.name: self.estat.cluster_stats(cluster.stats_name) for cluster in self.diag.clusters.values()}
```
In this case, the cluster names are matching (_I've created pod called weby to test traffic shown in green color_)

<img width="1133" alt="Screen Shot 2022-09-16 at 2 40 57 PM" src="https://user-images.githubusercontent.com/103530646/190729123-1cb6dec2-7957-489e-af65-84d1f3e62286.png">

So this output is way different from the original, due to cluster names matching avoiding the condition 

https://github.com/emissary-ingress/emissary/blob/77a348c34617acf59b934aa71b74d2f510967b41/python/ambassador/diagnostics/envoy_stats.py#L110
<img width="1792" alt="Screen Shot 2022-09-16 at 2 40 10 PM" src="https://user-images.githubusercontent.com/103530646/190729142-61fa8d97-3879-44f5-be9e-e9f31e969c3f.png">

#### UPDATE:
I've changed `cluster.envoy_name` in favor of `cluster.name` due to issues when `envoy_name` surpasses the 60 characters gets truncated causing undefined stats

<img width="1140" alt="Screen Shot 2022-09-19 at 1 07 54 PM" src="https://user-images.githubusercontent.com/103530646/191084666-aff41972-0a47-4ddf-8030-310a5fe2d971.png">


## Related Issues
List related issues.

## Testing
Manual, built a kubeception cluster, then make a couple of requests and trigger a 5xx error to see the health percent change.


## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `CHANGELOG.md`.

   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations

 - [x] This is unlikely to impact how Ambassador performs at scale.

   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability

 - [x] My change is adequately tested.

   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points

 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.

 - [ ] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
