### PR TITLE
Only watch tls secrets

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -78,7 +78,7 @@ Here is a list of tools that are used by the build system to generate the build 
 - bash
 - rsync
 - golang - `go.mod` for current version
-- python 3.8 or 3.9
+- python 3.9
 - kubectl
 - a kubernetes cluster (you need permissions to create resources, i.e. crds, deployments, services, etc...)
 - a Docker registry
@@ -739,9 +739,10 @@ If you want to build within a container instead of setting up dependencies on yo
 
 1. `docker pull docker:latest`
 2. `docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -it docker:latest sh`
-3. `apk add --update --no-cache bash build-base go curl rsync python3 python2 git libarchive-tools gawk jq`
-4. `git clone https://github.com/emissary-ingress/emissary.git && cd emissary`
-5. `make images`
+3. `apk add --update --no-cache bash build-base curl rsync python3 git libarchive-tools gawk jq`
+4. `cd /tmp; wget https://golang.org/dl/go1.19.1.linux-amd64.tar.gz; tar -C /usr/local -xzf go1.19.1.linux-amd64.tar.gz; export PATH=$PATH:/usr/local/go/bin`
+5. `git clone https://github.com/emissary-ingress/emissary.git && cd emissary`
+6. `make images`
 
 Steps 0 and 1 are run on your machine, and 2 - 4 are from within the docker container. The base image is a "Docker in Docker" image, ran with `-v /var/run/docker.sock:/var/run/docker.sock` in order to connect to your local daemon from the docker inside the container. More info on Docker in Docker [here](https://hub.docker.com/_/docker).
 

--- a/cmd/entrypoint/env.go
+++ b/cmd/entrypoint/env.go
@@ -35,12 +35,22 @@ func GetAmbassadorNamespace() string {
 	return env("AMBASSADOR_NAMESPACE", "default")
 }
 
+// GetAmbassadorFieldSelector is depreacted, replaced by GetAmbassadorWatcherFieldSelector
 func GetAmbassadorFieldSelector() string {
 	return env("AMBASSADOR_FIELD_SELECTOR", "")
 }
 
+// GetAmbassadorLabelSelector is depreacted, replaced by GetAmbassadorWatcherLabelSelector
 func GetAmbassadorLabelSelector() string {
 	return env("AMBASSADOR_LABEL_SELECTOR", "")
+}
+
+func GetAmbassadorWatcherFieldSelector() string {
+	return env("AMBASSADOR_WATCHER_FIELD_SELECTOR", "")
+}
+
+func GetAmbassadorWatcherLabelSelector() string {
+	return env("AMBASSADOR_WATCHER_LABEL_SELECTOR", "")
 }
 
 func GetAmbassadorRoot() string {

--- a/cmd/entrypoint/interesting_types_test.go
+++ b/cmd/entrypoint/interesting_types_test.go
@@ -80,6 +80,54 @@ func TestInterestingTypesQueryies(t *testing.T) {
 				{Name: "Secrets", Kind: "secrets.v1", Namespace: "", FieldSelector: "type=kubernetes.io/tls", LabelSelector: "version=v2"},
 			},
 		},
+		{
+			name: "Combine resourcegroup and generic selector",
+			q: map[string]thingToWatch{
+				"Resource": {
+					typename: "resourcegroup.v1",
+				},
+				"Secrets": {
+					typename: "secrets.v1",
+				},
+			},
+			labelSelector: "secrets.v1:version=v2;version=v1",
+			expect: []kates.Query{
+				{Name: "Resource", Kind: "resourcegroup.v1", Namespace: "", FieldSelector: "", LabelSelector: "version=v1"},
+				{Name: "Secrets", Kind: "secrets.v1", Namespace: "", FieldSelector: "", LabelSelector: "version=v2"},
+			},
+		},
+		{
+			name: "resourcegroup selector is weighted more than a generic selector",
+			q: map[string]thingToWatch{
+				"Resource": {
+					typename: "resourcegroup.v1",
+				},
+				"Secrets": {
+					typename: "secrets.v1",
+				},
+			},
+			labelSelector: "version=v1;secrets.v1:version=v2",
+			expect: []kates.Query{
+				{Name: "Resource", Kind: "resourcegroup.v1", Namespace: "", FieldSelector: "", LabelSelector: "version=v1"},
+				{Name: "Secrets", Kind: "secrets.v1", Namespace: "", FieldSelector: "", LabelSelector: "version=v2"},
+			},
+		},
+		{
+			name: "Selector without specific apiversion",
+			q: map[string]thingToWatch{
+				"Resource": {
+					typename: "resourcegroup.v1",
+				},
+				"Secrets": {
+					typename: "secrets.v1",
+				},
+			},
+			labelSelector: "secrets:version=v1",
+			expect: []kates.Query{
+				{Name: "Resource", Kind: "resourcegroup.v1", Namespace: "", FieldSelector: "", LabelSelector: ""},
+				{Name: "Secrets", Kind: "secrets.v1", Namespace: "", FieldSelector: "", LabelSelector: "version=v1"},
+			},
+		},
 	}
 
 	defer func() {

--- a/cmd/entrypoint/interesting_types_test.go
+++ b/cmd/entrypoint/interesting_types_test.go
@@ -1,0 +1,112 @@
+package entrypoint
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/emissary-ingress/emissary/v3/pkg/kates"
+	"github.com/stretchr/testify/assert"
+)
+
+type queryTest struct {
+	name          string
+	q             map[string]thingToWatch
+	fieldSelector string
+	labelSelector string
+	expect        []kates.Query
+}
+
+func TestInterestingTypesQueryies(t *testing.T) {
+	tests := []queryTest{
+		{
+			name: "build simple query",
+			q: map[string]thingToWatch{
+				"Resource": {
+					typename: "resourcegroup.v1",
+				},
+			},
+			expect: []kates.Query{
+				{Name: "Resource", Kind: "resourcegroup.v1", Namespace: "", FieldSelector: "", LabelSelector: ""},
+			},
+		},
+		{
+			name: "Only select secrets of type tls",
+			q: map[string]thingToWatch{
+				"Resource": {
+					typename: "resourcegroup.v1",
+				},
+				"Secrets": {
+					typename: "secrets.v1",
+				},
+			},
+			fieldSelector: "secrets.v1:type=kubernetes.io/tls",
+			expect: []kates.Query{
+				{Name: "Resource", Kind: "resourcegroup.v1", Namespace: "", FieldSelector: "", LabelSelector: ""},
+				{Name: "Secrets", Kind: "secrets.v1", Namespace: "", FieldSelector: "type=kubernetes.io/tls", LabelSelector: ""},
+			},
+		},
+		{
+			name: "Only select secrets of type tls and version: v2 label",
+			q: map[string]thingToWatch{
+				"Resource": {
+					typename: "resourcegroup.v1",
+				},
+				"Secrets": {
+					typename: "secrets.v1",
+				},
+			},
+			fieldSelector: "secrets.v1:type=kubernetes.io/tls",
+			labelSelector: "secrets.v1:version=v2",
+			expect: []kates.Query{
+				{Name: "Resource", Kind: "resourcegroup.v1", Namespace: "", FieldSelector: "", LabelSelector: ""},
+				{Name: "Secrets", Kind: "secrets.v1", Namespace: "", FieldSelector: "type=kubernetes.io/tls", LabelSelector: "version=v2"},
+			},
+		},
+		{
+			name: "Only select resources labeled by version: v2 and specific fields",
+			q: map[string]thingToWatch{
+				"Resource": {
+					typename: "resourcegroup.v1",
+				},
+				"Secrets": {
+					typename: "secrets.v1",
+				},
+			},
+			fieldSelector: "secrets.v1:type=kubernetes.io/tls;resourcegroup.v1:metadata.name=name",
+			labelSelector: "secrets.v1:version=v2;resourcegroup.v1:version=v2",
+			expect: []kates.Query{
+				{Name: "Resource", Kind: "resourcegroup.v1", Namespace: "", FieldSelector: "metadata.name=name", LabelSelector: "version=v2"},
+				{Name: "Secrets", Kind: "secrets.v1", Namespace: "", FieldSelector: "type=kubernetes.io/tls", LabelSelector: "version=v2"},
+			},
+		},
+	}
+
+	defer func() {
+		os.Setenv("AMBASSADOR_WATCHER_FIELD_SELECTOR", "")
+		os.Setenv("AMBASSADOR_WATCHER_LABEL_SELECTOR", "")
+	}()
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			os.Setenv("AMBASSADOR_WATCHER_FIELD_SELECTOR", test.fieldSelector)
+			os.Setenv("AMBASSADOR_WATCHER_LABEL_SELECTOR", test.labelSelector)
+			queries := GetQueries(context.TODO(), test.q)
+
+			for _, gotQuery := range queries {
+				for _, expectQuery := range test.expect {
+					if expectQuery.Name != gotQuery.Name {
+						continue
+					}
+
+					assert.Equal(t, expectQuery.Kind, gotQuery.Kind)
+					assert.Equal(t, expectQuery.Namespace, gotQuery.Namespace)
+					assert.Equal(t, expectQuery.FieldSelector, gotQuery.FieldSelector)
+					assert.Equal(t, expectQuery.LabelSelector, gotQuery.LabelSelector)
+				}
+			}
+
+			assert.Equal(t, len(test.expect), len(queries))
+		})
+	}
+}


### PR DESCRIPTION
## Description
Emissary has quite some performance problems on our cluster. It's using 1 full core  and over 7G memory without any requests. Basically on standby.
![Screenshot from 2022-09-22 09-48-43](https://user-images.githubusercontent.com/2376735/191775597-f4090a3a-83bd-4357-a243-27020e14a485.png)

Profiling:
![Screenshot from 2022-09-22 09-39-11](https://user-images.githubusercontent.com/2376735/191775633-dc26209d-d333-4657-a6f8-5119669f7d4d.png)

The problem is that ambassador basically ends up reconciling non stop because it watches quite a big resource list including secrets, ingresses, ep and so on.
On a big cluster this can be quite cpu/mem heavy.
In our case we have ~10.000 secrets on the cluster and emissary globally (not single namespace) will read all  10.000 secrets.
On top of that some secrets change quite often which triggers basically an infinite reconcile loop.

The solution for this is:
* Remove ingress access for emissary from the clusterrole (we only use ambassador mappings)
* This pr, as ambassador should only read tls secrets. I don't see a reason why ambassador should read other secrets. (This reduces the number of secrets from 10.000 to like 30 in our case).

After those changes emissary uses like 120m/400Mi on average.


If non tls secrets are used for any reason there should be a possibility to declare a resource filter instead.


**Note**: I also updated the dev guide as the things there do not work as stated.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `CHANGELOG.md`.

   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations

 - [x] This is unlikely to impact how Ambassador performs at scale.

   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability

 - [ ] My change is adequately tested.

   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points

 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.

 - [ ] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
