### PR TITLE
community: Use environment variables to configure healthcheck server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,17 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
   unhealthy. The healthy pods will continue to receive traffic normally while the unhealthy pods
   will not receive any traffic until they recover by passing the health check.
 
+- Feature: The healthcheck server's bind address, bind port and IP family can now be configured
+  using environment variables:
+  - `AMBASSADOR_HEALTHCHECK_BIND_ADDRESS`: The address to bind the
+  healthcheck server to.
+  - `AMBASSADOR_HEALTHCHECK_BIND_PORT`: The port to bind the healthcheck
+  server to.
+  - `AMBASSADOR_HEALTHCHECK_IP_FAMILY`: The IP family to use for the healthcheck
+  server.
+  This allows the healthcheck server to be configured to use IPv6-only k8s environments. 
+  (Thanks to <a href="https://github.com/TimonOmsk">Dmitry Golushko</a>!).
+
 ## [3.3.0] November 02, 2022
 [3.3.0]: https://github.com/emissary-ingress/emissary/compare/v3.2.0...v3.3.0
 

--- a/cmd/entrypoint/env.go
+++ b/cmd/entrypoint/env.go
@@ -297,3 +297,36 @@ func GetSidecarUrl() string {
 func IsKnativeEnabled() bool {
 	return strings.ToLower(env("AMBASSADOR_KNATIVE_SUPPORT", "")) == "true"
 }
+
+// getHealthCheckHost will return address that the health check server will bind to.
+// If not provided it will default to all interfaces (`0.0.0.0`).
+func getHealthCheckHost() string {
+	return env("AMBASSADOR_HEALTHCHECK_BIND_ADDRESS", "0.0.0.0")
+}
+
+// getHealthCheckPort will return the port that the health check server will bind to.
+// If not provided it will default to port `8877`
+func getHealthCheckPort() string {
+	return env("AMBASSADOR_HEALTHCHECK_BIND_PORT", "8877")
+}
+
+// getHealthCheckIPNetworkFamily will return the network IP family that the health checker server
+// will listen on. Set the AMBASSADOR_HEALTHCHECK_IP_FAMILIY environment variable to
+// "ANY", "IPV4_ONLY" or "IPV6_ONLY".
+//
+// Here is a list of supported values and how they translate to the supported
+// net.Listen networks:
+//   - ANY => tcp (default)
+//   - IPV4_ONLY => tcp4
+//   - IPV6_ONLY => tcp6
+func getHealthCheckIPNetworkFamily() string {
+	ipFamily := strings.ToUpper(env("AMBASSADOR_HEALTHCHECK_IP_FAMILY", "ANY"))
+
+	switch ipFamily {
+	case "IPV4_ONLY":
+		return "tcp4"
+	case "IPV6_ONLY":
+		return "tcp6"
+	}
+	return "tcp"
+}

--- a/cmd/entrypoint/env_test.go
+++ b/cmd/entrypoint/env_test.go
@@ -30,3 +30,50 @@ func TestGetEnvoyFlags(t *testing.T) {
 	assert.True(t, foundFlag)
 	assert.True(t, foundValue)
 }
+
+func TestGetHealthCheckIPNetworkFamily(t *testing.T) {
+	type testCase struct {
+		description string
+		inputFamily string
+		expected    string
+	}
+
+	testcases := []testCase{
+		{
+			description: "non-supported value",
+			inputFamily: "not-a-good-value",
+			expected:    "tcp",
+		},
+		{
+			description: "ipv6 only",
+			inputFamily: "IPV6_ONLY",
+			expected:    "tcp6",
+		},
+		{
+			description: "ipv4 only",
+			inputFamily: "IPV4_ONLY",
+			expected:    "tcp4",
+		},
+		{
+			description: "case-insensitve",
+			inputFamily: "ipv4_oNly",
+			expected:    "tcp4",
+		},
+		{
+			description: "env var not set",
+			inputFamily: "",
+			expected:    "tcp",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.description, func(t *testing.T) {
+			if tc.inputFamily != "" {
+				t.Setenv("AMBASSADOR_HEALTHCHECK_IP_FAMILY", tc.inputFamily)
+			}
+
+			result := getHealthCheckIPNetworkFamily()
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/cmd/entrypoint/healthcheck_server.go
+++ b/cmd/entrypoint/healthcheck_server.go
@@ -104,17 +104,14 @@ func healthCheckHandler(ctx context.Context, ambwatch *acp.AmbassadorWatcher) er
 	// the magic catchall path.
 	sm.HandleFunc("/", reverseProxy.ServeHTTP)
 
-	// Create a listener by hand, so that we can listen on TCP v4. If we don't
-	// explicitly say "tcp4" here, we seem to listen _only_ on v6, and Bad Things
-	// Happen.
-	//
-	// XXX Why, exactly, is this? That's a lovely question -- we _should_ be OK
-	// here on a proper dualstack system, but apparently we don't have a proper
-	// dualstack system? It's quite bizarre, but Kubernetes won't become ready
-	// without this.
-	//
-	// XXX In fact, should we set up another Listener for v6??
-	listener, err := net.Listen("tcp4", ":8877")
+	// Set up listener.
+	// The default value for network is ANY.
+	// It means in case of any wildcard address, the listener will try to listen on both IPv4 and IPv6
+	// If you want to specify AF explicitly,
+	// you can set the AMBASSADOR_HEALTHCHECK_IP_FAMILY environment variable to IPV4_ONLY or IPV6_ONLY respectively
+	addr := net.JoinHostPort(getHealthCheckHost(), getHealthCheckPort())
+	network := getHealthCheckIPNetworkFamily()
+	listener, err := net.Listen(network, addr)
 	if err != nil {
 		return err
 	}

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -51,6 +51,20 @@ items:
           If the upstream fails its configured health check then Envoy will mark the upstream as unhealthy and no longer send
           traffic to that upstream. Single pods within a group may can be marked as unhealthy. The healthy pods will continue to receive
           traffic normally while the unhealthy pods will not receive any traffic until they recover by passing the health check.
+      
+      - title: Add environment variables to the healthcheck server.
+        type: feature
+        body: >-
+          The healthcheck server's bind address, bind port and IP family can now be configured using environment variables:
+
+          - `AMBASSADOR_HEALTHCHECK_BIND_ADDRESS`: The address to bind the healthcheck server to.
+
+          - `AMBASSADOR_HEALTHCHECK_BIND_PORT`: The port to bind the healthcheck server to.
+          
+          - `AMBASSADOR_HEALTHCHECK_IP_FAMILY`: The IP family to use for the healthcheck server.
+          
+          This allows the healthcheck server to be configured to use IPv6-only k8s environments. 
+          (Thanks to <a href="https://github.com/TimonOmsk">Dmitry Golushko</a>!).
 
   - version: 3.3.0
     prevVersion: 3.2.0


### PR DESCRIPTION
## Description

This pulls in the work from the community contribution on making the healthcheck server configurable via Environment variables so that we can support IPV6 setups. This will include the PR run and just cleaning up the docs.

See existing community PR.
https://github.com/emissary-ingress/emissary/pull/4301

## Related Issues
Fixes https://github.com/emissary-ingress/emissary/issues/4274

## Testing
CI and this is being used in production for community members product.

## Checklist

- [ ] **Does my change need to be backported to a previous release?**
- [x] **I made sure to update `CHANGELOG.md`.**
- [x] **This is unlikely to impact how Ambassador performs at scale.**
- [x] **My change is adequately tested.**
- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**
- [x] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
