### PR TITLE
deps: upgrade to golang 1.19.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,17 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
 
 ## RELEASE NOTES
 
+## [3.3.1] December 08, 2022
+[3.3.1]: https://github.com/emissary-ingress/emissary/compare/v3.3.0...v3.3.1
+
+### Emissary-ingress and Ambassador Edge Stack
+
+- Security: Update Golang to release 1.19.4. Two CVE's were annouced in this z patch release.
+  CVE-2022-41720 only affects Windows environments and Emissary-ingress runs in linux. The second
+  one  CVE-2022-41717 only affects HTTP/2 server connections exposed to external clients.
+  Emissary-ingress does  not expose any Golang http servers to outside clients. The data-plane of
+  Envoy is not affected by either of these. 
+
 ## [3.3.0] November 02, 2022
 [3.3.0]: https://github.com/emissary-ingress/emissary/compare/v3.2.0...v3.3.0
 

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -3,7 +3,7 @@ following Free and Open Source software:
 
     Name                                                                                       Version                                      License(s)
     ----                                                                                       -------                                      ----------
-    the Go language standard library ("std")                                                   v1.19.2                                      3-clause BSD license
+    the Go language standard library ("std")                                                   v1.19.4                                      3-clause BSD license
     cloud.google.com/go/compute                                                                v1.2.0                                       Apache License 2.0
     github.com/Azure/go-ansiterm                                                               v0.0.0-20210617225240-d185dfc1b5a1           MIT license
     github.com/Azure/go-autorest                                                               v14.2.0+incompatible                         Apache License 2.0

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -145,7 +145,6 @@ libraries:
     PyYAML              5.4.1      MIT license
     Werkzeug            2.2.1      3-clause BSD license
     appdirs             1.4.4      MIT license
-    attrs               21.4.0     MIT license
     cachetools          5.0.0      MIT license
     certifi             2021.10.8  Mozilla Public License 2.0
     charset-normalizer  2.0.11     MIT license
@@ -165,7 +164,6 @@ libraries:
     itsdangerous        2.0.1      3-clause BSD license
     jsonpatch           1.32       3-clause BSD license
     jsonpointer         2.2        3-clause BSD license
-    jsonschema          4.4.0      MIT license
     kubernetes          21.7.0     Apache License 2.0
     lockfile            0.12.2     MIT license
     msgpack             1.0.2      Apache License 2.0
@@ -177,11 +175,9 @@ libraries:
     pip-tools           6.3.1      3-clause BSD license
     progress            1.6        ISC license
     prometheus-client   0.13.1     Apache License 2.0
-    protobuf            3.19.4     3-clause BSD license
     pyasn1              0.4.8      2-clause BSD license
     pyasn1-modules      0.2.8      2-clause BSD license
     pyparsing           2.4.7      MIT license
-    pyrsistent          0.18.1     MIT license
     python-dateutil     2.8.2      3-clause BSD license, Apache License 2.0
     python-json-logger  2.0.2      2-clause BSD license
     requests            2.27.1     Apache License 2.0

--- a/Makefile
+++ b/Makefile
@@ -155,3 +155,11 @@ python-dev-setup:
 
 # activate venv
 	@echo "run 'source ./venv/bin/activate' to activate venv in local shell"
+
+# re-generate docs
+.PHONY: clean-changelog
+clean-changelog:
+	rm CHANGELOG.md
+
+.PHONY: generate-changelog
+generate-changelog: clean-changelog $(PWD)/CHANGELOG.md

--- a/docker/base-python/Dockerfile
+++ b/docker/base-python/Dockerfile
@@ -24,12 +24,30 @@ WORKDIR /buildroot
 
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin:/buildroot/bin
 
+# For the most-part, you should not pin specific versions in this
+# `apk` command; it will always choose the latest version being
+# shipped by pinned version of Alpine.  This will automatically pull
+# in any patches, but not breaking changes.
+#
+# Because of how we cache the base image
+# (`docker/base-python.docker.gen`), it'll keep selected versions
+# around for a week.  If there's a security patch that we want to pull
+# in without waiting a week for the cache to roll over, instead of
+# fussing with pinning a specific package version, simply make an
+# inconsequential change that changes the file's checksum (such as
+# bumping this comment):
+#
+#   forced-bumps: 0
+#
+# The exception to this is that we pin 'python3' and 'py3-pip' because
+# we have other code that will need to change if those versions
+# change.
 RUN apk --no-cache add \
   bash \
   gcc \
   make \
   musl-dev \
-  curl=~7.80 \
+  curl \
   cython \
   docker-cli \
   git \
@@ -38,8 +56,8 @@ RUN apk --no-cache add \
   libcap \
   libcap-dev \
   libffi-dev \
-  ncurses=6.3_p20211120-r1 \
-  openssl-dev=1.1.1q-r0 \
+  ncurses \
+  openssl-dev \
   py3-pip=~20.3.4 \
   python3=~3.9.13 \
   python3-dev \

--- a/docker/base-python/Dockerfile
+++ b/docker/base-python/Dockerfile
@@ -78,7 +78,7 @@ RUN apk --no-cache add \
 # 'python3' versions above.
 RUN pip3 install pip-tools==6.3.1
 
-RUN curl --fail -L https://dl.google.com/go/go1.19.2.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+RUN curl --fail -L https://dl.google.com/go/go1.19.4.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 
 RUN curl --fail -L https://storage.googleapis.com/kubernetes-release/release/v1.23.3/bin/linux/amd64/kubectl -o /usr/bin/kubectl && \
   chmod a+x /usr/bin/kubectl

--- a/docker/base-python/Dockerfile
+++ b/docker/base-python/Dockerfile
@@ -40,8 +40,10 @@ ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local
 #   forced-bumps: 0
 #
 # The exception to this is that we pin 'python3' and 'py3-pip' because
-# we have other code that will need to change if those versions
-# change.
+# the 'pip-tools' version below will also need to change if those
+# versions change.  And even then, don't get more precise with the
+# version number than we need to ensure that the pip-tools version
+# agrees.
 RUN apk --no-cache add \
   bash \
   gcc \
@@ -58,8 +60,8 @@ RUN apk --no-cache add \
   libffi-dev \
   ncurses \
   openssl-dev \
-  py3-pip=~20.3.4 \
-  python3=~3.9.13 \
+  py3-pip=~20.3 \
+  python3=~3.9 \
   python3-dev \
   rust \
   cargo \

--- a/docker/test-http/Dockerfile
+++ b/docker/test-http/Dockerfile
@@ -1,7 +1,7 @@
 # The `test-http` image gets built by `pkg/kubeapply` for use by
 # various kubeapply-templated YAML files.
 
-FROM golang:1.19.2
+FROM golang:1.19
 COPY httptest.go /usr/local/bin/httptest.go
 RUN go build -o /usr/local/bin/httptest /usr/local/bin/httptest.go
 ENTRYPOINT ["/usr/local/bin/httptest"]

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -32,6 +32,18 @@
 
 changelog: https://github.com/emissary-ingress/emissary/blob/$branch$/CHANGELOG.md
 items:
+  - version: 3.3.1
+    prevVersion: 3.3.0
+    date: '2022-12-08'
+    notes:
+      - title: Update Golang to 1.19.4
+        type: security
+        body: >-
+          Update Golang to release 1.19.4. Two CVE's were annouced in this z patch release.
+          CVE-2022-41720 only affects Windows environments and $productName$ runs in linux. The second one 
+          CVE-2022-41717 only affects HTTP/2 server connections exposed to external clients. $productName$ does 
+          not expose any Golang http servers to outside clients. The data-plane of Envoy
+          is not affected by either of these. 
   - version: 3.3.0
     prevVersion: 3.2.0
     date: '2022-11-02'

--- a/python/ambassador/ambscout.py
+++ b/python/ambassador/ambscout.py
@@ -1,9 +1,8 @@
 import datetime
-import json
 import logging
 import os
 import re
-from typing import Any, ClassVar, Dict, List, Optional, Tuple, Union
+from typing import Any, ClassVar, Dict, List, Optional, Union
 from typing import cast as typecast
 
 import semantic_version

--- a/python/ambassador/cache.py
+++ b/python/ambassador/cache.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Set, Tuple
+from typing import Any, Callable, Dict, Optional, Set, Tuple
 
 
 class Cacheable(dict):
@@ -242,7 +242,6 @@ class NullCache(Cache):
         self.logger = logger
         self.logger.debug("NullCache: INIT")
         self.reset_stats()
-        pass
 
     def add(self, rsrc: Cacheable, on_delete: Optional[DeletionHandler] = None) -> None:
         pass
@@ -252,7 +251,6 @@ class NullCache(Cache):
 
     def invalidate(self, key: str) -> None:
         self.invalidate_calls += 1
-        pass
 
     def __getitem__(self, key: str) -> Any:
         self.misses += 1

--- a/python/ambassador/compile.py
+++ b/python/ambassador/compile.py
@@ -13,7 +13,7 @@
 # limitations under the License
 
 import logging
-from typing import Any, Dict, Literal, Optional, Union, cast
+from typing import Optional
 
 from typing_extensions import NotRequired, TypedDict
 
@@ -23,7 +23,7 @@ from .envoy import EnvoyConfig
 from .fetch import ResourceFetcher
 from .ir import IR
 from .ir.ir import IRFileChecker
-from .utils import NullSecretHandler, SecretHandler, Timer
+from .utils import NullSecretHandler, SecretHandler
 
 
 class _CompileResult(TypedDict):

--- a/python/ambassador/config/config.py
+++ b/python/ambassador/config/config.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 import collections
-import importlib
-import json
 import logging
 import os
 import socket
@@ -21,13 +19,10 @@ from functools import singledispatchmethod
 from typing import TYPE_CHECKING, Any, ClassVar, Dict, Iterable, List, Optional, Tuple, Union
 from typing import cast as typecast
 
-import jsonschema
-from google.protobuf import json_format
 from pkg_resources import Requirement, resource_filename
 
 from ..resource import Resource
 from ..utils import RichStatus, dump_json, parse_bool
-from .acmapping import ACMapping
 from .acresource import ACResource
 
 if TYPE_CHECKING:

--- a/python/ambassador/diagnostics/diagnostics.py
+++ b/python/ambassador/diagnostics/diagnostics.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 
-import json
 import logging
 import re
 from typing import Any, Dict, List, Optional, Tuple

--- a/python/ambassador/diagnostics/envoy_stats.py
+++ b/python/ambassador/diagnostics/envoy_stats.py
@@ -13,7 +13,6 @@
 # limitations under the License
 
 import logging
-import re
 import threading
 import time
 from dataclasses import dataclass

--- a/python/ambassador/envoy/common.py
+++ b/python/ambassador/envoy/common.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 
-import json
 from abc import abstractmethod
 from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
 

--- a/python/ambassador/envoy/v3/v3bootstrap.py
+++ b/python/ambassador/envoy/v3/v3bootstrap.py
@@ -5,7 +5,6 @@ from urllib.parse import urlparse
 
 from ...ir.ircluster import IRCluster
 from ...ir.irlogservice import IRLogService
-from ...ir.irratelimit import IRRateLimit
 from ...ir.irtracing import IRTracing
 from .v3cluster import V3Cluster
 
@@ -96,14 +95,6 @@ class V3Bootstrap(dict):
                 log_service = typecast(IRLogService, als)
                 assert log_service.cluster
                 clusters.append(V3Cluster(config, typecast(IRCluster, log_service.cluster)))
-
-        # if config.ratelimit:
-        #     self['rate_limit_service'] = dict(config.ratelimit)
-        #
-        #     ratelimit = typecast(IRRateLimit, config.ir.ratelimit)
-        #
-        #     assert ratelimit.cluster
-        #     clusters.append(V3Cluster(config, ratelimit.cluster))
 
         stats_sinks = []
 

--- a/python/ambassador/envoy/v3/v3cluster.py
+++ b/python/ambassador/envoy/v3/v3cluster.py
@@ -16,7 +16,6 @@ import urllib
 from typing import TYPE_CHECKING, Dict, List, Union
 
 from ...cache import Cacheable
-from ...config import Config
 from ...ir.ircluster import IRCluster
 from .v3tls import V3TLSContext
 

--- a/python/ambassador/envoy/v3/v3config.py
+++ b/python/ambassador/envoy/v3/v3config.py
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 
-import json
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 from ...cache import Cache, NullCache
-from ..common import EnvoyConfig, sanitize_pre_json
+from ..common import EnvoyConfig
 from .v3_static_resources import V3StaticResources
 from .v3admin import V3Admin
 from .v3bootstrap import V3Bootstrap

--- a/python/ambassador/envoy/v3/v3httpfilter.py
+++ b/python/ambassador/envoy/v3/v3httpfilter.py
@@ -13,7 +13,7 @@
 # limitations under the License
 import logging
 from functools import singledispatch
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 from typing import cast as typecast
 
 from ...ir.irauth import IRAuth

--- a/python/ambassador/envoy/v3/v3listener.py
+++ b/python/ambassador/envoy/v3/v3listener.py
@@ -12,15 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 import logging
-import sys
-from os import environ
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union
 from typing import cast as typecast
 
 from ...ir.irhost import IRHost
 from ...ir.irlistener import IRListener
 from ...ir.irtcpmappinggroup import IRTCPMappingGroup
-from ...utils import dump_json, parse_bool
+from ...utils import parse_bool
 from .v3route import DictifiedV3Route, V3Route, V3RouteVariants, hostglob_matches, v3prettyroute
 from .v3tls import V3TLSContext
 

--- a/python/ambassador/envoy/v3/v3route.py
+++ b/python/ambassador/envoy/v3/v3route.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 from typing import cast as typecast
 
 from ...cache import Cacheable

--- a/python/ambassador/fetch/fetcher.py
+++ b/python/ambassador/fetch/fetcher.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import yaml
 
 from ..config import ACResource, Config
-from ..utils import dump_json, parse_bool, parse_json, parse_yaml
+from ..utils import parse_bool, parse_json, parse_yaml
 from .ambassador import AmbassadorProcessor
 from .dependency import (
     DependencyManager,

--- a/python/ambassador/fetch/resource.py
+++ b/python/ambassador/fetch/resource.py
@@ -6,9 +6,9 @@ import os
 from typing import Any, ClassVar, Dict, List, Optional
 
 from ..config import ACResource, Config
-from ..utils import dump_json, dump_yaml, parse_bool, parse_yaml
+from ..utils import dump_json, dump_yaml, parse_bool
 from .dependency import DependencyManager
-from .k8sobject import KubernetesObject, KubernetesObjectScope
+from .k8sobject import KubernetesObject
 from .location import LocationManager
 
 

--- a/python/ambassador/fetch/secret.py
+++ b/python/ambassador/fetch/secret.py
@@ -1,7 +1,6 @@
 from typing import FrozenSet
 
 from ..config import Config
-from ..utils import dump_json
 from .dependency import SecretDependency
 from .k8sobject import KubernetesGVK, KubernetesObject
 from .k8sprocessor import ManagedKubernetesProcessor

--- a/python/ambassador/fetch/service.py
+++ b/python/ambassador/fetch/service.py
@@ -2,7 +2,6 @@ import dataclasses
 from typing import Dict, FrozenSet, List, Optional
 
 from ..config import Config
-from ..utils import dump_json
 from .dependency import ServiceDependency
 from .k8sobject import KubernetesGVK, KubernetesObject, KubernetesObjectKey
 from .k8sprocessor import AggregateKubernetesProcessor, ManagedKubernetesProcessor

--- a/python/ambassador/ir/irambassador.py
+++ b/python/ambassador/ir/irambassador.py
@@ -11,8 +11,6 @@ from .irhttpmapping import IRHTTPMapping
 from .iripallowdeny import IRIPAllowDeny
 from .irresource import IRResource
 from .irretrypolicy import IRRetryPolicy
-from .irtls import IRAmbassadorTLS
-from .irtlscontext import IRTLSContext
 
 if TYPE_CHECKING:
     from .ir import IR  # pragma: no cover

--- a/python/ambassador/ir/irauth.py
+++ b/python/ambassador/ir/irauth.py
@@ -6,7 +6,6 @@ from ..resource import Resource
 from ..utils import RichStatus
 from .ircluster import IRCluster
 from .irfilter import IRFilter
-from .irretrypolicy import IRRetryPolicy
 
 if TYPE_CHECKING:
     from .ir import IR  # pragma: no cover

--- a/python/ambassador/ir/irbasemapping.py
+++ b/python/ambassador/ir/irbasemapping.py
@@ -1,6 +1,5 @@
-import json
 import re
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 from urllib.parse import quote as urlquote
 from urllib.parse import scheme_chars
 from urllib.parse import unquote as urlunquote

--- a/python/ambassador/ir/irbasemappinggroup.py
+++ b/python/ambassador/ir/irbasemappinggroup.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from ..config import Config
 from .irbasemapping import IRBaseMapping

--- a/python/ambassador/ir/irbuffer.py
+++ b/python/ambassador/ir/irbuffer.py
@@ -1,10 +1,7 @@
-from typing import TYPE_CHECKING, Optional
-from typing import cast as typecast
+from typing import TYPE_CHECKING
 
 from ..config import Config
-from ..resource import Resource
 from ..utils import RichStatus
-from .ircluster import IRCluster
 from .irfilter import IRFilter
 
 if TYPE_CHECKING:

--- a/python/ambassador/ir/ircluster.py
+++ b/python/ambassador/ir/ircluster.py
@@ -12,10 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 
-import json
 import re
 import urllib.parse
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 from typing import cast as typecast
 
 from ..config import Config

--- a/python/ambassador/ir/ircors.py
+++ b/python/ambassador/ir/ircors.py
@@ -2,7 +2,6 @@ import copy
 from typing import TYPE_CHECKING, Any, Dict
 
 from ..config import Config
-from ..utils import RichStatus
 from .irresource import IRResource
 
 if TYPE_CHECKING:

--- a/python/ambassador/ir/irerrorresponse.py
+++ b/python/ambassador/ir/irerrorresponse.py
@@ -1,5 +1,4 @@
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional
-from typing import cast as typecast
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from ..config import Config
 from .irfilter import IRFilter

--- a/python/ambassador/ir/irgzip.py
+++ b/python/ambassador/ir/irgzip.py
@@ -1,10 +1,6 @@
-from typing import TYPE_CHECKING, Optional
-from typing import cast as typecast
+from typing import TYPE_CHECKING
 
 from ..config import Config
-from ..resource import Resource
-from ..utils import RichStatus
-from .ircluster import IRCluster
 from .irfilter import IRFilter
 
 if TYPE_CHECKING:

--- a/python/ambassador/ir/irhost.py
+++ b/python/ambassador/ir/irhost.py
@@ -1,8 +1,4 @@
-import copy
-import os
-from typing import TYPE_CHECKING, Dict, List, Optional, Union
-
-from ambassador.utils import parse_bool
+from typing import TYPE_CHECKING, List, Optional, Union
 
 from ..config import Config
 from ..utils import SavedSecret, dump_json

--- a/python/ambassador/ir/irhttpmappinggroup.py
+++ b/python/ambassador/ir/irhttpmappinggroup.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional, Tuple
 from typing import cast as typecast
 
 from ambassador.utils import RichStatus

--- a/python/ambassador/ir/iripallowdeny.py
+++ b/python/ambassador/ir/iripallowdeny.py
@@ -1,5 +1,4 @@
 from typing import TYPE_CHECKING, ClassVar, Dict, List, Optional, Tuple
-from typing import cast as typecast
 
 from ..config import Config
 from .irfilter import IRFilter

--- a/python/ambassador/ir/irlistener.py
+++ b/python/ambassador/ir/irlistener.py
@@ -1,9 +1,6 @@
-import copy
-import json
-from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Tuple
+from typing import TYPE_CHECKING, Dict, List, Literal, Optional
 
 from ..config import Config
-from ..utils import dump_json
 from .irhost import IRHost
 from .irresource import IRResource
 from .irtcpmappinggroup import IRTCPMappingGroup

--- a/python/ambassador/ir/irlogservice.py
+++ b/python/ambassador/ir/irlogservice.py
@@ -1,7 +1,6 @@
 from typing import TYPE_CHECKING, Literal, Optional
 
 from ..config import Config
-from ..utils import RichStatus
 from .ircluster import IRCluster
 from .irresource import IRResource
 

--- a/python/ambassador/ir/irmappingfactory.py
+++ b/python/ambassador/ir/irmappingfactory.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional, Tuple, Type, Union
+from typing import TYPE_CHECKING, List, Optional, Type
 
 from ..config import Config
 from .irbasemapping import IRBaseMapping

--- a/python/ambassador/ir/irretrypolicy.py
+++ b/python/ambassador/ir/irretrypolicy.py
@@ -1,7 +1,6 @@
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from ..config import Config
-from ..utils import RichStatus
 from .irresource import IRResource
 
 if TYPE_CHECKING:

--- a/python/ambassador/ir/irserviceresolver.py
+++ b/python/ambassador/ir/irserviceresolver.py
@@ -1,14 +1,8 @@
-import json
-import logging
-import re
-import urllib.parse
 from ipaddress import ip_address
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 
 from ..config import Config
-from ..utils import RichStatus
 from .irresource import IRResource
-from .irtlscontext import IRTLSContext
 
 if TYPE_CHECKING:
     from .ir import IR  # pragma: no cover

--- a/python/ambassador/ir/irtcpmapping.py
+++ b/python/ambassador/ir/irtcpmapping.py
@@ -1,7 +1,5 @@
 import hashlib
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional, Type, Union
-
-from ambassador.utils import RichStatus
+from typing import TYPE_CHECKING, ClassVar, Dict, List, Optional, Type, Union
 
 from ..config import Config
 from .irbasemapping import IRBaseMapping, normalize_service_name

--- a/python/ambassador/ir/irtcpmappinggroup.py
+++ b/python/ambassador/ir/irtcpmappinggroup.py
@@ -1,7 +1,4 @@
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional, Tuple, Union
-from typing import cast as typecast
-
-from ambassador.utils import RichStatus
+from typing import TYPE_CHECKING, ClassVar, Dict, List, Optional, Tuple
 
 from ..config import Config
 from .irbasemapping import IRBaseMapping

--- a/python/ambassador/ir/irtls.py
+++ b/python/ambassador/ir/irtls.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 
-from typing import TYPE_CHECKING, ClassVar
-
-from ambassador.utils import RichStatus
+from typing import TYPE_CHECKING
 
 from ..config import Config
 from .irresource import IRResource as IRResource

--- a/python/ambassador/ir/irtlscontext.py
+++ b/python/ambassador/ir/irtlscontext.py
@@ -1,6 +1,5 @@
 import base64
 import logging
-import os
 from typing import TYPE_CHECKING, ClassVar, Dict, List, Optional
 
 from ..config import Config

--- a/python/ambassador/resource.py
+++ b/python/ambassador/resource.py
@@ -1,6 +1,5 @@
-import json
 import sys
-from typing import Any, Dict, List, Optional, Type, TypeVar
+from typing import Any, Dict, Optional, Type, TypeVar
 
 from .cache import Cacheable
 from .utils import dump_json, parse_yaml

--- a/python/ambassador/scout.py
+++ b/python/ambassador/scout.py
@@ -8,7 +8,6 @@ import traceback
 from uuid import uuid4
 
 import requests
-from requests.exceptions import Timeout
 
 
 class Scout:

--- a/python/ambassador/utils.py
+++ b/python/ambassador/utils.py
@@ -17,7 +17,6 @@
 import binascii
 import hashlib
 import io
-import json
 import logging
 import os
 import re

--- a/python/ambassador_cli/ambassador.py
+++ b/python/ambassador_cli/ambassador.py
@@ -23,15 +23,12 @@ import cProfile
 import json
 import logging
 import os
-import pstats
-import signal
 import sys
 import traceback
 from typing import TYPE_CHECKING, ClassVar, Optional, Set
 from typing import cast as typecast
 
 import click
-import orjson
 
 from ambassador import IR, Config, Diagnostics, Scout, Version
 from ambassador.envoy import EnvoyConfig, V3Config
@@ -564,7 +561,6 @@ def main():
 
     to see Ambassador's version.
     """
-    pass
 
 
 if __name__ == "__main__":

--- a/python/ambassador_cli/mockery.py
+++ b/python/ambassador_cli/mockery.py
@@ -26,10 +26,8 @@ import errno
 import filecmp
 import functools
 import io
-import json
 import logging
 import os
-import shlex
 import shutil
 import sys
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
@@ -45,7 +43,6 @@ click_option_no_default = functools.partial(click.option, show_default=False)
 from ambassador import IR, Config, Diagnostics, EnvoyConfig
 from ambassador.fetch import ResourceFetcher
 from ambassador.utils import SecretHandler, SecretInfo, dump_json, parse_bool, parse_yaml
-from kat.utils import ShellCommand
 
 if TYPE_CHECKING:
     from ambassador.ir import IRResource

--- a/python/ambassador_diag/diagd.py
+++ b/python/ambassador_diag/diagd.py
@@ -31,13 +31,12 @@ import threading
 import time
 import traceback
 import uuid
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Type, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union
 from typing import cast as typecast
 
 import click
 import gunicorn.app.base
 import jsonpatch
-import orjson
 import requests
 from expiringdict import ExpiringDict
 from flask import Flask, Response
@@ -54,13 +53,10 @@ from ambassador.constants import Constants
 from ambassador.diagnostics import EnvoyStats, EnvoyStatsMgr
 from ambassador.fetch import ResourceFetcher
 from ambassador.ir.irambassador import IRAmbassador
-from ambassador.ir.irbasemapping import IRBaseMapping
 from ambassador.reconfig_stats import ReconfigStats
 from ambassador.utils import (
     FSSecretHandler,
-    KubewatchSecretHandler,
     PeriodicTrigger,
-    SavedSecret,
     SecretHandler,
     SystemInfo,
     Timer,
@@ -587,7 +583,6 @@ class DiagApp(Flask):
                     os.rename(from_path, to_path)
                 except IOError as e:
                     self.logger.debug("skip %s -> %s: %s" % (from_path, to_path, e))
-                    pass
                 except Exception as e:
                     self.logger.debug("could not rename %s -> %s: %s" % (from_path, to_path, e))
 
@@ -1767,7 +1762,6 @@ class AmbassadorEventWatcher(threading.Thread):
                     os.rename(from_path, to_path)
                 except IOError as e:
                     self.logger.debug("skip %s -> %s: %s" % (from_path, to_path, e))
-                    pass
                 except Exception as e:
                     self.logger.debug("could not rename %s -> %s: %s" % (from_path, to_path, e))
 

--- a/python/kat/harness.py
+++ b/python/kat/harness.py
@@ -13,19 +13,7 @@ from abc import ABC
 from collections import OrderedDict
 from functools import singledispatch
 from hashlib import sha256
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    List,
-    NamedTuple,
-    Optional,
-    Sequence,
-    Tuple,
-    Type,
-    Union,
-    cast,
-)
+from typing import Any, Dict, List, NamedTuple, Optional, Sequence, Tuple, Type, Union, cast
 
 import pytest
 import yaml as pyyaml
@@ -35,7 +23,6 @@ from yaml.scanner import ScannerError as YAMLScanError
 
 import tests.integration.manifests as integration_manifests
 from ambassador.utils import parse_bool
-from tests.kubeutils import apply_kube_artifacts
 from tests.manifests import cleartext_host_manifest, default_listener_manifest
 
 from .parser import SequenceView, Tag, dump, load

--- a/python/kubewatch.py
+++ b/python/kubewatch.py
@@ -66,7 +66,6 @@ def kube_v1():
         except FileNotFoundError:
             # Meh, just ride through.
             logger.info("No K8s")
-            pass
 
     return k8s_api
 

--- a/python/post_update.py
+++ b/python/post_update.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import urllib
 
 import requests
 

--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -1,7 +1,7 @@
 # Dev requirements
 gitpython
 httpretty
-mypy
+mypy<0.990
 packaging
 pexpect
 pyOpenSSL

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -4,8 +4,6 @@
 #
 #    pip-compile --allow-unsafe --no-build-isolation
 #
-attrs==21.4.0
-    # via jsonschema
 cachetools==5.0.0
     # via google-auth
 certifi==2021.10.8
@@ -42,8 +40,6 @@ jsonpatch==1.32
     # via -r requirements.in
 jsonpointer==2.2
     # via jsonpatch
-jsonschema==4.4.0
-    # via -r requirements.in
 kubernetes==21.7.0
     # via -r requirements.in
 markupsafe==2.1.1
@@ -56,16 +52,12 @@ orjson==3.6.6
     # via -r requirements.in
 prometheus-client==0.13.1
     # via -r requirements.in
-protobuf==3.19.4
-    # via -r requirements.in
 pyasn1==0.4.8
     # via
     #   pyasn1-modules
     #   rsa
 pyasn1-modules==0.2.8
     # via google-auth
-pyrsistent==0.18.1
-    # via jsonschema
 python-dateutil==2.8.2
     # via kubernetes
 python-json-logger==2.0.2

--- a/python/setup.py
+++ b/python/setup.py
@@ -14,7 +14,6 @@
 
 import os
 
-import setuptools
 from setuptools import find_packages, setup
 
 # from ambassador.VERSION import Version

--- a/python/tests/integration/manifests.py
+++ b/python/tests/integration/manifests.py
@@ -2,7 +2,7 @@ import json
 import os
 import subprocess
 from base64 import b64encode
-from typing import Dict, Final, Optional
+from typing import Dict, Optional
 
 
 def _get_images() -> Dict[str, str]:

--- a/python/tests/integration/test_header_case_overrides.py
+++ b/python/tests/integration/test_header_case_overrides.py
@@ -22,7 +22,6 @@ logger = logging.getLogger("ambassador")
 from ambassador import IR, Config
 from ambassador.envoy import EnvoyConfig
 from ambassador.fetch import ResourceFetcher
-from ambassador.ir.irerrorresponse import IRErrorResponse
 from ambassador.utils import NullSecretHandler
 
 headerecho_manifests = """

--- a/python/tests/integration/test_knative.py
+++ b/python/tests/integration/test_knative.py
@@ -1,10 +1,8 @@
 import logging
 import os
 import sys
-import time
 
 import pytest
-from retry import retry
 
 import tests.integration.manifests as integration_manifests
 from ambassador import IR, Config
@@ -12,9 +10,9 @@ from ambassador.fetch import ResourceFetcher
 from ambassador.utils import NullSecretHandler, parse_bool
 from kat.harness import is_knative_compatible
 from tests.integration.utils import create_qotm_mapping, get_code_with_retry, install_ambassador
-from tests.kubeutils import apply_kube_artifacts, delete_kube_artifacts
+from tests.kubeutils import apply_kube_artifacts
 from tests.manifests import qotm_manifests
-from tests.runutils import run_and_assert, run_with_retry
+from tests.runutils import run_and_assert
 
 logger = logging.getLogger("ambassador")
 

--- a/python/tests/integration/test_scout.py
+++ b/python/tests/integration/test_scout.py
@@ -7,8 +7,6 @@ import pexpect
 import pytest
 import requests
 
-from tests.runutils import run_and_assert
-
 DOCKER_IMAGE = os.environ.get("AMBASSADOR_DOCKER_IMAGE", None)
 
 child: Optional[pexpect.spawnbase.SpawnBase] = None  # see docker_start()

--- a/python/tests/integration/test_watt_scaling.py
+++ b/python/tests/integration/test_watt_scaling.py
@@ -6,7 +6,7 @@ import pytest
 from tests.integration.utils import get_code_with_retry, install_ambassador
 from tests.kubeutils import apply_kube_artifacts, delete_kube_artifacts
 from tests.manifests import qotm_manifests
-from tests.runutils import run_and_assert, run_with_retry
+from tests.runutils import run_and_assert
 
 
 class WattTesting:

--- a/python/tests/integration/utils.py
+++ b/python/tests/integration/utils.py
@@ -1,20 +1,12 @@
-import json
-import logging
 import os
 import socket
-import subprocess
-import tempfile
 import time
 from collections import namedtuple
 
 import requests
 import yaml
-from retry import retry
 
 import tests.integration.manifests as integration_manifests
-from ambassador import IR, Cache
-from ambassador.compile import Compile
-from ambassador.utils import NullSecretHandler
 from tests.kubeutils import apply_kube_artifacts
 from tests.manifests import cleartext_host_manifest
 from tests.runutils import run_and_assert

--- a/python/tests/kat/t_basics.py
+++ b/python/tests/kat/t_basics.py
@@ -3,7 +3,7 @@ from typing import Generator, Tuple, Union
 
 import yaml
 
-from abstract_tests import HTTP, AmbassadorTest, Node, ServiceType, assert_default_errors
+from abstract_tests import HTTP, AmbassadorTest, Node, ServiceType
 from kat.harness import EDGE_STACK, Query
 from tests.integration.manifests import namespace_manifest
 

--- a/python/tests/kat/t_bufferlimitbytes.py
+++ b/python/tests/kat/t_bufferlimitbytes.py
@@ -1,4 +1,3 @@
-import json
 from typing import Generator, Tuple, Union
 
 from abstract_tests import HTTP, AmbassadorTest, Node, ServiceType

--- a/python/tests/kat/t_chunked_length.py
+++ b/python/tests/kat/t_chunked_length.py
@@ -1,4 +1,3 @@
-import json
 from typing import Generator, Tuple, Union
 
 from abstract_tests import HTTP, AmbassadorTest, Node, ServiceType

--- a/python/tests/kat/t_circuitbreaker.py
+++ b/python/tests/kat/t_circuitbreaker.py
@@ -1,5 +1,4 @@
-import os
-from typing import ClassVar, Generator, Tuple, Union
+from typing import Generator, Tuple, Union
 
 import pytest
 

--- a/python/tests/kat/t_dns_type.py
+++ b/python/tests/kat/t_dns_type.py
@@ -1,4 +1,3 @@
-import json
 from typing import Generator, Tuple, Union
 
 from abstract_tests import HTTP, AmbassadorTest, Node, ServiceType

--- a/python/tests/kat/t_extauth.py
+++ b/python/tests/kat/t_extauth.py
@@ -1,11 +1,7 @@
 import json
-import os
 from typing import Generator, Literal, Tuple, Union, cast
 
-import pytest
-
 from abstract_tests import AGRPC, AHTTP, HTTP, AmbassadorTest, Node, ServiceType, WebsocketEcho
-from ambassador import Config
 from kat.harness import EDGE_STACK, Query
 from tests.selfsigned import TLSCerts
 

--- a/python/tests/kat/t_grpc_web.py
+++ b/python/tests/kat/t_grpc_web.py
@@ -1,4 +1,3 @@
-import json
 from typing import Generator, Tuple, Union
 
 from abstract_tests import EGRPC, AmbassadorTest, Node, ServiceType

--- a/python/tests/kat/t_hosts.py
+++ b/python/tests/kat/t_hosts.py
@@ -1,7 +1,4 @@
-from typing import Generator, Tuple, Union
-
-from abstract_tests import HTTP, AmbassadorTest, Node, ServiceType
-from ambassador import Config
+from abstract_tests import HTTP, AmbassadorTest, ServiceType
 from kat.harness import EDGE_STACK, Query
 from tests.integration.manifests import namespace_manifest
 from tests.selfsigned import TLSCerts

--- a/python/tests/kat/t_ingress.py
+++ b/python/tests/kat/t_ingress.py
@@ -6,7 +6,7 @@ import time
 
 import pytest
 
-from abstract_tests import HTTP, AmbassadorTest, ServiceType
+from abstract_tests import HTTP, AmbassadorTest
 from ambassador.utils import parse_bool
 from kat.harness import Query, is_ingress_class_compatible
 from tests.integration.manifests import namespace_manifest

--- a/python/tests/kat/t_loadbalancer.py
+++ b/python/tests/kat/t_loadbalancer.py
@@ -1,4 +1,3 @@
-import os
 from typing import Dict, Generator, Tuple, Union
 
 import tests.integration.manifests as integration_manifests

--- a/python/tests/kat/t_logservice.py
+++ b/python/tests/kat/t_logservice.py
@@ -1,8 +1,6 @@
-import json
 from typing import Generator, Literal, Tuple, Union, cast
 
 from abstract_tests import ALSGRPC, HTTP, AmbassadorTest, Node, ServiceType
-from ambassador import Config
 from kat.harness import Query
 
 

--- a/python/tests/kat/t_mappingtests_default.py
+++ b/python/tests/kat/t_mappingtests_default.py
@@ -2,7 +2,7 @@ from typing import Generator, Tuple, Union
 
 from abstract_tests import HTTP, AmbassadorTest, HTTPBin, Node, ServiceType
 from ambassador.constants import Constants
-from kat.harness import EDGE_STACK, Query, variants
+from kat.harness import Query
 from tests.integration.manifests import namespace_manifest
 
 # This is the place to add new MappingTests that run in the default namespace

--- a/python/tests/kat/t_no_ui.py
+++ b/python/tests/kat/t_no_ui.py
@@ -1,5 +1,5 @@
-from abstract_tests import HTTP, AmbassadorTest, ServiceType
-from kat.harness import EDGE_STACK, Query
+from abstract_tests import AmbassadorTest
+from kat.harness import Query
 
 
 class NoUITest(AmbassadorTest):

--- a/python/tests/kat/t_no_ui_allow_non_local.py
+++ b/python/tests/kat/t_no_ui_allow_non_local.py
@@ -1,5 +1,5 @@
-from abstract_tests import HTTP, AmbassadorTest, ServiceType
-from kat.harness import EDGE_STACK, Query
+from abstract_tests import AmbassadorTest
+from kat.harness import Query
 
 
 class NoUITestAllowNoLocal(AmbassadorTest):

--- a/python/tests/kat/t_plain.py
+++ b/python/tests/kat/t_plain.py
@@ -1,7 +1,5 @@
 from typing import Generator, Tuple, Union
 
-import t_mappingtests_plain
-import t_optiontests
 from abstract_tests import AmbassadorTest, MappingTest, Node
 from kat.harness import EDGE_STACK, Query, variants
 from tests.integration.manifests import namespace_manifest

--- a/python/tests/kat/t_ratelimit.py
+++ b/python/tests/kat/t_ratelimit.py
@@ -1,7 +1,6 @@
 from typing import Generator, Literal, Tuple, Union, cast
 
 from abstract_tests import HTTP, RLSGRPC, AmbassadorTest, Node, ServiceType
-from ambassador import Config
 from kat.harness import Query
 from tests.selfsigned import TLSCerts
 

--- a/python/tests/kat/t_regexrewrite_forwarding.py
+++ b/python/tests/kat/t_regexrewrite_forwarding.py
@@ -1,7 +1,7 @@
 from typing import Generator, Tuple, Union
 
 from abstract_tests import HTTP, AmbassadorTest, Node, ServiceType
-from kat.harness import Query, variants
+from kat.harness import Query
 
 
 class RegexRewriteForwardingTest(AmbassadorTest):

--- a/python/tests/kat/t_shadow.py
+++ b/python/tests/kat/t_shadow.py
@@ -1,6 +1,6 @@
 from typing import ClassVar, Generator, Tuple, Union
 
-from abstract_tests import HTTP, AmbassadorTest, MappingTest, Node, ServiceType
+from abstract_tests import HTTP, MappingTest, Node, ServiceType
 from kat.harness import Query
 
 

--- a/python/tests/kat/t_stats.py
+++ b/python/tests/kat/t_stats.py
@@ -1,4 +1,3 @@
-import os
 from typing import Generator, Tuple, Union
 
 from abstract_tests import DEV, HTTP, AmbassadorTest, Node, ServiceType, StatsDSink

--- a/python/tests/kat/t_tracing.py
+++ b/python/tests/kat/t_tracing.py
@@ -3,7 +3,6 @@ from random import random
 from typing import ClassVar, Generator, Tuple, Union
 
 from abstract_tests import AHTTP, HTTP, AmbassadorTest, Node, ServiceType
-from ambassador import Config
 from kat.harness import EDGE_STACK, Query
 
 # The phase that we should wait until before performing test checks. Normally

--- a/python/tests/unit/test_acme_privatekey_secrets.py
+++ b/python/tests/unit/test_acme_privatekey_secrets.py
@@ -1,6 +1,4 @@
 import hashlib
-import io
-import json
 import logging
 import os
 from typing import Optional, Tuple

--- a/python/tests/unit/test_bootstrap.py
+++ b/python/tests/unit/test_bootstrap.py
@@ -1,7 +1,5 @@
 import os
 
-import pytest
-
 from tests.utils import assert_valid_envoy_config, econf_compile, module_and_mapping_manifests
 
 
@@ -20,7 +18,7 @@ def _test_bootstrap(yaml, expectations={}):
         if expected is None:
             assert key not in bootstrap
         else:
-            import json
+            pass
 
             assert key in bootstrap
             assert bootstrap[key] == expected

--- a/python/tests/unit/test_cache.py
+++ b/python/tests/unit/test_cache.py
@@ -6,7 +6,7 @@ import random
 import re
 import sys
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import pytest
 import yaml
@@ -22,8 +22,7 @@ logger.setLevel(logging.DEBUG)
 
 from ambassador import IR, Cache, Config, EnvoyConfig
 from ambassador.fetch import ResourceFetcher
-from ambassador.ir.ir import IRFileChecker
-from ambassador.utils import NullSecretHandler, SecretHandler, Timer
+from ambassador.utils import NullSecretHandler
 
 
 class Builder:

--- a/python/tests/unit/test_cluster_options.py
+++ b/python/tests/unit/test_cluster_options.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 
 from tests.utils import econf_compile, econf_foreach_cluster, module_and_mapping_manifests

--- a/python/tests/unit/test_envoy_stats.py
+++ b/python/tests/unit/test_envoy_stats.py
@@ -15,7 +15,7 @@ logging.basicConfig(
 
 logger = logging.getLogger("ambassador")
 
-from ambassador.diagnostics import EnvoyStats, EnvoyStatsMgr
+from ambassador.diagnostics import EnvoyStatsMgr
 
 
 class EnvoyStatsMocker:

--- a/python/tests/unit/test_envvar_expansion.py
+++ b/python/tests/unit/test_envvar_expansion.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import sys
-from typing import Optional
 
 import pytest
 
@@ -13,11 +12,8 @@ logging.basicConfig(
 
 logger = logging.getLogger("ambassador")
 
-from ambassador import IR, Config
+from ambassador import Config
 from ambassador.fetch import ResourceFetcher
-from ambassador.ir import IRResource
-from ambassador.ir.irbuffer import IRBuffer
-from ambassador.utils import NullSecretHandler
 
 yaml = """
 ---

--- a/python/tests/unit/test_fetch.py
+++ b/python/tests/unit/test_fetch.py
@@ -12,7 +12,6 @@ logging.basicConfig(
 logger = logging.getLogger("ambassador")
 
 from ambassador import Config
-from ambassador.fetch import ResourceFetcher
 from ambassador.fetch.ambassador import AmbassadorProcessor
 from ambassador.fetch.dependency import (
     DependencyManager,
@@ -34,7 +33,6 @@ from ambassador.fetch.k8sprocessor import (
 )
 from ambassador.fetch.location import LocationManager
 from ambassador.fetch.resource import NormalizedResource, ResourceManager
-from ambassador.fetch.service import ServiceProcessor
 from ambassador.utils import parse_yaml
 
 

--- a/python/tests/unit/test_host_redirect_errors.py
+++ b/python/tests/unit/test_host_redirect_errors.py
@@ -1,13 +1,7 @@
-import difflib
-import json
 import logging
-import os
-import random
-import sys
-from typing import Any, Dict, List, Tuple
+from typing import List, Tuple
 
 import pytest
-import yaml
 
 logging.basicConfig(
     level=logging.INFO,
@@ -19,7 +13,6 @@ logger = logging.getLogger("ambassador")
 
 from ambassador import IR, Cache
 from ambassador.compile import Compile
-from ambassador.utils import NullSecretHandler
 
 
 def require_no_errors(ir: IR):

--- a/python/tests/unit/test_ir.py
+++ b/python/tests/unit/test_ir.py
@@ -1,8 +1,6 @@
 import logging
 from dataclasses import dataclass
-from typing import List, Optional
-
-import pytest
+from typing import Optional
 
 from tests.utils import (
     Compile,

--- a/python/tests/unit/test_irauth.py
+++ b/python/tests/unit/test_irauth.py
@@ -1,6 +1,4 @@
-import copy
 import logging
-import sys
 
 import pytest
 

--- a/python/tests/unit/test_irlogservice.py
+++ b/python/tests/unit/test_irlogservice.py
@@ -1,7 +1,5 @@
-import copy
 import logging
-import sys
-from typing import Literal, Union
+from typing import Literal
 
 import pytest
 

--- a/python/tests/unit/test_irmapping.py
+++ b/python/tests/unit/test_irmapping.py
@@ -1,6 +1,4 @@
-import copy
 import logging
-import sys
 from typing import List
 
 import pytest

--- a/python/tests/unit/test_irratelimit.py
+++ b/python/tests/unit/test_irratelimit.py
@@ -1,6 +1,4 @@
-import copy
 import logging
-import sys
 
 import pytest
 

--- a/python/tests/unit/test_listener_statsprefix.py
+++ b/python/tests/unit/test_listener_statsprefix.py
@@ -1,5 +1,3 @@
-import json
-
 import pytest
 
 from tests.utils import (

--- a/python/tests/unit/test_lookup.py
+++ b/python/tests/unit/test_lookup.py
@@ -1,6 +1,5 @@
 import logging
 import sys
-from typing import Optional
 
 import pytest
 
@@ -14,7 +13,6 @@ logger = logging.getLogger("ambassador")
 
 from ambassador import IR, Config
 from ambassador.fetch import ResourceFetcher
-from ambassador.ir import IRResource
 from ambassador.ir.irbuffer import IRBuffer
 from ambassador.utils import NullSecretHandler
 

--- a/python/tests/unit/test_qualify_service.py
+++ b/python/tests/unit/test_qualify_service.py
@@ -14,7 +14,6 @@ logger = logging.getLogger("ambassador")
 
 from ambassador import IR, Config
 from ambassador.fetch import ResourceFetcher
-from ambassador.ir import IRResource
 from ambassador.ir.irbasemapping import normalize_service_name
 from ambassador.utils import NullSecretHandler
 

--- a/python/tests/unit/test_reconfig_stats.py
+++ b/python/tests/unit/test_reconfig_stats.py
@@ -1,6 +1,5 @@
 import logging
 
-import pexpect
 import pytest
 
 from ambassador_diag.diagd import ReconfigStats

--- a/python/tests/unit/test_statsd.py
+++ b/python/tests/unit/test_statsd.py
@@ -1,8 +1,5 @@
-import copy
-import json
 import logging
 import os
-import sys
 
 import httpretty
 import pytest

--- a/python/tests/unit/test_timer.py
+++ b/python/tests/unit/test_timer.py
@@ -1,7 +1,5 @@
 import sys
-import time
 
-import pexpect
 import pytest
 
 from ambassador.utils import Timer

--- a/python/tests/utils.py
+++ b/python/tests/utils.py
@@ -1,25 +1,16 @@
 import json
 import logging
 import os
-import socket
 import subprocess
 import tempfile
-import time
 from base64 import b64encode
 from collections import namedtuple
-from typing import List, Literal, cast
 
-import requests
-import yaml
 from OpenSSL import crypto
-from retry import retry
 
 from ambassador import IR, Cache
 from ambassador.compile import Compile
 from ambassador.utils import NullSecretHandler
-from tests.kubeutils import apply_kube_artifacts
-from tests.manifests import cleartext_host_manifest
-from tests.runutils import run_and_assert
 
 logger = logging.getLogger("ambassador")
 

--- a/python/watch_hook.py
+++ b/python/watch_hook.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 
-import json
 import logging
 import os
 import sys


### PR DESCRIPTION
## Description

Update Golang to release 1.19.4. 

Two CVE's were announced in this z patch release. 

- CVE-2022-41720 only affects Windows environments and Emissary-ingress runs in linux.
- CVE-2022-41717 only affects HTTP/2 server connections that would be exposed to user input. We do not expose our http servers externally from the cluster thus we are not affected by this.

The data-plane of Envoy is not affected by either of these since this is a Golang issue.

However, this ensures we are on the latest and greatest. We will also ensure this is pulled into Edge Stack as well. 

**Note: I pulled in a few additional commits that were needed due to alpine and mypy changes that had already landed on master so they were just back ported here to make CI happy**

## Related Issues

N/A

## Testing

CI is green

## Checklist


- [x] **Does my change need to be backported to a previous release?**
     YES, we should backport to v2.5 as well
- [x] **I made sure to update `CHANGELOG.md`.**
- [x] **This is unlikely to impact how Ambassador performs at scale.**
- [x] **My change is adequately tested.**
- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**
- [x] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
