### PR TITLE
[v2.5] ci: allow promote-rc to run on -dev base tags

### DIFF
--- a/.github/workflows/promote-rc.yml
+++ b/.github/workflows/promote-rc.yml
@@ -3,6 +3,7 @@ name: promote-to-rc
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-dev'
 jobs:
   promote-to-rc:
     runs-on: ubuntu-latest

--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -495,7 +495,7 @@ endif
 
 release/promote-oss/to-rc: $(tools/devversion)
 	@test -n "$(RELEASE_REGISTRY)" || (printf "$${RELEASE_REGISTRY_ERR}\n"; exit 1)
-	@[[ "$(VERSION)" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$$ ]] || (printf '$(RED)ERROR: VERSION=%s does not look like an RC tag\n' "$(VERSION)"; exit 1)
+	@[[ "$(VERSION)" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+|-dev)$$ ]] || (printf '$(RED)ERROR: VERSION=%s does not look like an RC or dev tag\n' "$(VERSION)"; exit 1)
 	@set -e; { \
 	  dev_version=$$($(tools/devversion)); \
 	  printf "$(CYN)==> $(GRN)found version $(BLU)$$dev_version$(GRN).$(END)\n"; \


### PR DESCRIPTION
## Description

This backports the CI changes for running promote-rc builds on **-dev** tags. 

To prepare a branch for the next minor verision we leverage an initial `-dev` tag which allows the Go psuedo version logic to properly version a build as part of the upcoming "next" minor version release.

This updates the RC CI process so that it will run and publish an initial dev build. This is needed for dependent projects like AES.

## Related Issues

Backport of this: https://github.com/emissary-ingress/emissary/pull/4667

## Testing

will test in upcoming RC's

## Checklist

- [ ] **Does my change need to be backported to a previous release?**
- [ ] **I made sure to update `CHANGELOG.md`.**
- [x] **This is unlikely to impact how Ambassador performs at scale.**
- [x] **My change is adequately tested.**
- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**
- [ ] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
