### PR TITLE
[v2.5] Bump the Python version

### DIFF
--- a/docker/base-python/Dockerfile
+++ b/docker/base-python/Dockerfile
@@ -40,8 +40,10 @@ ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local
 #   forced-bumps: 0
 #
 # The exception to this is that we pin 'python3' and 'py3-pip' because
-# we have other code that will need to change if those versions
-# change.
+# the 'pip-tools' version below will also need to change if those
+# versions change.  And even then, don't get more precise with the
+# version number than we need to ensure that the pip-tools version
+# agrees.
 RUN apk --no-cache add \
   bash \
   gcc \
@@ -58,8 +60,8 @@ RUN apk --no-cache add \
   libffi-dev \
   ncurses \
   openssl-dev \
-  py3-pip=~20.3.4 \
-  python3=~3.9.13 \
+  py3-pip=~20.3 \
+  python3=~3.9 \
   python3-dev \
   rust \
   cargo \

--- a/docker/base-python/Dockerfile
+++ b/docker/base-python/Dockerfile
@@ -24,12 +24,30 @@ WORKDIR /buildroot
 
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin:/buildroot/bin
 
+# For the most-part, you should not pin specific versions in this
+# `apk` command; it will always choose the latest version being
+# shipped by pinned version of Alpine.  This will automatically pull
+# in any patches, but not breaking changes.
+#
+# Because of how we cache the base image
+# (`docker/base-python.docker.gen`), it'll keep selected versions
+# around for a week.  If there's a security patch that we want to pull
+# in without waiting a week for the cache to roll over, instead of
+# fussing with pinning a specific package version, simply make an
+# inconsequential change that changes the file's checksum (such as
+# bumping this comment):
+#
+#   forced-bumps: 0
+#
+# The exception to this is that we pin 'python3' and 'py3-pip' because
+# we have other code that will need to change if those versions
+# change.
 RUN apk --no-cache add \
   bash \
   gcc \
   make \
   musl-dev \
-  curl=~7.80 \
+  curl \
   cython \
   docker-cli \
   git \
@@ -38,8 +56,8 @@ RUN apk --no-cache add \
   libcap \
   libcap-dev \
   libffi-dev \
-  ncurses=6.3_p20211120-r1 \
-  openssl-dev~=1.1.1 \
+  ncurses \
+  openssl-dev \
   py3-pip=~20.3.4 \
   python3=~3.9.13 \
   python3-dev \


### PR DESCRIPTION
## Description


> This is the 32.5 equivalent of https://github.com/emissary-ingress/emissary/pull/4684

We're pinning Python 3.9.13, but Alpine now only has 3.9.15 available, so relax the pin in order to upgrade to that, in order to fix the build.  While I'm at it, clean up the pinned versions, and add a comment explaining a decent package pinning policy.

## Related Issues

(none)

## Testing

(CI should cover it)

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->
- [ ] **Does my change need to be backported to a previous release?**
  - What backport versions were discussed with the Maintainers in the Issue?

- [ ] **I made sure to update `CHANGELOG.md`.** - I don't think this is worthy of a changelog entry

   Remember, the CHANGELOG needs to mention:
  - Any new features
  - Any changes to our included version of Envoy
  - Any non-backward-compatible changes
  - Any deprecations

- [x] **This is unlikely to impact how Ambassador performs at scale.**

   Remember, things that might have an impact at scale include:
  - Any significant changes in memory use that might require adjusting the memory limits
  - Any significant changes in CPU use that might require adjusting the CPU limits
  - Anything that might change how many replicas users should use
  - Changes that impact data-plane latency/scalability

- [x] **My change is adequately tested.**

   Remember when considering testing:
  - Your change needs to be specifically covered by tests.
    - Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
  - You also need to make sure that the _entire area being changed_ has adequate test coverage.
    - If existing tests don't actually cover the entire area being changed, add tests.
    - This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
  - We should lean on the bulk of code being covered by unit tests, but...
  - ... an end-to-end test should cover the integration points

- [x] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.** - OK, not DEVELOPING.md, but I did add comments about this.

- [ ] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
