### PR TITLE
[CC]charts: add startupProbe to emissary-ingress deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,13 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
 
 ### Emissary-ingress and Ambassador Edge Stack
 
+- Change: emissary-ingress can be slow to start when there is a lot of mappings. Kubernetes
+  recommends using a startupProbe over tweaking the initialDelaySeconds of the livenessProbe and
+  readinessProbe. The Helm chart was updated to allow setting a startupProbe on the emissary-ingress
+  deployment. ([#4649])
+
+[#4649]: https://github.com/emissary-ingress/emissary/pull/4649
+
 ## [3.4.0] January 03, 2023
 [3.4.0]: https://github.com/emissary-ingress/emissary/compare/v3.3.0...v3.4.0
 

--- a/charts/emissary-ingress/CHANGELOG.md
+++ b/charts/emissary-ingress/CHANGELOG.md
@@ -6,6 +6,7 @@ numbering uses [semantic versioning](http://semver.org).
 ## v8.5.0 - TBD
 
 - Upgrade Emissary to v3.5.0 [CHANGELOG](https://github.com/emissary-ingress/emissary/blob/master/CHANGELOG.md)
+- Adds opt-in settings to configure a startupProbe for the Emissary-ingress pod
 
 ## v8.4.0 - 2022-01-03
 

--- a/charts/emissary-ingress/templates/deployment-canary.yaml
+++ b/charts/emissary-ingress/templates/deployment-canary.yaml
@@ -200,6 +200,13 @@ spec:
               path: /ambassador/v0/check_ready
               port: admin
             {{- toYaml .Values.readinessProbe | nindent 12 }}
+          {{- if .Values.startupProbe }}
+          startupProbe:
+            httpGet:
+              path: /ambassador/v0/check_ready
+              port: admin
+            {{- toYaml .Values.startupProbe | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: ambassador-pod-info
               mountPath: /tmp/ambassador-pod-info

--- a/charts/emissary-ingress/templates/deployment.yaml
+++ b/charts/emissary-ingress/templates/deployment.yaml
@@ -221,6 +221,13 @@ spec:
               path: /ambassador/v0/check_ready
               port: admin
             {{- toYaml .Values.readinessProbe | nindent 12 }}
+          {{- if .Values.startupProbe }}
+          startupProbe:
+            httpGet:
+              path: /ambassador/v0/check_ready
+              port: admin
+            {{- toYaml .Values.startupProbe | nindent 12 }}
+          {{- end }}
           {{- if .Values.lifecycle }}
           lifecycle:
             {{- toYaml .Values.lifecycle | nindent 12 }}

--- a/charts/emissary-ingress/values.yaml.in
+++ b/charts/emissary-ingress/values.yaml.in
@@ -258,12 +258,16 @@ livenessProbe: # +doc-gen:break
   periodSeconds: 3
   failureThreshold: 3
 
-# Liveness probe for emissary pods
+# Readiness probe for emissary pods
 readinessProbe: # +doc-gen:break
   initialDelaySeconds: 30
   periodSeconds: 3
   failureThreshold: 3
 
+# Startup probe for emissary pods
+startupProbe: {}
+# periodSeconds: 10
+# failureThreshold: 6
 
 volumes: []
 

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -35,7 +35,17 @@ items:
   - version: 3.5.0
     prevVersion: 3.4.0
     date: 'TBD'
-    notes: []
+    notes:
+      - title: Add support for startupProbe on the emissary-ingress deployments
+        type: change
+        body: >-
+          emissary-ingress can be slow to start when there is a lot of mappings. Kubernetes
+          recommends using a startupProbe over tweaking the initialDelaySeconds of the livenessProbe
+          and readinessProbe. The Helm chart was updated to allow setting a startupProbe on the
+          emissary-ingress deployment.
+        github:
+        - title: "#4649"
+          link: https://github.com/emissary-ingress/emissary/pull/4649
 
   - version: 3.4.0
     prevVersion: 3.3.0


### PR DESCRIPTION
## Description

I'm pulling in the a community-contribution for CI run. The original PR  can be found here https://github.com/emissary-ingress/emissary/pull/4649, with a rundown of what the PR does.

> emissary-ingress can be slow to start when the number of mappings grow. In that case, using a startupProbe is preferred over tweaking the initialDelaySeconds of the livenessProbe and readinessProbe.
> 
> startupProbe allow us to be generous with how long the pod takes to be ready, defined as `periodSeconds * failureThreshold`, but if it takes less time than allowed it will become ready faster (compared to having a high value for the initialDelaySeconds).
> 
> For example:
> - startupProbe set with periodSeconds=10 failureThreshold=30 = 5mins
> - livenessProbe/readinessProbe set with initialDelaySeconds=0
> 
> If the /check_ready endpoint returns OK after 2mins, the the startupProbe finish and the livenessProbe/readinessProbe immediatetly succeed, changing the pod state to live and ready.
> 
> If instead we didn't have the startupProbe but initialDelaySeconds was set to 300 (5min), the pod would always take 5min to be live and ready, even if /check_ready returns OK after 2mins.

## Related Issues

N/A

## Testing

CI and I will pull into AES to verify as well. General note to reviewers, we need to look over our helm chart tests and get a better handle on them, (in the future).

## Checklist

- [ ] **Does my change need to be backported to a previous release?**
- [x] **I made sure to update `CHANGELOG.md`.**
- [x] **This is unlikely to impact how Ambassador performs at scale.**
    The feature is opt-in so by default it will not get added unless a user actively attempts to add it.
- [x] **My change is adequately tested.**
- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**
- [x] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
