### PR TITLE
dep: bump go to 1.19.2 to address security fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,14 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
 
 ## RELEASE NOTES
 
+## [3.2.1] TBD
+[3.2.1]: https://github.com/emissary-ingress/emissary/compare/v3.2.0...v3.2.1
+
+### Emissary-ingress and Ambassador Edge Stack
+
+- Security: Updated Golang to 1.19.2 to address the CVEs: CVE-2022-2879, CVE-2022-2880,
+  CVE-2022-41715.
+
 ## [3.2.0] September 26, 2022
 [3.2.0]: https://github.com/emissary-ingress/emissary/compare/v3.1.0...v3.2.0
 

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -3,7 +3,7 @@ following Free and Open Source software:
 
     Name                                                                                       Version                                      License(s)
     ----                                                                                       -------                                      ----------
-    the Go language standard library ("std")                                                   v1.19.1                                      3-clause BSD license
+    the Go language standard library ("std")                                                   v1.19.2                                      3-clause BSD license
     cloud.google.com/go/compute                                                                v1.2.0                                       Apache License 2.0
     github.com/Azure/go-ansiterm                                                               v0.0.0-20210617225240-d185dfc1b5a1           MIT license
     github.com/Azure/go-autorest                                                               v14.2.0+incompatible                         Apache License 2.0

--- a/docker/base-python/Dockerfile
+++ b/docker/base-python/Dockerfile
@@ -58,7 +58,7 @@ RUN apk --no-cache add \
 # 'python3' versions above.
 RUN pip3 install pip-tools==6.3.1
 
-RUN curl --fail -L https://dl.google.com/go/go1.19.1.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+RUN curl --fail -L https://dl.google.com/go/go1.19.2.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 
 RUN curl --fail -L https://storage.googleapis.com/kubernetes-release/release/v1.23.3/bin/linux/amd64/kubectl -o /usr/bin/kubectl && \
   chmod a+x /usr/bin/kubectl

--- a/docker/test-http/Dockerfile
+++ b/docker/test-http/Dockerfile
@@ -1,7 +1,7 @@
 # The `test-http` image gets built by `pkg/kubeapply` for use by
 # various kubeapply-templated YAML files.
 
-FROM golang:1.19.1
+FROM golang:1.19.2
 COPY httptest.go /usr/local/bin/httptest.go
 RUN go build -o /usr/local/bin/httptest /usr/local/bin/httptest.go
 ENTRYPOINT ["/usr/local/bin/httptest"]

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -32,6 +32,15 @@
 
 changelog: https://github.com/emissary-ingress/emissary/blob/$branch$/CHANGELOG.md
 items:
+  - version: 3.2.1
+    prevVersion: 3.2.0
+    date: 'TBD'
+    notes:
+      - title: Update Golang to 1.19.2
+        type: security
+        body: >-
+          Updated Golang to 1.19.2 to address the CVEs: CVE-2022-2879, CVE-2022-2880, CVE-2022-41715.
+
   - version: 3.2.0
     prevVersion: 3.1.0
     date: '2022-09-26'


### PR DESCRIPTION
Signed-off-by: David Dymko <ddymko@datawire.io>

## Description
New patch version of Go has three CVE fixes. These CVEs do not affected us but we should nonetheless stay on top of it.

## Related Issues
resolves #4597 

## Testing
CI goes green

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `CHANGELOG.md`.

   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations

 - [x] This is unlikely to impact how Ambassador performs at scale.

   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability

 - [x] My change is adequately tested.

   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points

 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.

 - [x] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
