### PR TITLE
[support ticket 2365] `.Values.security.podSecurityContext` and `.Values.security.container SecurityContext` now applies to agent deployment as well.

### DIFF
--- a/charts/emissary-ingress/CHANGELOG.md
+++ b/charts/emissary-ingress/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Ambassador Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v8.5.0 - TBD
+
+- `.Values.security.podSecurityContext` and `.Values.security.containerSecurityContext` now applies to agent deployment as well.
+
 ## v8.4.0 - TBD
 
 - Upgrade Emissary to v3.4.0 [CHANGELOG](https://github.com/emissary-ingress/emissary/blob/master/CHANGELOG.md)
@@ -217,7 +221,7 @@ Emissary Ingress chart v7.0.0-ea provides early access to Emissary 2.0 features.
 ## v6.7.0
 
 - Update Ambassador to version 1.13.0: [CHANGELOG](https://github.com/datawire/ambassador/blob/master/CHANGELOG.md)
-- Feature: Ambassador Agent now available for API Gateway (https://app.getambassador.io)
+- Feature: Ambassador Agent now available for API Gateway (<https://app.getambassador.io>)
 - Feature: Add support for [pod toplology spread constraints](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/) via the `topologySpreadConstraints` helm value to the Ambassador deployment. (thanks, [@lawliet89](https://github.com/lawliet89)!)
 - BugFix: Add missing `ambassador_id` for resolvers.
 - Change: Ambassador ClusterRoles are now aggregated under the label `rbac.getambassador.io/role-group`. The aggregated role has the same name as the previous role name (so no need to update ClusterRoleBindings).
@@ -242,7 +246,7 @@ Emissary Ingress chart v7.0.0-ea provides early access to Emissary 2.0 features.
 ## v6.6.0
 
 - Update Ambassador to version 1.12.1: [CHANGELOG](https://github.com/datawire/ambassador/blob/master/CHANGELOG.md)
-- Feature: Apply Ambassador Agent deployment by default to enable Service Catalog reporting (https://app.getambassador.io)
+- Feature: Apply Ambassador Agent deployment by default to enable Service Catalog reporting (<https://app.getambassador.io>)
 
 ## v6.5.22
 
@@ -252,7 +256,7 @@ Emissary Ingress chart v7.0.0-ea provides early access to Emissary 2.0 features.
 ## v6.5.21
 
 - Update Ambassador to version 1.12.0: [CHANGELOG](https://github.com/datawire/ambassador/blob/master/CHANGELOG.md)
-- Feature: Add support for the ambassador-agent, reporting to Service Catalog (https://app.getambassador.io)
+- Feature: Add support for the ambassador-agent, reporting to Service Catalog (<https://app.getambassador.io>)
 - Feature: All services are automatically instrumented with discovery annotations.
 
 ## v6.5.20

--- a/charts/emissary-ingress/templates/ambassador-agent.yaml
+++ b/charts/emissary-ingress/templates/ambassador-agent.yaml
@@ -216,6 +216,19 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ include "ambassador.fullname" . }}-agent
       app.kubernetes.io/instance: {{ .Release.Name }}
+
+  {{- /* Check if .Values.securityContext is set for backwards compatibility */ -}}
+  {{- if .Values.securityContext -}}
+  {{- with .Values.securityContext }}
+  securityContext:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
+  {{- else -}}
+  {{- with .Values.security.podSecurityContext }}
+  securityContext:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
+  {{- end -}}
   template:
     metadata:
       labels:
@@ -247,6 +260,10 @@ spec:
           value: {{ .Values.agent.reportDiagnostics | quote }}
         - name: AES_DIAGNOSTICS_URL
           value: "http://{{ include "ambassador.fullname" . }}-admin.{{ include "ambassador.namespace" . }}:{{ .Values.adminService.port }}/ambassador/v0/diag/?json=true"
+        {{- with .Values.security.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
   {{ if .Values.progressDeadlines }}
   {{ if hasKey .Values.progressDeadlines "agent" }}
   progressDeadlineSeconds: {{ .Values.progressDeadlines.agent }}


### PR DESCRIPTION
## Description

Need to apply security context to the agent component as well to make edge-stack work in the cluster where strict policies are enforced. E.g. `runAsNonRoot`.

**TODO:** Redis deployment does not live in this repo, it is in the top level chart ` datawire/edge-stack`... need to add the ability to specify `securityContext` there as well.

**WARNING:** if clients have added more to `securityContext` and these changes are not compatible with agent itself, this might cause issues. maybe we should add new section into values like `.Values.agent.security...`

## Related Issues

When `runAsNonRoot` policy is enforced, Redis and Agent won't start

## Testing

the deployment is manually updated with:
```
Agent pod needs: runAsUser: 8888
Redis pod needs:  runAsUser: 1000
```
and `runAsNonRoot` is enforced via mutation, edge-stack is working, else Redis and Agent pods wont start

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->
- [ ] **Does my change need to be backported to a previous release?**
  - What backport versions were discussed with the Maintainers in the Issue?

- [x] **I made sure to update `CHANGELOG.md`.**

   Remember, the CHANGELOG needs to mention:
  - Any new features
  - Any changes to our included version of Envoy
  - Any non-backward-compatible changes
  - Any deprecations

- [x] **This is unlikely to impact how Ambassador performs at scale.**

   Remember, things that might have an impact at scale include:
  - Any significant changes in memory use that might require adjusting the memory limits
  - Any significant changes in CPU use that might require adjusting the CPU limits
  - Anything that might change how many replicas users should use
  - Changes that impact data-plane latency/scalability

- [ ] **My change is adequately tested.**

   Remember when considering testing:
  - Your change needs to be specifically covered by tests.
    - Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
  - You also need to make sure that the _entire area being changed_ has adequate test coverage.
    - If existing tests don't actually cover the entire area being changed, add tests.
    - This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
  - We should lean on the bulk of code being covered by unit tests, but...
  - ... an end-to-end test should cover the integration points

- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**

- [x] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
