### PR TITLE
diagnostics: enable agent reporting of diagnostics

### DIFF
--- a/charts/emissary-ingress/CHANGELOG.md
+++ b/charts/emissary-ingress/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Ambassador Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v8.2.1 - TBD
+
+- Change: By default, the Ambassador agent will report diagnostics to the Ambassador Cloud
+
 ## v8.2.0
 
 - Upgrade Emissary to v3.2.0 [CHANGELOG](https://github.com/emissary-ingress/emissary/blob/master/CHANGELOG.md)

--- a/charts/emissary-ingress/templates/ambassador-agent.yaml
+++ b/charts/emissary-ingress/templates/ambassador-agent.yaml
@@ -243,6 +243,10 @@ spec:
           value: {{ .Values.agent.rpcAddress }}
         - name: AES_SNAPSHOT_URL
           value: "http://{{ include "ambassador.fullname" . }}-admin.{{ include "ambassador.namespace" . }}:{{ .Values.adminService.snapshotPort }}/snapshot-external"
+        - name: AES_REPORT_DIAGNOSTICS_TO_CLOUD
+          value: {{ .Values.agent.reportDiagnostics | quote }}
+        - name: AES_DIAGNOSTICS_URL
+          value: "http://{{ include "ambassador.fullname" . }}-admin.{{ include "ambassador.namespace" . }}:{{ .Values.adminService.port }}/ambassador/v0/diag/?json=true"
   {{ if .Values.progressDeadlines }}
   {{ if hasKey .Values.progressDeadlines "agent" }}
   progressDeadlineSeconds: {{ .Values.progressDeadlines.agent }}

--- a/charts/emissary-ingress/values.yaml.in
+++ b/charts/emissary-ingress/values.yaml.in
@@ -393,6 +393,10 @@ agent:
   cloudConnectToken: ''
   # Address of the Ambassador Cloud rpc server.
   rpcAddress: https://app.getambassador.io/
+
+  # If `true`, Ambassador Agent will report diagnostics to Ambassador Cloud
+  reportDiagnostics: true
+
   createArgoRBAC: true
   image:
     # Leave blank to use image.repository and image.tag

--- a/manifests/emissary/emissary-defaultns.yaml.in
+++ b/manifests/emissary/emissary-defaultns.yaml.in
@@ -639,6 +639,10 @@ spec:
           value: https://app.getambassador.io/
         - name: AES_SNAPSHOT_URL
           value: http://emissary-ingress-admin.default:8005/snapshot-external
+        - name: AES_REPORT_DIAGNOSTICS_TO_CLOUD
+          value: "true"
+        - name: AES_DIAGNOSTICS_URL
+          value: http://emissary-ingress-admin.default:8877/ambassador/v0/diag/?json=true
         image: docker.io/emissaryingress/emissary:3.1.0
         imagePullPolicy: IfNotPresent
         name: agent

--- a/manifests/emissary/emissary-emissaryns.yaml.in
+++ b/manifests/emissary/emissary-emissaryns.yaml.in
@@ -639,6 +639,10 @@ spec:
           value: https://app.getambassador.io/
         - name: AES_SNAPSHOT_URL
           value: http://emissary-ingress-admin.emissary:8005/snapshot-external
+        - name: AES_REPORT_DIAGNOSTICS_TO_CLOUD
+          value: "true"
+        - name: AES_DIAGNOSTICS_URL
+          value: http://emissary-ingress-admin.emissary:8877/ambassador/v0/diag/?json=true
         image: docker.io/emissaryingress/emissary:3.1.0
         imagePullPolicy: IfNotPresent
         name: agent


### PR DESCRIPTION

## Description
This updates the defaults for the manifest and helm charts for the Agent to report diagnostics by default. Users can disable it by setting `agent.reportDiagnostics = false` in the helm values file.

 For raw yaml manifest files, users can toggle it via the
 `AES_REPORT_DIAGNOSTICS_TO_CLOUD` environment
 variable.

## Related Issues
n/a

## Testing
Tested in local cluster, CI Testing and will be tested again in RC process.

## Checklist

 - [x] I made sure to update `CHANGELOG.md`.
 - [x] This is unlikely to impact how Ambassador performs at scale.
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [ ] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
