### PR TITLE
[v2.4] Port commits from PR #4488 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,10 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
   config. This has been fixed and the `alt_stats_name` field in the cluster config is now set
   correctly. (Thanks to <a href="https://github.com/psalaberria002">Paul</a>!)
 
+- Feature: The `AMBASSADOR_RECONFIG_MAX_DELAY` env var can be optionally set to batch changes for
+  the specified  non-negative window period in seconds before doing an Envoy reconfiguration.
+  Default is "1" if not set.
+
 ## [1.14.5] TBD
 [1.14.5]: https://github.com/emissary-ingress/emissary/compare/v2.3.2...v1.14.5
 

--- a/cmd/entrypoint/watcher.go
+++ b/cmd/entrypoint/watcher.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	gw "sigs.k8s.io/gateway-api/apis/v1alpha1"
 
@@ -33,6 +35,16 @@ func WatchAllTheThings(
 	if err != nil {
 		return err
 	}
+	intv, err := strconv.Atoi(env("AMBASSADOR_RECONFIG_MAX_DELAY", "1"))
+	if err != nil {
+		return err
+	}
+	maxInterval := time.Duration(intv) * time.Second
+	err = client.MaxAccumulatorInterval(maxInterval)
+	if err != nil {
+		return err
+	}
+	dlog.Infof(ctx, "AMBASSADOR_RECONFIG_MAX_DELAY set to %d", intv)
 
 	serverTypeList, err := client.ServerResources()
 	if err != nil {

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -58,6 +58,12 @@ items:
           config. This has been fixed and the <code>alt_stats_name</code> field in the cluster config is now set correctly.
           (Thanks to <a href="https://github.com/psalaberria002">Paul</a>!)
 
+      - title: Add support for config change batch window before reconfiguring Envoy
+        type: feature
+        body: >-
+          The <code>AMBASSADOR_RECONFIG_MAX_DELAY</code> env var can be optionally set to batch changes for the specified 
+          non-negative window period in seconds before doing an Envoy reconfiguration. Default is "1" if not set.
+
   - version: 1.14.5
     date: 'TBD'
     notes:

--- a/pkg/kates/accumulator_test.go
+++ b/pkg/kates/accumulator_test.go
@@ -1,7 +1,9 @@
 package kates
 
 import (
+	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -18,7 +20,7 @@ type Snap struct {
 func TestBootstrapNoNotifyBeforeSync(t *testing.T) {
 	// Create a set of 10 configmaps to give us some resources to watch.
 	ctx, cli := testClient(t, nil)
-	var cms [10]*ConfigMap 
+	var cms [10]*ConfigMap
 	for i := 0; i < 10; i++ {
 		cm := &ConfigMap{
 			TypeMeta: TypeMeta{
@@ -91,4 +93,227 @@ func TestBootstrapNotifyEvenOnEmptyWatch(t *testing.T) {
 	// When we are here the first notification will have happened, and since there were no resources
 	// that satisfy the selector, the ConfigMaps field should be empty.
 	assert.Equal(t, 0, len(snap.ConfigMaps))
+}
+
+// Make sure we coalesce raw changes before sending an update when a batch of resources
+// are created/modified in quick succession.
+func TestBatchChangesBeforeNotify(t *testing.T) {
+	ctx, cli := testClient(t, nil)
+	// Set a long enough interval to make sure all changes are batched before sending.
+	err := cli.MaxAccumulatorInterval(10 * time.Second)
+	require.NoError(t, err)
+	acc, err := cli.Watch(ctx, Query{Name: "ConfigMaps", Kind: "ConfigMap", LabelSelector: "test=test-batch"})
+	require.NoError(t, err)
+
+	snap := &Snap{}
+
+	// Listen for changes from the Accumulator. Here it will listen for only 2 updates
+	// The first update should be the one sent during bootstrap. No resources should have changed
+	// in this update. The second update should contain resource changes.
+	<-acc.Changed()
+	updated, err := acc.Update(ctx, snap)
+	require.NoError(t, err)
+	if !updated {
+		t.Error("Expected snapshot to be successfully updated after receiving first change event")
+	}
+	assert.Equal(t, 0, len(snap.ConfigMaps))
+
+	// Use a separate client to create resources to avoid any potential uses of the cache
+	_, cli2 := testClient(t, nil)
+
+	// Create a set of 10 Configmaps after the Accumulator is watching to simulate getting
+	// a bunch of resources at once mid-watch.
+	var cms [10]*ConfigMap
+	for i := 0; i < 10; i++ {
+		cm := &ConfigMap{
+			TypeMeta: TypeMeta{
+				Kind: "ConfigMap",
+			},
+			ObjectMeta: ObjectMeta{
+				Name: fmt.Sprintf("test-batch-%d", i),
+				Labels: map[string]string{
+					"test": "test-batch",
+				},
+			},
+		}
+		err := cli2.Upsert(ctx, cm, cm, &cm)
+		require.NoError(t, err)
+		cms[i] = cm
+	}
+
+	<-acc.Changed()
+	updated, err = acc.Update(ctx, snap)
+	require.NoError(t, err)
+	if !updated {
+		t.Error("Expected snapshot to be successfully updated after receiving second change event")
+	}
+
+	// After receiving 2 updates from the Accumulator, we should have 10 ConfigMaps
+	// in our Snapshot due to the Accumulator coalescing changes before sending an update.
+	assert.Equal(t, 10, len(snap.ConfigMaps))
+
+	t.Cleanup(func() {
+		for _, cm := range cms {
+			if err := cli.Delete(ctx, cm, nil); err != nil && !IsNotFound(err) {
+				t.Error(err)
+			}
+		}
+	})
+}
+
+// Make sure we send an update after the window period expires when we keep
+// sending changes less than the batch interval. This is to test against an edge case where a
+// a change event is never triggered due to constant changes.
+func TestNotifyNotInfinitelyBlocked(t *testing.T) {
+	ctx, cli := testClient(t, nil)
+	err := cli.MaxAccumulatorInterval(5 * time.Second)
+	require.NoError(t, err)
+	acc, err := cli.Watch(ctx, Query{Name: "ConfigMaps", Kind: "ConfigMap", LabelSelector: "test=test-batch-max"})
+	require.NoError(t, err)
+
+	snap := &Snap{}
+
+	<-acc.Changed()
+	updated, err := acc.Update(ctx, snap)
+	require.NoError(t, err)
+	if !updated {
+		t.Error("Expected snapshot to be successfully updated after receiving first change event")
+	}
+	assert.Equal(t, 0, len(snap.ConfigMaps))
+
+	var cms []*ConfigMap
+	ctx2, cli2 := testClient(t, nil)
+	ctx2, cancel := context.WithCancel(ctx2)
+	var wg sync.WaitGroup
+	// Create a new Configmap every 2 seconds < 5 second interval to simulate a constant changes
+	go func() {
+		wg.Add(1)
+		defer wg.Done()
+		var i int
+		ticker := time.NewTicker(2 * time.Second)
+		for {
+			select {
+			case <-ticker.C:
+				cm := &ConfigMap{
+					TypeMeta: TypeMeta{
+						Kind: "ConfigMap",
+					},
+					ObjectMeta: ObjectMeta{
+						Name: fmt.Sprintf("test-batch-%d", i),
+						Labels: map[string]string{
+							"test": "test-batch-max",
+						},
+					},
+				}
+				err := cli2.Upsert(ctx, cm, cm, &cm)
+				require.NoError(t, err)
+				cms = append(cms, cm)
+				i++
+			case <-ctx2.Done():
+				return
+			}
+		}
+	}()
+
+	// Watch for second change. Actually validating this is tricky. Idiosyncratic timing differences
+	// can cause the number of Configmaps in the change event to change across test runs resulting in a
+	// flakey test. We're just concerned that we got _a_ change when constant updates are being made
+	// less than the batch window interval so that we're not infinitely blocked. So we're just going to
+	// check that the snapshot is non-empty after we get the change. If we don't
+	// get a change after some time then we fail the test.
+	select {
+	case <-acc.Changed():
+		updated, err = acc.Update(ctx, snap)
+		require.NoError(t, err)
+		if !updated {
+			t.Error("Expected snapshot to be successfully updated after receiving second change event")
+		}
+		assert.Greater(t, len(snap.ConfigMaps), 0)
+		cancel()
+		wg.Wait()
+	case <-time.After(10 * time.Second):
+		cancel()
+		wg.Wait()
+		t.Error("Timeout after 10s listening for second change. It's possible it's infinitely blocked")
+	}
+
+	t.Cleanup(func() {
+		for _, cm := range cms {
+			if err := cli.Delete(ctx, cm, nil); err != nil && !IsNotFound(err) {
+				t.Error(err)
+			}
+		}
+	})
+}
+
+// Make sure we get single updates when changes are submitted after the batch interval has expired.
+func TestNotifyOnUpdate(t *testing.T) {
+	ctx, cli := testClient(t, nil)
+	err := cli.MaxAccumulatorInterval(2 * time.Second)
+	require.NoError(t, err)
+	acc, err := cli.Watch(ctx, Query{Name: "ConfigMaps", Kind: "ConfigMap", LabelSelector: "test=test-isolated"})
+	require.NoError(t, err)
+
+	snap := &Snap{}
+
+	waitForChange := func() {
+		<-acc.Changed()
+		updated, err := acc.Update(ctx, snap)
+		require.NoError(t, err)
+		if !updated {
+			t.Error("Expected snapshot to be successfully updated after receiving change event")
+		}
+	}
+
+	waitForChange()
+	assert.Equal(t, 0, len(snap.ConfigMaps))
+
+	var cms [2]*ConfigMap
+
+	cm := &ConfigMap{
+		TypeMeta: TypeMeta{
+			Kind: "ConfigMap",
+		},
+		ObjectMeta: ObjectMeta{
+			Name: "test-isolated-1",
+			Labels: map[string]string{
+				"test": "test-isolated",
+			},
+		},
+	}
+	err = cli.Upsert(ctx, cm, cm, &cm)
+	require.NoError(t, err)
+	cms[0] = cm
+
+	waitForChange()
+	assert.Equal(t, 1, len(snap.ConfigMaps))
+
+	// Send the next change after the 2 second batch interval
+	time.Sleep(3)
+
+	cm = &ConfigMap{
+		TypeMeta: TypeMeta{
+			Kind: "ConfigMap",
+		},
+		ObjectMeta: ObjectMeta{
+			Name: "test-isolated-2",
+			Labels: map[string]string{
+				"test": "test-isolated",
+			},
+		},
+	}
+	err = cli.Upsert(ctx, cm, cm, &cm)
+	require.NoError(t, err)
+	cms[1] = cm
+
+	waitForChange()
+	assert.Equal(t, 2, len(snap.ConfigMaps))
+
+	t.Cleanup(func() {
+		for _, cm := range cms {
+			if err := cli.Delete(ctx, cm, nil); err != nil && !IsNotFound(err) {
+				t.Error(err)
+			}
+		}
+	})
 }

--- a/pkg/kates/client.go
+++ b/pkg/kates/client.go
@@ -77,12 +77,13 @@ import (
 //   2. The Accumulator API is guaranteed to bootstrap (i.e. perform an initial List operation) on
 //      all watches prior to notifying the user that resources are available to process.
 type Client struct {
-	config    *ConfigFlags
-	cli       dynamic.Interface
-	mapper    meta.RESTMapper
-	disco     discovery.CachedDiscoveryInterface
-	mutex     sync.Mutex
-	canonical map[string]*Unstructured
+	config                 *ConfigFlags
+	cli                    dynamic.Interface
+	mapper                 meta.RESTMapper
+	disco                  discovery.CachedDiscoveryInterface
+	mutex                  sync.Mutex
+	canonical              map[string]*Unstructured
+	maxAccumulatorInterval time.Duration
 
 	// This is an internal interface for testing, it lets us deliberately introduce delays into the
 	// implementation, e.g. effectively increasing the latency to the api server in a controllable
@@ -149,14 +150,15 @@ func NewClientFromConfigFlags(config *ConfigFlags) (*Client, error) {
 	}
 
 	return &Client{
-		config:       config,
-		cli:          cli,
-		mapper:       mapper,
-		disco:        disco,
-		canonical:    make(map[string]*Unstructured),
-		watchAdded:   func(oldObj, newObj *Unstructured) {},
-		watchUpdated: func(oldObj, newObj *Unstructured) {},
-		watchDeleted: func(oldObj, newObj *Unstructured) {},
+		config:                 config,
+		cli:                    cli,
+		mapper:                 mapper,
+		disco:                  disco,
+		canonical:              make(map[string]*Unstructured),
+		maxAccumulatorInterval: 1 * time.Second,
+		watchAdded:             func(oldObj, newObj *Unstructured) {},
+		watchUpdated:           func(oldObj, newObj *Unstructured) {},
+		watchDeleted:           func(oldObj, newObj *Unstructured) {},
 	}, nil
 }
 
@@ -209,6 +211,18 @@ func InCluster() bool {
 	return os.Getenv("KUBERNETES_SERVICE_HOST") != "" &&
 		os.Getenv("KUBERNETES_SERVICE_PORT") != "" &&
 		err == nil && !fi.IsDir()
+}
+
+// Sets the max interval to wait before sending changes for snapshot updates. The interval must
+// be non-negative, otherwise it will return an error.
+func (c *Client) MaxAccumulatorInterval(interval time.Duration) error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	if interval <= 0 {
+		return fmt.Errorf("interval must be positive")
+	}
+	c.maxAccumulatorInterval = interval
+	return nil
 }
 
 // DynamicInterface is an accessor method to the k8s dynamic client
@@ -371,7 +385,7 @@ func (c *Client) watchRaw(ctx context.Context, query Query, target chan rawUpdat
 	// resource instances of the kind being watched
 	lw := newListWatcher(ctx, cli, query, func(lw *lw) {
 		if lw.hasSynced() {
-			target <- rawUpdate{query.Name, true, nil, nil}
+			target <- rawUpdate{query.Name, true, nil, nil, time.Now()}
 		}
 	})
 	informer = cache.NewSharedInformer(lw, &Unstructured{}, 5*time.Minute)
@@ -410,7 +424,7 @@ func (c *Client) watchRaw(ctx context.Context, query Query, target chan rawUpdat
 				// better/faster tests.
 				c.watchAdded(nil, obj.(*Unstructured))
 				lw.countAddEvent()
-				target <- rawUpdate{query.Name, lw.hasSynced(), nil, obj.(*Unstructured)}
+				target <- rawUpdate{query.Name, lw.hasSynced(), nil, obj.(*Unstructured), time.Now()}
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
 				old := oldObj.(*Unstructured)
@@ -421,7 +435,7 @@ func (c *Client) watchRaw(ctx context.Context, query Query, target chan rawUpdat
 				// nicer prettier set of hooks, but for now all we need is this hack for
 				// better/faster tests.
 				c.watchUpdated(old, new)
-				target <- rawUpdate{query.Name, lw.hasSynced(), old, new}
+				target <- rawUpdate{query.Name, lw.hasSynced(), old, new, time.Now()}
 			},
 			DeleteFunc: func(obj interface{}) {
 				var old *Unstructured
@@ -444,7 +458,7 @@ func (c *Client) watchRaw(ctx context.Context, query Query, target chan rawUpdat
 				c.mutex.Lock()
 				delete(c.canonical, key)
 				c.mutex.Unlock()
-				target <- rawUpdate{query.Name, lw.hasSynced(), old, nil}
+				target <- rawUpdate{query.Name, lw.hasSynced(), old, nil, time.Now()}
 			},
 		},
 	)
@@ -457,6 +471,7 @@ type rawUpdate struct {
 	synced bool
 	old    *unstructured.Unstructured
 	new    *unstructured.Unstructured
+	ts     time.Time
 }
 
 type lw struct {
@@ -499,7 +514,7 @@ func (lw *lw) countAddEvent() {
 // dispatched to consider things synced at the dispatch layer.
 //
 // So to track syncedness properly for our users, when we do our first List() we remember how many
-// resourcees there are and we do not consider ourselves synced until we have dispatched at least as
+// resources there are and we do not consider ourselves synced until we have dispatched at least as
 // many Add events as there are resources.
 func (lw *lw) hasSynced() (result bool) {
 	lw.withMutex(func() {


### PR DESCRIPTION
## Description
Cherry-pick from #4488
- 71b2a111225204e94ccc31e9762519aa7f3a5542
- 5bc6f8b7a44cebbe30bebcdb7638fbc64154ed91
- e924b3e9e105e010d14f6de146ad8504eb90cde3

091be77 updates 2.4 release notes

## Related Issues
N/A

## Testing
CI

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `CHANGELOG.md`.

   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations

 - [ ] This is unlikely to impact how Ambassador performs at scale.

   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability

 - [x] My change is adequately tested.

   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points

 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently. - N/A

 - [ ] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
