### PR TITLE
Fix finding Ingress TLS secrets

### DIFF
--- a/cmd/entrypoint/secrets.go
+++ b/cmd/entrypoint/secrets.go
@@ -17,7 +17,7 @@ import (
 	"github.com/datawire/dlib/dlog"
 	amb "github.com/emissary-ingress/emissary/v3/pkg/api/getambassador.io/v3alpha1"
 	"github.com/emissary-ingress/emissary/v3/pkg/kates"
-	"github.com/emissary-ingress/emissary/v3/pkg/kates/k8s_resource_types"
+	"github.com/emissary-ingress/emissary/v3/pkg/snapshot/v1"
 	snapshotTypes "github.com/emissary-ingress/emissary/v3/pkg/snapshot/v1"
 )
 
@@ -522,7 +522,7 @@ func findSecretRefs(ctx context.Context, resource kates.Object, secretNamespacin
 			secretRef(r.GetNamespace(), secs.Client.Secret, secretNamespacing, action)
 		}
 
-	case *k8s_resource_types.Ingress:
+	case *snapshot.Ingress:
 		// Ingress is pretty straightforward, too, just look in spec.tls.
 		for _, itls := range r.Spec.TLS {
 			if itls.SecretName != "" {


### PR DESCRIPTION
## Description

Emissary has not been able to save secrets from Ingress due to checking the wrong type.

## Related Issues

#3959 This one was closed due to there being a workaround

## Testing
Manually tested. No existing tests exists around any of this code.


## Checklist

 - [x] This is unlikely to impact how Ambassador performs at scale.

   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability

 - [x] My change is adequately tested.

   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points

 - [x] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
