### PR TITLE
Bumping the statsd-sink sample deployment versions to apps/v1

### DIFF
--- a/deployments/statsd-sink/datadog/dd-statsd-sink.yaml
+++ b/deployments/statsd-sink/datadog/dd-statsd-sink.yaml
@@ -1,15 +1,16 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   name: statsd-sink
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      service: statsd-sink
   strategy: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         service: statsd-sink
     spec:
@@ -29,12 +30,10 @@ spec:
           - name: SD_BACKEND
             value: docker
       restartPolicy: Always
-status: {}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     service: statsd-sink
   name: statsd-sink

--- a/deployments/statsd-sink/graphite/graphite-statsd-sink.yaml
+++ b/deployments/statsd-sink/graphite/graphite-statsd-sink.yaml
@@ -1,15 +1,16 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   name: statsd-sink
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      service: statsd-sink
   strategy: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         service: statsd-sink
     spec:
@@ -18,12 +19,10 @@ spec:
         image: hopsoft/graphite-statsd:latest
         resources: {}
       restartPolicy: Always
-status: {}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     service: statsd-sink
   name: statsd-sink

--- a/deployments/statsd-sink/prometheus/prometheus.yaml
+++ b/deployments/statsd-sink/prometheus/prometheus.yaml
@@ -122,7 +122,7 @@ spec:
     requests:
       memory: 400Mi
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/deployments/statsd-sink/prometheus/statsd-sink.yaml
+++ b/deployments/statsd-sink/prometheus/statsd-sink.yaml
@@ -1,15 +1,16 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   name: statsd-sink
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      service: statsd-sink
   strategy: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         service: statsd-sink
     spec:
@@ -18,12 +19,10 @@ spec:
         image: prom/statsd-exporter:v0.7.0
         resources: {}
       restartPolicy: Always
-status: {}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     service: statsd-sink
   name: statsd-sink


### PR DESCRIPTION
Signed-off-by: alex <alex@datawire.io>

## Description
Bumping the statsd-sink sample deployment versions to apps/v1. These samples were a bit stale, and caused me friction when testing our metrics integration tutorials on the website.

I don't believe this change is worthy of a CHANGELOG entry as it is not part of any release artifact.

## Related Issues
See also https://github.com/datawire/getambassador.io/pull/2174

## Testing
Kubectl-applied the manifests on a Kubernetes 1.18 cluster.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `CHANGELOG.md`.

   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations

 - [x] This is unlikely to impact how Ambassador performs at scale.

   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability

 - [x] My change is adequately tested.

   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points

 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.

 - [ ] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
