### PR TITLE
Pinning build dependency version

### DIFF
--- a/docker/base-python/Dockerfile
+++ b/docker/base-python/Dockerfile
@@ -75,7 +75,8 @@ RUN apk --no-cache add \
 # https://github.com/jazzband/pip-tools/#versions-and-compatibility to
 # select a pip-tools version that corresponds to the 'py3-pip' and
 # 'python3' versions above.
-RUN pip3 install pip-tools==6.12.1
+# Pinning build version due to missing license info from pip show in newer versions
+RUN pip3 install pip-tools==6.12.1 build==0.9.0
 
 RUN curl --fail -L https://dl.google.com/go/go1.19.4.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 


### PR DESCRIPTION
Signed-off-by: Tenshin Higashi <thigashi@datawire.io>

## Description

The purpose of this PR is to pin the `build` dependency to version 0.9.0. 

`build` version 0.10.0 omitted its license info from `pip show` which `py-mkopensource` relies on to generate `DEPENDENCIES.md`. Pinning `build` to an older version allows us to properly generate `DEPENDENCIES.md` on python 3.10. 

## Related Issues

List related issues.

## Testing

A few sentences describing what testing you've done, e.g., manual tests, automated tests, deployed in production, etc.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->
- [ ] **Does my change need to be backported to a previous release?**
  - What backport versions were discussed with the Maintainers in the Issue?

- [ ] **I made sure to update `CHANGELOG.md`.**

   Remember, the CHANGELOG needs to mention:
  - Any new features
  - Any changes to our included version of Envoy
  - Any non-backward-compatible changes
  - Any deprecations

- [ x ] **This is unlikely to impact how Ambassador performs at scale.**

   Remember, things that might have an impact at scale include:
  - Any significant changes in memory use that might require adjusting the memory limits
  - Any significant changes in CPU use that might require adjusting the CPU limits
  - Anything that might change how many replicas users should use
  - Changes that impact data-plane latency/scalability

- [ ] **My change is adequately tested.**

   Remember when considering testing:
  - Your change needs to be specifically covered by tests.
    - Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
  - You also need to make sure that the _entire area being changed_ has adequate test coverage.
    - If existing tests don't actually cover the entire area being changed, add tests.
    - This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
  - We should lean on the bulk of code being covered by unit tests, but...
  - ... an end-to-end test should cover the integration points

- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**

- [ ] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
