### PR TITLE
repo: prepare bits for next version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,11 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
 
 ## RELEASE NOTES
 
+## [3.5.0] TBD
+[3.5.0]: https://github.com/emissary-ingress/emissary/compare/v3.4.0...v3.5.0
+
+### Emissary-ingress and Ambassador Edge Stack
+
 ## [3.4.0] January 03, 2023
 [3.4.0]: https://github.com/emissary-ingress/emissary/compare/v3.3.0...v3.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
 
 ## RELEASE NOTES
 
-## [3.4.0] TBD
+## [3.4.0] January 03, 2023
 [3.4.0]: https://github.com/emissary-ingress/emissary/compare/v3.3.0...v3.4.0
 
 ### Emissary-ingress and Ambassador Edge Stack
@@ -96,18 +96,6 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
   Emissary-ingress.  That unserved `v1` could cause an excess of errors to be logged by the
   Kubernetes Nodes (regardless of whether the installation was migrated from 1.y or was a fresh 2.y
   install); fully supporting `v1` again should resolve these errors.
-
-- Security: Update Golang to release 1.19.4. Two CVE's were annouced in this z patch release.
-  CVE-2022-41720 only affects Windows environments and Emissary-ingress runs in linux. The second
-  one  CVE-2022-41717 only affects HTTP/2 server connections exposed to external clients.
-  Emissary-ingress does  not expose any Golang http servers to outside clients. The data-plane of
-  Envoy is not affected by either of these. 
-
-- Security: Updated Golang to the latest z patch. We are not vulnerable to the CVE-2022-3602 that
-  was  released in 1.19.3 and you can read more about it here:
-  <https://medium.com/ambassador-api-gateway/ambassador-labs-security-impact-assessment-of-nov-1-openssl-golang-vulnerabilities-f11b5ec37a7e>.
-  Updating to the latest z patch as part of our normal dependency update process and this will help
-  reduce the noise of security scanners.
 
 - Feature: It is now possible to configure active healhchecking for upstreams within a `Mapping`. If
   the upstream fails its configured health check then Envoy will mark the upstream as unhealthy and

--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ python-dev-setup:
 # re-generate docs
 .PHONY: clean-changelog
 clean-changelog:
-	rm CHANGELOG.md
+	rm -f CHANGELOG.md
 
 .PHONY: generate-changelog
 generate-changelog: clean-changelog $(PWD)/CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Branches
 (If you are looking at this list on a branch other than `master`, it
 may be out of date.)
 
-- [`master`](https://github.com/emissary-ingress/emissary/tree/master) - branch for Emissary-ingress 3.3.z work (:heavy_check_mark: upcoming release)
-- [`release/v3.3`](https://github.com/emissary-ingress/emissary/tree/release/v3.3) - branch for Emissary-ingress 3.3.z work
+- [`master`](https://github.com/emissary-ingress/emissary/tree/master) - branch for Emissary-ingress 3.5.z work (:heavy_check_mark: upcoming release)
+- [`release/v3.4`](https://github.com/emissary-ingress/emissary/tree/release/v3.4) - branch for Emissary-ingress 3.4.z work
 - [`release/v2.5`](https://github.com/emissary-ingress/emissary/tree/release/v2.5) - branch for Emissary-ingress 2.5.z work (:heavy_check_mark: upcoming release)
 - [`release/v1.14`](https://github.com/emissary-ingress/emissary/tree/release/v1.14) - branch for Emissary-ingress 1.14.z work (:heavy_check_mark: maintenance, supported through September 2022)
 

--- a/charts/emissary-ingress/CHANGELOG.md
+++ b/charts/emissary-ingress/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Ambassador Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v8.5.0 - TBD
+
+- Upgrade Emissary to v3.5.0 [CHANGELOG](https://github.com/emissary-ingress/emissary/blob/master/CHANGELOG.md)
+
 ## v8.4.0 - 2022-01-03
 
 - Upgrade Emissary to v3.4.0 [CHANGELOG](https://github.com/emissary-ingress/emissary/blob/master/CHANGELOG.md)

--- a/charts/emissary-ingress/CHANGELOG.md
+++ b/charts/emissary-ingress/CHANGELOG.md
@@ -3,9 +3,11 @@
 This file documents all notable changes to Ambassador Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
-## v8.4.0 - TBD
+## v8.4.0 - 2022-01-03
 
 - Upgrade Emissary to v3.4.0 [CHANGELOG](https://github.com/emissary-ingress/emissary/blob/master/CHANGELOG.md)
+
+- The Ambassador agent that was previously embedded in Emissary Ingress has been moved to a standalone container.
 
 ## v8.3.0
 

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -34,7 +34,7 @@ changelog: https://github.com/emissary-ingress/emissary/blob/$branch$/CHANGELOG.
 items:
   - version: 3.4.0
     prevVersion: 3.3.0
-    date: 'TBD'
+    date: '2023-01-03'
     notes:
       - title: Re-add support for getambassador.io/v1
         type: feature
@@ -47,23 +47,6 @@ items:
           installation was migrated from 1.y or was a fresh 2.y install); fully supporting
           <code>v1</code> again should resolve these errors.
 
-      - title: Update Golang to 1.19.4
-        type: security
-        body: >-
-          Update Golang to release 1.19.4. Two CVE's were annouced in this z patch release.
-          CVE-2022-41720 only affects Windows environments and $productName$ runs in linux. The second one 
-          CVE-2022-41717 only affects HTTP/2 server connections exposed to external clients. $productName$ does 
-          not expose any Golang http servers to outside clients. The data-plane of Envoy
-          is not affected by either of these. 
-
-      - title: Update Golang to 1.19.3
-        type: security
-        body: >-
-          Updated Golang to the latest z patch. We are not vulnerable to the CVE-2022-3602 that was 
-          released in 1.19.3 and you can read more about it here: <https://medium.com/ambassador-api-gateway/ambassador-labs-security-impact-assessment-of-nov-1-openssl-golang-vulnerabilities-f11b5ec37a7e>.
-          Updating to the latest z patch as part of our normal dependency update process
-          and this will help reduce the noise of security scanners.
-
       - title: Add support for active health checking configuration.
         type: feature
         body: >-
@@ -71,7 +54,7 @@ items:
           If the upstream fails its configured health check then Envoy will mark the upstream as unhealthy and no longer send
           traffic to that upstream. Single pods within a group may can be marked as unhealthy. The healthy pods will continue to receive
           traffic normally while the unhealthy pods will not receive any traffic until they recover by passing the health check.
-      
+
       - title: Add environment variables to the healthcheck server.
         type: feature
         body: >-

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -32,6 +32,11 @@
 
 changelog: https://github.com/emissary-ingress/emissary/blob/$branch$/CHANGELOG.md
 items:
+  - version: 3.5.0
+    prevVersion: 3.4.0
+    date: 'TBD'
+    notes: []
+
   - version: 3.4.0
     prevVersion: 3.3.0
     date: '2023-01-03'


### PR DESCRIPTION
## Description

Prepares master for the next version (3.5.0) and pulls in the updated changelog from the `release/v3.4` branch. 

> once this lands here, it can be pulled into Edge Stack as well for preparing it for the next version as well.

## Related Issues
N/a

## Testing
CI is green.

**Note** - the check branch will likely fail until it is tagged properly which I will do once this lands on master.

## Checklist

- [ ] **Does my change need to be backported to a previous release?**
- [x] **I made sure to update `CHANGELOG.md`.**
- [x] **This is unlikely to impact how Ambassador performs at scale.**
- [x] **My change is adequately tested.**
- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**
- [x] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
