### PR TITLE
Add a feature to IngressProcessor to resolve named ports

### DIFF
--- a/python/ambassador/fetch/dependency.py
+++ b/python/ambassador/fetch/dependency.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from typing import (
     Any,
     Collection,
+    Dict,
     Iterator,
     Mapping,
     MutableSet,
@@ -13,7 +14,7 @@ from typing import (
     TypeVar,
 )
 
-from .k8sobject import KubernetesObject
+from .k8sobject import KubernetesObjectKey, KubernetesObject
 
 
 class Dependency(Protocol):
@@ -35,9 +36,11 @@ class ServiceDependency(Dependency):
     """
 
     ambassador_service: Optional[KubernetesObject]
+    discovered_services: Dict[KubernetesObjectKey, KubernetesObject]
 
     def __init__(self) -> None:
         self.ambassador_service = None
+        self.discovered_services = {}
 
     def watt_key(self) -> str:
         return "service"

--- a/python/ambassador/fetch/dependency.py
+++ b/python/ambassador/fetch/dependency.py
@@ -14,7 +14,7 @@ from typing import (
     TypeVar,
 )
 
-from .k8sobject import KubernetesObjectKey, KubernetesObject
+from .k8sobject import KubernetesObject, KubernetesObjectKey
 
 
 class Dependency(Protocol):

--- a/python/ambassador/fetch/ingress.py
+++ b/python/ambassador/fetch/ingress.py
@@ -104,19 +104,19 @@ class IngressProcessor(ManagedKubernetesProcessor):
                 f"Not reconciling Ingress {obj.name}: observed and current statuses are in sync"
             )
 
-    def _resolve_service_port_number(self, namespaceName, serviceName, servicePort):
+    def _resolve_service_port_number(self, namespace, service_name, service_port):
         for k8s_svc in self.service_dep.discovered_services.values():
             key = f'{k8s_svc.name}.{k8s_svc.namespace}'
 
-            if key != f'{serviceName}.{namespaceName}':
+            if key != f'{service_name}.{namespace}':
                 continue
 
             for port in k8s_svc.spec.get('ports', []):
-                if servicePort == port.get('name', None):
-                    return port.get('port', servicePort)
-            self.logger.debug(f"Could not resolve port '{servicePort}' for service '{key}'")
+                if service_port == port.get('name', None):
+                    return port.get('port', service_port)
+            self.logger.debug(f"Could not resolve port '{service_port}' for service '{key}'")
 
-        return servicePort
+        return service_port
 
     def _process(self, obj: KubernetesObject) -> None:
         ingress_class_name = obj.spec.get("ingressClassName", "")

--- a/python/ambassador/fetch/ingress.py
+++ b/python/ambassador/fetch/ingress.py
@@ -104,7 +104,7 @@ class IngressProcessor(ManagedKubernetesProcessor):
                 f"Not reconciling Ingress {obj.name}: observed and current statuses are in sync"
             )
 
-    def _resolve_service_port_number(self, namespace, service_name, service_port):
+    def _try_resolve_service_port_number(self, namespace, service_name, service_port):
         self.logger.debug(f"Resolving named port '{service_port}' in service '{service_name}'")
 
         key = KubernetesObjectKey(KubernetesGVK("v1", "Service"), namespace, service_name)
@@ -241,7 +241,7 @@ class IngressProcessor(ManagedKubernetesProcessor):
                 try:
                     service_port = int(service_port)
                 except:
-                    service_port = self._resolve_service_port_number(
+                    service_port = self._try_resolve_service_port_number(
                         obj.namespace, service_name, service_port
                     )
 

--- a/python/ambassador/fetch/ingress.py
+++ b/python/ambassador/fetch/ingress.py
@@ -106,14 +106,14 @@ class IngressProcessor(ManagedKubernetesProcessor):
 
     def _resolve_service_port_number(self, namespace, service_name, service_port):
         for k8s_svc in self.service_dep.discovered_services.values():
-            key = f'{k8s_svc.name}.{k8s_svc.namespace}'
+            key = f"{k8s_svc.name}.{k8s_svc.namespace}"
 
-            if key != f'{service_name}.{namespace}':
+            if key != f"{service_name}.{namespace}":
                 continue
 
-            for port in k8s_svc.spec.get('ports', []):
-                if service_port == port.get('name', None):
-                    return port.get('port', service_port)
+            for port in k8s_svc.spec.get("ports", []):
+                if service_port == port.get("name", None):
+                    return port.get("port", service_port)
             self.logger.debug(f"Could not resolve port '{service_port}' for service '{key}'")
 
         return service_port
@@ -238,7 +238,9 @@ class IngressProcessor(ManagedKubernetesProcessor):
                 try:
                     service_port = int(service_port)
                 except:
-                    service_port = self._resolve_service_port_number(obj.namespace, service_name, service_port)
+                    service_port = self._resolve_service_port_number(
+                        obj.namespace, service_name, service_port
+                    )
 
                 if not service_name or not service_port or not path_location:
                     continue

--- a/python/ambassador/fetch/service.py
+++ b/python/ambassador/fetch/service.py
@@ -257,7 +257,7 @@ class ServiceProcessor(ManagedKubernetesProcessor):
         # self.logger.debug("==== FINALIZE START\n%s" % dump_json(od, pretty=True))
 
         for k8s_svc in self.service_dep.discovered_services.values():
-            key = f'{k8s_svc.name}.{k8s_svc.namespace}'
+            key = f"{k8s_svc.name}.{k8s_svc.namespace}"
 
             target_ports = {}
             target_addrs = []

--- a/python/ambassador/fetch/service.py
+++ b/python/ambassador/fetch/service.py
@@ -40,14 +40,12 @@ class InternalServiceProcessor(ManagedKubernetesProcessor):
 
     service_dep: ServiceDependency
     helm_chart: Optional[str]
-    discovered_services: Dict[KubernetesObjectKey, KubernetesObject]
 
     def __init__(self, manager: ResourceManager) -> None:
         super().__init__(manager)
 
         self.service_dep = self.deps.provide(ServiceDependency)
         self.helm_chart = None
-        self.discovered_services = {}
 
     def kinds(self) -> FrozenSet[KubernetesGVK]:
         return frozenset([KubernetesGVK("v1", "Service")])
@@ -93,7 +91,7 @@ class InternalServiceProcessor(ManagedKubernetesProcessor):
                 f"not saving Kubernetes Service {obj.name}.{obj.namespace} with no ports"
             )
         else:
-            self.discovered_services[obj.key] = obj
+            self.service_dep.discovered_services[obj.key] = obj
 
             if self._is_ambassador_service(obj):
                 self.logger.debug(f"Found Ambassador service: {obj.name}")
@@ -204,6 +202,7 @@ class ServiceProcessor(ManagedKubernetesProcessor):
     Ambassador service resources.
     """
 
+    service_dep: ServiceDependency
     services: InternalServiceProcessor
     endpoints: InternalEndpointsProcessor
     delegate: AggregateKubernetesProcessor
@@ -212,6 +211,7 @@ class ServiceProcessor(ManagedKubernetesProcessor):
     def __init__(self, manager: ResourceManager, watch_only: bool = False):
         super().__init__(manager)
 
+        self.service_dep = self.deps.want(ServiceDependency)
         self.services = InternalServiceProcessor(manager)
         self.endpoints = InternalEndpointsProcessor(manager)
         self.delegate = AggregateKubernetesProcessor([self.services, self.endpoints])
@@ -226,7 +226,7 @@ class ServiceProcessor(ManagedKubernetesProcessor):
     def finalize(self) -> None:
         self.delegate.finalize()
 
-        # The point here is to sort out self.services.discovered_services and
+        # The point here is to sort out self.service_dep.discovered_services and
         # self.endpoints.discovered_endpoints and turn them into proper
         # Ambassador Service resources. This is a bit annoying, because of the
         # annoyances of Kubernetes, but we'll give it a go.
@@ -251,13 +251,13 @@ class ServiceProcessor(ManagedKubernetesProcessor):
         # od = {
         #     'elements': [ x.as_dict() for x in self.elements ],
         #     'k8s_endpoints': self.endpoints.discovered_endpoints,
-        #     'k8s_services': self.services.discovered_services,
+        #     'k8s_services': self.service_dep.discovered_services,
         # }
         #
         # self.logger.debug("==== FINALIZE START\n%s" % dump_json(od, pretty=True))
 
-        for k8s_svc in self.services.discovered_services.values():
-            key = f"{k8s_svc.name}.{k8s_svc.namespace}"
+        for k8s_svc in self.service_dep.discovered_services.values():
+            key = f'{k8s_svc.name}.{k8s_svc.namespace}'
 
             target_ports = {}
             target_addrs = []

--- a/python/tests/unit/test_fetch.py
+++ b/python/tests/unit/test_fetch.py
@@ -331,7 +331,6 @@ status:
         assert len(mappings) == 1
 
         mapping = next(iter(mappings.values()))
-        assert mapping.apiVersion == valid_mapping_v1.gvk.api_version
         assert mapping.name == "quote-0-0"
         assert mapping.namespace == "default"
         assert mapping.prefix == "/"

--- a/python/tests/unit/test_fetch.py
+++ b/python/tests/unit/test_fetch.py
@@ -280,7 +280,7 @@ class TestAmbassadorProcessor:
         assert mapping.service == valid_mapping_v1.spec["service"]
 
     def test_ingress_with_named_port(self):
-        yaml = '''
+        yaml = """
 ---
 apiVersion: v1
 kind: Service
@@ -316,7 +316,7 @@ spec:
         pathType: ImplementationSpecific
 status:
   loadBalancer: {}
-'''
+"""
         aconf = Config()
         fetcher = ResourceFetcher(logger, aconf)
         fetcher.parse_yaml(yaml, True)
@@ -327,7 +327,7 @@ status:
         aconf.load_all(fetcher.sorted())
         assert len(aconf.errors) == 0
 
-        mappings = aconf.get_config('mappings')
+        mappings = aconf.get_config("mappings")
         assert len(mappings) == 1
 
         mapping = next(iter(mappings.values()))

--- a/python/tests/unit/test_fetch.py
+++ b/python/tests/unit/test_fetch.py
@@ -328,6 +328,7 @@ status:
         assert len(aconf.errors) == 0
 
         mappings = aconf.get_config("mappings")
+        assert mappings
         assert len(mappings) == 1
 
         mapping = next(iter(mappings.values()))

--- a/python/tests/unit/test_fetch.py
+++ b/python/tests/unit/test_fetch.py
@@ -12,6 +12,7 @@ logging.basicConfig(
 logger = logging.getLogger("ambassador")
 
 from ambassador import Config
+from ambassador.fetch import ResourceFetcher
 from ambassador.fetch.ambassador import AmbassadorProcessor
 from ambassador.fetch.dependency import (
     DependencyManager,
@@ -277,6 +278,64 @@ class TestAmbassadorProcessor:
         assert mapping.namespace == valid_mapping_v1.namespace
         assert mapping.prefix == valid_mapping_v1.spec["prefix"]
         assert mapping.service == valid_mapping_v1.spec["service"]
+
+    def test_ingress_with_named_port(self):
+        yaml = '''
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: quote
+  namespace: default
+spec:
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 3000
+    protocol: TCP
+    targetPort: 3000
+  selector:
+    app: quote
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    getambassador.io/ambassador-id: default
+    kubernetes.io/ingress.class: ambassador
+  name: quote
+  namespace: default
+spec:
+  rules:
+  - http:
+      paths:
+      - backend:
+          serviceName: quote
+          servicePort: http
+        path: /
+        pathType: ImplementationSpecific
+status:
+  loadBalancer: {}
+'''
+        aconf = Config()
+        fetcher = ResourceFetcher(logger, aconf)
+        fetcher.parse_yaml(yaml, True)
+
+        mgr = fetcher.manager
+        assert len(mgr.elements) == 2
+
+        aconf.load_all(fetcher.sorted())
+        assert len(aconf.errors) == 0
+
+        mappings = aconf.get_config('mappings')
+        assert len(mappings) == 1
+
+        mapping = next(iter(mappings.values()))
+        assert mapping.apiVersion == valid_mapping_v1.gvk.api_version
+        assert mapping.name == "quote-0-0"
+        assert mapping.namespace == "default"
+        assert mapping.prefix == "/"
+        assert mapping.service == "quote.default:3000"
 
 
 class TestAggregateKubernetesProcessor:


### PR DESCRIPTION
## Problem statement

The Ingress processor ignores the named service port and replaces it with `80`. 

## Related Issues

closes #4322

## Testing

Added a test case to `test_fetcher.py`

## Checklist

- [x] **Does my change need to be backported to a previous release?**
  - would be nice to backport this to v2.4 as well (#4810)

- [ ] **I made sure to update `CHANGELOG.md`.**
- [x] **This is unlikely to impact how Ambassador performs at scale.**
- [x] **My change is adequately tested.**
- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**
- [ ] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
