### PR TITLE
ci: allow promote-rc to run on -dev base tags

### DIFF
--- a/.github/workflows/promote-rc.yml
+++ b/.github/workflows/promote-rc.yml
@@ -3,6 +3,7 @@ name: promote-to-rc
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-dev'
 jobs:
   promote-to-rc:
     runs-on: ubuntu-latest

--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -472,7 +472,7 @@ endif
 
 release/promote-oss/to-rc: $(tools/devversion)
 	@test -n "$(RELEASE_REGISTRY)" || (printf "$${RELEASE_REGISTRY_ERR}\n"; exit 1)
-	@[[ "$(VERSION)" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$$ ]] || (printf '$(RED)ERROR: VERSION=%s does not look like an RC tag\n' "$(VERSION)"; exit 1)
+	@[[ "$(VERSION)" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+|-dev)$$ ]] || (printf '$(RED)ERROR: VERSION=%s does not look like an RC or dev tag\n' "$(VERSION)"; exit 1)
 	@set -e; { \
 	  dev_version=$$($(tools/devversion)); \
 	  printf "$(CYN)==> $(GRN)found version $(BLU)$$dev_version$(GRN).$(END)\n"; \


### PR DESCRIPTION
## Description

To prepare a branch for the next minor version we leverage an initial `v3.Y.Z-dev` tag which allows the Go psuedo version logic to properly version a build as part of the upcoming "next" minor version release.

The current RC process only runs on `-rc.n` tags so the base container is not published. This causes issues for dependent projects like AES which are extensions to Emissary-ingress. This changes the Github Action's glob and the make targets regex to allow `-dev` tags to trigger the RC process too.

## Related Issues
N/A - cleanup from v3.3.0 release cycle.

## Testing

Verified glob and regex patterns work with online testers. 

## Checklist

- [x] **Does my change need to be backported to a previous release?**
     _Yes, we will need to backport this to the v2.5.0 release branch._
- [ ] **I made sure to update `CHANGELOG.md`.**
- [x] **This is unlikely to impact how Ambassador performs at scale.**
- [ ] **My change is adequately tested.**
- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**
- [x] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
