### PR TITLE
[v2.4] More log capturing to try to track down the XFPRedirect flake

### DIFF
--- a/.github/actions/collect-logs/action.yml
+++ b/.github/actions/collect-logs/action.yml
@@ -51,6 +51,7 @@ runs:
           tools/bin/kubectl cp xfpredirect:/tmp/ambassador/snapshots /tmp/test-logs/cluster/xfpredirect.snapshots || true
         fi
         cp /tmp/*.yaml /tmp/test-logs || true
+        cp /tmp/kat-* /tmp/test-logs || true
     - name: "Upload Logs"
       uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
## Description
A CI run for https://github.com/emissary-ingress/emissary/pull/4518 saw the XFPRedirect flake, and so I grabbed the logs for that run to try to track down the problem.

The econf.json between a passing run and the failing run match. The pod's logs claim that it responded with the correct code. So now I'm wondering if it's a problem with the kat-client or the kat harness mixing up requests?  So, let's grab the `kat-*` files out of `/tmp` so I can see what KAT sees...

## Related Issues
I don't think we have a ticket for this flake. The flake first came to my attention when working on https://github.com/emissary-ingress/emissary/pull/4507, but it was pre-existing.

## Testing
A few sentences describing what testing you've done, e.g., manual tests, automated tests, deployed in production, etc.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `CHANGELOG.md`. - no applicable changes

   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations

 - [x] This is unlikely to impact how Ambassador performs at scale. - not a runtime change

   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability

 - [ ] My change is adequately tested.

   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points

 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.

 - [ ] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
