### PR TITLE
backport: address ci gha deprecations warnings

### DIFF
--- a/.github/actions/collect-logs/action.yml
+++ b/.github/actions/collect-logs/action.yml
@@ -52,7 +52,7 @@ runs:
         fi
         cp /tmp/*.yaml /tmp/test-logs || true
     - name: "Upload Logs"
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: logs-${{ inputs.jobname }}
         path: /tmp/test-logs

--- a/.github/actions/setup-deps/action.yml
+++ b/.github/actions/setup-deps/action.yml
@@ -9,21 +9,15 @@ runs:
       run: |
         sudo apt-get update -y
         sudo apt-get install -y libarchive-tools
-    - name: "Install Python requirements with pip"
-      uses: BSFishy/pip-action@v1
-      with:
-        packages: |
-          awscli
-          packaging
     # Go: Do this first because `Makefile` checks that the `go` version is correct.
     - name: "Get Go version from builder container"
       id: step-detect-go
       shell: bash
       run: |
         make "$PWD/build-aux/go-version.txt"
-        echo "::set-output name=go_version::$(cat "$PWD/build-aux/go-version.txt")"
+        echo "go_version=$(cat "$PWD/build-aux/go-version.txt")" >> $GITHUB_OUTPUT
     - name: "Install Go (${{ steps.step-detect-go.outputs.go_version }})"
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: "${{ steps.step-detect-go.outputs.go_version }}"
     # Python
@@ -32,8 +26,12 @@ runs:
       shell: bash
       run: |
         make "$PWD/build-aux/py-version.txt"
-        echo "::set-output name=py_version::$(cat "$PWD/build-aux/py-version.txt")"
+        echo "py_version=$(cat "$PWD/build-aux/py-version.txt")" >> $GITHUB_OUTPUT
     - name: "Install Py (${{ steps.step-detect-py.outputs.py_version }})"
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: "${{ steps.step-detect-py.outputs.py_version }}"
+    - name: "Install Python requirements with pip"
+      shell: bash
+      run: python -m pip install awscli packaging
+

--- a/.github/workflows/check-branch-version.yml
+++ b/.github/workflows/check-branch-version.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           # Set tag_majorminor
           tag_majorminor=$(git describe --tags --match='v*'|sed 's/^v//'|cut -d. -f1,2)
-          echo "::set-output name=tag_majorminor::${tag_majorminor}"
+          echo "tag_majorminor=${tag_majorminor}" >> $GITHUB_OUTPUT
 
           # Set branch_majorminor
           case "$GITHUB_REF" in
@@ -51,13 +51,13 @@ jobs:
           else
              branch_majorminor=${branch#release/v}
           fi
-          echo "::set-output name=branch_majorminor::${branch_majorminor}"
+          echo "branch_majorminor=${branch_majorminor}" >> $GITHUB_OUTPUT
 
           # Set relnotes_majorminor
           make tools/bin/yq
           relnotes_version=$(tools/bin/yq read docs/releaseNotes.yml items[0].version)
           relnotes_majorminor=$(cut -d. -f1,2 <<<"$relnotes_version")
-          echo "::set-output name=relnotes_majorminor::${relnotes_majorminor}"
+          echo "relnotes_majorminor=${relnotes_majorminor}" >> $GITHUB_OUTPUT
 
           declare -p tag_majorminor branch_majorminor relnotes_majorminor
       - name: Check version numbers

--- a/.github/workflows/execute-tests-and-promote.yml
+++ b/.github/workflows/execute-tests-and-promote.yml
@@ -47,7 +47,7 @@ jobs:
             install -m600 /dev/stdin ~/.ssh/id_rsa <<<'${{ secrets.GHA_SSH_KEY }}'
           fi
       - name: "Docker Login"
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ${{ (!startsWith(secrets.RELEASE_REGISTRY, 'docker.io/')) && secrets.RELEASE_REGISTRY || null }}
           username: ${{ secrets.GH_DOCKER_RELEASE_USERNAME }}
@@ -86,7 +86,7 @@ jobs:
           fi
       - name: "Docker Login"
         # This is important if ENVOY_DOCKER_REPO is a private repo.
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ${{ (!startsWith(secrets.DEV_REGISTRY, 'docker.io/')) && secrets.DEV_REGISTRY || null }}
           username: ${{ secrets.GH_DOCKER_BUILD_USERNAME }}
@@ -108,7 +108,7 @@ jobs:
       - name: Install Deps
         uses: ./.github/actions/setup-deps
       - name: "Docker Login"
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ${{ (!startsWith(secrets.DEV_REGISTRY, 'docker.io/')) && secrets.DEV_REGISTRY || null }}
           username: ${{ secrets.GH_DOCKER_BUILD_USERNAME }}
@@ -160,7 +160,7 @@ jobs:
       - name: Install Deps
         uses: ./.github/actions/setup-deps
       - name: "Docker Login"
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ${{ (!startsWith(secrets.DEV_REGISTRY, 'docker.io/')) && secrets.DEV_REGISTRY || null }}
           username: ${{ secrets.GH_DOCKER_BUILD_USERNAME }}
@@ -203,7 +203,7 @@ jobs:
       - name: Install Deps
         uses: ./.github/actions/setup-deps
       - name: "Docker Login"
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ${{ (!startsWith(secrets.DEV_REGISTRY, 'docker.io/')) && secrets.DEV_REGISTRY || null }}
           username: ${{ secrets.GH_DOCKER_BUILD_USERNAME }}
@@ -235,7 +235,7 @@ jobs:
       DOCKER_BUILD_USERNAME: ${{ secrets.GH_DOCKER_BUILD_USERNAME }}
       DOCKER_BUILD_PASSWORD: ${{ secrets.GH_DOCKER_BUILD_TOKEN }}
     steps:
-      - uses: docker/login-action@v1
+      - uses: docker/login-action@v2
         with:
           registry: ${{ (!startsWith(secrets.DEV_REGISTRY, 'docker.io/')) && secrets.DEV_REGISTRY || null }}
           username: ${{ secrets.GH_DOCKER_BUILD_USERNAME }}
@@ -269,7 +269,7 @@ jobs:
       - name: Install Deps
         uses: ./.github/actions/setup-deps
       - name: "Docker Login"
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ${{ (!startsWith(secrets.DEV_REGISTRY, 'docker.io/')) && secrets.DEV_REGISTRY || null }}
           username: ${{ secrets.GH_DOCKER_BUILD_USERNAME }}

--- a/.github/workflows/promote-ga.yml
+++ b/.github/workflows/promote-ga.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: "Docker Login"
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ${{ (!startsWith(secrets.RELEASE_REGISTRY, 'docker.io/')) && secrets.RELEASE_REGISTRY || null }}
           username: ${{ secrets.GH_DOCKER_RELEASE_USERNAME }}
@@ -33,7 +33,7 @@ jobs:
         if: always()
       - id: check-slack-webhook
         name: Assign slack webhook variable
-        run: echo '::set-output name=slack_webhook_url::${{secrets.SLACK_WEBHOOK_URL}}'
+        run: echo "slack_webhook_url=${{secrets.SLACK_WEBHOOK_URL}}" >> $GITHUB_OUTPUT
       - name: Slack notification
         if: steps.check-slack-webhook.outputs.slack_webhook_url && always()
         uses: edge/simple-slack-notify@master
@@ -72,7 +72,7 @@ jobs:
           make release/ga/create-gh-release
       - id: check-slack-webhook
         name: Assign slack webhook variable
-        run: echo '::set-output name=slack_webhook_url::${{secrets.SLACK_WEBHOOK_URL}}'
+        run: echo "slack_webhook_url=${{secrets.SLACK_WEBHOOK_URL}}" >> $GITHUB_OUTPUT
       - name: Slack notification
         if: steps.check-slack-webhook.outputs.slack_webhook_url && always()
         uses: edge/simple-slack-notify@master

--- a/.github/workflows/promote-rc.yml
+++ b/.github/workflows/promote-rc.yml
@@ -21,7 +21,7 @@ jobs:
       - name: "Install Deps"
         uses: ./.github/actions/setup-deps
       - name: "Docker Login"
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ${{ (!startsWith(secrets.RELEASE_REGISTRY, 'docker.io/')) && secrets.RELEASE_REGISTRY || null }}
           username: ${{ secrets.GH_DOCKER_RELEASE_USERNAME }}
@@ -29,11 +29,11 @@ jobs:
       - id: step-main
         run: |
           make release/promote-oss/to-rc
-          echo "::set-output name=version::$(go run ./tools/src/goversion | sed s/^v//)"
-          echo "::set-output name=chart_version::$(go run ./tools/src/goversion --dir-prefix=chart | sed s/^v//)"
+          echo "version=$(go run ./tools/src/goversion | sed s/^v//)" >> $GITHUB_OUTPUT
+          echo "chart_version=$(go run ./tools/src/goversion --dir-prefix=chart | sed s/^v//)" >> $GITHUB_OUTPUT
       - id: check-slack-webhook
         name: Assign slack webhook variable
-        run: echo '::set-output name=slack_webhook_url::${{secrets.SLACK_WEBHOOK_URL}}'
+        run: echo "slack_webhook_url=${{secrets.SLACK_WEBHOOK_URL}}" >> $GITHUB_OUTPUT
       - name: Slack notification
         if: steps.check-slack-webhook.outputs.slack_webhook_url && always()
         uses: edge/simple-slack-notify@master

--- a/.github/workflows/publish-chart.yml
+++ b/.github/workflows/publish-chart.yml
@@ -25,7 +25,7 @@ jobs:
           make release/push-chart
       - id: check-slack-webhook
         name: Assign slack webhook variable
-        run: echo '::set-output name=slack_webhook_url::${{secrets.SLACK_WEBHOOK_URL}}'
+        run: echo "slack_webhook_url=${{secrets.SLACK_WEBHOOK_URL}}" >> $GITHUB_OUTPUT
       - name: Slack notification
         if: steps.check-slack-webhook.outputs.slack_webhook_url && always()
         uses: edge/simple-slack-notify@master
@@ -65,7 +65,7 @@ jobs:
           make release/chart-create-gh-release
       - id: check-slack-webhook
         name: Assign slack webhook variable
-        run: echo '::set-output name=slack_webhook_url::${{secrets.SLACK_WEBHOOK_URL}}'
+        run: echo "slack_webhook_url=${{secrets.SLACK_WEBHOOK_URL}}" >> $GITHUB_OUTPUT
       - name: Slack notification
         if: steps.check-slack-webhook.outputs.slack_webhook_url && always()
         uses: edge/simple-slack-notify@master

--- a/releng/chart-create-gh-release
+++ b/releng/chart-create-gh-release
@@ -49,7 +49,7 @@ View changelog - https://github.com/emissary-ingress/emissary/blob/master/charts
         "--jq=.url",
         "--repo="+get_gh_repo(),
         content_gittag])
-    print(f'::set-output name=url::{url}')
+    print(f'echo "url={url}" >> $GITHUB_OUTPUT')
 
 
 if __name__ == '__main__':

--- a/releng/release-create-github
+++ b/releng/release-create-github
@@ -95,7 +95,7 @@ def main(release_version: str) -> int:
         "--jq=.url",
         "--repo="+get_gh_repo(),
         "v"+release_version])
-    print(f'::set-output name=url::{url}')
+    print(f'echo "url={url}" >> $GITHUB_OUTPUT')
     if os.getenv("AMBASSADOR_RELENG_NO_GUI") == '':
         print('Release info from github:')
         run(["gh", "release", "view", "--repo="+get_gh_repo(), f"v{release_version}"])


### PR DESCRIPTION
## Description

This is a back-port of #4676. Two differences:

1. commit for fixes to `generate-base-python` was dropped because we currently don't run this for v2 branch.
2. commit 9a543047eca2f4085669da1c2c6992bdef31a093 for `execute-tests-and-promote` was amended due to not having Trivy security scanning running on v2.Y branch.

## Related Issues

Steward duties

## Testing

CI is green! and upcoming testing for RC's should do it too.

## Checklist

- [ ] **Does my change need to be backported to a previous release?**
- [ ] **I made sure to update `CHANGELOG.md`.**
- [x] **This is unlikely to impact how Ambassador performs at scale.**
- [x] **My change is adequately tested.**
- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**
- [x] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
