### PR TITLE
fix: perform https redirect prior to ext_authz calls

### DIFF
--- a/.github/actions/collect-logs/action.yml
+++ b/.github/actions/collect-logs/action.yml
@@ -39,7 +39,9 @@ runs:
           tools/bin/kubectl describe pods --all-namespaces >/tmp/test-logs/cluster/all-pods-described.txt || true
 
           tools/bin/kubectl get pods --all-namespaces -ocustom-columns="name:.metadata.name,namespace:.metadata.namespace" --no-headers | while read -r name namespace; do
+            echo "Pulling logs for ${name}.${namespace}"
             tools/bin/kubectl --namespace="$namespace" logs "$name" >"/tmp/test-logs/cluster/pod.${namespace}.${name}.log" || true
+            tools/bin/kubectl exec -n $namespace $name -- tar -czf /tmp/ambassador-config-base.tgz /tmp/ambassador --exclude=secrets-decoded --exclude=webui --exclude=sidecars && kubectl cp -n "$namespace" "$name":/tmp/ambassador-config-base.tgz /tmp/test-logs/cluster/${namespace}-${name}-pod-config-base.tgz || true
           done
 
           tools/bin/kubectl cp xfpredirect:/tmp/ambassador/snapshots /tmp/test-logs/cluster/xfpredirect.snapshots || true

--- a/.github/workflows/execute-tests-and-promote.yml
+++ b/.github/workflows/execute-tests-and-promote.yml
@@ -14,7 +14,7 @@ jobs:
       # See docker/base-python.docker.gen
       BASE_PYTHON_REPO: ${{ secrets.BASE_PYTHON_REPO }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Install Deps
@@ -34,7 +34,7 @@ jobs:
       # See docker/base-python.docker.gen
       BASE_PYTHON_REPO: ${{ secrets.BASE_PYTHON_REPO }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Install Deps
@@ -72,7 +72,7 @@ jobs:
       # See docker/base-python.docker.gen
       BASE_PYTHON_REPO: ${{ secrets.BASE_PYTHON_REPO }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Install Deps
@@ -101,7 +101,7 @@ jobs:
       # See docker/base-python.docker.gen
       BASE_PYTHON_REPO: ${{ secrets.BASE_PYTHON_REPO }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Install Deps
@@ -146,7 +146,7 @@ jobs:
           #- kat-local
     name: pytest-${{ matrix.test }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Install Deps
@@ -187,7 +187,7 @@ jobs:
           - unit
     name: pytest-${{ matrix.test }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Install Deps
@@ -229,7 +229,7 @@ jobs:
           registry: ${{ (!startsWith(secrets.DEV_REGISTRY, 'docker.io/')) && secrets.DEV_REGISTRY || null }}
           username: ${{ secrets.GH_DOCKER_BUILD_USERNAME }}
           password: ${{ secrets.GH_DOCKER_BUILD_TOKEN }}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
@@ -253,7 +253,7 @@ jobs:
     outputs:
       image-tag: ${{ steps.build-image.outputs.image-tag }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
@@ -288,7 +288,7 @@ jobs:
     needs: [build]
     steps:
       # upload of results to github uses git so checkout of code is needed
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/generate-base-python.yml
+++ b/.github/workflows/generate-base-python.yml
@@ -11,7 +11,7 @@ jobs:
         # See docker/base-python.docker.gen
         BASE_PYTHON_REPO: ${{ secrets.BASE_PYTHON_REPO }}
       steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           with:
             fetch-depth: 0
         - name: Install Deps

--- a/.github/workflows/promote-ga.yml
+++ b/.github/workflows/promote-ga.yml
@@ -15,7 +15,7 @@ jobs:
       DEV_REGISTRY: ${{ secrets.DEV_REGISTRY }}
       RELEASE_REGISTRY: ${{ secrets.RELEASE_REGISTRY }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: "Docker Login"
@@ -58,7 +58,7 @@ jobs:
     env:
       AMBASSADOR_RELENG_NO_GUI: "1"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: "Install Deps"

--- a/.github/workflows/promote-rc.yml
+++ b/.github/workflows/promote-rc.yml
@@ -15,7 +15,7 @@ jobs:
       DEV_REGISTRY: ${{ secrets.DEV_REGISTRY }}
       RELEASE_REGISTRY: ${{ secrets.RELEASE_REGISTRY }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: "Install Deps"

--- a/.github/workflows/publish-chart.yml
+++ b/.github/workflows/publish-chart.yml
@@ -16,7 +16,7 @@ jobs:
       DEV_REGISTRY: ${{ secrets.DEV_REGISTRY }}
       RELEASE_REGISTRY: ${{ secrets.RELEASE_REGISTRY }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: "Install Deps"
@@ -51,7 +51,7 @@ jobs:
     env:
       GIT_TOKEN: ${{ secrets.GH_GITHUB_API_KEY }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: "Install Deps"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,17 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
 - Security: Updated Golang to 1.19.2 to address the CVEs: CVE-2022-2879, CVE-2022-2880,
   CVE-2022-41715.
 
+- Bugfix: By default Emissary-ingress adds routes for http to https redirection. When an AuthService
+  is applied in v2.Y of Emissary-ingress, Envoy would skip the ext_authz call for non-tls http
+  request and would perform the https  redirect. In Envoy 1.20+ the behavior has changed where Envoy
+  will  always call the ext_authz filter and must be disabled on a per route  basis. 
+  This new
+  behavior change introduced a regression in v3.0 of  Emissary-ingress when it was upgraded to Envoy
+  1.22. The http to https  redirection no longer works when an AuthService was applied. This fix 
+  restores the previous behavior by disabling the ext_authz call on the  https redirect routes. ([#4620])
+
+[#4620]: https://github.com/emissary-ingress/emissary/issues/4620
+
 ## [3.2.0] September 26, 2022
 [3.2.0]: https://github.com/emissary-ingress/emissary/compare/v3.1.0...v3.2.0
 

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -41,6 +41,25 @@ items:
         body: >-
           Updated Golang to 1.19.2 to address the CVEs: CVE-2022-2879, CVE-2022-2880, CVE-2022-41715.
 
+      - title: Fix regression in http to https redirects with AuthService
+        type: bugfix
+        body: >-
+          By default $productName$ adds routes for http to https redirection. When
+          an AuthService is applied in v2.Y of $productName$, Envoy would skip the
+          ext_authz call for non-tls http request and would perform the https 
+          redirect. In Envoy 1.20+ the behavior has changed where Envoy will 
+          always call the ext_authz filter and must be disabled on a per route 
+          basis. 
+          
+          This new behavior change introduced a regression in v3.0 of 
+          $productName$ when it was upgraded to Envoy 1.22. The http to https 
+          redirection no longer works when an AuthService was applied. This fix 
+          restores the previous behavior by disabling the ext_authz call on the 
+          https redirect routes.
+        github:
+        - title: "#4620"
+          link: https://github.com/emissary-ingress/emissary/issues/4620
+
   - version: 3.2.0
     prevVersion: 3.1.0
     date: '2022-09-26'

--- a/python/ambassador/envoy/v3/v3route.py
+++ b/python/ambassador/envoy/v3/v3route.py
@@ -238,6 +238,16 @@ class V3RouteVariants:
     def action_redirect(self, variant) -> None:
         variant.pop("route", None)
         variant["redirect"] = {"https_redirect": True}
+        for filter in self.route._group.ir.filters:
+            if filter.kind == "IRAuth":
+                # Required to ensure that the redirect occurs prior to calling ext_authz
+                # when an AuthService is applied
+                variant["typed_per_filter_config"] = {
+                    "envoy.filters.http.ext_authz": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
+                        "disabled": True,
+                    }
+                }
 
 
 # Model an Envoy route.


### PR DESCRIPTION
## Description

Fixes a regression with https_redirection when an AuthService is applied. This was introduced in v3+ due to upgrading Envoy where a behavior change was introduced for the ext_authz http filter. This restores the previous behavior by disabling ext_authz calls on a per route basis when an AuthService is applied.

Before change: 

```json
{
    "match": {
      "case_sensitive": true,
      "prefix": "/backend/",
      "runtime_fraction": {
        "default_value": {
          "denominator": "HUNDRED",
          "numerator": 100
        },
        "runtime_key": "routing.traffic_shift.cluster_quote_default_default"
      }
    },
    "redirect": {
      "https_redirect": true
    }
```

After change:

```json
{
    "match": {
      "case_sensitive": true,
      "prefix": "/backend/",
      "runtime_fraction": {
        "default_value": {
          "denominator": "HUNDRED",
          "numerator": 100
        },
        "runtime_key": "routing.traffic_shift.cluster_quote_default_default"
      }
    },
    "redirect": {
      "https_redirect": true
    },
    "typed_per_filter_config": {
      "envoy.filters.http.ext_authz": {
        "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
        "disabled": true
      }
    }
  }
```

**IMPORTANT**: this is only applied to the https_redirect routes that are added by default for all Host which has `requestPolicy.insecure.action = Redirect` as the default action.


## Related Issues
#4620

## Testing

Manual Verification:
- reproduced in a cluster with 3.2.0
- tested dev build and verified https redirection occurs 
- visually inspected the envoy.json to ensure expected config was generated

Automtates Test:
- Added two new Unit Test to verify generated envoy config from diagd
- Added new KAT test to verify 301 redirect for non-tls request

## Checklist
 - [x] I made sure to update `CHANGELOG.md`.
 - [x] This is unlikely to impact how Ambassador performs at scale.
 - [x] My change is adequately tested.
 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.
 - [x] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
