### PR TITLE
[v1.14] releaseNotes.yml, CHANGELOG.tpl: Let an 'unplanned' date hide a release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,7 +204,6 @@ commands:
     steps:
     # setup
     - amb-linux-install
-    - install-gotestsum
     - amb-checkout
     - amb-config-registry
     - run:
@@ -504,12 +503,6 @@ commands:
             echo "Chart version ${thisversion} doesn't match tag << pipeline.git.tag >>; aborting"
             exit 1
           fi
-  install-gotestsum:
-    steps:
-    - run:
-        name: "Install gotestsum"
-        command: |
-          go get gotest.tools/gotestsum
   install-redis:
     steps:
     - run:

--- a/.circleci/config.yml.d/amb_jobs.yml
+++ b/.circleci/config.yml.d/amb_jobs.yml
@@ -222,7 +222,6 @@ commands:
     steps:
       # setup
       - amb-linux-install
-      - install-gotestsum
       - amb-checkout
       - amb-config-registry
       - run:

--- a/.circleci/config.yml.d/generic_util.yml
+++ b/.circleci/config.yml.d/generic_util.yml
@@ -5,12 +5,6 @@
 version: 2.1
 
 commands:
-  "install-gotestsum":
-    steps:
-    - run:
-        name: "Install gotestsum"
-        command: |
-          go get gotest.tools/gotestsum
   "install-redis":
     steps:
     - run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,15 +66,6 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 
 ## RELEASE NOTES
 
-## [1.14.5] TBD
-[1.14.5]: https://github.com/emissary-ingress/emissary/compare/v1.14.4...v1.14.5
-
-### Emissary Ingress and Ambassador Edge Stack
-
-- Bugfix: When using gzip compression, upstream services will no longer receive compressed data.
-  This bug was introduced in 1.14.0. The fix restores the default behavior of not sending compressed
-  data to upstream services.
-
 ## [1.14.4] June 13, 2022
 [1.14.4]: https://github.com/emissary-ingress/emissary/compare/v1.14.3...v1.14.4
 

--- a/builder/Dockerfile.base
+++ b/builder/Dockerfile.base
@@ -75,7 +75,6 @@ RUN curl --fail -L https://raw.githubusercontent.com/ahmetb/kubectx/v0.7.0/kubec
     curl --fail -L https://raw.githubusercontent.com/ahmetb/kubectx/v0.7.0/completion/kubectx.bash -o /usr/share/bash-completion/completions/kubectx
 RUN curl --fail -L https://raw.githubusercontent.com/ahmetb/kubectx/v0.7.0/kubens -o /usr/local/bin/kubens && chmod a+x /usr/local/bin/kubens && \
     curl --fail -L https://raw.githubusercontent.com/ahmetb/kubectx/v0.7.0/completion/kubens.bash -o /usr/share/bash-completion/completions/kubens
-RUN curl --fail -L https://github.com/gotestyourself/gotestsum/releases/download/v0.6.0/gotestsum_0.6.0_linux_amd64.tar.gz | tar -C /usr/local/bin -xzf -
 RUN mkdir helmtmp && curl -o helmtmp/helm.tar.gz https://get.helm.sh/helm-v3.4.1-linux-amd64.tar.gz && tar -zxvf helmtmp/helm.tar.gz -C helmtmp && mv helmtmp/linux-amd64/helm /usr/local/bin/helm && rm -rf helmtmp
 RUN curl --fail -L https://app.getambassador.io/download/tel2/linux/amd64/2.6.6/telepresence -o /usr/local/bin/telepresence && chmod a+x /usr/local/bin/telepresence
 RUN curl --fail -L https://raw.githubusercontent.com/jonmosco/kube-ps1/v0.7.0/kube-ps1.sh -o /usr/local/bin/kube-ps1.sh

--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -556,15 +556,6 @@ mypy: mypy-server
 	docker exec -it $(shell $(BUILDER)) /buildroot/builder.sh mypy-internal check
 .PHONY: mypy
 
-GOTEST_PKGS = github.com/datawire/ambassador/...
-GOTEST_MODDIRS = $(OSS_HOME)
-export GOTEST_PKGS
-export GOTEST_MODDIRS
-
-GOTEST_ARGS ?= -race -count=1
-GOTEST_ARGS += -parallel=150 # The ./pkg/envoy-control-plane/cache/v{2,3}/ tests require high parallelism to reliably work
-export GOTEST_ARGS
-
 create-venv:
 	[[ -d $(OSS_HOME)/venv ]] || python3 -m venv $(OSS_HOME)/venv
 .PHONY: create-venv
@@ -592,11 +583,14 @@ setup-diagd: create-venv
 	. $(OSS_HOME)/venv/bin/activate && $(MAKE) setup-venv
 .PHONY: setup-diagd
 
+GOTEST_ARGS ?= -race -count=1
+GOTEST_ARGS += -parallel=150 # The ./pkg/envoy-control-plane/cache/v{2,3}/ tests require high parallelism to reliably work
+GOTEST_PKGS ?= ./...
 gotest: setup-diagd
 	@printf "$(CYN)==> $(GRN)Running $(BLU)go$(GRN) tests$(END)\n"
 	. $(OSS_HOME)/venv/bin/activate; \
 		EDGE_STACK=$(GOTEST_AES_ENABLED) \
-		$(OSS_HOME)/builder/builder.sh gotest-local
+		go test $(GOTEST_ARGS) $(GOTEST_PKGS)
 .PHONY: gotest
 
 # Ingress v1 conformance tests, using KIND and the Ingress Conformance Tests suite.

--- a/builder/builder.sh
+++ b/builder/builder.sh
@@ -688,29 +688,6 @@ case "${cmd}" in
             exit 1
         fi
         ;;
-    gotest-local)
-        [ -n "${TEST_XML_DIR}" ] && mkdir -p ${TEST_XML_DIR}
-        fail=""
-        for MODDIR in ${GOTEST_MODDIRS} ; do
-            if [ -e "${MODDIR}/go.mod" ]; then
-                pkgs=$(cd ${MODDIR} && go list -f='{{ if or (gt (len .TestGoFiles) 0) (gt (len .XTestGoFiles) 0) }}{{ .ImportPath }}{{ end }}' ${GOTEST_PKGS})
-                if [ -n "${pkgs}" ]; then
-                    modname=`basename ${MODDIR}`
-                    junitarg=
-                    if [[ -n "${TEST_XML_DIR}" ]] ; then
-                        junitarg="--junitfile ${TEST_XML_DIR}/${modname}-gotest.xml"
-                    fi
-                    if ! (cd ${MODDIR} && gotestsum ${junitarg} --rerun-fails=3 --packages="${pkgs}" -- ${GOTEST_ARGS}) ; then
-                       fail="yes"
-                    fi
-                fi
-            fi
-        done
-
-        if [ "${fail}" = yes ]; then
-            exit 1
-        fi
-        ;;
     build-builder-base)
         build_builder_base >&2
         echo "${builder_base_image}"

--- a/docs/CHANGELOG.tpl
+++ b/docs/CHANGELOG.tpl
@@ -69,6 +69,7 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 {{ $ghName := "emissary-ingress/emissary" -}}
 
 {{ range $i, $release := $relnotes.items -}}
+{{ if ne $release.date "unplanned" -}}
 {{ $prevVersion := "1.13.3" -}}
 {{- if index $release "prevVersion" -}}
   {{- $prevVersion = $release.prevVersion -}}
@@ -118,6 +119,7 @@ Please see the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest
 	strings.Indent 2 |
 	strings.TrimPrefix "  " }}
 {{ end }}{{ end -}}
+{{ end -}}
 {{ end }}
 ## [1.13.3] May 03, 2021
 [1.13.3]: https://github.com/datawire/ambassador/compare/v1.13.2...v1.13.3

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -33,7 +33,7 @@ changelog: https://github.com/emissary-ingress/emissary/blob/$branch$/CHANGELOG.
 items:
 
   - version: 1.14.5
-    date: 'TBD'
+    date: 'unplanned'
     notes:
       - title: When using gzip, upstreams will no longer receive encoded data
         type: bugfix


### PR DESCRIPTION
## Description

This way hypothetical "just in case" release notes for releases we don't actually intend to do don't show up in CHANGELOG.md.

I've also backported the dropping of `gotestsum`, because otherwise CI is broken on `release/v1.14`; see the commit message for more details.

Slack DMs from 2022-08-26:

> @kflynn:
>
> > So… is Emissary 3.0.1 a thing? `master` mentions it in
> > `docs/releaseNotes.yml` but it has a “TBD” date, it’s out of
> > order, it duplicates stuff previously listed for 3.1.0, and
> > there’s no `v3.0.1` tag.  :thinking_face:
>
> @AliceProxy:
>
> > It must be a typo for 3.1.0
>
> …
>
> @LukeShu:
>
> > 3.0.1 is probably not a thing, but isn't a typo either.  I'd added
> > a CI check that looks at the 'major.minor' of the first changelog
> > entry to make sure that you're targeting the correct branch.  And
> > so I needed to add a 3.0.1 section for the `release/v3.0` leg of
> > the v2.3→2.4→3.0→3.1→3.2 repatriation chain.
>
> @kflynn:
>
> > Ew. The 3.0.0 section wasn’t enough?
>
> @LukeShu:
>
> > Not if you wanna have them be in chronological order, since
> > various 2.3 patch releases happened after 3.0
>
> @kflynn:
>
> > Is there a gomplate special-case in there so that the CHANGELOG
> > doesn’t show an empty 3.0.1 release?
>
> @LukeShu:
>
> > Updating the `CHANGELOG.tpl` to skip a release if `len(.notes) == 0`
> > is a good idea
> >
> > Oh, but 3.0.1 isn't empty, since if we did one, it'd include
> > security patches that both 2.3 and 3.1 already have.
>
> @kflynn:
>
> > It’s empty until you actually do one, though.
>
> @LukeShu:
>
> > But its section in `releaseNotes.yml` isn't empty
> >
> > said patches are already on `release/v3.0`
>
> @kflynn:
>
> > Let me phrase that differently.  :slightly_smiling_face:
> >
> > It’s silly to have the CHANGELOG on `master` talk about a release
> > that does not exist.
>
> @LukeShu:
>
> > so maybe we should add a "don't include this release" flag in
> > `releaseNotes.yml`
>
> @kflynn:
>
> > That might be simplest, yeah.
>
> @LukeShu:
>
> > It already uses `date: "N/A"` to have it emit "not issued". So how
> > about `date: unplanned` to skip it entirely?
>
> @kflynn:
>
> > :+1:
>
> @LukeShu:
>
> > Will do in the near future. Probably not today.
>
> @kflynn:
>
> > Works for me.

## Related Issues
(none)

## Testing
(none)

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `CHANGELOG.md`. - that's all this is

   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations

 - [x] This is unlikely to impact how Ambassador performs at scale. - not a runtime change

   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability

 - [x] My change is adequately tested.

   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points

 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently. - no tricks

 - [ ] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
