### PR TITLE
fix: bypass ext_authz for host_redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,8 +85,8 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
 
 ## RELEASE NOTES
 
-## [3.2.1] TBD
-[3.2.1]: https://github.com/emissary-ingress/emissary/compare/v3.2.0...v3.2.1
+## [3.3.0] TBD
+[3.3.0]: https://github.com/emissary-ingress/emissary/compare/v3.2.0...v3.3.0
 
 ### Emissary-ingress and Ambassador Edge Stack
 
@@ -102,7 +102,17 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
   1.22. The http to https  redirection no longer works when an AuthService was applied. This fix 
   restores the previous behavior by disabling the ext_authz call on the  https redirect routes. ([#4620])
 
+- Bugfix: When an AuthService is applied in v2.Y of Emissary-ingress,  Envoy would skip the
+  ext_authz call for all redirect routes and  would perform the redirect. In Envoy 1.20+ the
+  behavior has changed  where Envoy will always call the ext_authz filter so it must be  disabled on
+  a per route basis. 
+  This new behavior change introduced a regression in v3.0 of  Emissary-ingress
+  when it was upgraded to Envoy 1.22. The host_redirect  would call an AuthService prior to redirect
+  if applied. This fix  restores the previous behavior by disabling the ext_authz call on the 
+  host_redirect routes. ([#4640])
+
 [#4620]: https://github.com/emissary-ingress/emissary/issues/4620
+[#4640]: https://github.com/emissary-ingress/emissary/issues/4640
 
 ## [3.2.0] September 26, 2022
 [3.2.0]: https://github.com/emissary-ingress/emissary/compare/v3.1.0...v3.2.0

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -32,7 +32,7 @@
 
 changelog: https://github.com/emissary-ingress/emissary/blob/$branch$/CHANGELOG.md
 items:
-  - version: 3.2.1
+  - version: 3.3.0
     prevVersion: 3.2.0
     date: 'TBD'
     notes:
@@ -59,6 +59,24 @@ items:
         github:
         - title: "#4620"
           link: https://github.com/emissary-ingress/emissary/issues/4620
+          
+      - title: Fix regression in host_redirects with AuthService
+        type: bugfix
+        body: >-
+          When an AuthService is applied in v2.Y of $productName$, 
+          Envoy would skip the ext_authz call for all redirect routes and 
+          would perform the redirect. In Envoy 1.20+ the behavior has changed 
+          where Envoy will always call the ext_authz filter so it must be 
+          disabled on a per route basis. 
+          
+          This new behavior change introduced a regression in v3.0 of 
+          $productName$ when it was upgraded to Envoy 1.22. The host_redirect 
+          would call an AuthService prior to redirect if applied. This fix 
+          restores the previous behavior by disabling the ext_authz call on the 
+          host_redirect routes.
+        github:
+        - title: "#4640"
+          link: https://github.com/emissary-ingress/emissary/issues/4640
 
   - version: 3.2.0
     prevVersion: 3.1.0

--- a/python/ambassador/envoy/v3/v3route.py
+++ b/python/ambassador/envoy/v3/v3route.py
@@ -378,7 +378,7 @@ class V3Route(Cacheable):
                         "response_map": {"mappers": filter_config["mappers"]},
                     }
 
-        if mapping.get("bypass_auth", False):
+        if mapping.get("bypass_auth", False) or (group.get("host_redirect", None) != None):
             typed_per_filter_config["envoy.filters.http.ext_authz"] = {
                 "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
                 "disabled": True,


### PR DESCRIPTION
## Description

Fixes regression in v3.Y of Emissary-ingress by disabling ext_authz on host_redirect routes. This restores the existing behavior so that the redirect happens prior to calling ext_authz.

A few sentences describing the overall goals of the pull request's commits.

## Related Issues

https://github.com/emissary-ingress/emissary/issues/4640

## Testing

Adds new unit test and KAT test to ensure correct expected behavior.

## Checklist

- [ ] **Does my change need to be backported to a previous release?**
- [x] **I made sure to update `CHANGELOG.md`.**
- [x] **This is unlikely to impact how Ambassador performs at scale.**
- [x] **My change is adequately tested.**
- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**
- [x] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
