### PR TITLE
diagnostics: properly parse metrics with colons in name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,11 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
   the specified  non-negative window period in seconds before doing an Envoy reconfiguration.
   Default is "1" if not set.
 
+- Bugfix: If a `Host` or `TLSContext` contained a hostname with a `:` then when using the 
+  diagnostics endpoints `ambassador/v0/diagd` then an error would be thrown due to the parsing logic
+  not  being able to handle the extra colon. This has been fixed and Emissary-ingress will not throw
+  an error when parsing envoy metrics for the diagnostics user interface.
+
 [#4354]: https://github.com/emissary-ingress/emissary/issues/4354
 
 ## [3.1.1] TBD

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -86,6 +86,14 @@ items:
         body: >-
           The <code>AMBASSADOR_RECONFIG_MAX_DELAY</code> env var can be optionally set to batch changes for the specified 
           non-negative window period in seconds before doing an Envoy reconfiguration. Default is "1" if not set.
+      
+      - title: Diagnostics stats properly handles parsing envoy metrics with colons
+        type: bugfix
+        body: >-
+          If a <code>Host</code> or <code>TLSContext</code> contained a hostname with a <code>:</code> then when using the 
+          diagnostics endpoints <code>ambassador/v0/diagd</code> then an error would be thrown due to the parsing logic not 
+          being able to handle the extra colon. This has been fixed and $productName$ will not throw an error when parsing
+          envoy metrics for the diagnostics user interface.
 
   - version: 3.1.1
     prevVersion: 3.1.0

--- a/python/ambassador/diagnostics/envoy_stats.py
+++ b/python/ambassador/diagnostics/envoy_stats.py
@@ -13,6 +13,7 @@
 # limitations under the License
 
 import logging
+import re
 import threading
 import time
 from dataclasses import dataclass
@@ -313,7 +314,10 @@ class EnvoyStatsMgr:
             if not line:
                 continue
 
-            key, value = line.split(":")
+            # TODO: Splitting from the right is a work-around for the
+            # following issue: https://github.com/emissary-ingress/emissary/issues/4528
+            # and needs to be addressed via a behavior change
+            key, value = line.rsplit(":", 1)
             keypath = key.split(".")
 
             node = envoy_stats

--- a/python/ambassador/diagnostics/envoy_stats.py
+++ b/python/ambassador/diagnostics/envoy_stats.py
@@ -207,7 +207,6 @@ class EnvoyStatsMgr:
         structures for others to look at.
         """
 
-        # self.logger.info("updating levels")
         text = self.fetch_log_levels(level)
 
         if not text:
@@ -242,8 +241,6 @@ class EnvoyStatsMgr:
                 x = levels.setdefault(level, {})
                 x[logtype] = True
 
-        # self.logger.info("levels: %s" % levels)
-
         loginfo: Dict[str, Union[str, List[str]]]
 
         if len(levels.keys()) == 1:
@@ -253,8 +250,6 @@ class EnvoyStatsMgr:
 
         with self.access_lock:
             self.loginfo = loginfo
-
-            # self.logger.info("loginfo: %s" % self.loginfo)
             return True
 
     def get_stats(self) -> EnvoyStats:
@@ -318,7 +313,6 @@ class EnvoyStatsMgr:
             if not line:
                 continue
 
-            # self.logger.info('line: %s' % line)
             key, value = line.split(":")
             keypath = key.split(".")
 
@@ -331,13 +325,6 @@ class EnvoyStatsMgr:
                 node = node[key]
 
             value = value.strip()
-
-            # Skip histograms for the moment.
-            # if value.startswith("P0("):
-            #     continue
-            #     # for field in value.split(' '):
-            #     #     if field.startswith('P95('):
-            #     #         value = field.split(',')
 
             try:
                 node[keypath[-1]] = int(value)
@@ -372,14 +359,6 @@ class EnvoyStatsMgr:
             for cluster_name in envoy_stats["cluster"]:
                 cluster = envoy_stats["cluster"][cluster_name]
 
-                # # Toss any _%d -- that's madness with our Istio code at the moment.
-                # cluster_name = re.sub('_\d+$', '', cluster_name)
-
-                # mapping_name = active_cluster_map[cluster_name]
-                # active_mappings[mapping_name] = {}
-
-                # self.logger.info("cluster %s stats: %s" % (cluster_name, cluster))
-
                 healthy_percent: Optional[int]
 
                 healthy_members = cluster["membership_healthy"]
@@ -390,9 +369,6 @@ class EnvoyStatsMgr:
                 update_successes = cluster["update_success"]
                 update_percent = percentage(update_successes, update_attempts)
 
-                # Weird.
-                # upstream_ok = cluster.get('upstream_rq_2xx', 0)
-                # upstream_total = cluster.get('upstream_rq_pending_total', 0)
                 upstream_total = cluster.get("upstream_rq_completed", 0)
 
                 upstream_4xx = cluster.get("upstream_rq_4xx", 0)
@@ -401,14 +377,10 @@ class EnvoyStatsMgr:
 
                 upstream_ok = upstream_total - upstream_bad
 
-                # self.logger.info("%s total %s bad %s ok %s" % (cluster_name, upstream_total, upstream_bad, upstream_ok))
-
                 if upstream_total > 0:
                     healthy_percent = percentage(upstream_ok, upstream_total)
-                    # self.logger.debug("cluster %s is %d%% healthy" % (cluster_name, healthy_percent))
                 else:
                     healthy_percent = None
-                    # self.logger.debug("cluster %s has had no requests" % cluster_name)
 
                 active_clusters[cluster_name] = {
                     "healthy_members": healthy_members,
@@ -443,8 +415,6 @@ class EnvoyStatsMgr:
         with self.access_lock:
             self.stats = new_stats
 
-            # self.logger.info("stats updated")
-
     def update(self) -> None:
         """
         Update the Envoy stats object, including our take on Envoy's loglevel and
@@ -461,8 +431,6 @@ class EnvoyStatsMgr:
         the heavy lifting around talking to Envoy, managing the access_lock, and
         actually writing new data into the Envoy stats object.
         """
-
-        # self.logger.info("updating estats")
 
         # First up, try bailing early.
         if not self.update_lock.acquire(blocking=False):


### PR DESCRIPTION
## Description
This PR partially addresses #4528 by making sure that the parsing logic doesn't throw errors when parsing metric names with colons in them. A more robust solution will need to introduce behavior change and will take more time so this is to ensure users that are effected by this are unblocked.

See the issue for more details but TL;DR;

Parse from right-to-left and only look for a single colon. That way the metric name with the colon is still considered part of the key and will not throw an error.

## Related Issues
#4528 

## Testing
CI is green, pushed to cluster and tested to make sure that it wasn't throwing any errors.

## Checklist
 - [x] I made sure to update `CHANGELOG.md`.
 - [x] This is unlikely to impact how Ambassador performs at scale.
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
