### PR TITLE
(Community Contribution) Fix Ingress resrource TLS secrets 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,21 +95,26 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
 
 - Bugfix: By default Emissary-ingress adds routes for http to https redirection. When an AuthService
   is applied in v2.Y of Emissary-ingress, Envoy would skip the ext_authz call for non-tls http
-  request and would perform the https  redirect. In Envoy 1.20+ the behavior has changed where Envoy
-  will  always call the ext_authz filter and must be disabled on a per route  basis. 
-  This new
-  behavior change introduced a regression in v3.0 of  Emissary-ingress when it was upgraded to Envoy
-  1.22. The http to https  redirection no longer works when an AuthService was applied. This fix 
-  restores the previous behavior by disabling the ext_authz call on the  https redirect routes. ([#4620])
+  request and would perform the https redirect. In Envoy 1.20+ the behavior has changed where Envoy
+  will always call the ext_authz filter and must be disabled on a per route basis.
+  This new behavior
+  change introduced a regression in v3.0 of Emissary-ingress when it was upgraded to Envoy 1.22. The
+  http to https redirection no longer works when an AuthService was applied. This fix restores the
+  previous behavior by disabling the ext_authz call on the https redirect routes. ([#4620])
 
-- Bugfix: When an AuthService is applied in v2.Y of Emissary-ingress,  Envoy would skip the
-  ext_authz call for all redirect routes and  would perform the redirect. In Envoy 1.20+ the
-  behavior has changed  where Envoy will always call the ext_authz filter so it must be  disabled on
-  a per route basis. 
-  This new behavior change introduced a regression in v3.0 of  Emissary-ingress
-  when it was upgraded to Envoy 1.22. The host_redirect  would call an AuthService prior to redirect
-  if applied. This fix  restores the previous behavior by disabling the ext_authz call on the 
-  host_redirect routes. ([#4640])
+- Bugfix: When an AuthService is applied in v2.Y of Emissary-ingress, Envoy would skip the ext_authz
+  call for all redirect routes and would perform the redirect. In Envoy 1.20+ the behavior has
+  changed where Envoy will always call the ext_authz filter so it must be disabled on a per route
+  basis.
+  This new behavior change introduced a regression in v3.0 of Emissary-ingress when it was
+  upgraded to Envoy 1.22. The host_redirect would call an AuthService prior to redirect if applied.
+  This fix restores the previous behavior by disabling the ext_authz call on the host_redirect
+  routes. ([#4640])
+
+- Bugfix: Previous versions of Emissary-ingress required a workaround using `TLSContexts` to find
+  tls secrets referenced from `Ingress` resources. Now tls secrets referenced are properly detected
+  without requiring an additional `TLSContext` to reference them. (Thanks to <a
+  href="https://github.com/olemarkus">Ole Markus</a>!).
 
 [#4620]: https://github.com/emissary-ingress/emissary/issues/4620
 [#4640]: https://github.com/emissary-ingress/emissary/issues/4640
@@ -133,7 +138,7 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
   to `Mappings` you want to associate with the `Host`. You can opt-out of the new behaviour by
   setting the environment variable `DISABLE_STRICT_LABEL_SELECTORS` to `"true"` (default:
   `"false"`). (Thanks to <a href="https://github.com/f-herceg">Filip Herceg</a> and <a
-  href="https://github.com/dynajoe">Joe Andaverde</a>!).      
+  href="https://github.com/dynajoe">Joe Andaverde</a>!).
 
 - Feature: Previously the `Host` resource could only use secrets that are in the namespace as the
   Host. The `tlsSecret` field in the Host has a new subfield `namespace` that will allow the use of
@@ -141,7 +146,7 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
 
 - Change: Set `AMBASSADOR_EDS_BYPASS` to `true` to bypass EDS handling of endpoints and have
   endpoints be inserted to clusters manually. This can help resolve with `503 UH` caused by
-  certification rotation relating to a delay between EDS + CDS. The default is `false`.     
+  certification rotation relating to a delay between EDS + CDS. The default is `false`.
 
 - Bugfix: Distinct services with names that are the same in the first forty characters will no
   longer be incorrectly mapped to the same cluster. ([#4354])

--- a/cmd/entrypoint/secrets.go
+++ b/cmd/entrypoint/secrets.go
@@ -17,7 +17,7 @@ import (
 	"github.com/datawire/dlib/dlog"
 	amb "github.com/emissary-ingress/emissary/v3/pkg/api/getambassador.io/v3alpha1"
 	"github.com/emissary-ingress/emissary/v3/pkg/kates"
-	"github.com/emissary-ingress/emissary/v3/pkg/kates/k8s_resource_types"
+	"github.com/emissary-ingress/emissary/v3/pkg/snapshot/v1"
 	snapshotTypes "github.com/emissary-ingress/emissary/v3/pkg/snapshot/v1"
 )
 
@@ -522,7 +522,7 @@ func findSecretRefs(ctx context.Context, resource kates.Object, secretNamespacin
 			secretRef(r.GetNamespace(), secs.Client.Secret, secretNamespacing, action)
 		}
 
-	case *k8s_resource_types.Ingress:
+	case *snapshot.Ingress:
 		// Ingress is pretty straightforward, too, just look in spec.tls.
 		for _, itls := range r.Spec.TLS {
 			if itls.SecretName != "" {

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -46,37 +46,45 @@ items:
         body: >-
           By default $productName$ adds routes for http to https redirection. When
           an AuthService is applied in v2.Y of $productName$, Envoy would skip the
-          ext_authz call for non-tls http request and would perform the https 
-          redirect. In Envoy 1.20+ the behavior has changed where Envoy will 
-          always call the ext_authz filter and must be disabled on a per route 
-          basis. 
-          
-          This new behavior change introduced a regression in v3.0 of 
-          $productName$ when it was upgraded to Envoy 1.22. The http to https 
-          redirection no longer works when an AuthService was applied. This fix 
-          restores the previous behavior by disabling the ext_authz call on the 
+          ext_authz call for non-tls http request and would perform the https
+          redirect. In Envoy 1.20+ the behavior has changed where Envoy will
+          always call the ext_authz filter and must be disabled on a per route
+          basis.
+
+          This new behavior change introduced a regression in v3.0 of
+          $productName$ when it was upgraded to Envoy 1.22. The http to https
+          redirection no longer works when an AuthService was applied. This fix
+          restores the previous behavior by disabling the ext_authz call on the
           https redirect routes.
         github:
         - title: "#4620"
           link: https://github.com/emissary-ingress/emissary/issues/4620
-          
+
       - title: Fix regression in host_redirects with AuthService
         type: bugfix
         body: >-
-          When an AuthService is applied in v2.Y of $productName$, 
-          Envoy would skip the ext_authz call for all redirect routes and 
-          would perform the redirect. In Envoy 1.20+ the behavior has changed 
-          where Envoy will always call the ext_authz filter so it must be 
-          disabled on a per route basis. 
-          
-          This new behavior change introduced a regression in v3.0 of 
-          $productName$ when it was upgraded to Envoy 1.22. The host_redirect 
-          would call an AuthService prior to redirect if applied. This fix 
-          restores the previous behavior by disabling the ext_authz call on the 
+          When an AuthService is applied in v2.Y of $productName$,
+          Envoy would skip the ext_authz call for all redirect routes and
+          would perform the redirect. In Envoy 1.20+ the behavior has changed
+          where Envoy will always call the ext_authz filter so it must be
+          disabled on a per route basis.
+
+          This new behavior change introduced a regression in v3.0 of
+          $productName$ when it was upgraded to Envoy 1.22. The host_redirect
+          would call an AuthService prior to redirect if applied. This fix
+          restores the previous behavior by disabling the ext_authz call on the
           host_redirect routes.
         github:
         - title: "#4640"
           link: https://github.com/emissary-ingress/emissary/issues/4640
+
+      - title: Fixed finding ingress resource tls secrets
+        type: bugfix
+        body: >-
+          Previous versions of $productName$ required a workaround using <code>TLSContexts</code> to find tls secrets referenced from
+          <code>Ingress</code> resources. Now tls secrets referenced are properly detected without requiring an additional <code>TLSContext</code> to
+          reference them.
+          (Thanks to <a href="https://github.com/olemarkus">Ole Markus</a>!).
 
   - version: 3.2.0
     prevVersion: 3.1.0
@@ -100,7 +108,7 @@ items:
           in Kubernetes. To avoid unexpected behaviour after the upgrade, add all labels that Hosts have in their
           <code>mappingSelector</code> to <code>Mappings</code> you want to associate with the <code>Host</code>. You can opt-out of the new behaviour
           by setting the environment variable <code>DISABLE_STRICT_LABEL_SELECTORS</code> to <code>"true"</code> (default: <code>"false"</code>).
-          (Thanks to <a href="https://github.com/f-herceg">Filip Herceg</a> and <a href="https://github.com/dynajoe">Joe Andaverde</a>!).      
+          (Thanks to <a href="https://github.com/f-herceg">Filip Herceg</a> and <a href="https://github.com/dynajoe">Joe Andaverde</a>!).
       - title: Add support for Host resources using secrets from different namespaces
         type: feature
         body: >-
@@ -112,7 +120,7 @@ items:
         body: >-
           Set `AMBASSADOR_EDS_BYPASS` to `true` to bypass EDS handling of endpoints and have endpoints be
           inserted to clusters manually. This can help resolve with `503 UH` caused by certification rotation relating to
-          a delay between EDS + CDS. The default is `false`.     
+          a delay between EDS + CDS. The default is `false`.
       - title: Correctly manage cluster names when service names are very long
         type: bugfix
         body: >-


### PR DESCRIPTION
Signed-off-by: Ole Markus With <o.with@sportradar.com>

## Description
In the current version of edgissary, if you have an `Ingress` resource that references a TLS Secret, then that secret will not work unless you create a `TLSContext` to pick up the secret. This change fixes that so the `TLSContext` is no longer required. Passes CI and I confirmed the broken behaviour in `3.2` and that this fix resolves the issue. 

Original PR: https://github.com/emissary-ingress/emissary/pull/4607

## Related Issues
List related issues.

## Testing
A few sentences describing what testing you've done, e.g., manual tests, automated tests, deployed in production, etc.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [x] I made sure to update `CHANGELOG.md`.

   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations

 - [x] This is unlikely to impact how Ambassador performs at scale.

   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability

 - [ ] My change is adequately tested.

   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points

 - [x] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.

 - [ ] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
