### PR TITLE
backport: fixes for auth service and stats parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,20 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
 
 ## RELEASE NOTES
 
+## [2.4.1] TBD
+[2.4.1]: https://github.com/emissary-ingress/emissary/compare/v2.4.0...v2.4.1
+
+### Emissary-ingress and Ambassador Edge Stack
+
+- Bugfix: If a `Host` or `TLSContext` contained a hostname with a `:` then when using the 
+  diagnostics endpoints `ambassador/v0/diagd` then an error would be thrown due to the parsing logic
+  not  being able to handle the extra colon. This has been fixed and Emissary-ingress will not throw
+  an error when parsing envoy metrics for the diagnostics user interface.
+
+- Bugfix: The synthetic AuthService didn't correctly handle AmbassadorID, which was fixed in version
+  3.1 of Emissary-ingress. The fix has been backported to make sure the AuthService is handled
+  correctly during upgrades.
+
 ## [2.4.0] September 19, 2022
 [2.4.0]: https://github.com/emissary-ingress/emissary/compare/v2.3.2...v2.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,7 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
 
 ## RELEASE NOTES
 
-## [2.4.1] TBD
+## [2.4.1] October 10, 2022
 [2.4.1]: https://github.com/emissary-ingress/emissary/compare/v2.4.0...v2.4.1
 
 ### Emissary-ingress and Ambassador Edge Stack

--- a/cmd/entrypoint/consul.go
+++ b/cmd/entrypoint/consul.go
@@ -325,7 +325,7 @@ func watchConsul(
 
 	w.Watch(func(endpoints consulwatch.Endpoints, e error) {
 		if endpoints.Id == "" {
-			// For Ambassador, overwrite the Id with the resolver's datacenter -- the
+			// For Ambassador, overwrite the ID with the resolver's datacenter -- the
 			// Consul watcher doesn't actually hand back the DC, and we need it.
 			endpoints.Id = resolver.Spec.Datacenter
 		}

--- a/cmd/entrypoint/endpoints.go
+++ b/cmd/entrypoint/endpoints.go
@@ -78,7 +78,7 @@ func (eri *endpointRoutingInfo) reconcileEndpointWatches(ctx context.Context, s 
 			if _, isInvalid := a.(*kates.Unstructured); isInvalid {
 				continue
 			}
-			if include(GetAmbId(ctx, a)) {
+			if include(GetAmbID(ctx, a)) {
 				eri.checkResourcePhase1(ctx, a, "annotation")
 			}
 		}
@@ -128,7 +128,7 @@ func (eri *endpointRoutingInfo) reconcileEndpointWatches(ctx context.Context, s 
 			if _, isInvalid := a.(*kates.Unstructured); isInvalid {
 				continue
 			}
-			if include(GetAmbId(ctx, a)) {
+			if include(GetAmbID(ctx, a)) {
 				eri.checkResourcePhase2(ctx, a, "annotation")
 			}
 		}

--- a/cmd/entrypoint/entrypoint.go
+++ b/cmd/entrypoint/entrypoint.go
@@ -77,8 +77,6 @@ import (
 // manager (e.g. kubernetes) is expected to take note and restart if
 // appropriate.
 
-const envAmbassadorDemoMode string = "AMBASSADOR_DEMO_MODE"
-
 func Main(ctx context.Context, Version string, args ...string) error {
 	// Setup logging according to AES_LOG_LEVEL
 	busy.SetLogLevel(logutil.DefaultLogLevel)
@@ -105,8 +103,6 @@ func Main(ctx context.Context, Version string, args ...string) error {
 		// Demo mode!
 		dlog.Infof(ctx, "DEMO MODE")
 		demoMode = true
-		// Set an environment variable so that other parts of the code can check if demo mode is active (mainly used for disabling synthetic authservice injection)
-		os.Setenv(envAmbassadorDemoMode, "true")
 	}
 
 	clusterID := GetClusterID(ctx)

--- a/cmd/entrypoint/entrypoint.go
+++ b/cmd/entrypoint/entrypoint.go
@@ -217,7 +217,7 @@ func Main(ctx context.Context, Version string, args ...string) error {
 }
 
 func clusterIDFromRootID(rootID string) string {
-	clusterUrl := fmt.Sprintf("d6e_id://%s/%s", rootID, GetAmbassadorId())
+	clusterUrl := fmt.Sprintf("d6e_id://%s/%s", rootID, GetAmbassadorID())
 	uid := uuid.NewSHA1(uuid.NameSpaceURL, []byte(clusterUrl))
 
 	return strings.ToLower(uid.String())

--- a/cmd/entrypoint/env.go
+++ b/cmd/entrypoint/env.go
@@ -19,7 +19,7 @@ func GetAgentService() string {
 	return ""
 }
 
-func GetAmbassadorId() string {
+func GetAmbassadorID() string {
 	id := os.Getenv("AMBASSADOR_ID")
 	if id != "" {
 		return id
@@ -67,7 +67,7 @@ func GetEnvoyBootstrapFile() string {
 	return env("ENVOY_BOOTSTRAP_FILE", path.Join(GetAmbassadorConfigBaseDir(), "bootstrap-ads.json"))
 }
 
-func GetEnvoyBaseId() string {
+func GetEnvoyBaseID() string {
 	return env("AMBASSADOR_ENVOY_BASE_ID", "0")
 }
 
@@ -153,7 +153,7 @@ func isDebug(name string) bool {
 }
 
 func GetEnvoyFlags() []string {
-	result := []string{"-c", GetEnvoyBootstrapFile(), "--base-id", GetEnvoyBaseId()}
+	result := []string{"-c", GetEnvoyBootstrapFile(), "--base-id", GetEnvoyBaseID()}
 	svc := GetAgentService()
 	if svc != "" {
 		result = append(result, "--drain-time-s", "1")

--- a/cmd/entrypoint/helpers.go
+++ b/cmd/entrypoint/helpers.go
@@ -78,7 +78,7 @@ func include(id amb.AmbassadorID) bool {
 
 	// It's not "_automatic_", so we have to actually do the work. Grab
 	// our AmbassadorID...
-	me := GetAmbassadorId()
+	me := GetAmbassadorID()
 
 	// ...force an empty AmbassadorID to "default", per the documentation...
 	if len(id) == 0 {

--- a/cmd/entrypoint/secrets.go
+++ b/cmd/entrypoint/secrets.go
@@ -190,7 +190,7 @@ func ReconcileSecrets(ctx context.Context, sh *SnapshotHolder) error {
 			if _, isInvalid := a.(*kates.Unstructured); isInvalid {
 				continue
 			}
-			if include(GetAmbId(ctx, a)) {
+			if include(GetAmbID(ctx, a)) {
 				resources = append(resources, a)
 			}
 		}

--- a/cmd/entrypoint/snapshot.go
+++ b/cmd/entrypoint/snapshot.go
@@ -19,8 +19,8 @@ func NewKubernetesSnapshot() *snapshotTypes.KubernetesSnapshot {
 	return a
 }
 
-// GetAmbId extracts the AmbassadorId from the kubernetes resource.
-func GetAmbId(ctx context.Context, resource kates.Object) amb.AmbassadorID {
+// GetAmbID extracts the AmbassadorID from the kubernetes resource.
+func GetAmbID(ctx context.Context, resource kates.Object) amb.AmbassadorID {
 	switch r := resource.(type) {
 	case *amb.Host:
 		var id amb.AmbassadorID

--- a/cmd/entrypoint/syntheticauth.go
+++ b/cmd/entrypoint/syntheticauth.go
@@ -2,28 +2,13 @@ package entrypoint
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/datawire/ambassador/v2/pkg/api/getambassador.io/v3alpha1"
 	"github.com/datawire/ambassador/v2/pkg/emissaryutil"
 	"github.com/datawire/ambassador/v2/pkg/kates"
-	"github.com/datawire/ambassador/v2/pkg/snapshot/v1"
 	"github.com/datawire/dlib/dlog"
 )
-
-// Iterates over the annotations in a snapshot to check if any AuthServices are present.
-func annotationsContainAuthService(annotations map[string]snapshot.AnnotationList) bool {
-	for _, list := range annotations {
-		for _, obj := range list {
-			switch obj.(type) {
-			case *v3alpha1.AuthService:
-				return true
-			default:
-				continue
-			}
-		}
-	}
-	return false
-}
 
 // Checks if the provided string is a loopback IP address with port 8500
 func IsLocalhost8500(svcStr string) bool {
@@ -31,155 +16,103 @@ func IsLocalhost8500(svcStr string) bool {
 	return err == nil && port == 8500 && emissaryutil.IsLocalhost(hostname)
 }
 
+func iterateOverAuthServices(sh *SnapshotHolder, cb func(
+	authService *v3alpha1.AuthService, // duh
+	name string, // name to unambiguously refer to the authService by; might be more complex than "name.namespace" if it's an annotation
+	parentName string, // name of the thing that the annotation is on (or empty if not an annotation)
+	idx int, // index of the authService; either in sh.k8sSnapshot.AuthServices or in sh.k8sSnapshot.Annotations[parentName]
+)) {
+	envAmbID := GetAmbassadorID()
+
+	for i, authService := range sh.k8sSnapshot.AuthServices {
+		if authService.Spec.AmbassadorID.Matches(envAmbID) {
+			name := authService.TypeMeta.Kind + "/" + authService.ObjectMeta.Name + "." + authService.ObjectMeta.Namespace
+			cb(authService, name, "", i)
+		}
+	}
+	for parentName, list := range sh.k8sSnapshot.Annotations {
+		for i, obj := range list {
+			if authService, ok := obj.(*v3alpha1.AuthService); ok && authService.Spec.AmbassadorID.Matches(envAmbID) {
+				name := fmt.Sprintf("%s#%d", parentName, i)
+				cb(authService, name, parentName, i)
+			}
+		}
+	}
+}
+
 // This is a gross hack to remove all AuthServices using protocol_version: v2 only when running Edge-Stack and then inject an
 // AuthService with protocol_version: v3 if needed. The purpose of this hack is to prevent Edge-Stack 2.3 from
 // using any other AuthService than the default one running as part of amb-sidecar and force the protocol version to v3.
 func ReconcileAuthServices(ctx context.Context, sh *SnapshotHolder, deltas *[]*kates.Delta) error {
 	// We only want to remove AuthServices if this is an instance of Edge-Stack
-	isEdgeStack, err := IsEdgeStack()
-	if err != nil {
-		return err
+	if isEdgeStack, err := IsEdgeStack(); err != nil {
+		return fmt.Errorf("ReconcileAuthServices: %w", err)
 	} else if !isEdgeStack {
 		return nil
 	}
 
-	// Construct a synthetic AuthService to be injected if we dont find any valid AuthServices
-	injectSyntheticAuth := true
-	syntheticAuth := &v3alpha1.AuthService{
-		TypeMeta: kates.TypeMeta{
-			Kind:       "AuthService",
-			APIVersion: "getambassador.io/v3alpha1",
-		},
-		ObjectMeta: kates.ObjectMeta{
-			Name:      "synthetic-edge-stack-auth",
-			Namespace: GetAmbassadorNamespace(),
-		},
-		Spec: v3alpha1.AuthServiceSpec{
-			AuthService:     "127.0.0.1:8500",
-			Proto:           "grpc",
-			ProtocolVersion: "v3",
-			AmbassadorID:    []string{"_automatic_"},
-		},
-	}
+	// using a name with underscores prevents it from colliding with anything real in the
+	// cluster--Kubernetes resources can't have underscores in their name.
+	const syntheticAuthServiceName = "synthetic_edge_stack_auth"
 
-	var authServices []*v3alpha1.AuthService
-	syntheticAuthExists := false
-	for _, authService := range sh.k8sSnapshot.AuthServices {
-		// check if the AuthService points at 127.0.0.1:8500 (edge-stack)
+	var (
+		numAuthServices  uint64
+		syntheticAuth    *v3alpha1.AuthService
+		syntheticAuthIdx int
+	)
+	iterateOverAuthServices(sh, func(authService *v3alpha1.AuthService, name, parentName string, i int) {
+		numAuthServices++
 		if IsLocalhost8500(authService.Spec.AuthService) {
-			// If it does point at localhost, make sure it is v3, otherwise we need to inject the synthetic AuthService
-			if authService.Spec.ProtocolVersion == "v3" {
-				injectSyntheticAuth = false
-				if authService.ObjectMeta.Name == "synthetic-edge-stack-auth" {
-					syntheticAuthExists = true
-				} else {
-					authServices = append(authServices, authService)
-				}
-			} else {
-				// In the event that there is an AuthService that does not have protocol_version: v3
-				// Then we use the spec of that AuthService as the Synthetic v3 AuthService we will inject later
-				syntheticAuth.Spec = authService.Spec
-				syntheticAuth.Spec.ProtocolVersion = "v3"
+			if parentName == "" && authService.ObjectMeta.Name == syntheticAuthServiceName {
+				syntheticAuth = authService
+				syntheticAuthIdx = i
 			}
-		} else {
-			// By default we keep any custom AuthServices that do not point at localhost
-			authServices = append(authServices, authService)
-			injectSyntheticAuth = false
-		}
-	}
-
-	// TODO if there are v3 authServices, still remove any that are not `v3`
-
-	// Also loop over the annotations and remove authservices that are not v3. We do
-	// this by looping over each entry in the annotations map, removing all the non-v3
-	// AuthService entries, and then removing any keys that end up with empty lists.
-
-	// OK. Loop over all the keys and their corrauthServicesesponding lists of annotations...
-	if annotationsContainAuthService(sh.k8sSnapshot.Annotations) {
-		for key, list := range sh.k8sSnapshot.Annotations {
-			// ...and build up our edited list of things.
-			editedList := snapshot.AnnotationList{}
-
-			for _, obj := range list {
-				switch annotationObj := obj.(type) {
-				case *v3alpha1.AuthService:
-					if IsLocalhost8500(annotationObj.Spec.AuthService) {
-						// If it does point at localhost, make sure it is v3, otherwise we need to inject the synthetic AuthService
-						if annotationObj.Spec.ProtocolVersion == "v3" {
-							injectSyntheticAuth = false
-							if annotationObj.ObjectMeta.Name == "synthetic-edge-stack-auth" {
-								syntheticAuthExists = true
-							} else {
-								authServices = append(authServices, annotationObj)
-								editedList = append(editedList, annotationObj)
-							}
-						} else {
-							// In the event that there is an AuthService that does not have protocol_version: v3
-							// Then we use the spec of that AuthService as the Synthetic v3 AuthService we will inject later
-							syntheticAuth.Spec = annotationObj.Spec
-							syntheticAuth.Spec.ProtocolVersion = "v3"
-						}
-					} else {
-						// By default we keep any custom AuthServices that do not point at localhost
-						authServices = append(authServices, annotationObj)
-						editedList = append(editedList, annotationObj)
-						injectSyntheticAuth = false
-					}
-				default:
-					// This isn't an AuthService at all, so we'll keep it.
-					editedList = append(editedList, annotationObj)
-				}
-			}
-
-			// Once here, is our editedList is empty?
-			if len(editedList) == 0 {
-				// Yes. Delete the whole key for this list.
-				delete(sh.k8sSnapshot.Annotations, key)
-			} else {
-				// Nope, not empty. Save the edited list.
-				sh.k8sSnapshot.Annotations[key] = editedList
+			if authService.Spec.ProtocolVersion != "v3" {
+				// Force the Edge Stack AuthService to be protocol_version=v3.  This
+				// is important so that <2.3 and >=2.3 installations can coexist.
+				// This is important, because for zero-downtime upgrades, they must
+				// coexist briefly while the new Deployment is getting rolled out.
+				dlog.Debugf(ctx, "ReconcileAuthServices: Forcing protocol_version=v3 on %s", name)
+				authService.Spec.ProtocolVersion = "v3"
 			}
 		}
-	}
+	})
 
-	if injectSyntheticAuth {
-		dlog.Debugf(ctx, "[WATCHER]: No valid AuthServices with protocol_version: v3 detected, injecting Synthetic AuthService")
-		// There are no valid AuthServices with protocol_version: v3. A synthetic one needs to be injected.
-		authServices = append(authServices, syntheticAuth)
-
-		// loop through the deltas and remove any AuthService deltas adding other AuthServices before the Synthetic delta is inserted
-		var newDeltas []*kates.Delta
-		for _, delta := range *deltas {
-			// Keep all the deltas that are not for AuthServices. The AuthService deltas can be kept as long as they are not an add delta.
-			if (delta.Kind != "AuthService") || (delta.Kind == "AuthService" && delta.DeltaType != kates.ObjectAdd) {
-				newDeltas = append(newDeltas, delta)
-			}
+	switch {
+	case numAuthServices == 0: // add the synthetic auth service
+		dlog.Debug(ctx, "ReconcileAuthServices: No user-provided AuthServices detected; injecting synthetic AuthService")
+		syntheticAuth = &v3alpha1.AuthService{
+			TypeMeta: kates.TypeMeta{
+				Kind:       "AuthService",
+				APIVersion: "getambassador.io/v3alpha1",
+			},
+			ObjectMeta: kates.ObjectMeta{
+				Name:      syntheticAuthServiceName,
+				Namespace: GetAmbassadorNamespace(),
+			},
+			Spec: v3alpha1.AuthServiceSpec{
+				AmbassadorID:    []string{GetAmbassadorID()},
+				AuthService:     "127.0.0.1:8500",
+				Proto:           "grpc",
+				ProtocolVersion: "v3",
+			},
 		}
-		newDeltas = append(newDeltas, &kates.Delta{
+		sh.k8sSnapshot.AuthServices = append(sh.k8sSnapshot.AuthServices, syntheticAuth)
+		*deltas = append(*deltas, &kates.Delta{
 			TypeMeta:   syntheticAuth.TypeMeta,
 			ObjectMeta: syntheticAuth.ObjectMeta,
 			DeltaType:  kates.ObjectAdd,
 		})
-
-		*deltas = newDeltas
-		sh.k8sSnapshot.AuthServices = authServices
-	} else if len(authServices) >= 1 {
-		// Write back the list of valid AuthServices.
-		sh.k8sSnapshot.AuthServices = authServices
-
-		// The synthetic AuthService needs to be removed since one or more valid AuthServices are present.
-		if syntheticAuthExists {
-			dlog.Debugf(ctx, "[WATCHER]: Valid AuthServices using protocol_version: v3 detected alongside the Synthetic AuthService, removing Synthetic...")
-			// One or more Valid AuthServices are present. The synthetic AuthService exists and needs to be removed now.
-			var newDeltas []*kates.Delta
-			*deltas = append(*deltas, &kates.Delta{
-				TypeMeta:   syntheticAuth.TypeMeta,
-				ObjectMeta: syntheticAuth.ObjectMeta,
-				DeltaType:  kates.ObjectDelete,
-			})
-
-			*deltas = newDeltas
-		}
+	case numAuthServices > 1 && syntheticAuth != nil: // remove the synthetic auth service
+		dlog.Debugf(ctx, "ReconcileAuthServices: %d user-provided AuthServices detected; removing synthetic AuthService", numAuthServices-1)
+		sh.k8sSnapshot.AuthServices = append(
+			sh.k8sSnapshot.AuthServices[:syntheticAuthIdx],
+			sh.k8sSnapshot.AuthServices[syntheticAuthIdx+1:]...)
+		*deltas = append(*deltas, &kates.Delta{
+			TypeMeta:   syntheticAuth.TypeMeta,
+			ObjectMeta: syntheticAuth.ObjectMeta,
+			DeltaType:  kates.ObjectDelete,
+		})
 	}
 
 	return nil

--- a/cmd/entrypoint/syntheticauth.go
+++ b/cmd/entrypoint/syntheticauth.go
@@ -42,10 +42,6 @@ func ReconcileAuthServices(ctx context.Context, sh *SnapshotHolder, deltas *[]*k
 	} else if !isEdgeStack {
 		return nil
 	}
-	// We also dont want to do anything with AuthServices if the Docker demo mode is running
-	if envbool("AMBASSADOR_DEMO_MODE") {
-		return nil
-	}
 
 	// Construct a synthetic AuthService to be injected if we dont find any valid AuthServices
 	injectSyntheticAuth := true

--- a/cmd/entrypoint/testutil_fake_syntheticauth_test.go
+++ b/cmd/entrypoint/testutil_fake_syntheticauth_test.go
@@ -29,11 +29,13 @@ func HasAuthService(namespace, name string) func(snapshot *snapshot.Snapshot) bo
 // Tests the synthetic auth generation when a valid AuthService is created.  This AuthService has
 // `protocol_version: v3` and should not be replaced by the synthetic AuthService.
 func TestSyntheticAuthValid(t *testing.T) {
-	t.Setenv("EDGE_STACK", "true")
+	if true {
+		if true {
+			t.Setenv("EDGE_STACK", "true")
 
-	f := entrypoint.RunFake(t, entrypoint.FakeConfig{EnvoyConfig: true}, nil)
+			f := entrypoint.RunFake(t, entrypoint.FakeConfig{EnvoyConfig: true}, nil)
 
-	err := f.UpsertYAML(`
+			err := f.UpsertYAML(`
 ---
 apiVersion: getambassador.io/v3alpha1
 kind: AuthService
@@ -45,49 +47,54 @@ spec:
   protocol_version: "v3"
   proto: "grpc"
 `)
-	assert.NoError(t, err)
-	f.Flush()
+			assert.NoError(t, err)
+			f.Flush()
 
-	// Use the predicate above to check that the snapshot contains the AuthService defined
-	// above.  The AuthService has `protocol_version: v3` so it should not be removed/replaced
-	// by the synthetic AuthService injected by syntheticauth.go
-	snap, err := f.GetSnapshot(HasAuthService("foo", "edge-stack-auth-test"))
-	assert.NoError(t, err)
-	assert.NotNil(t, snap)
+			// Use the predicate above to check that the snapshot contains the
+			// AuthService defined above.  The AuthService has `protocol_version: v3` so
+			// it should not be removed/replaced by the synthetic AuthService injected
+			// by syntheticauth.go
+			snap, err := f.GetSnapshot(HasAuthService("foo", "edge-stack-auth-test"))
+			assert.NoError(t, err)
+			assert.NotNil(t, snap)
 
-	assert.Equal(t, "edge-stack-auth-test", snap.Kubernetes.AuthServices[0].Name)
-	// In edge-stack we should only ever have 1 AuthService.
-	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
+			assert.Equal(t, "edge-stack-auth-test", snap.Kubernetes.AuthServices[0].Name)
+			// In edge-stack we should only ever have 1 AuthService.
+			assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
 
-	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are
-	// harder to check since they always have the same name).  The namespace for this extauthz
-	// cluster should be foo (since that is the namespace of the valid AuthService above).
-	isAuthCluster := func(c *v3cluster.Cluster) bool {
-		return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_foo")
+			// Check for an ext_authz cluster name matching the provided AuthService
+			// (Http_Filters are harder to check since they always have the same name).
+			// The namespace for this extauthz cluster should be foo (since that is the
+			// namespace of the valid AuthService above).
+			isAuthCluster := func(c *v3cluster.Cluster) bool {
+				return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_foo")
+			}
+
+			// Grab the next Envoy config that has an Edge Stack auth cluster on
+			// 127.0.0.1:8500
+			envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
+				return FindCluster(envoy, isAuthCluster) != nil
+			})
+			require.NoError(t, err)
+
+			// Make sure an Envoy Config containing a extauth cluster for the
+			// AuthService that was defined.
+			assert.NotNil(t, envoyConfig)
+		}
 	}
-
-	// Grab the next Envoy config that has an Edge Stack auth cluster on 127.0.0.1:8500
-	envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
-		return FindCluster(envoy, isAuthCluster) != nil
-	})
-	require.NoError(t, err)
-
-	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was
-	// defined.
-	assert.NotNil(t, envoyConfig)
-
-	t.Setenv("EDGE_STACK", "")
 }
 
 // Tests the synthetic auth generation when a valid AuthService is created as a getambassador.io/v2
 // resource.  This AuthService has `protocol_version: v3` and should not be replaced by the
 // synthetic AuthService.
 func TestSyntheticAuthValidV2(t *testing.T) {
-	t.Setenv("EDGE_STACK", "true")
+	if true {
+		if true {
+			t.Setenv("EDGE_STACK", "true")
 
-	f := entrypoint.RunFake(t, entrypoint.FakeConfig{EnvoyConfig: true}, nil)
+			f := entrypoint.RunFake(t, entrypoint.FakeConfig{EnvoyConfig: true}, nil)
 
-	err := f.UpsertYAML(`
+			err := f.UpsertYAML(`
 ---
 apiVersion: getambassador.io/v2
 kind: AuthService
@@ -99,48 +106,53 @@ spec:
   protocol_version: "v3"
   proto: "grpc"
 `)
-	assert.NoError(t, err)
-	f.Flush()
+			assert.NoError(t, err)
+			f.Flush()
 
-	// Use the predicate above to check that the snapshot contains the AuthService defined
-	// above.  The AuthService has `protocol_version: v3` so it should not be removed/replaced
-	// by the synthetic AuthService injected by syntheticauth.go
-	snap, err := f.GetSnapshot(HasAuthService("foo", "edge-stack-auth-test"))
-	assert.NoError(t, err)
-	assert.NotNil(t, snap)
+			// Use the predicate above to check that the snapshot contains the
+			// AuthService defined above.  The AuthService has `protocol_version: v3` so
+			// it should not be removed/replaced by the synthetic AuthService injected
+			// by syntheticauth.go
+			snap, err := f.GetSnapshot(HasAuthService("foo", "edge-stack-auth-test"))
+			assert.NoError(t, err)
+			assert.NotNil(t, snap)
 
-	assert.Equal(t, "edge-stack-auth-test", snap.Kubernetes.AuthServices[0].Name)
-	// In edge-stack we should only ever have 1 AuthService.
-	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
+			assert.Equal(t, "edge-stack-auth-test", snap.Kubernetes.AuthServices[0].Name)
+			// In edge-stack we should only ever have 1 AuthService.
+			assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
 
-	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are
-	// harder to check since they always have the same name).  The namespace for this extauthz
-	// cluster should be foo (since that is the namespace of the valid AuthService above).
-	isAuthCluster := func(c *v3cluster.Cluster) bool {
-		return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_foo")
+			// Check for an ext_authz cluster name matching the provided AuthService
+			// (Http_Filters are harder to check since they always have the same name).
+			// The namespace for this extauthz cluster should be foo (since that is the
+			// namespace of the valid AuthService above).
+			isAuthCluster := func(c *v3cluster.Cluster) bool {
+				return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_foo")
+			}
+
+			// Grab the next Envoy config that has an Edge Stack auth cluster on
+			// 127.0.0.1:8500
+			envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
+				return FindCluster(envoy, isAuthCluster) != nil
+			})
+			require.NoError(t, err)
+
+			// Make sure an Envoy Config containing a extauth cluster for the
+			// AuthService that was defined.
+			assert.NotNil(t, envoyConfig)
+		}
 	}
-
-	// Grab the next Envoy config that has an Edge Stack auth cluster on 127.0.0.1:8500
-	envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
-		return FindCluster(envoy, isAuthCluster) != nil
-	})
-	require.NoError(t, err)
-
-	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was
-	// defined.
-	assert.NotNil(t, envoyConfig)
-
-	t.Setenv("EDGE_STACK", "")
 }
 
 // This tests with a provided AuthService that has no protocol_version (which defaults to v2).  The
 // synthetic AuthService should be created instead.
 func TestSyntheticAuthReplace(t *testing.T) {
-	t.Setenv("EDGE_STACK", "true")
+	if true {
+		if true {
+			t.Setenv("EDGE_STACK", "true")
 
-	f := entrypoint.RunFake(t, entrypoint.FakeConfig{EnvoyConfig: true}, nil)
+			f := entrypoint.RunFake(t, entrypoint.FakeConfig{EnvoyConfig: true}, nil)
 
-	err := f.UpsertYAML(`
+			err := f.UpsertYAML(`
 ---
 apiVersion: getambassador.io/v3alpha1
 kind: AuthService
@@ -151,49 +163,55 @@ spec:
   auth_service: 127.0.0.1:8500
   proto: "grpc"
 `)
-	assert.NoError(t, err)
-	f.Flush()
+			assert.NoError(t, err)
+			f.Flush()
 
-	// Use the predicate above to check that the snapshot contains the AuthService defined
-	// above.  The AuthService does not have `protocol_version: v3` so it should be removed and
-	// replaced by the synthetic AuthService injected by syntheticauth.go
-	snap, err := f.GetSnapshot(HasAuthService("default", "synthetic-edge-stack-auth"))
-	assert.NoError(t, err)
-	assert.NotNil(t, snap)
+			// Use the predicate above to check that the snapshot contains the
+			// AuthService defined above.  The AuthService does not have
+			// `protocol_version: v3` so it should be removed and replaced by the
+			// synthetic AuthService injected by syntheticauth.go
+			snap, err := f.GetSnapshot(HasAuthService("default", "synthetic-edge-stack-auth"))
+			assert.NoError(t, err)
+			assert.NotNil(t, snap)
 
-	// The snapshot should only have the synthetic AuthService and not the one defined above.
-	assert.Equal(t, "synthetic-edge-stack-auth", snap.Kubernetes.AuthServices[0].Name)
-	// In edge-stack we should only ever have 1 AuthService.
-	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
+			// The snapshot should only have the synthetic AuthService and not the one
+			// defined above.
+			assert.Equal(t, "synthetic-edge-stack-auth", snap.Kubernetes.AuthServices[0].Name)
+			// In edge-stack we should only ever have 1 AuthService.
+			assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
 
-	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are
-	// harder to check since they always have the same name).  The namespace for this extauthz
-	// cluster should be default (since that is the namespace of the synthetic AuthService).
-	isAuthCluster := func(c *v3cluster.Cluster) bool {
-		return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_default")
+			// Check for an ext_authz cluster name matching the provided AuthService
+			// (Http_Filters are harder to check since they always have the same name).
+			// The namespace for this extauthz cluster should be default (since that is
+			// the namespace of the synthetic AuthService).
+			isAuthCluster := func(c *v3cluster.Cluster) bool {
+				return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_default")
+			}
+
+			// Grab the next Envoy config that has an Edge Stack auth cluster on
+			// 127.0.0.1:8500
+			envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
+				return FindCluster(envoy, isAuthCluster) != nil
+			})
+			require.NoError(t, err)
+
+			// Make sure an Envoy Config containing a extauth cluster for the
+			// AuthService that was defined.
+			assert.NotNil(t, envoyConfig)
+		}
 	}
-
-	// Grab the next Envoy config that has an Edge Stack auth cluster on 127.0.0.1:8500
-	envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
-		return FindCluster(envoy, isAuthCluster) != nil
-	})
-	require.NoError(t, err)
-
-	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was
-	// defined.
-	assert.NotNil(t, envoyConfig)
-
-	t.Setenv("EDGE_STACK", "")
 }
 
 // This tests with a provided AuthService that has no protocol_version (which defaults to v2).  The
 // synthetic AuthService should be created instead.
 func TestSyntheticAuthReplaceV2(t *testing.T) {
-	t.Setenv("EDGE_STACK", "true")
+	if true {
+		if true {
+			t.Setenv("EDGE_STACK", "true")
 
-	f := entrypoint.RunFake(t, entrypoint.FakeConfig{EnvoyConfig: true}, nil)
+			f := entrypoint.RunFake(t, entrypoint.FakeConfig{EnvoyConfig: true}, nil)
 
-	err := f.UpsertYAML(`
+			err := f.UpsertYAML(`
 ---
 apiVersion: getambassador.io/v2
 kind: AuthService
@@ -204,39 +222,43 @@ spec:
   auth_service: 127.0.0.1:8500
   proto: "grpc"
 `)
-	assert.NoError(t, err)
-	f.Flush()
+			assert.NoError(t, err)
+			f.Flush()
 
-	// Use the predicate above to check that the snapshot contains the AuthService defined
-	// above.  The AuthService does not have `protocol_version: v3` so it should be removed and
-	// replaced by the synthetic AuthService injected by syntheticauth.go
-	snap, err := f.GetSnapshot(HasAuthService("default", "synthetic-edge-stack-auth"))
-	assert.NoError(t, err)
-	assert.NotNil(t, snap)
+			// Use the predicate above to check that the snapshot contains the
+			// AuthService defined above.  The AuthService does not have
+			// `protocol_version: v3` so it should be removed and replaced by the
+			// synthetic AuthService injected by syntheticauth.go
+			snap, err := f.GetSnapshot(HasAuthService("default", "synthetic-edge-stack-auth"))
+			assert.NoError(t, err)
+			assert.NotNil(t, snap)
 
-	// The snapshot should only have the synthetic AuthService and not the one defined above.
-	assert.Equal(t, "synthetic-edge-stack-auth", snap.Kubernetes.AuthServices[0].Name)
-	// In edge-stack we should only ever have 1 AuthService.
-	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
+			// The snapshot should only have the synthetic AuthService and not the one
+			// defined above.
+			assert.Equal(t, "synthetic-edge-stack-auth", snap.Kubernetes.AuthServices[0].Name)
+			// In edge-stack we should only ever have 1 AuthService.
+			assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
 
-	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are
-	// harder to check since they always have the same name).  The namespace for this extauthz
-	// cluster should be default (since that is the namespace of the synthetic AuthService).
-	isAuthCluster := func(c *v3cluster.Cluster) bool {
-		return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_default")
+			// Check for an ext_authz cluster name matching the provided AuthService
+			// (Http_Filters are harder to check since they always have the same name).
+			// The namespace for this extauthz cluster should be default (since that is
+			// the namespace of the synthetic AuthService).
+			isAuthCluster := func(c *v3cluster.Cluster) bool {
+				return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_default")
+			}
+
+			// Grab the next Envoy config that has an Edge Stack auth cluster on
+			// 127.0.0.1:8500
+			envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
+				return FindCluster(envoy, isAuthCluster) != nil
+			})
+			require.NoError(t, err)
+
+			// Make sure an Envoy Config containing a extauth cluster for the
+			// AuthService that was defined.
+			assert.NotNil(t, envoyConfig)
+		}
 	}
-
-	// Grab the next Envoy config that has an Edge Stack auth cluster on 127.0.0.1:8500
-	envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
-		return FindCluster(envoy, isAuthCluster) != nil
-	})
-	require.NoError(t, err)
-
-	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was
-	// defined.
-	assert.NotNil(t, envoyConfig)
-
-	t.Setenv("EDGE_STACK", "")
 }
 
 // Tests the synthetic auth generation when an invalid AuthService is created.  This AuthService has
@@ -244,11 +266,13 @@ spec:
 // a bogus value because the bogus field will be dropped when it is loaded and we will be left with
 // a valid AuthService.
 func TestSyntheticAuthBogusField(t *testing.T) {
-	t.Setenv("EDGE_STACK", "true")
+	if true {
+		if true {
+			t.Setenv("EDGE_STACK", "true")
 
-	f := entrypoint.RunFake(t, entrypoint.FakeConfig{EnvoyConfig: true}, nil)
+			f := entrypoint.RunFake(t, entrypoint.FakeConfig{EnvoyConfig: true}, nil)
 
-	err := f.UpsertYAML(`
+			err := f.UpsertYAML(`
 ---
 apiVersion: getambassador.io/v3alpha1
 kind: AuthService
@@ -261,49 +285,54 @@ spec:
   proto: "grpc"
   bogus_field: "foo"
 `)
-	assert.NoError(t, err)
-	f.Flush()
+			assert.NoError(t, err)
+			f.Flush()
 
-	// Use the predicate above to check that the snapshot contains the AuthService defined
-	// above.  The AuthService has `protocol_version: v3` so it should not be removed/replaced by
-	// the synthetic AuthService injected by syntheticauth.go
-	snap, err := f.GetSnapshot(HasAuthService("foo", "edge-stack-auth-test"))
-	assert.NoError(t, err)
-	assert.NotNil(t, snap)
+			// Use the predicate above to check that the snapshot contains the
+			// AuthService defined above.  The AuthService has `protocol_version: v3` so
+			// it should not be removed/replaced by the synthetic AuthService injected
+			// by syntheticauth.go
+			snap, err := f.GetSnapshot(HasAuthService("foo", "edge-stack-auth-test"))
+			assert.NoError(t, err)
+			assert.NotNil(t, snap)
 
-	assert.Equal(t, "edge-stack-auth-test", snap.Kubernetes.AuthServices[0].Name)
-	// In edge-stack we should only ever have 1 AuthService.
-	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
+			assert.Equal(t, "edge-stack-auth-test", snap.Kubernetes.AuthServices[0].Name)
+			// In edge-stack we should only ever have 1 AuthService.
+			assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
 
-	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are
-	// harder to check since they always have the same name).  The namespace for this extauthz
-	// cluster should be foo (since that is the namespace of the valid AuthService above).
-	isAuthCluster := func(c *v3cluster.Cluster) bool {
-		return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_foo")
+			// Check for an ext_authz cluster name matching the provided AuthService
+			// (Http_Filters are harder to check since they always have the same name).
+			// The namespace for this extauthz cluster should be foo (since that is the
+			// namespace of the valid AuthService above).
+			isAuthCluster := func(c *v3cluster.Cluster) bool {
+				return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_foo")
+			}
+
+			// Grab the next Envoy config that has an Edge Stack auth cluster on
+			// 127.0.0.1:8500
+			envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
+				return FindCluster(envoy, isAuthCluster) != nil
+			})
+			require.NoError(t, err)
+
+			// Make sure an Envoy Config containing a extauth cluster for the
+			// AuthService that was defined.
+			assert.NotNil(t, envoyConfig)
+		}
 	}
-
-	// Grab the next Envoy config that has an Edge Stack auth cluster on 127.0.0.1:8500
-	envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
-		return FindCluster(envoy, isAuthCluster) != nil
-	})
-	require.NoError(t, err)
-
-	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was
-	// defined.
-	assert.NotNil(t, envoyConfig)
-
-	t.Setenv("EDGE_STACK", "")
 }
 
 // Tests the synthetic auth generation when an invalid AuthService is created as a
 // getambassador.io/v2 resource.  This AuthService has `protocol_version: v3` and should be replaced
 // by the synthetic AuthService because it contains a bogus field and is not valid.
 func TestSyntheticAuthBogusFieldV2(t *testing.T) {
-	t.Setenv("EDGE_STACK", "true")
+	if true {
+		if true {
+			t.Setenv("EDGE_STACK", "true")
 
-	f := entrypoint.RunFake(t, entrypoint.FakeConfig{EnvoyConfig: true}, nil)
+			f := entrypoint.RunFake(t, entrypoint.FakeConfig{EnvoyConfig: true}, nil)
 
-	err := f.UpsertYAML(`
+			err := f.UpsertYAML(`
 ---
 apiVersion: getambassador.io/v2
 kind: AuthService
@@ -316,39 +345,41 @@ spec:
   proto: "grpc"
   bogus_field: "foo"
 `)
-	assert.NoError(t, err)
-	f.Flush()
+			assert.NoError(t, err)
+			f.Flush()
 
-	// Use the predicate above to check that the snapshot contains the AuthService defined
-	// above.  The AuthService has `protocol_version: v3` so it should not be removed/replaced
-	// by the synthetic AuthService injected by syntheticauth.go
-	snap, err := f.GetSnapshot(HasAuthService("foo", "edge-stack-auth-test"))
-	assert.NoError(t, err)
-	assert.NotNil(t, snap)
+			// Use the predicate above to check that the snapshot contains the
+			// AuthService defined above.  The AuthService has `protocol_version: v3` so
+			// it should not be removed/replaced by the synthetic AuthService injected
+			// by syntheticauth.go
+			snap, err := f.GetSnapshot(HasAuthService("foo", "edge-stack-auth-test"))
+			assert.NoError(t, err)
+			assert.NotNil(t, snap)
 
-	assert.Equal(t, "edge-stack-auth-test", snap.Kubernetes.AuthServices[0].Name)
-	// In edge-stack we should only ever have 1 AuthService.
-	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
+			assert.Equal(t, "edge-stack-auth-test", snap.Kubernetes.AuthServices[0].Name)
+			// In edge-stack we should only ever have 1 AuthService.
+			assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
 
-	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are
-	// harder to check since they always have the same name).  The namespace for this extauthz
-	// cluster should be foo (since that is the namespace of the valid AuthService above).
-	isAuthCluster := func(c *v3cluster.Cluster) bool {
-		return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_foo")
+			// Check for an ext_authz cluster name matching the provided AuthService
+			// (Http_Filters are harder to check since they always have the same name).
+			// The namespace for this extauthz cluster should be foo (since that is the
+			// namespace of the valid AuthService above).
+			isAuthCluster := func(c *v3cluster.Cluster) bool {
+				return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_foo")
+			}
+
+			// Grab the next Envoy config that has an Edge Stack auth cluster on
+			// 127.0.0.1:8500
+			envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
+				return FindCluster(envoy, isAuthCluster) != nil
+			})
+			require.NoError(t, err)
+
+			// Make sure an Envoy Config containing a extauth cluster for the
+			// AuthService that was defined.
+			assert.NotNil(t, envoyConfig)
+		}
 	}
-
-	// Grab the next Envoy config that has an Edge Stack auth cluster on 127.0.0.1:8500
-	envoyConfig, err := f.GetEnvoyConfig(func(envoy *v3bootstrap.Bootstrap) bool {
-		return FindCluster(envoy, isAuthCluster) != nil
-	})
-	require.NoError(t, err)
-
-	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was
-	// defined.
-	assert.NotNil(t, envoyConfig)
-
-	t.Setenv("EDGE_STACK", "")
-
 }
 
 // Tests the synthetic auth generation when an invalid AuthService (because the protocol_version is

--- a/cmd/entrypoint/testutil_fake_syntheticauth_test.go
+++ b/cmd/entrypoint/testutil_fake_syntheticauth_test.go
@@ -59,9 +59,9 @@ spec:
 			assert.NoError(t, err)
 			assert.NotNil(t, snap)
 
-			assert.Equal(t, "edge-stack-auth-test", snap.Kubernetes.AuthServices[0].Name)
 			// In edge-stack we should only ever have 1 AuthService.
 			assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
+			assert.Equal(t, "edge-stack-auth-test", snap.Kubernetes.AuthServices[0].Name)
 
 			// Check for an ext_authz cluster name matching the provided AuthService
 			// (Http_Filters are harder to check since they always have the same name).
@@ -117,11 +117,11 @@ spec:
 			assert.NoError(t, err)
 			assert.NotNil(t, snap)
 
+			// In edge-stack we should only ever have 1 AuthService.
+			assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
 			// The snapshot should only have the synthetic AuthService and not the one
 			// defined above.
 			assert.Equal(t, "synthetic-edge-stack-auth", snap.Kubernetes.AuthServices[0].Name)
-			// In edge-stack we should only ever have 1 AuthService.
-			assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
 
 			// Check for an ext_authz cluster name matching the provided AuthService
 			// (Http_Filters are harder to check since they always have the same name).
@@ -181,9 +181,9 @@ spec:
 			assert.NoError(t, err)
 			assert.NotNil(t, snap)
 
-			assert.Equal(t, "edge-stack-auth-test", snap.Kubernetes.AuthServices[0].Name)
 			// In edge-stack we should only ever have 1 AuthService.
 			assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
+			assert.Equal(t, "edge-stack-auth-test", snap.Kubernetes.AuthServices[0].Name)
 
 			// Check for an ext_authz cluster name matching the provided AuthService
 			// (Http_Filters are harder to check since they always have the same name).
@@ -238,10 +238,10 @@ spec:
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
 
-	// The snapshot should only have the synthetic AuthService and not the one defined above.
-	assert.Equal(t, "synthetic-edge-stack-auth", snap.Kubernetes.AuthServices[0].Name)
 	// In edge-stack we should only ever have 1 AuthService.
 	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
+	// The snapshot should only have the synthetic AuthService and not the one defined above.
+	assert.Equal(t, "synthetic-edge-stack-auth", snap.Kubernetes.AuthServices[0].Name)
 
 	// Check for an ext_authz cluster name matching the synthetic AuthService.  The namespace
 	// for this extauthz cluster should be default (since that is the namespace of the synthetic
@@ -332,10 +332,10 @@ spec:
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
 
-	// The snapshot should only have the synthetic AuthService and not the one defined above.
-	assert.Equal(t, "edge-stack-auth-test", snap.Kubernetes.AuthServices[0].Name)
 	// In edge-stack we should only ever have 1 AuthService.
 	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
+	// The snapshot should only have the synthetic AuthService and not the one defined above.
+	assert.Equal(t, "edge-stack-auth-test", snap.Kubernetes.AuthServices[0].Name)
 
 	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are
 	// harder to check since they always have the same name).  The namespace for this extauthz
@@ -387,10 +387,10 @@ spec:
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
 
-	// The snapshot should only have the synthetic AuthService and not the one defined above.
-	assert.Equal(t, "synthetic-edge-stack-auth", snap.Kubernetes.AuthServices[0].Name)
 	// We should only have 1 AuthService.
 	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
+	// The snapshot should only have the synthetic AuthService and not the one defined above.
+	assert.Equal(t, "synthetic-edge-stack-auth", snap.Kubernetes.AuthServices[0].Name)
 
 	// Check for an ext_authz cluster name matching the synthetic AuthService.  The namespace
 	// for this extauthz cluster should be default (since that is the namespace of the synthetic
@@ -435,9 +435,9 @@ spec:
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
 
-	assert.Equal(t, "edge-stack-auth-test", snap.Kubernetes.AuthServices[0].Name)
 	// In edge-stack we should only ever have 1 AuthService.
 	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
+	assert.Equal(t, "edge-stack-auth-test", snap.Kubernetes.AuthServices[0].Name)
 
 	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are
 	// harder to check since they always have the same name).  The namespace for this extauthz
@@ -492,10 +492,10 @@ spec:
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
 
-	// The snapshot should only have the synthetic AuthService
-	assert.Equal(t, "synthetic-edge-stack-auth", snap.Kubernetes.AuthServices[0].Name)
 	// In edge-stack we should only ever have 1 AuthService.
 	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
+	// The snapshot should only have the synthetic AuthService
+	assert.Equal(t, "synthetic-edge-stack-auth", snap.Kubernetes.AuthServices[0].Name)
 
 	// Even though it is the synthetic AuthService, we should have the custom timeout_ms and v3
 	// protocol version.
@@ -553,9 +553,9 @@ spec:
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
 
-	assert.Equal(t, "edge-stack-auth-test", snap.Kubernetes.AuthServices[0].Name)
 	// In edge-stack we should only ever have 1 AuthService.
 	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
+	assert.Equal(t, "edge-stack-auth-test", snap.Kubernetes.AuthServices[0].Name)
 
 	for _, authService := range snap.Kubernetes.AuthServices {
 		assert.Equal(t, "dummy-service", authService.Spec.AuthService)

--- a/cmd/entrypoint/testutil_fake_syntheticauth_test.go
+++ b/cmd/entrypoint/testutil_fake_syntheticauth_test.go
@@ -85,8 +85,8 @@ spec:
 	}
 }
 
-// This tests with a provided AuthService that has no protocol_version (which defaults to v2).  The
-// synthetic AuthService should be created instead.
+// This tests with a provided AuthService that has no protocol_version (which defaults to v2).  It
+// should get forcibly overridden to be v3.
 func TestSyntheticAuthReplace(t *testing.T) {
 	for _, apiVersion := range []string{"v2", "v3alpha1"} {
 		apiVersion := apiVersion // capture loop variable
@@ -109,26 +109,25 @@ spec:
 			assert.NoError(t, err)
 			f.Flush()
 
-			// Use the predicate above to check that the snapshot contains the
-			// AuthService defined above.  The AuthService does not have
-			// `protocol_version: v3` so it should be removed and replaced by the
-			// synthetic AuthService injected by syntheticauth.go
-			snap, err := f.GetSnapshot(HasAuthService("default", "synthetic-edge-stack-auth"))
+			// The AuthService does not have `protocol_version: v3` so it should be
+			// forcibly edited to say `protocol_version: v3` by syntheticauth.go
+			snap, err := f.GetSnapshot(HasAuthService("foo", "edge-stack-auth-test"))
 			assert.NoError(t, err)
 			assert.NotNil(t, snap)
 
 			// In edge-stack we should only ever have 1 AuthService.
 			assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
-			// The snapshot should only have the synthetic AuthService and not the one
-			// defined above.
-			assert.Equal(t, "synthetic-edge-stack-auth", snap.Kubernetes.AuthServices[0].Name)
+			// The snapshot should only have the one defined above.
+			assert.Equal(t, "edge-stack-auth-test", snap.Kubernetes.AuthServices[0].Name)
+			// The protocol version should be forcibly set to v3.
+			assert.Equal(t, "v3", snap.Kubernetes.AuthServices[0].Spec.ProtocolVersion)
 
 			// Check for an ext_authz cluster name matching the provided AuthService
 			// (Http_Filters are harder to check since they always have the same name).
-			// The namespace for this extauthz cluster should be default (since that is
-			// the namespace of the synthetic AuthService).
+			// The namespace for this extauthz cluster should be "foo" (since that is
+			// the namespace of the AuthService).
 			isAuthCluster := func(c *v3cluster.Cluster) bool {
-				return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_default")
+				return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_foo")
 			}
 
 			// Grab the next Envoy config that has an Edge Stack auth cluster on
@@ -187,8 +186,8 @@ spec:
 
 			// Check for an ext_authz cluster name matching the provided AuthService
 			// (Http_Filters are harder to check since they always have the same name).
-			// The namespace for this extauthz cluster should be foo (since that is the
-			// namespace of the valid AuthService above).
+			// The namespace for this extauthz cluster should be "foo" (since that is
+			// the namespace of the valid AuthService above).
 			isAuthCluster := func(c *v3cluster.Cluster) bool {
 				return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_foo")
 			}
@@ -224,7 +223,7 @@ metadata:
   namespace: foo
 spec:
   auth_service: 127.0.0.1:8500
-  protocol_version: "v4"
+  protocol_version: "vBogus"
   proto: "grpc"
   bogus_field: "foo"
 `)
@@ -234,14 +233,14 @@ spec:
 	// Use the predicate above to check that the snapshot contains the synthetic AuthService.
 	// The AuthService has `protocol_version: v3`, but it has a bogus field so it should not be
 	// validated and instead we inject the synthetic AuthService.
-	snap, err := f.GetSnapshot(HasAuthService("default", "synthetic-edge-stack-auth"))
+	snap, err := f.GetSnapshot(HasAuthService("default", "synthetic_edge_stack_auth"))
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
 
 	// In edge-stack we should only ever have 1 AuthService.
 	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
 	// The snapshot should only have the synthetic AuthService and not the one defined above.
-	assert.Equal(t, "synthetic-edge-stack-auth", snap.Kubernetes.AuthServices[0].Name)
+	assert.Equal(t, "synthetic_edge_stack_auth", snap.Kubernetes.AuthServices[0].Name)
 
 	// Check for an ext_authz cluster name matching the synthetic AuthService.  The namespace
 	// for this extauthz cluster should be default (since that is the namespace of the synthetic
@@ -376,21 +375,21 @@ metadata:
 spec:
   auth_service: 127.0.0.1:8500
   proto: "grpc"
-  bogus_field: "foo"
+  protocol_version: "vBogus"
 `)
 	assert.NoError(t, err)
 
 	// Use the predicate above to check that the snapshot contains the synthetic AuthService.
-	// The AuthService has `protocol_version: v3`, but it has a bogus field so it should not be
-	// validated and instead we inject the synthetic AuthService.
-	snap, err := f.GetSnapshot(HasAuthService("default", "synthetic-edge-stack-auth"))
+	// The user-provided AuthService is invalid and so it should be ignored and instead we
+	// inject the synthetic AuthService.
+	snap, err := f.GetSnapshot(HasAuthService("default", "synthetic_edge_stack_auth"))
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
 
 	// We should only have 1 AuthService.
 	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
 	// The snapshot should only have the synthetic AuthService and not the one defined above.
-	assert.Equal(t, "synthetic-edge-stack-auth", snap.Kubernetes.AuthServices[0].Name)
+	assert.Equal(t, "synthetic_edge_stack_auth", snap.Kubernetes.AuthServices[0].Name)
 
 	// Check for an ext_authz cluster name matching the synthetic AuthService.  The namespace
 	// for this extauthz cluster should be default (since that is the namespace of the synthetic
@@ -408,8 +407,6 @@ spec:
 	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was
 	// defined.
 	assert.NotNil(t, envoyConfig)
-
-	t.Setenv("EDGE_STACK", "")
 
 	// Updating the yaml for that AuthService to include `protocol_version: v3` should make it
 	// valid and then remove our synthetic AuthService and allow the now valid AuthService to be
@@ -461,8 +458,8 @@ spec:
 }
 
 // This AuthService points at 127.0.0.1:8500, but it does not have `protocol_version: v3`.  It also
-// has additional fields set.  The correct action is to create a SyntheticAuth copy of this
-// AuthService with the same fields but with `protocol_version: v3`.
+// has additional fields set.  The correct action is to edit the AuthService to say
+// `protocol_version: v3`.
 func TestSyntheticAuthCopyFields(t *testing.T) {
 	t.Setenv("EDGE_STACK", "true")
 
@@ -484,31 +481,24 @@ spec:
 	assert.NoError(t, err)
 	f.Flush()
 
-	// Use the predicate above to check that the snapshot contains the synthetic AuthService.
-	// The AuthService has `protocol_version: v3`, but it is missing the `protocol_version: v3`
-	// field.  We expect the synthetic AuthService to be injected, but later we will check that
-	// the synthetic AuthService has Our custom timeout_ms field.
-	snap, err := f.GetSnapshot(HasAuthService("default", "synthetic-edge-stack-auth"))
+	// Use the predicate above to check that the snapshot contains the AuthService.
+	snap, err := f.GetSnapshot(HasAuthService("foo", "edge-stack-auth-test"))
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
 
 	// In edge-stack we should only ever have 1 AuthService.
 	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
-	// The snapshot should only have the synthetic AuthService
-	assert.Equal(t, "synthetic-edge-stack-auth", snap.Kubernetes.AuthServices[0].Name)
-
-	// Even though it is the synthetic AuthService, we should have the custom timeout_ms and v3
-	// protocol version.
-	for _, authService := range snap.Kubernetes.AuthServices {
-		assert.Equal(t, int64(12345), authService.Spec.Timeout.Duration.Milliseconds())
-		assert.Equal(t, "v3", authService.Spec.ProtocolVersion)
-	}
+	// It should be that user-provided AuthService...
+	assert.Equal(t, "edge-stack-auth-test", snap.Kubernetes.AuthServices[0].Name)
+	assert.Equal(t, int64(12345), snap.Kubernetes.AuthServices[0].Spec.Timeout.Duration.Milliseconds())
+	// ... but with `protocol_version: v3` set.
+	assert.Equal(t, "v3", snap.Kubernetes.AuthServices[0].Spec.ProtocolVersion)
 
 	// Check for an ext_authz cluster name matching the synthetic AuthService.  The namespace
 	// for this extauthz cluster should be default (since that is the namespace of the synthetic
 	// AuthService).
 	isAuthCluster := func(c *v3cluster.Cluster) bool {
-		return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_default")
+		return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_foo")
 	}
 
 	// Grab the next Envoy config that has an Edge Stack auth cluster on 127.0.0.1:8500

--- a/cmd/entrypoint/testutil_fake_syntheticauth_test.go
+++ b/cmd/entrypoint/testutil_fake_syntheticauth_test.go
@@ -13,7 +13,8 @@ import (
 	"github.com/datawire/ambassador/v2/pkg/snapshot/v1"
 )
 
-// This predicate is used to check k8s snapshots for an AuthService matching the provided name and namespace
+// This predicate is used to check k8s snapshots for an AuthService matching the provided name and
+// namespace.
 func HasAuthService(namespace, name string) func(snapshot *snapshot.Snapshot) bool {
 	return func(snapshot *snapshot.Snapshot) bool {
 		for _, m := range snapshot.Kubernetes.AuthServices {
@@ -25,8 +26,8 @@ func HasAuthService(namespace, name string) func(snapshot *snapshot.Snapshot) bo
 	}
 }
 
-// Tests the synthetic auth generation when a valid AuthService is created
-// This authservice has protocol_Version: v3 and should not be replaced by the synthetic AuthService
+// Tests the synthetic auth generation when a valid AuthService is created.  This AuthService has
+// `protocol_version: v3` and should not be replaced by the synthetic AuthService.
 func TestSyntheticAuthValid(t *testing.T) {
 	t.Setenv("EDGE_STACK", "true")
 
@@ -47,9 +48,9 @@ spec:
 	assert.NoError(t, err)
 	f.Flush()
 
-	// Use the predicate above to check that the snapshot contains the AuthService defined above
-	// The AuthService has protocol_Version: v3 so it should not be removed/replaced by the synthetic AuthService
-	// injected by syntheticauth.go
+	// Use the predicate above to check that the snapshot contains the AuthService defined
+	// above.  The AuthService has `protocol_version: v3` so it should not be removed/replaced
+	// by the synthetic AuthService injected by syntheticauth.go
 	snap, err := f.GetSnapshot(HasAuthService("foo", "edge-stack-auth-test"))
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
@@ -58,8 +59,9 @@ spec:
 	// In edge-stack we should only ever have 1 AuthService.
 	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
 
-	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are harder to check since they always have the same name)
-	// the namespace for this extauthz cluster should be foo (since that is the namespace of the valid AuthService above)
+	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are
+	// harder to check since they always have the same name).  The namespace for this extauthz
+	// cluster should be foo (since that is the namespace of the valid AuthService above).
 	isAuthCluster := func(c *v3cluster.Cluster) bool {
 		return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_foo")
 	}
@@ -70,14 +72,16 @@ spec:
 	})
 	require.NoError(t, err)
 
-	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was defined
+	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was
+	// defined.
 	assert.NotNil(t, envoyConfig)
 
 	t.Setenv("EDGE_STACK", "")
 }
 
-// Tests the synthetic auth generation when a valid AuthService is created as a getambassador.io/v2 resource
-// This authservice has protocol_Version: v3 and should not be replaced by the synthetic AuthService
+// Tests the synthetic auth generation when a valid AuthService is created as a getambassador.io/v2
+// resource.  This AuthService has `protocol_version: v3` and should not be replaced by the
+// synthetic AuthService.
 func TestSyntheticAuthValidV2(t *testing.T) {
 	t.Setenv("EDGE_STACK", "true")
 
@@ -98,9 +102,9 @@ spec:
 	assert.NoError(t, err)
 	f.Flush()
 
-	// Use the predicate above to check that the snapshot contains the AuthService defined above
-	// The AuthService has protocol_Version: v3 so it should not be removed/replaced by the synthetic AuthService
-	// injected by syntheticauth.go
+	// Use the predicate above to check that the snapshot contains the AuthService defined
+	// above.  The AuthService has `protocol_version: v3` so it should not be removed/replaced
+	// by the synthetic AuthService injected by syntheticauth.go
 	snap, err := f.GetSnapshot(HasAuthService("foo", "edge-stack-auth-test"))
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
@@ -109,8 +113,9 @@ spec:
 	// In edge-stack we should only ever have 1 AuthService.
 	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
 
-	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are harder to check since they always have the same name)
-	// the namespace for this extauthz cluster should be foo (since that is the namespace of the valid AuthService above)
+	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are
+	// harder to check since they always have the same name).  The namespace for this extauthz
+	// cluster should be foo (since that is the namespace of the valid AuthService above).
 	isAuthCluster := func(c *v3cluster.Cluster) bool {
 		return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_foo")
 	}
@@ -121,14 +126,15 @@ spec:
 	})
 	require.NoError(t, err)
 
-	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was defined
+	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was
+	// defined.
 	assert.NotNil(t, envoyConfig)
 
 	t.Setenv("EDGE_STACK", "")
 }
 
-// This tests with a provided AuthService that has no protocol_version (which defaults to v2)
-// The synthetic AuthService should be created instead
+// This tests with a provided AuthService that has no protocol_version (which defaults to v2).  The
+// synthetic AuthService should be created instead.
 func TestSyntheticAuthReplace(t *testing.T) {
 	t.Setenv("EDGE_STACK", "true")
 
@@ -148,20 +154,21 @@ spec:
 	assert.NoError(t, err)
 	f.Flush()
 
-	// Use the predicate above to check that the snapshot contains the AuthService defined above
-	// The AuthService does not have protocol_Version: v3 so it should be removed and replaced by the synthetic AuthService
-	// injected by syntheticauth.go
+	// Use the predicate above to check that the snapshot contains the AuthService defined
+	// above.  The AuthService does not have `protocol_version: v3` so it should be removed and
+	// replaced by the synthetic AuthService injected by syntheticauth.go
 	snap, err := f.GetSnapshot(HasAuthService("default", "synthetic-edge-stack-auth"))
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
 
-	// The snapshot should only have the synthetic AuthService and not the one defined above
+	// The snapshot should only have the synthetic AuthService and not the one defined above.
 	assert.Equal(t, "synthetic-edge-stack-auth", snap.Kubernetes.AuthServices[0].Name)
 	// In edge-stack we should only ever have 1 AuthService.
 	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
 
-	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are harder to check since they always have the same name)
-	// the namespace for this extauthz cluster should be default (since that is the namespace of the synthetic AuthService)
+	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are
+	// harder to check since they always have the same name).  The namespace for this extauthz
+	// cluster should be default (since that is the namespace of the synthetic AuthService).
 	isAuthCluster := func(c *v3cluster.Cluster) bool {
 		return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_default")
 	}
@@ -172,14 +179,15 @@ spec:
 	})
 	require.NoError(t, err)
 
-	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was defined
+	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was
+	// defined.
 	assert.NotNil(t, envoyConfig)
 
 	t.Setenv("EDGE_STACK", "")
 }
 
-// This tests with a provided AuthService that has no protocol_version (which defaults to v2)
-// The synthetic AuthService should be created instead
+// This tests with a provided AuthService that has no protocol_version (which defaults to v2).  The
+// synthetic AuthService should be created instead.
 func TestSyntheticAuthReplaceV2(t *testing.T) {
 	t.Setenv("EDGE_STACK", "true")
 
@@ -199,20 +207,21 @@ spec:
 	assert.NoError(t, err)
 	f.Flush()
 
-	// Use the predicate above to check that the snapshot contains the AuthService defined above
-	// The AuthService does not have protocol_Version: v3 so it should be removed and replaced by the synthetic AuthService
-	// injected by syntheticauth.go
+	// Use the predicate above to check that the snapshot contains the AuthService defined
+	// above.  The AuthService does not have `protocol_version: v3` so it should be removed and
+	// replaced by the synthetic AuthService injected by syntheticauth.go
 	snap, err := f.GetSnapshot(HasAuthService("default", "synthetic-edge-stack-auth"))
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
 
-	// The snapshot should only have the synthetic AuthService and not the one defined above
+	// The snapshot should only have the synthetic AuthService and not the one defined above.
 	assert.Equal(t, "synthetic-edge-stack-auth", snap.Kubernetes.AuthServices[0].Name)
 	// In edge-stack we should only ever have 1 AuthService.
 	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
 
-	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are harder to check since they always have the same name)
-	// the namespace for this extauthz cluster should be default (since that is the namespace of the synthetic AuthService)
+	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are
+	// harder to check since they always have the same name).  The namespace for this extauthz
+	// cluster should be default (since that is the namespace of the synthetic AuthService).
 	isAuthCluster := func(c *v3cluster.Cluster) bool {
 		return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_default")
 	}
@@ -223,15 +232,17 @@ spec:
 	})
 	require.NoError(t, err)
 
-	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was defined
+	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was
+	// defined.
 	assert.NotNil(t, envoyConfig)
 
 	t.Setenv("EDGE_STACK", "")
 }
 
-// Tests the synthetic auth generation when an invalid AuthService is created as a getambassador.io/v2 resource
-// This authservice has protocol_Version: v3 and should not be replaced by the synthetic AuthService even though it has a bogus value
-// because the bogus field will be dropped when it is loaded and we will be left with a Valid AuthService
+// Tests the synthetic auth generation when an invalid AuthService is created.  This AuthService has
+// `protocol_version: v3` and should not be replaced by the synthetic AuthService even though it has
+// a bogus value because the bogus field will be dropped when it is loaded and we will be left with
+// a valid AuthService.
 func TestSyntheticAuthBogusField(t *testing.T) {
 	t.Setenv("EDGE_STACK", "true")
 
@@ -253,9 +264,9 @@ spec:
 	assert.NoError(t, err)
 	f.Flush()
 
-	// Use the predicate above to check that the snapshot contains the AuthService defined above
-	// The AuthService has protocol_Version: v3 so it should not be removed/replaced by the synthetic AuthService
-	// injected by syntheticauth.go
+	// Use the predicate above to check that the snapshot contains the AuthService defined
+	// above.  The AuthService has `protocol_version: v3` so it should not be removed/replaced by
+	// the synthetic AuthService injected by syntheticauth.go
 	snap, err := f.GetSnapshot(HasAuthService("foo", "edge-stack-auth-test"))
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
@@ -264,8 +275,9 @@ spec:
 	// In edge-stack we should only ever have 1 AuthService.
 	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
 
-	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are harder to check since they always have the same name)
-	// the namespace for this extauthz cluster should be foo (since that is the namespace of the valid AuthService above)
+	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are
+	// harder to check since they always have the same name).  The namespace for this extauthz
+	// cluster should be foo (since that is the namespace of the valid AuthService above).
 	isAuthCluster := func(c *v3cluster.Cluster) bool {
 		return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_foo")
 	}
@@ -276,14 +288,16 @@ spec:
 	})
 	require.NoError(t, err)
 
-	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was defined
+	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was
+	// defined.
 	assert.NotNil(t, envoyConfig)
 
 	t.Setenv("EDGE_STACK", "")
 }
 
-// Tests the synthetic auth generation when an invalid AuthService is created as a getambassador.io/v2 resource
-// This authservice has protocol_Version: v3 and should be replaced by the synthetic AuthService because it contains a bogus field and is not valid.
+// Tests the synthetic auth generation when an invalid AuthService is created as a
+// getambassador.io/v2 resource.  This AuthService has `protocol_version: v3` and should be replaced
+// by the synthetic AuthService because it contains a bogus field and is not valid.
 func TestSyntheticAuthBogusFieldV2(t *testing.T) {
 	t.Setenv("EDGE_STACK", "true")
 
@@ -305,9 +319,9 @@ spec:
 	assert.NoError(t, err)
 	f.Flush()
 
-	// Use the predicate above to check that the snapshot contains the AuthService defined above
-	// The AuthService has protocol_Version: v3 so it should not be removed/replaced by the synthetic AuthService
-	// injected by syntheticauth.go
+	// Use the predicate above to check that the snapshot contains the AuthService defined
+	// above.  The AuthService has `protocol_version: v3` so it should not be removed/replaced
+	// by the synthetic AuthService injected by syntheticauth.go
 	snap, err := f.GetSnapshot(HasAuthService("foo", "edge-stack-auth-test"))
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
@@ -316,8 +330,9 @@ spec:
 	// In edge-stack we should only ever have 1 AuthService.
 	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
 
-	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are harder to check since they always have the same name)
-	// the namespace for this extauthz cluster should be foo (since that is the namespace of the valid AuthService above)
+	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are
+	// harder to check since they always have the same name).  The namespace for this extauthz
+	// cluster should be foo (since that is the namespace of the valid AuthService above).
 	isAuthCluster := func(c *v3cluster.Cluster) bool {
 		return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_foo")
 	}
@@ -328,15 +343,17 @@ spec:
 	})
 	require.NoError(t, err)
 
-	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was defined
+	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was
+	// defined.
 	assert.NotNil(t, envoyConfig)
 
 	t.Setenv("EDGE_STACK", "")
 
 }
 
-// Tests the synthetic auth generation when an invalid AuthService (because the protocol_version is invalid for the supported enums)
-// This AuthService should be tossed out an the synthetic AuthService should be injected
+// Tests the synthetic auth generation when an invalid AuthService (because the protocol_version is
+// invalid for the supported enums).  This AuthService should be tossed out an the synthetic
+// AuthService should be injected.
 func TestSyntheticAuthInvalidProtocolVer(t *testing.T) {
 	t.Setenv("EDGE_STACK", "true")
 
@@ -358,19 +375,21 @@ spec:
 	assert.NoError(t, err)
 	f.Flush()
 
-	// Use the predicate above to check that the snapshot contains the Synthetic AuthService
-	// The AuthService has protocol_Version: v3, but it has a bogus field so it should not be validated and instead we inject the synthetic authservice
+	// Use the predicate above to check that the snapshot contains the synthetic AuthService.
+	// The AuthService has `protocol_version: v3`, but it has a bogus field so it should not be
+	// validated and instead we inject the synthetic AuthService.
 	snap, err := f.GetSnapshot(HasAuthService("default", "synthetic-edge-stack-auth"))
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
 
-	// The snapshot should only have the synthetic AuthService and not the one defined above
+	// The snapshot should only have the synthetic AuthService and not the one defined above.
 	assert.Equal(t, "synthetic-edge-stack-auth", snap.Kubernetes.AuthServices[0].Name)
 	// In edge-stack we should only ever have 1 AuthService.
 	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
 
-	// Check for an ext_authz cluster name matching the synthetic AuthService.
-	// the namespace for this extauthz cluster should be default (since that is the namespace of the synthetic AuthService)
+	// Check for an ext_authz cluster name matching the synthetic AuthService.  The namespace
+	// for this extauthz cluster should be default (since that is the namespace of the synthetic
+	// AuthService).
 	isAuthCluster := func(c *v3cluster.Cluster) bool {
 		return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_default")
 	}
@@ -381,16 +400,18 @@ spec:
 	})
 	require.NoError(t, err)
 
-	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was defined
+	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was
+	// defined.
 	assert.NotNil(t, envoyConfig)
 
 	t.Setenv("EDGE_STACK", "")
 }
 
-// Tests the synthetic auth generation when an invalid AuthService is created and edited several times in succession.
-// After the config is edited several times, we should see that the final result is our provided valid AuthService.
-// There should not be any duplicate AuthService resources, and the synthetic AuthService that gets created when the first
-// Invalid AuthService is applied should be removed when the final edit makes it a valid AuthService.
+// Tests the synthetic auth generation when an invalid AuthService is created and edited several
+// times in succession.  After the config is edited several times, we should see that the final
+// result is our provided valid AuthService.  There should not be any duplicate AuthService
+// resources, and the synthetic AuthService that gets created when the first invalid AuthService is
+// applied should be removed when the final edit makes it a valid AuthService.
 func TestSyntheticAuthChurn(t *testing.T) {
 	t.Setenv("EDGE_STACK", "true")
 
@@ -448,20 +469,21 @@ spec:
 `)
 	assert.NoError(t, err)
 
-	// Use the predicate above to check that the snapshot contains the AuthService defined above
-	// The AuthService has protocol_Version: v3 so it should not be removed/replaced by the synthetic AuthService
-	// injected by syntheticauth.go
+	// Use the predicate above to check that the snapshot contains the AuthService defined
+	// above.  The AuthService has `protocol_version: v3` so it should not be removed/replaced
+	// by the synthetic AuthService injected by syntheticauth.go
 	snap, err := f.GetSnapshot(HasAuthService("foo", "edge-stack-auth-test"))
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
 
-	// The snapshot should only have the synthetic AuthService and not the one defined above
+	// The snapshot should only have the synthetic AuthService and not the one defined above.
 	assert.Equal(t, "edge-stack-auth-test", snap.Kubernetes.AuthServices[0].Name)
 	// In edge-stack we should only ever have 1 AuthService.
 	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
 
-	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are harder to check since they always have the same name)
-	// the namespace for this extauthz cluster should be foo (since that is the namespace of the valid AuthService above)
+	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are
+	// harder to check since they always have the same name).  The namespace for this extauthz
+	// cluster should be foo (since that is the namespace of the valid AuthService above)
 	isAuthCluster := func(c *v3cluster.Cluster) bool {
 		return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_foo")
 	}
@@ -478,15 +500,16 @@ spec:
 	t.Setenv("EDGE_STACK", "")
 }
 
-// Tests the synthetic auth generation by first creating an invalid AuthService and confirming that the synthetic AuthService gets injected.
-// Afterwards, a valid AuthService is applied and we expect the synthetic AuthService to be removed in favor of the new valid AuthService.
+// Tests the synthetic auth generation by first creating an invalid AuthService and confirming that
+// the synthetic AuthService gets injected.  Afterwards, a valid AuthService is applied and we
+// expect the synthetic AuthService to be removed in favor of the new valid AuthService.
 func TestSyntheticAuthInjectAndRemove(t *testing.T) {
 	t.Setenv("EDGE_STACK", "true")
 
 	f := entrypoint.RunFake(t, entrypoint.FakeConfig{EnvoyConfig: true}, nil)
 	f.AutoFlush(true)
 
-	// This will cause a synthethic authservice to be injected
+	// This will cause a synthethic AuthService to be injected.
 	err := f.UpsertYAML(`
 ---
 apiVersion: getambassador.io/v3alpha1
@@ -501,19 +524,21 @@ spec:
 `)
 	assert.NoError(t, err)
 
-	// Use the predicate above to check that the snapshot contains the Synthetic AuthService
-	// The AuthService has protocol_Version: v3, but it has a bogus field so it should not be validated and instead we inject the synthetic authservice
+	// Use the predicate above to check that the snapshot contains the synthetic AuthService.
+	// The AuthService has `protocol_version: v3`, but it has a bogus field so it should not be
+	// validated and instead we inject the synthetic AuthService.
 	snap, err := f.GetSnapshot(HasAuthService("default", "synthetic-edge-stack-auth"))
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
 
-	// The snapshot should only have the synthetic AuthService and not the one defined above
+	// The snapshot should only have the synthetic AuthService and not the one defined above.
 	assert.Equal(t, "synthetic-edge-stack-auth", snap.Kubernetes.AuthServices[0].Name)
 	// We should only have 1 AuthService.
 	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
 
-	// Check for an ext_authz cluster name matching the synthetic AuthService.
-	// the namespace for this extauthz cluster should be default (since that is the namespace of the synthetic AuthService)
+	// Check for an ext_authz cluster name matching the synthetic AuthService.  The namespace
+	// for this extauthz cluster should be default (since that is the namespace of the synthetic
+	// AuthService).
 	isAuthCluster := func(c *v3cluster.Cluster) bool {
 		return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_default")
 	}
@@ -524,13 +549,15 @@ spec:
 	})
 	require.NoError(t, err)
 
-	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was defined
+	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was
+	// defined.
 	assert.NotNil(t, envoyConfig)
 
 	t.Setenv("EDGE_STACK", "")
 
-	// Updating the yaml for that AuthService to include protocol_version: v3 should make it valid and then
-	// Remove our synthetic AuthService and allow the now valid AuthService to be used.
+	// Updating the yaml for that AuthService to include `protocol_version: v3` should make it
+	// valid and then remove our synthetic AuthService and allow the now valid AuthService to be
+	// used.
 	err = f.UpsertYAML(`
 ---
 apiVersion: getambassador.io/v3alpha1
@@ -545,9 +572,9 @@ spec:
 `)
 	assert.NoError(t, err)
 
-	// Use the predicate above to check that the snapshot contains the AuthService defined above
-	// The AuthService has protocol_Version: v3 so it should not be removed/replaced by the synthetic AuthService
-	// injected by syntheticauth.go
+	// Use the predicate above to check that the snapshot contains the AuthService defined
+	// above.  The AuthService has `protocol_version: v3` so it should not be removed/replaced
+	// by the synthetic AuthService injected by syntheticauth.go
 	snap, err = f.GetSnapshot(HasAuthService("foo", "edge-stack-auth-test"))
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
@@ -556,8 +583,9 @@ spec:
 	// In edge-stack we should only ever have 1 AuthService.
 	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
 
-	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are harder to check since they always have the same name)
-	// the namespace for this extauthz cluster should be foo (since that is the namespace of the valid AuthService above)
+	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are
+	// harder to check since they always have the same name).  The namespace for this extauthz
+	// cluster should be foo (since that is the namespace of the valid AuthService above).
 	isAuthCluster = func(c *v3cluster.Cluster) bool {
 		return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_foo")
 	}
@@ -568,15 +596,17 @@ spec:
 	})
 	require.NoError(t, err)
 
-	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was defined
+	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was
+	// defined.
 	assert.NotNil(t, envoyConfig)
 
 	t.Setenv("EDGE_STACK", "")
 
 }
 
-// This AuthService points at 127.0.0.1:8500, but it does not have protocol_version: v3. It also has additional fields set.
-// The correct action is to create a SyntheticAuth copy of this AuthService with the same fields but with protocol_version: v3
+// This AuthService points at 127.0.0.1:8500, but it does not have `protocol_version: v3`.  It also
+// has additional fields set.  The correct action is to create a SyntheticAuth copy of this
+// AuthService with the same fields but with `protocol_version: v3`.
 func TestSyntheticAuthCopyFields(t *testing.T) {
 	t.Setenv("EDGE_STACK", "true")
 
@@ -598,10 +628,10 @@ spec:
 	assert.NoError(t, err)
 	f.Flush()
 
-	// Use the predicate above to check that the snapshot contains the Synthetic AuthService
-	// The AuthService has protocol_Version: v3, but it is missing the protocol_version: v3 field.
-	// We expect the synthetic AuthService to be injected, but later we will check that the synthetic AuthService has
-	// Our custom timeout_ms field
+	// Use the predicate above to check that the snapshot contains the synthetic AuthService.
+	// The AuthService has `protocol_version: v3`, but it is missing the `protocol_version: v3`
+	// field.  We expect the synthetic AuthService to be injected, but later we will check that
+	// the synthetic AuthService has Our custom timeout_ms field.
 	snap, err := f.GetSnapshot(HasAuthService("default", "synthetic-edge-stack-auth"))
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
@@ -611,14 +641,16 @@ spec:
 	// In edge-stack we should only ever have 1 AuthService.
 	assert.Equal(t, 1, len(snap.Kubernetes.AuthServices))
 
-	// Even though it is the synthetic AuthService, we should have the custom timeout_ms and v3 protocol version
+	// Even though it is the synthetic AuthService, we should have the custom timeout_ms and v3
+	// protocol version.
 	for _, authService := range snap.Kubernetes.AuthServices {
 		assert.Equal(t, int64(12345), authService.Spec.Timeout.Duration.Milliseconds())
 		assert.Equal(t, "v3", authService.Spec.ProtocolVersion)
 	}
 
-	// Check for an ext_authz cluster name matching the synthetic AuthService.
-	// the namespace for this extauthz cluster should be default (since that is the namespace of the synthetic AuthService)
+	// Check for an ext_authz cluster name matching the synthetic AuthService.  The namespace
+	// for this extauthz cluster should be default (since that is the namespace of the synthetic
+	// AuthService).
 	isAuthCluster := func(c *v3cluster.Cluster) bool {
 		return strings.Contains(c.Name, "cluster_extauth_127_0_0_1_8500_default")
 	}
@@ -629,14 +661,15 @@ spec:
 	})
 	require.NoError(t, err)
 
-	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was defined
+	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was
+	// defined.
 	assert.NotNil(t, envoyConfig)
 
 	t.Setenv("EDGE_STACK", "")
 }
 
-// This AuthService does not point at 127.0.0.1:8500, so despite not having protocol_version: v3, we leave it alone
-// The strict enforcement of protocol_version: v3 is only important for the AuthService that points at edge-stack
+// This AuthService does not point at 127.0.0.1:8500, we leave it alone rather than adding a
+// synthetic one.
 func TestSyntheticAuthCustomAuthService(t *testing.T) {
 	t.Setenv("EDGE_STACK", "true")
 
@@ -657,9 +690,9 @@ spec:
 	assert.NoError(t, err)
 	f.Flush()
 
-	// Use the predicate above to check that the snapshot contains the AuthService defined above
-	// The AuthService has protocol_Version: v3 so it should not be removed/replaced by the synthetic AuthService
-	// injected by syntheticauth.go
+	// Use the predicate above to check that the snapshot contains the AuthService defined
+	// above.  The AuthService has `protocol_version: v3` so it should not be removed/replaced
+	// by the synthetic AuthService injected by syntheticauth.go
 	snap, err := f.GetSnapshot(HasAuthService("foo", "edge-stack-auth-test"))
 	assert.NoError(t, err)
 	assert.NotNil(t, snap)
@@ -672,8 +705,9 @@ spec:
 		assert.Equal(t, "dummy-service", authService.Spec.AuthService)
 	}
 
-	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are harder to check since they always have the same name)
-	// the namespace for this extauthz cluster should be foo (since that is the namespace of the valid AuthService above)
+	// Check for an ext_authz cluster name matching the provided AuthService (Http_Filters are
+	// harder to check since they always have the same name).  the namespace for this extauthz
+	// cluster should be foo (since that is the namespace of the valid AuthService above).
 	isAuthCluster := func(c *v3cluster.Cluster) bool {
 		return strings.Contains(c.Name, "cluster_extauth_dummy_service_foo")
 	}
@@ -684,14 +718,15 @@ spec:
 	})
 	require.NoError(t, err)
 
-	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was defined
+	// Make sure an Envoy Config containing a extauth cluster for the AuthService that was
+	// defined.
 	assert.NotNil(t, envoyConfig)
 
 	t.Setenv("EDGE_STACK", "")
 }
 
-// When deciding if we need to inject a synthetic AuthService or not, we need to be able to reliably determine if that
-// AuthService points at a localhost:8500 or not
+// When deciding if we need to inject a synthetic AuthService or not, we need to be able to reliably
+// determine if that AuthService points at a localhost:8500 or not.
 func TestIsLocalhost8500(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/entrypoint/watcher.go
+++ b/cmd/entrypoint/watcher.go
@@ -56,7 +56,7 @@ func WatchAllTheThings(
 	interestingTypes := GetInterestingTypes(ctx, serverTypeList)
 	queries := GetQueries(ctx, interestingTypes)
 
-	ambassadorMeta := getAmbassadorMeta(GetAmbassadorId(), clusterID, version, client)
+	ambassadorMeta := getAmbassadorMeta(GetAmbassadorID(), clusterID, version, client)
 
 	// **** SETUP DONE for the Kubernetes Watcher
 

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -32,6 +32,23 @@
 
 changelog: https://github.com/emissary-ingress/emissary/blob/$branch$/CHANGELOG.md
 items:
+  - version: 2.4.1
+    date: 'TBD'
+    notes:
+      - title: Diagnostics stats properly handles parsing envoy metrics with colons
+        type: bugfix
+        body: >-
+          If a <code>Host</code> or <code>TLSContext</code> contained a hostname with a <code>:</code> then when using the 
+          diagnostics endpoints <code>ambassador/v0/diagd</code> then an error would be thrown due to the parsing logic not 
+          being able to handle the extra colon. This has been fixed and $productName$ will not throw an error when parsing
+          envoy metrics for the diagnostics user interface.
+          
+      - title: Backport fixes for handling synthetic auth services
+        type: bugfix
+        body: >-
+          The synthetic AuthService didn't correctly handle AmbassadorID, which was fixed in version 3.1 of $productName$.
+          The fix has been backported to make sure the AuthService is handled correctly during upgrades.
+
   - version: 2.4.0
     date: '2022-09-19'
     prevVersion: 2.3.2

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -33,7 +33,7 @@
 changelog: https://github.com/emissary-ingress/emissary/blob/$branch$/CHANGELOG.md
 items:
   - version: 2.4.1
-    date: 'TBD'
+    date: '2022-10-10'
     notes:
       - title: Diagnostics stats properly handles parsing envoy metrics with colons
         type: bugfix

--- a/python/ambassador/diagnostics/envoy_stats.py
+++ b/python/ambassador/diagnostics/envoy_stats.py
@@ -319,8 +319,11 @@ class EnvoyStatsMgr:
             if not line:
                 continue
 
-            key, value = line.split(":")
-            keypath = key.split('.')
+            # TODO: Splitting from the right is a work-around for the
+            # following issue: https://github.com/emissary-ingress/emissary/issues/4528
+            # and needs to be addressed via a behavior change
+            key, value = line.rsplit(":", 1)
+            keypath = key.split(".")
 
             node = envoy_stats
 


### PR DESCRIPTION
## Description

This back ports the fixes need for issues:
- Synthetic AuthService fixes for handling AmbassadorID correctly
- stats parsing issues with virtual hosts

These fixes were originally done in v3 series (master) and were back ported to the `release/v2.5` branch. However, this is effecting users that are currently trying to upgrade to the 2.4 version. Therefore, we need to back port these to the `release/v2.4` branch and cut a 2.4.1 release.

## Related Issues
N/A

## Testing
release/v2.5 is the same as release/v2.4 and these changes were verified by users via a dev build.

## Checklist

 - [x] I made sure to update `CHANGELOG.md`.
 - [x] This is unlikely to impact how Ambassador performs at scale.
 - [ ] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [x] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
