### PR TITLE
[v3.2.0] Release PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
 
 ## RELEASE NOTES
 
-## [3.2.0] TBD
+## [3.2.0] September 26, 2022
 [3.2.0]: https://github.com/emissary-ingress/emissary/compare/v3.1.0...v3.2.0
 
 ### Emissary-ingress and Ambassador Edge Stack
@@ -104,7 +104,7 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
   to `Mappings` you want to associate with the `Host`. You can opt-out of the new behaviour by
   setting the environment variable `DISABLE_STRICT_LABEL_SELECTORS` to `"true"` (default:
   `"false"`). (Thanks to <a href="https://github.com/f-herceg">Filip Herceg</a> and <a
-  href="https://github.com/dynajoe">Joe Andaverde</a>!).
+  href="https://github.com/dynajoe">Joe Andaverde</a>!).      
 
 - Feature: Previously the `Host` resource could only use secrets that are in the namespace as the
   Host. The `tlsSecret` field in the Host has a new subfield `namespace` that will allow the use of
@@ -112,7 +112,7 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
 
 - Change: Set `AMBASSADOR_EDS_BYPASS` to `true` to bypass EDS handling of endpoints and have
   endpoints be inserted to clusters manually. This can help resolve with `503 UH` caused by
-  certification rotation relating to a delay between EDS + CDS. The default is `false`.
+  certification rotation relating to a delay between EDS + CDS. The default is `false`.     
 
 - Bugfix: Distinct services with names that are the same in the first forty characters will no
   longer be incorrectly mapped to the same cluster. ([#4354])
@@ -132,10 +132,10 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
   the specified non-negative window period in seconds before doing an Envoy reconfiguration. Default
   is "1" if not set.
 
-- Bugfix: If a `Host` or `TLSContext` contained a hostname with a `:` then when using the
-  diagnostics endpoints `ambassador/v0/diagd` then an error would be thrown due to the parsing logic
-  not being able to handle the extra colon. This has been fixed and Emissary-ingress will not throw
-  an error when parsing envoy metrics for the diagnostics user interface.
+- Bugfix: If a `Host` or `TLSContext` contained a hostname with a `:` when using the diagnostics
+  endpoints `ambassador/v0/diagd` then an error would be thrown due to the parsing logic not being
+  able to handle the extra colon. This has been fixed and Emissary-ingress will not throw an error
+  when parsing envoy metrics for the diagnostics user interface.
 
 - Feature: It is now possible to set `custom_tags` in the `TracingService`. Trace tags can be set
   based on literal values, environment variables, or request headers. (Thanks to <a
@@ -157,30 +157,6 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
 
 [#4354]: https://github.com/emissary-ingress/emissary/issues/4354
 [#4181]: https://github.com/emissary-ingress/emissary/pull/4181
-
-## [3.1.1] TBD
-[3.1.1]: https://github.com/emissary-ingress/emissary/compare/v3.1.0...v3.1.1
-
-### Emissary-ingress and Ambassador Edge Stack
-
-## [3.0.1] TBD
-[3.0.1]: https://github.com/emissary-ingress/emissary/compare/v3.0.0...v3.0.1
-
-### Emissary-ingress and Ambassador Edge Stack
-
-- Bugfix: A regression was introduced in 2.3.0 causing the agent to miss some of the metrics coming
-  from emissary ingress before sending them to Ambassador cloud. This issue has been resolved to
-  ensure that all the nodes composing the emissary ingress cluster are reporting properly.
-
-- Security: Updated Golang to 1.17.12 to address the CVEs: CVE-2022-23806, CVE-2022-28327,
-  CVE-2022-24675, CVE-2022-24921, CVE-2022-23772.
-
-- Security: Updated Curl to 7.80.0-r2 to address the CVEs: CVE-2022-32207, CVE-2022-27782,
-  CVE-2022-27781, CVE-2022-27780.
-
-- Security: Updated openSSL-dev to 1.1.1q-r0 to address CVE-2022-2097.
-
-- Security: Updated ncurses to 1.1.1q-r0 to address CVE-2022-29458
 
 ## [3.1.0] August 01, 2022
 [3.1.0]: https://github.com/emissary-ingress/emissary/compare/v3.0.0...v3.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,8 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
   Emissary-ingress now allows `TCPMappings` to be used on the same `Listener` port as HTTP `Hosts`,
   as long as that `Listener` terminates TLS.
 
+- Security: Updated Golang to 1.19.1 to address the CVEs: CVE-2022-27664, CVE-2022-32190.
+
 [#4354]: https://github.com/emissary-ingress/emissary/issues/4354
 [#4181]: https://github.com/emissary-ingress/emissary/pull/4181
 

--- a/charts/emissary-ingress/CHANGELOG.md
+++ b/charts/emissary-ingress/CHANGELOG.md
@@ -9,8 +9,6 @@ numbering uses [semantic versioning](http://semver.org).
 
 - Bugfix: The default Role configuration of the Ambassador Agent Deployment will allow it to correctly watch Secret resources for Ambassador Cloud tokens.
 
-- Change: The ambassador-agent now uses image options from values.yaml.in
-
 ## v8.1.0
 
 - Upgrade Emissary to v3.1.0 [CHANGELOG](https://github.com/emissary-ingress/emissary/blob/master/CHANGELOG.md)

--- a/charts/emissary-ingress/CHANGELOG.md
+++ b/charts/emissary-ingress/CHANGELOG.md
@@ -3,7 +3,7 @@
 This file documents all notable changes to Ambassador Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
-## v8.2.0 (not yet released)
+## v8.2.0
 
 - Upgrade Emissary to v3.2.0 [CHANGELOG](https://github.com/emissary-ingress/emissary/blob/master/CHANGELOG.md)
 

--- a/charts/emissary-ingress/templates/_helpers.tpl
+++ b/charts/emissary-ingress/templates/_helpers.tpl
@@ -125,3 +125,23 @@ Define the http port of the Ambassador service
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Set the image that should be used for the agent.
+Use agent.repository and agent.tag if present,
+Then use fullImageOverride if present,
+Then if the image repository is explicitly set, use "repository:image"
+*/}}
+{{- define "agent.image" -}}
+
+{{- if .Values.agent.image.repository -}}
+    {{- printf "%s:%s" .Values.agent.image.repository .Values.agent.image.tag -}}
+{{- else if .Values.image.fullImageOverride -}}
+    {{- .Values.image.fullImageOverride }}
+{{- else if hasKey .Values.image "repository" -}}
+    {{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
+{{- else -}}
+    {{- printf "%s:%s" "docker.io/emissaryingress/emissary" .Values.image.tag -}}
+{{- end -}}
+
+{{- end -}}

--- a/charts/emissary-ingress/templates/ambassador-agent.yaml
+++ b/charts/emissary-ingress/templates/ambassador-agent.yaml
@@ -1,4 +1,24 @@
 {{- if .Values.agent.enabled }}
+{{- $allowAgent := false -}}
+
+  {{- /* This next bit is ugly. */ -}}
+  {{- /* Case 1: "fullImageOverride" means don't bother checking the tag. */ -}}
+  {{- /* Case 2: Otherwise, if it's not a semver-style version number,    */ -}}
+  {{- /*         assume we have a power user and turn the agent on.       */ -}}
+  {{- /* Case 3: Otherwise, it's OSS and we need at least 1.13.0.         */ -}}
+
+{{- if .Values.image.fullImageOverride }}
+  {{- /* Case 1 */ -}}
+  {{- $allowAgent = true }}
+{{- else if not (regexMatch "^\\d+\\.\\d+\\.\\d+$" .Values.image.tag ) }}
+  {{- /* Case 2 above: power user */ -}}
+  {{- $allowAgent = true }}
+{{- else if ne (semver "1.13.0" | (semver .Values.image.tag).Compare) -1 }}
+  {{- /* Case 3 above: OSS 1.13.0+ */ -}}
+  {{- $allowAgent = true }}
+{{- end }}
+
+{{- if $allowAgent }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -206,8 +226,9 @@ spec:
       serviceAccountName: {{ include "ambassador.fullname" . }}-agent
       containers:
       - name: agent
-        image: "{{ .Values.agent.image.repository }}:{{ .Values.agent.image.tag }}"
-        imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
+        image: {{ include "agent.image" . }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command: [ "agent" ]
         ports:
           - containerPort: 8080
             name: http
@@ -255,4 +276,5 @@ spec:
   selector:
     app.kubernetes.io/name: {{ include "ambassador.fullname" . }}-agent
     app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
 {{- end }}

--- a/charts/emissary-ingress/values.yaml.in
+++ b/charts/emissary-ingress/values.yaml.in
@@ -395,9 +395,9 @@ agent:
   rpcAddress: https://app.getambassador.io/
   createArgoRBAC: true
   image:
-    tag: 0.0.7
-    repository: docker.io/ambassador/ambassador-agent
-    pullPolicy: IfNotPresent
+    # Leave blank to use image.repository and image.tag
+    tag: 3.1.0
+    repository: docker.io/emissaryingress/emissary
 
 deploymentTool: ''
 

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -115,14 +115,12 @@ items:
         github:
         - title: "#4181"
           link: https://github.com/emissary-ingress/emissary/pull/4181
-
       - title: TCPMappings use correct SNI configuration
         type: bugfix
         body: >-
           $productName$ 2.0.0 introduced a bug where a <code>TCPMapping</code> that uses SNI,
           instead of using the hostname glob in the <code>TCPMapping</code>, uses the hostname glob
           in the <code>Host</code> that the TLS termination configuration comes from.
-
       - title: TCPMappings configure TLS termination without a Host resource
         type: bugfix
         body: >-
@@ -131,7 +129,6 @@ items:
           This was semi-intentional, but didn't make much sense.  You can now use a
           <code>TLSContext</code> without a <code>Host</code>as in $productName$ 1.y releases, or a
           <code>Host</code> with or without a <code>TLSContext</code> as in prior 2.y releases.
-
       - title: TCPMappings and HTTP Hosts can coexist on Listeners that terminate TLS
         type: bugfix
         body: >-
@@ -140,6 +137,10 @@ items:
           TLS+SNI would make this possible.  $productName$ now allows <code>TCPMappings</code> to be
           used on the same <code>Listener</code> port as HTTP <code>Hosts</code>, as long as that
           <code>Listener</code> terminates TLS.
+      - title: Update Golang to 1.19.1
+        type: security
+        body: >-
+          Updated Golang to 1.19.1 to address the CVEs: CVE-2022-27664, CVE-2022-32190.
 
   - version: 3.1.0
     date: '2022-08-01'

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -34,7 +34,7 @@ changelog: https://github.com/emissary-ingress/emissary/blob/$branch$/CHANGELOG.
 items:
   - version: 3.2.0
     prevVersion: 3.1.0
-    date: 'TBD'
+    date: '2022-09-26'
     notes:
       - title: Envoy upgraded to 1.23
         type: change
@@ -43,7 +43,6 @@ items:
           release of 1.23. This provides $productName$ with the latest security patches, performances enhancments,
           and features offered by the envoy proxy.
         docs: https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.23/v1.23.0
-
       - title: Fixed <code>mappingSelector</code> associating <code>Hosts</code> with <code>Mappings</code>
         type: change
         body: >-
@@ -55,8 +54,7 @@ items:
           in Kubernetes. To avoid unexpected behaviour after the upgrade, add all labels that Hosts have in their
           <code>mappingSelector</code> to <code>Mappings</code> you want to associate with the <code>Host</code>. You can opt-out of the new behaviour
           by setting the environment variable <code>DISABLE_STRICT_LABEL_SELECTORS</code> to <code>"true"</code> (default: <code>"false"</code>).
-          (Thanks to <a href="https://github.com/f-herceg">Filip Herceg</a> and <a href="https://github.com/dynajoe">Joe Andaverde</a>!).
-        
+          (Thanks to <a href="https://github.com/f-herceg">Filip Herceg</a> and <a href="https://github.com/dynajoe">Joe Andaverde</a>!).      
       - title: Add support for Host resources using secrets from different namespaces
         type: feature
         body: >-
@@ -68,8 +66,7 @@ items:
         body: >-
           Set `AMBASSADOR_EDS_BYPASS` to `true` to bypass EDS handling of endpoints and have endpoints be
           inserted to clusters manually. This can help resolve with `503 UH` caused by certification rotation relating to
-          a delay between EDS + CDS. The default is `false`.
-        
+          a delay between EDS + CDS. The default is `false`.     
       - title: Correctly manage cluster names when service names are very long
         type: bugfix
         body: >-
@@ -78,7 +75,6 @@ items:
         github:
         - title: "#4354"
           link: https://github.com/emissary-ingress/emissary/issues/4354
-      
       - title: Add failure_mode_deny option to the RateLimitService
         type: feature
         body: >-
@@ -102,15 +98,13 @@ items:
         body: >-
           The <code>AMBASSADOR_RECONFIG_MAX_DELAY</code> env var can be optionally set to batch changes for the specified
           non-negative window period in seconds before doing an Envoy reconfiguration. Default is "1" if not set.
-
       - title: Diagnostics stats properly handles parsing envoy metrics with colons
         type: bugfix
         body: >-
-          If a <code>Host</code> or <code>TLSContext</code> contained a hostname with a <code>:</code> then when using the
+          If a <code>Host</code> or <code>TLSContext</code> contained a hostname with a <code>:</code> when using the
           diagnostics endpoints <code>ambassador/v0/diagd</code> then an error would be thrown due to the parsing logic not
           being able to handle the extra colon. This has been fixed and $productName$ will not throw an error when parsing
           envoy metrics for the diagnostics user interface.
-          
       - title: Allow setting custom_tags for traces
         type: feature
         body: >-
@@ -146,40 +140,6 @@ items:
           TLS+SNI would make this possible.  $productName$ now allows <code>TCPMappings</code> to be
           used on the same <code>Listener</code> port as HTTP <code>Hosts</code>, as long as that
           <code>Listener</code> terminates TLS.
-
-  - version: 3.1.1
-    prevVersion: 3.1.0
-    date: 'TBD'
-    notes: []
-
-  - version: 3.0.1
-    prevVersion: 3.0.0
-    date: 'TBD'
-    notes:
-      - title: Fix regression in the agent for the metrics transfer.
-        type: bugfix
-        body: >-
-          A regression was introduced in 2.3.0 causing the agent to miss some of the metrics coming from
-          emissary ingress before sending them to Ambassador cloud. This issue has been resolved to ensure
-          that all the nodes composing the emissary ingress cluster are reporting properly.
-      - title: Update Golang to 1.17.12
-        type: security
-        body: >-
-          Updated Golang to 1.17.12 to address the CVEs: CVE-2022-23806, CVE-2022-28327, CVE-2022-24675,
-          CVE-2022-24921, CVE-2022-23772.
-      - title: Update Curl to 7.80.0-r2
-        type: security
-        body: >-
-          Updated Curl to 7.80.0-r2 to address the CVEs: CVE-2022-32207, CVE-2022-27782, CVE-2022-27781,
-          CVE-2022-27780.
-      - title: Update openSSL-dev to 1.1.1q-r0
-        type: security
-        body: >-
-          Updated openSSL-dev to 1.1.1q-r0 to address CVE-2022-2097.
-      - title: Update ncurses to 1.1.1q-r0
-        type: security
-        body: >-
-          Updated ncurses to 1.1.1q-r0 to address CVE-2022-29458
 
   - version: 3.1.0
     date: '2022-08-01'

--- a/manifests/emissary/emissary-defaultns.yaml.in
+++ b/manifests/emissary/emissary-defaultns.yaml.in
@@ -626,7 +626,9 @@ spec:
         product: aes
     spec:
       containers:
-      - env:
+      - command:
+        - agent
+        env:
         - name: AGENT_NAMESPACE
           valueFrom:
             fieldRef:
@@ -637,7 +639,7 @@ spec:
           value: https://app.getambassador.io/
         - name: AES_SNAPSHOT_URL
           value: http://emissary-ingress-admin.default:8005/snapshot-external
-        image: docker.io/ambassador/ambassador-agent:0.0.7
+        image: docker.io/emissaryingress/emissary:3.1.0
         imagePullPolicy: IfNotPresent
         name: agent
         ports:

--- a/manifests/emissary/emissary-emissaryns.yaml.in
+++ b/manifests/emissary/emissary-emissaryns.yaml.in
@@ -626,7 +626,9 @@ spec:
         product: aes
     spec:
       containers:
-      - env:
+      - command:
+        - agent
+        env:
         - name: AGENT_NAMESPACE
           valueFrom:
             fieldRef:
@@ -637,7 +639,7 @@ spec:
           value: https://app.getambassador.io/
         - name: AES_SNAPSHOT_URL
           value: http://emissary-ingress-admin.emissary:8005/snapshot-external
-        image: docker.io/ambassador/ambassador-agent:0.0.7
+        image: docker.io/emissaryingress/emissary:3.1.0
         imagePullPolicy: IfNotPresent
         name: agent
         ports:

--- a/python/ambassador/diagnostics/envoy_stats.py
+++ b/python/ambassador/diagnostics/envoy_stats.py
@@ -130,9 +130,15 @@ class EnvoyStats:
             elif pct < 90:
                 color = "yellow"
 
-            cstat.update({"health": "%d%% healthy" % pct, "hmetric": int(pct), "hcolor": color})
+            cstat.update({"health": "%d%% healthy" % pct, "hmetric": str(pct), "hcolor": color})
         else:
-            cstat.update({"health": "no requests yet", "hmetric": "waiting", "hcolor": "grey"})
+            cstat.update(
+                {
+                    "health": "Unknown health: no requests yet",
+                    "hmetric": "waiting",
+                    "hcolor": "grey",
+                }
+            )
 
         return cstat
 

--- a/python/templates/diag.html
+++ b/python/templates/diag.html
@@ -166,7 +166,6 @@ limitations under the License
                   <br/><br/>
                   <span style="color:{{ cluster._hcolor }}">
                     {% if cluster_stats[cluster.name].valid %}
-                      {{ 'Unknown health: ' if cluster._hmetric is not number }}
                       {{ cluster._health }}
                     {% else %}
                       Unknown health: {{ cluster_stats[cluster.name].reason }}


### PR DESCRIPTION
Signed-off-by: Hamzah Qudsi <hqudsi@datawire.io>

Notes:
- 57b18a2 is a cherry pick
- aa70060 was due to decision to revert back to v3.1.0 agent due to finding regressions in the new agent container. A chart patch release should include the new agent container when ready.
- @LanceEa has reviewed and approved b4f7362 and was to fix issues with diagnostics.