### PR TITLE
backport: update to golang 1.19.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,17 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
 
 ## RELEASE NOTES
 
+## [2.5.1] TBD
+[2.5.1]: https://github.com/emissary-ingress/emissary/compare/v2.5.0...v2.5.1
+
+### Emissary-ingress and Ambassador Edge Stack
+
+- Security: Updated Golang to the latest z patch. We are not vulnerable to the CVE-2022-3602 that
+  was  released in 1.19.3 and you can read more about it here:
+  <https://medium.com/ambassador-api-gateway/ambassador-labs-security-impact-assessment-of-nov-1-openssl-golang-vulnerabilities-f11b5ec37a7e>.
+  Updating to the latest z patch as part of our normal dependency update process and this will help
+  reduce the noise of security scanners.
+
 ## [2.5.0] November 03, 2022
 [2.5.0]: https://github.com/emissary-ingress/emissary/compare/v2.4.0...v2.5.0
 

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -3,7 +3,7 @@ following Free and Open Source software:
 
     Name                                                                                       Version                                      License(s)
     ----                                                                                       -------                                      ----------
-    the Go language standard library ("std")                                                   v1.19.2                                      3-clause BSD license
+    the Go language standard library ("std")                                                   v1.19.3                                      3-clause BSD license
     cloud.google.com/go/compute                                                                v1.2.0                                       Apache License 2.0
     github.com/Azure/go-ansiterm                                                               v0.0.0-20210617225240-d185dfc1b5a1           MIT license
     github.com/Azure/go-autorest                                                               v14.2.0+incompatible                         Apache License 2.0

--- a/Makefile
+++ b/Makefile
@@ -148,3 +148,11 @@ python-dev-setup:
 
 # activate venv
 	@echo "run 'source ./venv/bin/activate' to activate venv in local shell"
+
+# re-generate docs
+.PHONY: clean-changelog
+clean-changelog:
+	rm CHANGELOG.md
+
+.PHONY: generate-changelog
+generate-changelog: clean-changelog $(PWD)/CHANGELOG.md

--- a/docker/base-python/Dockerfile
+++ b/docker/base-python/Dockerfile
@@ -58,7 +58,7 @@ RUN apk --no-cache add \
 # 'python3' versions above.
 RUN pip3 install pip-tools==6.3.1
 
-RUN curl --fail -L https://dl.google.com/go/go1.19.2.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+RUN curl --fail -L https://dl.google.com/go/go1.19.3.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 
 RUN curl --fail -L https://storage.googleapis.com/kubernetes-release/release/v1.23.3/bin/linux/amd64/kubectl -o /usr/bin/kubectl && \
   chmod a+x /usr/bin/kubectl

--- a/docker/test-http/Dockerfile
+++ b/docker/test-http/Dockerfile
@@ -1,7 +1,7 @@
 # The `test-http` image gets built by `pkg/kubeapply` for use by
 # various kubeapply-templated YAML files.
 
-FROM golang:1.19.2
+FROM golang:1.19.3
 COPY httptest.go /usr/local/bin/httptest.go
 RUN go build -o /usr/local/bin/httptest /usr/local/bin/httptest.go
 ENTRYPOINT ["/usr/local/bin/httptest"]

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -32,6 +32,17 @@
 
 changelog: https://github.com/emissary-ingress/emissary/blob/$branch$/CHANGELOG.md
 items:
+  - version: 2.5.1
+    date: 'TBD'
+    notes:
+      - title: Update Golang to 1.19.3
+        type: security
+        body: >-
+          Updated Golang to the latest z patch. We are not vulnerable to the CVE-2022-3602 that was 
+          released in 1.19.3 and you can read more about it here: <https://medium.com/ambassador-api-gateway/ambassador-labs-security-impact-assessment-of-nov-1-openssl-golang-vulnerabilities-f11b5ec37a7e>.
+          Updating to the latest z patch as part of our normal dependency update process
+          and this will help reduce the noise of security scanners.
+
   - version: 2.5.0
     date: '2022-11-03'
     notes:


### PR DESCRIPTION
## Description

Backports Golang z patch update to v2.5 to make security scanners happy.

## Related Issues
Normal steward dev dependency updates

## Testing
CI

## Checklist
- [ ] **Does my change need to be backported to a previous release?**
- [x] **I made sure to update `CHANGELOG.md`.**
- [x] **This is unlikely to impact how Ambassador performs at scale.**
- [x] **My change is adequately tested.**
- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**
- [x] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
