### PR TITLE
[v2.5] back port diagnostics stats parsing fix 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,15 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
 
 ### Emissary-ingress and Ambassador Edge Stack
 
+- Bugfix: If a `Host` or `TLSContext` contained a hostname with a `:` then when using the 
+  diagnostics endpoints `ambassador/v0/diagd` then an error would be thrown due to the parsing logic
+  not  being able to handle the extra colon. This has been fixed and Emissary-ingress will not throw
+  an error when parsing envoy metrics for the diagnostics user interface.
+
+- Bugfix: The synthetic AuthService didn't correctly handle AmbassadorID, which was fixed in version
+  3.1 of Emissary-ingress. The fix has been backported to make sure the AuthService is handled
+  correctly during upgrades.
+
 ## [2.4.0] September 19, 2022
 [2.4.0]: https://github.com/emissary-ingress/emissary/compare/v2.3.2...v2.4.0
 

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -34,7 +34,20 @@ changelog: https://github.com/emissary-ingress/emissary/blob/$branch$/CHANGELOG.
 items:
   - version: 2.5.0
     date: 'TBD'
-    notes: []
+    notes:
+      - title: Diagnostics stats properly handles parsing envoy metrics with colons
+        type: bugfix
+        body: >-
+          If a <code>Host</code> or <code>TLSContext</code> contained a hostname with a <code>:</code> then when using the 
+          diagnostics endpoints <code>ambassador/v0/diagd</code> then an error would be thrown due to the parsing logic not 
+          being able to handle the extra colon. This has been fixed and $productName$ will not throw an error when parsing
+          envoy metrics for the diagnostics user interface.
+          
+      - title: Backport fixes for handling synthetic auth services
+        type: bugfix
+        body: >-
+          The synthetic AuthService didn't correctly handle AmbassadorID, which was fixed in version 3.1 of $productName$.
+          The fix has been backported to make sure the AuthService is handled correctly during upgrades.
 
   - version: 2.4.0
     date: '2022-09-19'

--- a/python/ambassador/diagnostics/envoy_stats.py
+++ b/python/ambassador/diagnostics/envoy_stats.py
@@ -319,8 +319,11 @@ class EnvoyStatsMgr:
             if not line:
                 continue
 
-            key, value = line.split(":")
-            keypath = key.split('.')
+            # TODO: Splitting from the right is a work-around for the
+            # following issue: https://github.com/emissary-ingress/emissary/issues/4528
+            # and needs to be addressed via a behavior change
+            key, value = line.rsplit(":", 1)
+            keypath = key.split(".")
 
             node = envoy_stats
 


### PR DESCRIPTION
## Description
This back ports the parsing fix from the following pr: https://github.com/emissary-ingress/emissary/pull/4529

Only change made:
1. Updated release notes to include the auth service back port fix - _sorry didn't want to waste CI runs for this and I was already fixing merge conflicts_

## Related Issues
https://github.com/emissary-ingress/emissary/issues/4528

## Testing
Tested for previous PR and CI is green

## Checklist
 - [x] I made sure to update `CHANGELOG.md`.
 - [x] This is unlikely to impact how Ambassador performs at scale.
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
