### PR TITLE
Updated documentation to avoid unnecessary changes to ClientConfig

### DIFF
--- a/pkg/kates/client.go
+++ b/pkg/kates/client.go
@@ -96,6 +96,12 @@ type Client struct {
 
 // The ClientConfig struct holds all the parameters and configuration
 // that can be passed upon construct of a new Client.
+// If you need support for additional parameters, consider creating a client with
+// NewClientFromConfigFlags like this:
+//
+// clientConfigFlags := NewConfigFlags(false)
+// clientConfigFlags.Impersonate = &username
+// client, err := NewClientFromConfigFlags(clientConfigFlags)
 type ClientConfig struct {
 	Kubeconfig string
 	Context    string


### PR DESCRIPTION
## Description
Documented that `NewClientFromConfigFlags` should be used when more control over the client settings is needed.

## Related Issues

## Testing
Not required

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->

 - [ ] I made sure to update `CHANGELOG.md`.

   Remember, the CHANGELOG needs to mention:
    + Any new features
    + Any changes to our included version of Envoy
    + Any non-backward-compatible changes
    + Any deprecations

 - [x] This is unlikely to impact how Ambassador performs at scale.

   Remember, things that might have an impact at scale include:
    + Any significant changes in memory use that might require adjusting the memory limits
    + Any significant changes in CPU use that might require adjusting the CPU limits
    + Anything that might change how many replicas users should use
    + Changes that impact data-plane latency/scalability

 - [ ] My change is adequately tested.

   Remember when considering testing:
    + Your change needs to be specifically covered by tests.
       + Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
    + You also need to make sure that the _entire area being changed_ has adequate test coverage.
       + If existing tests don't actually cover the entire area being changed, add tests.
       + This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
    + We should lean on the bulk of code being covered by unit tests, but...
    + ... an end-to-end test should cover the integration points

 - [ ] I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.

 - [x] The changes in this PR have been reviewed for security concerns and adherence to security best practices.