### PR TITLE
repo: prepare bits for next version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
 
 ## RELEASE NOTES
 
-## [3.3.0] TBD
+## [3.3.0] November 02, 2022
 [3.3.0]: https://github.com/emissary-ingress/emissary/compare/v3.2.0...v3.3.0
 
 ### Emissary-ingress and Ambassador Edge Stack

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,11 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
 
 ## RELEASE NOTES
 
+## [3.4.0] TBD
+[3.4.0]: https://github.com/emissary-ingress/emissary/compare/v3.3.0...v3.4.0
+
+### Emissary-ingress and Ambassador Edge Stack
+
 ## [3.3.0] November 02, 2022
 [3.3.0]: https://github.com/emissary-ingress/emissary/compare/v3.2.0...v3.3.0
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Branches
 may be out of date.)
 
 - [`master`](https://github.com/emissary-ingress/emissary/tree/master) - branch for Emissary-ingress 3.3.z work (:heavy_check_mark: upcoming release)
-- [`release/v3.2`](https://github.com/emissary-ingress/emissary/tree/release/v3.2) - branch for Emissary-ingress 3.2.z work
+- [`release/v3.3`](https://github.com/emissary-ingress/emissary/tree/release/v3.3) - branch for Emissary-ingress 3.3.z work
 - [`release/v2.5`](https://github.com/emissary-ingress/emissary/tree/release/v2.5) - branch for Emissary-ingress 2.5.z work (:heavy_check_mark: upcoming release)
 - [`release/v1.14`](https://github.com/emissary-ingress/emissary/tree/release/v1.14) - branch for Emissary-ingress 1.14.z work (:heavy_check_mark: maintenance, supported through September 2022)
 

--- a/charts/emissary-ingress/CHANGELOG.md
+++ b/charts/emissary-ingress/CHANGELOG.md
@@ -3,7 +3,7 @@
 This file documents all notable changes to Ambassador Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
-## v8.3.0 - TBD
+## v8.3.0
 
 - Upgrade Emissary to v3.3.0 [CHANGELOG](https://github.com/emissary-ingress/emissary/blob/master/CHANGELOG.md)
 

--- a/charts/emissary-ingress/CHANGELOG.md
+++ b/charts/emissary-ingress/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Ambassador Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v8.4.0 - TBD
+
+- Upgrade Emissary to v3.4.0 [CHANGELOG](https://github.com/emissary-ingress/emissary/blob/master/CHANGELOG.md)
+
 ## v8.3.0
 
 - Upgrade Emissary to v3.3.0 [CHANGELOG](https://github.com/emissary-ingress/emissary/blob/master/CHANGELOG.md)

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -32,6 +32,11 @@
 
 changelog: https://github.com/emissary-ingress/emissary/blob/$branch$/CHANGELOG.md
 items:
+  - version: 3.4.0
+    prevVersion: 3.3.0
+    date: 'TBD'
+    notes:
+
   - version: 3.3.0
     prevVersion: 3.2.0
     date: '2022-11-02'

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -34,7 +34,7 @@ changelog: https://github.com/emissary-ingress/emissary/blob/$branch$/CHANGELOG.
 items:
   - version: 3.3.0
     prevVersion: 3.2.0
-    date: 'TBD'
+    date: '2022-11-02'
     notes:
       - title: Update Golang to 1.19.2
         type: security


### PR DESCRIPTION
## Description

This updates our changelogs and readme for next version so that we can tag it with a `3.4.0-dev` tag to prepare for the "next" version release.

## Related Issues

n/a

## Testing
docs changes only

## Checklist

- [ ] **Does my change need to be backported to a previous release?**
- [x] **I made sure to update `CHANGELOG.md`.**
- [x] **This is unlikely to impact how Ambassador performs at scale.**
- [ ] **My change is adequately tested.**
- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**
- [ ] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
