### PR TITLE
Disable AMBASSADOR_GRPC_METRICS_SINK if agent is not enabled

### DIFF
--- a/charts/emissary-ingress/templates/deployment.yaml
+++ b/charts/emissary-ingress/templates/deployment.yaml
@@ -172,8 +172,10 @@ spec:
             - name: admin
               containerPort: {{ .Values.adminService.port }}
           env:
+            {{- if .Values.agent.enabled }}
             - name: AMBASSADOR_GRPC_METRICS_SINK
               value: {{ include "ambassador.fullname" . }}-agent:80
+            {{- end }}
             - name: HOST_IP
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
## Description

When not using the ambassador-agent emissary-ingress will produce a high number of 5xx errors when attempting to send metrics to the `envoy_metrics_service`.  This in turn generates prometheus alerts based on these errors.  If you are not using ambassador-agent you should not set the environment variable `AMBASSADOR_GRPC_METRICS_SINK`.  Without this environment variable the static_resources.clusters config will not create the `envoy_metrics_service`.  The default config when this environment variable is set creates this cluster config:

```
       {
        "connect_timeout": "1s",
        "http2_protocol_options": {},
        "load_assignment": {
          "cluster_name": "envoy_metrics_service",
          "endpoints": [
            {
              "lb_endpoints": [
                {
                  "endpoint": {
                    "address": {
                      "socket_address": {
                        "address": "ambassador-external-agent",
                        "port_value": 80,
                        "protocol": "TCP"
                      }
                    }
                  }
                }
              ]
            }
          ]
        },
```

This is uses a semi-hardcoded value for the destination.  Without ambassador agent enabled this is an invalid host.  

Here are some prometheus graphs showing the high 5xx rate on my local development cluster (it is higher in production):

![prometheus_5xx_steady_error_rate_ambassador_metrics_service](https://user-images.githubusercontent.com/1036414/198674776-569239a0-80c4-46dd-87f6-ea337cfc6857.png)

After applying this change the 5xx errors for this service stopped for both of our ambassador deployments:

![prometheus_5xx_error_drop_ambassador_internal](https://user-images.githubusercontent.com/1036414/198675346-6c87bca8-bfb3-495e-9571-01c915c28909.png)
![prometheus_5xx_error_drop_ambassador_external](https://user-images.githubusercontent.com/1036414/198675391-68443256-9236-4cd2-be85-a54fa589158b.png)

This is my first change to the ambassador/emissary-ingress ecosystem so please let me know any additional information that is needed.

## Related Issues

I did not find an existing issue and since I found the issue I decided to create a PR to address instead of an issue although I can still open an issue if that is preferred.

## Testing

To test this locally I did a helm pull and modified it locally while pointing our ArgoCD config at this change:

```
helm pull emissary-ingress --repo https://app.getambassador.io --version 8.0.0 --untar
```

I confirmed after this was applied that the ambassador config did no longer have the static_resources.clusters envoy_service_monitor config as well.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->
- [ ] **Does my change need to be backported to a previous release?**
  - What backport versions were discussed with the Maintainers in the Issue?

- [ ] **I made sure to update `CHANGELOG.md`.**

   Remember, the CHANGELOG needs to mention:
  - Any new features
  - Any changes to our included version of Envoy
  - Any non-backward-compatible changes
  - Any deprecations

- [ ] **This is unlikely to impact how Ambassador performs at scale.**

   Remember, things that might have an impact at scale include:
  - Any significant changes in memory use that might require adjusting the memory limits
  - Any significant changes in CPU use that might require adjusting the CPU limits
  - Anything that might change how many replicas users should use
  - Changes that impact data-plane latency/scalability

- [ ] **My change is adequately tested.**

   Remember when considering testing:
  - Your change needs to be specifically covered by tests.
    - Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
  - You also need to make sure that the _entire area being changed_ has adequate test coverage.
    - If existing tests don't actually cover the entire area being changed, add tests.
    - This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
  - We should lean on the bulk of code being covered by unit tests, but...
  - ... an end-to-end test should cover the integration points

- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**

- [ ] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
