### PR TITLE
fix: hostname port issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,12 +90,18 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
 
 ### Emissary-ingress and Ambassador Edge Stack
 
-- Change: emissary-ingress can be slow to start when there is a lot of mappings. Kubernetes
-  recommends using a startupProbe over tweaking the initialDelaySeconds of the livenessProbe and
-  readinessProbe. The Helm chart was updated to allow setting a startupProbe on the emissary-ingress
-  deployment. ([#4649])
+- Bugfix: When wanting to expose traffic to clients on ports other than 80/443, users will set a
+  port in the Host.hostname (eg.`Host.hostname=example.com:8500`. The config generated allowed
+  matching on the :authority header. This worked in v1.Y series due to the way emissary was
+  generating Envoy configuration under a single wild-card virtual_host and matching on
+  :authority.
 
-[#4649]: https://github.com/emissary-ingress/emissary/pull/4649
+  In v2.Y/v3.Y+, the way emissary generates Envoy configuration changed to address
+  memory pressure and improve route lookup speed in Envoy. However, when including a port in the
+  hostname, an incorrect configuration  was generated with an sni match including the port. This has
+  been fixed and the correct envoy configuration is being generated. ([fix: hostname port issue])
+
+[fix: hostname port issue]: https://github.com/emissary-ingress/emissary/pull/4816
 
 ## [3.4.0] January 03, 2023
 [3.4.0]: https://github.com/emissary-ingress/emissary/compare/v3.3.0...v3.4.0

--- a/charts/emissary-ingress/CHANGELOG.md
+++ b/charts/emissary-ingress/CHANGELOG.md
@@ -6,7 +6,9 @@ numbering uses [semantic versioning](http://semver.org).
 ## v8.5.0 - TBD
 
 - Upgrade Emissary to v3.5.0 [CHANGELOG](https://github.com/emissary-ingress/emissary/blob/master/CHANGELOG.md)
-- Adds opt-in settings to configure a startupProbe for the Emissary-ingress pod
+- Adds support for configuring a startupProbe on the emissary-ingress deployments. This is useful when a larger number of resources
+  are used and the initial startup needs additional time. See for details https://github.com/emissary-ingress/emissary/pull/4649.
+
 
 ## v8.4.0 - 2022-01-03
 

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -36,16 +36,23 @@ items:
     prevVersion: 3.4.0
     date: 'TBD'
     notes:
-      - title: Add support for startupProbe on the emissary-ingress deployments
-        type: change
+      - title: Fix envoy config generation when including port in Host.hostname
+        type: bugfix
         body: >-
-          emissary-ingress can be slow to start when there is a lot of mappings. Kubernetes
-          recommends using a startupProbe over tweaking the initialDelaySeconds of the livenessProbe
-          and readinessProbe. The Helm chart was updated to allow setting a startupProbe on the
-          emissary-ingress deployment.
+          When wanting to expose traffic to clients on ports other than 80/443, users will set
+          a port in the Host.hostname (eg.<code>Host.hostname=example.com:8500</code>. The config
+          generated allowed matching on the :authority header. This worked in v1.Y series due to the
+          way emissary was generating Envoy configuration under a single wild-card virtual_host and matching
+          on :authority.
+
+          
+          In v2.Y/v3.Y+, the way emissary generates Envoy configuration changed to address memory pressure and improve
+          route lookup speed in Envoy. However, when including a port in the hostname, an incorrect configuration  was
+          generated with an sni match including the port. This has been fixed and the correct envoy configuration is
+          being generated.
         github:
-        - title: "#4649"
-          link: https://github.com/emissary-ingress/emissary/pull/4649
+        - title: "fix: hostname port issue"
+          link: https://github.com/emissary-ingress/emissary/pull/4816
 
   - version: 3.4.0
     prevVersion: 3.3.0

--- a/python/ambassador/envoy/v3/v3listener.py
+++ b/python/ambassador/envoy/v3/v3listener.py
@@ -89,7 +89,7 @@ class V3Chain:
         hostname = tcpmapping.get("host", "*")
 
         if self.context:
-            self.server_names.add(server_name)
+            self.server_names.add(hostname)
 
         self.hosts[hostname] = tcpmapping
 

--- a/python/ambassador/envoy/v3/v3listener.py
+++ b/python/ambassador/envoy/v3/v3listener.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 import logging
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Set, Tuple, Union
 from typing import cast as typecast
 
 from ...ir.irhost import IRHost
@@ -50,10 +50,12 @@ class V3Chain:
     _logger: logging.Logger
     _log_debug: bool
 
-    # We can have multiple hosts here, primarily so that cleartext HTTP chains can DTRT.
     context: Optional["IRTLSContext"]
     hosts: Dict[str, Union[IRHost, IRTCPMappingGroup]]
-    routes: List[DictifiedV3Route]
+    # unique set of sni names to match on chain if terminating TLS
+    server_names: Set[str]
+    # routes is keyed on a per virtual_host.domain and with routes only matching a vhost
+    routes: Dict[str, List[DictifiedV3Route]]
 
     def __init__(self, config: "V3Config", context: Optional["IRTLSContext"]) -> None:
         self._config = config
@@ -62,7 +64,8 @@ class V3Chain:
 
         self.context = context
         self.hosts = {}
-        self.routes = []
+        self.server_names = set([])
+        self.routes = {}
 
     def add_tcphost(self, tcpmapping: IRTCPMappingGroup) -> None:
         if self._log_debug:
@@ -71,41 +74,65 @@ class V3Chain:
             )
 
         if len(self.hosts) > 0:
-            # If we have SNI, then each host gets its own chain, so we should never have more than 1
-            # self.hosts; if we don't have SNI then a single TLSContext takes over the entire chain
-            # and so we shouldn't have more than 1 self.hosts then either.
+            # If we have SNI, then each tcp host gets its own Filter Chain, so we should never have more than 1
+            # entry in self.hosts; if we don't have SNI then a single FilterChain with no filter_chain_match
+            # takes over the entire chain and so we still should not have more than 1 self.hosts then either.
             other = next(iter(self.hosts.values()))
             other_type = "TCPMapping" if isinstance(other, IRTCPMappingGroup) else "Host"
             tcpmapping.post_error(
-                "TCPMapping {tcpmapping.name}: discarding because it conflicts with {other_type} {other.name}"
+                f"TCPMapping {tcpmapping.name}: discarding because it conflicts with {other_type} {other.name}"
             )
             return
 
-        self.hosts[tcpmapping.get("host") or "*"] = tcpmapping
+        hostname = tcpmapping.get("host", "*")
+
+        if self.context:
+            server_name = hostname.rsplit(":", 1)[0]
+            self.server_names.add(server_name)
+
+        self.hosts[hostname] = tcpmapping
 
     def add_httphost(self, host: IRHost) -> None:
         if self._log_debug:
-            self._logger.debug(f"      CHAIN UPDATE: add HTTP host: hostname={repr(host.hostname)}")
+            self._logger.debug(
+                f"      CHAIN UPDATE: add HTTP virtual host: hostname={repr(host.hostname)}"
+            )
 
-        if self.context:
-            # If we have SNI, then each host gets its own chain, so we should never have more than 1
-            # self.hosts
-            if len(self.hosts) > 0:
-                other = next(iter(self.hosts.values()))
-                other_type = "TCPMapping" if isinstance(other, IRTCPMappingGroup) else "Host"
+        error_prefix = "TLS Host" if self.context else "Cleartext Host"
+
+        # we need to make sure this chain isn't already owned by TCPMapping
+        for other in self.hosts.values():
+            # if a TCPMapping is already claiming this filter_chain then we give it precedence and will drop this http host
+            if isinstance(other, IRTCPMappingGroup):
                 host.post_error(
-                    "TLS Host {host.name}: discarding because it conflicts with {other_type} {other.name}"
+                    f"{error_prefix} {host.name}: discarding because it conflicts with TCPMapping {other.name}"
                 )
                 return
-        else:
-            # If we don't have SNI then a single TLSContext takes over the entire chain.
-            for other in self.hosts.values():
-                if isinstance(other, IRTCPMappingGroup):
-                    host.post_error(
-                        "Cleartext Host {host.name}: discarding because it conflicts with TCPMapping {other.name}"
-                    )
-                    return
 
+        if self.context:
+            if not host.context:
+                host.post_error(
+                    f"{error_prefix} {host.name}: discarding because host is missing TLSContext"
+                )
+                return
+
+            # In most TLS scenarios a single Host will translate into a single Filter Chain and virtual host. However,
+            # when a user wants to allow clients to access the same dns hostname (example.com) on multiple ports like the
+            # standard https port of 443 and a non standard port like 8500. Then Hosts can be merged together on a single
+            # Filter Chain with multiple virtual hosts. However, we can only group them if they are using the same TLS Contexts
+            # because if they were not we wouldn't know which settings to take from which hosts.
+            if (
+                self.context.name != host.context.name
+                or self.context.namespace != host.context.namespace
+            ):
+                host.post_error(
+                    f"{error_prefix} {host.name}: discarding because mismatching TLSContext between Hosts matching on dns hostname={host.sni}"
+                )
+                return
+
+            self.server_names.add(host.sni)
+
+        self.routes[host.hostname] = []
         self.hosts[host.hostname] = host
 
     def hostglobs(self) -> List[str]:
@@ -120,8 +147,16 @@ class V3Chain:
                 rv.append(host)
         return rv
 
-    def add_route(self, route: DictifiedV3Route) -> None:
-        self.routes.append(route)
+    def add_route(self, virtual_host: str, route: DictifiedV3Route) -> None:
+        """
+        add_route will add the route to the matching virtual host. If the
+        virtual_host doesn't already exist in routes then we initialize an
+        empty list and append the route
+        """
+        if virtual_host not in self.routes:
+            self.routes[virtual_host] = []
+
+        self.routes[virtual_host].append(route)
 
     def __str__(self) -> str:
         ctxstr = f" ctx {self.context.name}" if self.context else ""
@@ -270,6 +305,7 @@ class V3Listener:
         chain_type: Literal["tcp", "http", "https"],
         context: Optional["IRTLSContext"],
         hostname: str,
+        sni: str,
     ) -> V3Chain:
         # Add a chain for a specific Host to this listener, while dealing with the fundamental
         # asymmetry that filter_chain_match can - and should - use SNI whenever the chain has
@@ -290,15 +326,9 @@ class V3Listener:
 
         hostname = hostname or "*"
 
-        chain_key = "tls" if context else "cleartext"
-        # I (LukeShu) can't really give an explanation of why `or chain_type == 'http'` belongs in
-        # this expression (it's what the above comment "we can - and do - separate HTTP chains into
-        # specific domains" is referring to), other than that it needs to be here in order for
-        # compute_routes() to work correctly.  Maybe that's bad and we should go fix
-        # compute_routes() and remove `or chain_type = 'http'`... I'd have to study compute_routes()
-        # a lot more in order to be able to answer that; but in the mean time, including it in the
-        # expression keeps things working.
-        if context or chain_type == "http":
+        chain_key = f"tls-{sni}" if context else "cleartext"
+
+        if chain_type == "http":
             chain_key += f"-{hostname}"
 
         chain = self._chains.get(chain_key)
@@ -306,9 +336,10 @@ class V3Listener:
         if chain is None:
             chain = V3Chain(self.config, context)
             self._chains[chain_key] = chain
+
         if self._log_debug:
             self.config.ir.logger.debug(
-                f"      CHAIN {verb}: tls={bool(context)} host={repr(hostname)} => chains[{repr(chain_key)}]={chain}"
+                f"      CHAIN {verb}: tls={bool(context)} host={repr(hostname)} sni={repr(sni)} => chains[{repr(chain_key)}]={repr(chain)}"
             )
 
         return chain
@@ -620,7 +651,7 @@ class V3Listener:
 
         if self._base_http_config:
             self.compute_httpchains()
-            self.compute_routes()
+            self.compute_http_routes()
             self.finalize_http()
 
     def finalize_tcp(self) -> None:
@@ -659,14 +690,9 @@ class V3Listener:
                     "filters": [tcp_filter],
                 }
 
-                # The chain as a whole has a single matcher.
                 filter_chain_match: Dict[str, Any] = {}
 
-                chain_hosts = chain.hostglobs()
-
-                # If we have a context...
                 if chain.context:
-                    # ...then we can ask for TLS.
                     filter_chain_match["transport_protocol"] = "tls"
 
                     # Note that we're modifying the filter_chain itself here, not
@@ -684,29 +710,25 @@ class V3Listener:
                 # We do server-name matching whether or not we have TLS, just to help
                 # make sure that we don't have two chains with an empty filter_match
                 # criterion (since Envoy will reject such a configuration).
+                server_names = list(chain.server_names)
 
-                if len(chain_hosts) > 0 and ("*" not in chain_hosts):
-                    filter_chain_match["server_names"] = chain_hosts
+                if len(server_names) > 0 and ("*" not in server_names):
+                    filter_chain_match["server_names"] = server_names
 
-                # Once all of that is done, hook in the match...
                 filter_chain["filter_chain_match"] = filter_chain_match
 
-                # ...and stick this chain into our filter.
                 self._filter_chains.append(filter_chain)
 
     def compute_tcpchains(self) -> None:
         self.config.ir.logger.debug("  compute_tcpchains")
 
         for irgroup in self.config.ir.ordered_groups():
-            # Only look at TCPMappingGroups here...
             if not isinstance(irgroup, IRTCPMappingGroup):
                 continue
 
             if self._log_debug:
                 self.config.ir.logger.debug(f"    consider {irgroup}")
 
-            # ...and make sure the group in question wants the same bind
-            # address that we do.
             if irgroup.bind_to() != self.bind_to:
                 self.config.ir.logger.debug("      reject")
                 continue
@@ -721,13 +743,15 @@ class V3Listener:
             if not group_host:  # cleartext
                 # Special case. No Host in a TCPMapping means an unconditional forward,
                 # so just add this immediately as a "*" chain.
-                self.add_chain("tcp", None, "*").add_tcphost(irgroup)
+                self.add_chain("tcp", None, "*", "*").add_tcphost(irgroup)
             else:  # TLS/SNI
                 context = tlscontext_for_tcpmapping(irgroup, self.config)
                 if not context:
                     irgroup.post_error("No matching TLSContext found, disabling!")
                     continue
-                self.add_chain("tcp", context, group_host).add_tcphost(irgroup)
+
+                sni = group_host.rsplit(":", 1)[0] if group_host else "*"
+                self.add_chain("tcp", context, group_host, group_host).add_tcphost(irgroup)
 
     def compute_httpchains(self) -> None:
         # Compute the set of chains we need, HTTP version. The core here is matching
@@ -772,15 +796,15 @@ class V3Listener:
                 and (not ((self._security_model == "SECURE") and host_will_reject_secure))
             ):
                 self.config.ir.logger.debug("      accept SECURE")
-                self.add_chain("https", host.context, host.hostname).add_httphost(host)
+                self.add_chain("https", host.context, host.hostname, host.sni).add_httphost(host)
 
             # Same idea on the insecure side: only skip the Host if the Listener's securityModel
             # is INSECURE but the Host's insecure_action is Reject.
             if not ((self._security_model == "INSECURE") and (host.insecure_action == "Reject")):
                 self.config.ir.logger.debug("      accept INSECURE")
-                self.add_chain("http", None, host.hostname).add_httphost(host)
+                self.add_chain("http", None, host.hostname, host.sni).add_httphost(host)
 
-    def compute_routes(self) -> None:
+    def compute_http_routes(self) -> None:
         # Compute the set of valid HTTP routes for _each chain_ in this Listener.
         #
         # Note that a route using XFP can match _any_ chain, whether HTTP or HTTPS.
@@ -827,7 +851,7 @@ class V3Listener:
                     # as the insecure world, depending on what the action is exactly (and note
                     # that, yes, we can have an action of None for an insecure_only listener).
                     #
-                    # "candidates" is host, matcher, action, V3RouteVariants
+                    # "candidates" is a list of tuples (host, matcher, action, V3RouteVariants)
                     candidates: List[Tuple[IRHost, str, str, V3RouteVariants]] = []
                     hostname = host.hostname
 
@@ -881,7 +905,8 @@ class V3Listener:
 
                             variant = dict(rv.get_variant(matcher, action.lower()))
                             variant["_host_constraints"] = set([hostname])
-                            chain.add_route(variant)
+                            # virtual_host domains are key by the hostname for :authority header matching
+                            chain.add_route(hostname, variant)
                         else:
                             if self._log_debug:
                                 self.config.ir.logger.debug(
@@ -898,20 +923,29 @@ class V3Listener:
 
                 self.config.ir.logger.debug("      punching a hole for ACME")
 
-                # Make sure to include _host_constraints in here for now so it can be
-                # applied to the correct vhost during future proccessing
-                chain.routes.insert(
-                    0,
-                    {
-                        "_host_constraints": set(),
-                        "match": {"case_sensitive": True, "prefix": "/.well-known/acme-challenge/"},
-                        "direct_response": {"status": 404},
-                    },
-                )
+                # we need to make sure the acme route is added to every virtual host domain
+                # so we must insert the route into each unique domains list of routes
+                for hostname in chain.hosts:
+                    # Make sure to include _host_constraints in here for now so it can be
+                    # applied to the correct vhost during future proccessing
+                    chain.routes[hostname].insert(
+                        0,
+                        {
+                            "_host_constraints": set(),
+                            "match": {
+                                "case_sensitive": True,
+                                "prefix": "/.well-known/acme-challenge/",
+                            },
+                            "direct_response": {"status": 404},
+                        },
+                    )
 
             if self._log_debug:
-                for route in chain.routes:
-                    self.config.ir.logger.debug("  CHAIN ROUTE: %s" % v3prettyroute(route))
+                for hostname in chain.hosts:
+                    for route in chain.routes[hostname]:
+                        self.config.ir.logger.debug(
+                            f"  CHAIN ROUTE: vhost={hostname} {v3prettyroute(route)}"
+                        )
 
     def finalize_http(self) -> None:
         # Finalize everything HTTP. Like the TCP side of the world, this is about walking
@@ -980,10 +1014,13 @@ class V3Listener:
                 }
                 filter_chain_match: Dict[str, Any] = {}
 
-                chain_hosts = chain.hostglobs()
+                server_names = list(chain.server_names)
 
                 if self._log_debug:
-                    self._irlistener.logger.debug(f"      tls for hostglobs={chain_hosts}")
+                    chain_hosts = chain.hostglobs()
+                    self._irlistener.logger.debug(
+                        f"      tls for hostglobs={chain_hosts} matched with server_names={server_names}"
+                    )
 
                 # Set up the server_names part of the match, if we have any names.
                 #
@@ -996,11 +1033,11 @@ class V3Listener:
                 #
                 # server_names: [ "foo.example.com" ]
                 #
-                # So, if "*" is present at all in our chain_hosts, we can't match server_names
+                # So, if "*" is present at all in our server_names, we can't match server_names
                 # at all.
 
-                if (len(chain_hosts) > 0) and ("*" not in chain_hosts):
-                    filter_chain_match["server_names"] = chain_hosts
+                if (len(server_names) > 0) and ("*" not in server_names):
+                    filter_chain_match["server_names"] = server_names
 
                 # Likewise, an HTTPS chain will ask for TLS or QUIC (when udp)
                 filter_chain_match["transport_protocol"] = (
@@ -1047,7 +1084,7 @@ class V3Listener:
                 # configuration.
                 routes = []
 
-                for r in chain.routes:
+                for r in chain.routes[host.hostname]:
                     routes.append({k: v for k, v in r.items() if k[0] != "_"})
 
                 # Do we - somehow - already have a vhost for this hostname? (This should
@@ -1185,8 +1222,11 @@ class V3Listener:
                     for k in sorted(v3listener._chains.keys()):
                         chain = v3listener._chains[k]
                         config.ir.logger.debug(f"  chain {chain}")
-                        for r in chain.routes:
-                            config.ir.logger.debug(f"    route {v3prettyroute(r)}")
+                        for hostname in chain.hosts:
+                            config.ir.logger.debug(f"    host {hostname}")
+                            routes = chain.routes.get(hostname, [])
+                            for r in routes:
+                                config.ir.logger.debug(f"      route {v3prettyroute(r)}")
 
             # Does this listener have any filter chains?
             if v3listener._filter_chains:

--- a/python/ambassador/ir/irhost.py
+++ b/python/ambassador/ir/irhost.py
@@ -207,7 +207,7 @@ class IRHost(IRResource):
                             name=ctx_name,
                             namespace=self.namespace,
                             location=self.location,
-                            hosts=[self.hostname or self.name],
+                            hosts=[self.hostname],
                             secret=tls_full_name,
                         )
 
@@ -259,7 +259,7 @@ class IRHost(IRResource):
                             name=ctx_name,
                             namespace=self.namespace,
                             location=self.location,
-                            hosts=[self.hostname or self.name],
+                            hosts=[self.hostname],
                             secret=tls_full_name,
                         )
 
@@ -394,17 +394,17 @@ class IRHost(IRResource):
         # TLS config is good, let's make sure the hosts line up too.
         context_hosts = ctx.get("hosts")
 
-        host_hosts = []
-
-        if self.hostname:
-            host_hosts.append(self.hostname)
+        # Technically a user can set the TLSContext.hosts to include a Host.name thus allowing it to pass
+        # the validation and saved as the context for this Host. Although, this is not intended
+        # or documented behavior it, removing it could break users so we need to mark it as deprecated.
+        # @deprecated - validating TLSContext.hosts against Host.name will be removed, use hostname for matching instead.
+        host_hosts = [self.hostname, self.name]
 
         if context_hosts:
             is_valid_hosts = False
 
             # we exact match here, which requires users being explicit about whether a TLSContext can attach
-            # to a Host. Potentially, a nicer UX would be to do glob matching but this would be a breaking change.
-            # The closest we have is to exclude `host` on the TLSContext so that it can attach to all Host.
+            # to a Host. Note: this does not do hostname glob matching.
             for host_tc in context_hosts:
                 if host_tc in host_hosts:
                     is_valid_hosts = True

--- a/python/tests/unit/test_hostglob_matches.py
+++ b/python/tests/unit/test_hostglob_matches.py
@@ -53,6 +53,15 @@ def test_hostglob_matches():
         ("*.example.com", "a.b.example.*", True),
         ("*.example.baz.com", "a.b.example.*", True),
         ("*.foo.bar", "baz.zing.*", True),
+        # The Host.hostname is overloaded in that it determines the SNI for TLS and the
+        # virtual host name for :authority header matching for HTTP. These are valid
+        # scenarios that users try when using non-standard ports so we make sure they work.
+        ("*.local:8500", "quote.local", False),
+        ("*.local:8500", "quote.local:8500", True),
+        ("*", "quote.local:8500", True),
+        ("quote.*", "quote.local:8500", True),
+        ("quote.*", "*.local:8500", True),
+        ("quote.com:8500", "quote.com:8500", True),
     ]:
         assert hostglob_matches(v1, v2) == wanted_result, f"1. {v1} ~ {v2} != {wanted_result}"
         assert hostglob_matches(v2, v1) == wanted_result, f"2. {v2} ~ {v1} != {wanted_result}"

--- a/python/tests/unit/testdata/listeners/host_missing_tls_in.yaml
+++ b/python/tests/unit/testdata/listeners/host_missing_tls_in.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Listener
+metadata:
+  name: listener-8080
+  namespace: ambassador
+spec:
+  port: 8080
+  protocol: HTTP
+  securityModel: XFP
+  hostBinding:
+    namespace:
+      from: ALL
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Listener
+metadata:
+  name: listener-8443
+  namespace: ambassador
+spec:
+  port: 8443
+  protocol: HTTPS
+  securityModel: XFP
+  hostBinding:
+    namespace:
+      from: ALL
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: minimal-host
+  namespace: default
+spec:
+  hostname: '*.local:8500'
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: quote-backend
+  namespace: default
+spec:
+  hostname: "quote.local:8500"
+  prefix: /backend/
+  service: quote

--- a/python/tests/unit/testdata/listeners/host_missing_tls_out.yaml
+++ b/python/tests/unit/testdata/listeners/host_missing_tls_out.yaml
@@ -1,0 +1,301 @@
+listeners:
+  - address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 8080
+        protocol: TCP
+    filter_chains:
+      - filter_chain_match: {}
+        filters:
+          - name: envoy.filters.network.http_connection_manager
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+              access_log:
+                - name: envoy.access_loggers.file
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+                    log_format:
+                      text_format_source:
+                        inline_string: |
+                          ACCESS [%START_TIME%] "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%" "%REQ(USER-AGENT)%" "%REQ(X-REQUEST-ID)%" "%REQ(:AUTHORITY)%" "%UPSTREAM_HOST%"
+
+                    path: "/dev/fd/1"
+              http_filters:
+                - name: envoy.filters.http.cors
+                - name: envoy.filters.http.router
+              http_protocol_options:
+                accept_http_10: false
+              normalize_path: true
+              preserve_external_request_id: false
+              route_config:
+                virtual_hosts:
+                  - domains:
+                      - "*.local:8500"
+                    name: listener-8080-*.local:8500
+                    routes:
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: https
+                              name: x-forwarded-proto
+                          prefix: /ambassador/v0/check_ready
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        route:
+                          cluster: cluster_127_0_0_1_8877_default
+                          prefix_rewrite: "/ambassador/v0/check_ready"
+                          priority:
+                          timeout: "10.000s"
+                      - match:
+                          case_sensitive: true
+                          prefix: /ambassador/v0/check_ready
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        redirect:
+                          https_redirect: true
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: https
+                              name: x-forwarded-proto
+                          prefix: /ambassador/v0/check_alive
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        route:
+                          cluster: cluster_127_0_0_1_8877_default
+                          prefix_rewrite: "/ambassador/v0/check_alive"
+                          priority:
+                          timeout: "10.000s"
+                      - match:
+                          case_sensitive: true
+                          prefix: /ambassador/v0/check_alive
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        redirect:
+                          https_redirect: true
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: https
+                              name: x-forwarded-proto
+                          prefix: /ambassador/v0/
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        route:
+                          cluster: cluster_127_0_0_1_8877_default
+                          prefix_rewrite: "/ambassador/v0/"
+                          priority:
+                          timeout: "10.000s"
+                      - match:
+                          case_sensitive: true
+                          prefix: /ambassador/v0/
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        redirect:
+                          https_redirect: true
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: "quote.local:8500"
+                              name: ":authority"
+                            - exact_match: "https"
+                              name: x-forwarded-proto
+                          prefix: "/backend/"
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_quote_default
+                        route:
+                          cluster: cluster_quote_default
+                          prefix_rewrite: "/"
+                          priority:
+                          timeout: 3.000s
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: "quote.local:8500"
+                              name: ":authority"
+                          prefix: "/backend/"
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_quote_default
+                        redirect:
+                          https_redirect: true
+              server_name: envoy
+              stat_prefix: ingress_http
+              use_remote_address: true
+        name: httphost-shared
+    name: listener-8080
+    traffic_direction: UNSPECIFIED
+  - address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 8443
+        protocol: TCP
+    filter_chains:
+      - filter_chain_match: {}
+        filters:
+          - name: envoy.filters.network.http_connection_manager
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+              access_log:
+                - name: envoy.access_loggers.file
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+                    log_format:
+                      text_format_source:
+                        inline_string: |
+                          ACCESS [%START_TIME%] "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%" "%REQ(USER-AGENT)%" "%REQ(X-REQUEST-ID)%" "%REQ(:AUTHORITY)%" "%UPSTREAM_HOST%"
+
+                    path: "/dev/fd/1"
+              http_filters:
+                - name: envoy.filters.http.cors
+                - name: envoy.filters.http.router
+              http_protocol_options:
+                accept_http_10: false
+              normalize_path: true
+              preserve_external_request_id: false
+              route_config:
+                virtual_hosts:
+                  - domains:
+                      - "*.local:8500"
+                    name: listener-8443-*.local:8500
+                    routes:
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: https
+                              name: x-forwarded-proto
+                          prefix: /ambassador/v0/check_ready
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        route:
+                          cluster: cluster_127_0_0_1_8877_default
+                          prefix_rewrite: "/ambassador/v0/check_ready"
+                          priority:
+                          timeout: "10.000s"
+                      - match:
+                          case_sensitive: true
+                          prefix: /ambassador/v0/check_ready
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        redirect:
+                          https_redirect: true
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: https
+                              name: x-forwarded-proto
+                          prefix: /ambassador/v0/check_alive
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        route:
+                          cluster: cluster_127_0_0_1_8877_default
+                          prefix_rewrite: "/ambassador/v0/check_alive"
+                          priority:
+                          timeout: "10.000s"
+                      - match:
+                          case_sensitive: true
+                          prefix: /ambassador/v0/check_alive
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        redirect:
+                          https_redirect: true
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: https
+                              name: x-forwarded-proto
+                          prefix: /ambassador/v0/
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        route:
+                          cluster: cluster_127_0_0_1_8877_default
+                          prefix_rewrite: "/ambassador/v0/"
+                          priority:
+                          timeout: "10.000s"
+                      - match:
+                          case_sensitive: true
+                          prefix: /ambassador/v0/
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        redirect:
+                          https_redirect: true
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: "quote.local:8500"
+                              name: ":authority"
+                            - exact_match: "https"
+                              name: x-forwarded-proto
+                          prefix: "/backend/"
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_quote_default
+                        route:
+                          cluster: cluster_quote_default
+                          prefix_rewrite: "/"
+                          priority:
+                          timeout: 3.000s
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: "quote.local:8500"
+                              name: ":authority"
+                          prefix: "/backend/"
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_quote_default
+                        redirect:
+                          https_redirect: true
+              server_name: envoy
+              stat_prefix: ingress_https
+              use_remote_address: true
+        name: httphost-shared
+    listener_filters:
+      - name: envoy.filters.listener.tls_inspector
+    name: listener-8443
+    traffic_direction: UNSPECIFIED

--- a/python/tests/unit/testdata/listeners/no_host_in.yaml
+++ b/python/tests/unit/testdata/listeners/no_host_in.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Listener
+metadata:
+  name: listener-8080
+  namespace: ambassador
+spec:
+  port: 8080
+  protocol: HTTP
+  securityModel: XFP
+  hostBinding:
+    namespace:
+      from: ALL
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Listener
+metadata:
+  name: listener-8443
+  namespace: ambassador
+spec:
+  port: 8443
+  protocol: HTTPS
+  securityModel: XFP
+  hostBinding:
+    namespace:
+      from: ALL
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: quote-backend
+  namespace: default
+spec:
+  hostname: "*.local:8500"
+  prefix: /backend/
+  service: quote

--- a/python/tests/unit/testdata/listeners/no_host_out.yaml
+++ b/python/tests/unit/testdata/listeners/no_host_out.yaml
@@ -1,0 +1,453 @@
+listeners:
+  - address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 8080
+        protocol: TCP
+    filter_chains:
+      - filter_chain_match: {}
+        filters:
+          - name: envoy.filters.network.http_connection_manager
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+              access_log:
+                - name: envoy.access_loggers.file
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+                    log_format:
+                      text_format_source:
+                        inline_string: |
+                          ACCESS [%START_TIME%] "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%" "%REQ(USER-AGENT)%" "%REQ(X-REQUEST-ID)%" "%REQ(:AUTHORITY)%" "%UPSTREAM_HOST%"
+
+                    path: "/dev/fd/1"
+              http_filters:
+                - name: envoy.filters.http.cors
+                - name: envoy.filters.http.router
+              http_protocol_options:
+                accept_http_10: false
+              normalize_path: true
+              preserve_external_request_id: false
+              route_config:
+                virtual_hosts:
+                  - domains:
+                      - "*"
+                    name: listener-8080-*
+                    routes:
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: https
+                              name: x-forwarded-proto
+                          prefix: /ambassador/v0/check_ready
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        route:
+                          cluster: cluster_127_0_0_1_8877_default
+                          prefix_rewrite: "/ambassador/v0/check_ready"
+                          priority:
+                          timeout: "10.000s"
+                      - match:
+                          case_sensitive: true
+                          prefix: /ambassador/v0/check_ready
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        redirect:
+                          https_redirect: true
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: https
+                              name: x-forwarded-proto
+                          prefix: /ambassador/v0/check_alive
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        route:
+                          cluster: cluster_127_0_0_1_8877_default
+                          prefix_rewrite: "/ambassador/v0/check_alive"
+                          priority:
+                          timeout: "10.000s"
+                      - match:
+                          case_sensitive: true
+                          prefix: /ambassador/v0/check_alive
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        redirect:
+                          https_redirect: true
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: https
+                              name: x-forwarded-proto
+                          prefix: /ambassador/v0/
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        route:
+                          cluster: cluster_127_0_0_1_8877_default
+                          prefix_rewrite: "/ambassador/v0/"
+                          priority:
+                          timeout: "10.000s"
+                      - match:
+                          case_sensitive: true
+                          prefix: /ambassador/v0/
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        redirect:
+                          https_redirect: true
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - name: ":authority"
+                              suffix_match: ".local:8500"
+                            - exact_match: "https"
+                              name: x-forwarded-proto
+                          prefix: "/backend/"
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_quote_default
+                        route:
+                          cluster: cluster_quote_default
+                          prefix_rewrite: "/"
+                          priority:
+                          timeout: 3.000s
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - name: ":authority"
+                              suffix_match: ".local:8500"
+                          prefix: "/backend/"
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_quote_default
+                        redirect:
+                          https_redirect: true
+              server_name: envoy
+              stat_prefix: ingress_http
+              use_remote_address: true
+        name: httphost-shared
+    name: listener-8080
+    traffic_direction: UNSPECIFIED
+  - address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 8443
+        protocol: TCP
+    filter_chains:
+      - filter_chain_match:
+          transport_protocol: tls
+        filters:
+          - name: envoy.filters.network.http_connection_manager
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+              access_log:
+                - name: envoy.access_loggers.file
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+                    log_format:
+                      text_format_source:
+                        inline_string: |
+                          ACCESS [%START_TIME%] "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%" "%REQ(USER-AGENT)%" "%REQ(X-REQUEST-ID)%" "%REQ(:AUTHORITY)%" "%UPSTREAM_HOST%"
+
+                    path: "/dev/fd/1"
+              http_filters:
+                - name: envoy.filters.http.cors
+                - name: envoy.filters.http.router
+              http_protocol_options:
+                accept_http_10: false
+              normalize_path: true
+              preserve_external_request_id: false
+              route_config:
+                virtual_hosts:
+                  - domains:
+                      - "*"
+                    name: listener-8443-*
+                    routes:
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: https
+                              name: x-forwarded-proto
+                          prefix: /ambassador/v0/check_ready
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        route:
+                          cluster: cluster_127_0_0_1_8877_default
+                          prefix_rewrite: "/ambassador/v0/check_ready"
+                          priority:
+                          timeout: "10.000s"
+                      - match:
+                          case_sensitive: true
+                          prefix: /ambassador/v0/check_ready
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        redirect:
+                          https_redirect: true
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: https
+                              name: x-forwarded-proto
+                          prefix: /ambassador/v0/check_alive
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        route:
+                          cluster: cluster_127_0_0_1_8877_default
+                          prefix_rewrite: "/ambassador/v0/check_alive"
+                          priority:
+                          timeout: "10.000s"
+                      - match:
+                          case_sensitive: true
+                          prefix: /ambassador/v0/check_alive
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        redirect:
+                          https_redirect: true
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: https
+                              name: x-forwarded-proto
+                          prefix: /ambassador/v0/
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        route:
+                          cluster: cluster_127_0_0_1_8877_default
+                          prefix_rewrite: "/ambassador/v0/"
+                          priority:
+                          timeout: "10.000s"
+                      - match:
+                          case_sensitive: true
+                          prefix: /ambassador/v0/
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        redirect:
+                          https_redirect: true
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - name: ":authority"
+                              suffix_match: ".local:8500"
+                            - exact_match: "https"
+                              name: x-forwarded-proto
+                          prefix: "/backend/"
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_quote_default
+                        route:
+                          cluster: cluster_quote_default
+                          prefix_rewrite: "/"
+                          priority:
+                          timeout: 3.000s
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - name: ":authority"
+                              suffix_match: ".local:8500"
+                          prefix: "/backend/"
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_quote_default
+                        redirect:
+                          https_redirect: true
+              server_name: envoy
+              stat_prefix: ingress_https
+              use_remote_address: true
+        name: httpshost-default-host
+        transport_socket:
+          name: envoy.transport_sockets.tls
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+            common_tls_context:
+              tls_certificates:
+                - certificate_chain:
+                    filename: test.crt
+                  private_key:
+                    filename: test.key
+      - filter_chain_match: {}
+        filters:
+          - name: envoy.filters.network.http_connection_manager
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+              access_log:
+                - name: envoy.access_loggers.file
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+                    log_format:
+                      text_format_source:
+                        inline_string: |
+                          ACCESS [%START_TIME%] "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%" "%REQ(USER-AGENT)%" "%REQ(X-REQUEST-ID)%" "%REQ(:AUTHORITY)%" "%UPSTREAM_HOST%"
+
+                    path: "/dev/fd/1"
+              http_filters:
+                - name: envoy.filters.http.cors
+                - name: envoy.filters.http.router
+              http_protocol_options:
+                accept_http_10: false
+              normalize_path: true
+              preserve_external_request_id: false
+              route_config:
+                virtual_hosts:
+                  - domains:
+                      - "*"
+                    name: listener-8443-*
+                    routes:
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: https
+                              name: x-forwarded-proto
+                          prefix: /ambassador/v0/check_ready
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        route:
+                          cluster: cluster_127_0_0_1_8877_default
+                          prefix_rewrite: "/ambassador/v0/check_ready"
+                          priority:
+                          timeout: "10.000s"
+                      - match:
+                          case_sensitive: true
+                          prefix: /ambassador/v0/check_ready
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        redirect:
+                          https_redirect: true
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: https
+                              name: x-forwarded-proto
+                          prefix: /ambassador/v0/check_alive
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        route:
+                          cluster: cluster_127_0_0_1_8877_default
+                          prefix_rewrite: "/ambassador/v0/check_alive"
+                          priority:
+                          timeout: "10.000s"
+                      - match:
+                          case_sensitive: true
+                          prefix: /ambassador/v0/check_alive
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        redirect:
+                          https_redirect: true
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: https
+                              name: x-forwarded-proto
+                          prefix: /ambassador/v0/
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        route:
+                          cluster: cluster_127_0_0_1_8877_default
+                          prefix_rewrite: "/ambassador/v0/"
+                          priority:
+                          timeout: "10.000s"
+                      - match:
+                          case_sensitive: true
+                          prefix: /ambassador/v0/
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        redirect:
+                          https_redirect: true
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - name: ":authority"
+                              suffix_match: ".local:8500"
+                            - exact_match: "https"
+                              name: x-forwarded-proto
+                          prefix: "/backend/"
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_quote_default
+                        route:
+                          cluster: cluster_quote_default
+                          prefix_rewrite: "/"
+                          priority:
+                          timeout: 3.000s
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - name: ":authority"
+                              suffix_match: ".local:8500"
+                          prefix: "/backend/"
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_quote_default
+                        redirect:
+                          https_redirect: true
+              server_name: envoy
+              stat_prefix: ingress_https
+              use_remote_address: true
+        name: "httphost-shared"
+    listener_filters:
+      - name: envoy.filters.listener.tls_inspector
+    name: listener-8443
+    traffic_direction: UNSPECIFIED

--- a/python/tests/unit/testdata/listeners/prefix_wildcard_and_hostname_with_port_in.yaml
+++ b/python/tests/unit/testdata/listeners/prefix_wildcard_and_hostname_with_port_in.yaml
@@ -1,0 +1,99 @@
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Listener
+metadata:
+  name: listener-8080
+  namespace: ambassador
+spec:
+  port: 8080
+  protocol: HTTP
+  securityModel: XFP
+  hostBinding:
+    namespace:
+      from: ALL
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Listener
+metadata:
+  name: listener-8443
+  namespace: ambassador
+spec:
+  port: 8443
+  protocol: HTTPS
+  securityModel: XFP
+  hostBinding:
+    namespace:
+      from: ALL
+---
+apiVersion: getambassador.io/v3alpha1
+kind: TLSContext
+metadata:
+  name: my-tls-context
+  namespace: default
+spec:
+  secret: tls-cert
+  hosts: ["*.local", "*.local:8500"]
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: minimal-host
+  namespace: default
+spec:
+  hostname: '*.local'
+  tlsSecret:
+    name: tls-cert
+  tlsContext: 
+    name: my-tls-context
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: minimal-host-2
+  namespace: default
+spec:
+  hostname: '*.local:8500'
+  tlsSecret:
+    name: tls-cert
+  tlsContext: 
+    name: my-tls-context
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: quote-backend-1
+  namespace: default
+spec:
+  hostname: "quote.local"
+  prefix: /backend/
+  service: quote
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: quote-backend-2
+  namespace: default
+spec:
+  hostname: "*.local"
+  prefix: /backend2/
+  service: quote2
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: quote-backend-3
+  namespace: default
+spec:
+  hostname: "quote.local:8500"
+  prefix: /backend3/
+  service: quote3
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: quote-backend-4
+  namespace: default
+spec:
+  hostname: "*.local:8500"
+  prefix: /backend4/
+  service: quote4

--- a/python/tests/unit/testdata/listeners/prefix_wildcard_and_hostname_with_port_out.yaml
+++ b/python/tests/unit/testdata/listeners/prefix_wildcard_and_hostname_with_port_out.yaml
@@ -1,0 +1,979 @@
+listeners:
+  - address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 8080
+        protocol: TCP
+    filter_chains:
+      - filter_chain_match: {}
+        filters:
+          - name: envoy.filters.network.http_connection_manager
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+              access_log:
+                - name: envoy.access_loggers.file
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+                    log_format:
+                      text_format_source:
+                        inline_string: |
+                          ACCESS [%START_TIME%] "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%" "%REQ(USER-AGENT)%" "%REQ(X-REQUEST-ID)%" "%REQ(:AUTHORITY)%" "%UPSTREAM_HOST%"
+
+                    path: "/dev/fd/1"
+              http_filters:
+                - name: envoy.filters.http.cors
+                - name: envoy.filters.http.router
+              http_protocol_options:
+                accept_http_10: false
+              normalize_path: true
+              preserve_external_request_id: false
+              route_config:
+                virtual_hosts:
+                  - domains:
+                      - "*.local"
+                    name: listener-8080-*.local
+                    routes:
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: https
+                              name: x-forwarded-proto
+                          prefix: /ambassador/v0/check_ready
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        route:
+                          cluster: cluster_127_0_0_1_8877_default
+                          prefix_rewrite: "/ambassador/v0/check_ready"
+                          priority:
+                          timeout: "10.000s"
+                      - match:
+                          case_sensitive: true
+                          prefix: /ambassador/v0/check_ready
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        redirect:
+                          https_redirect: true
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: https
+                              name: x-forwarded-proto
+                          prefix: /ambassador/v0/check_alive
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        route:
+                          cluster: cluster_127_0_0_1_8877_default
+                          prefix_rewrite: "/ambassador/v0/check_alive"
+                          priority:
+                          timeout: "10.000s"
+                      - match:
+                          case_sensitive: true
+                          prefix: /ambassador/v0/check_alive
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        redirect:
+                          https_redirect: true
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: https
+                              name: x-forwarded-proto
+                          prefix: /ambassador/v0/
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        route:
+                          cluster: cluster_127_0_0_1_8877_default
+                          prefix_rewrite: "/ambassador/v0/"
+                          priority:
+                          timeout: "10.000s"
+                      - match:
+                          case_sensitive: true
+                          prefix: /ambassador/v0/
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        redirect:
+                          https_redirect: true
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - name: ":authority"
+                              suffix_match: ".local"
+                            - exact_match: "https"
+                              name: x-forwarded-proto
+                          prefix: "/backend2/"
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_quote2_default
+                        route:
+                          cluster: cluster_quote2_default
+                          prefix_rewrite: "/"
+                          priority:
+                          timeout: 3.000s
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - name: ":authority"
+                              suffix_match: ".local"
+                          prefix: "/backend2/"
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_quote2_default
+                        redirect:
+                          https_redirect: true
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: "quote.local"
+                              name: ":authority"
+                            - exact_match: "https"
+                              name: x-forwarded-proto
+                          prefix: "/backend/"
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_quote_default
+                        route:
+                          cluster: cluster_quote_default
+                          prefix_rewrite: "/"
+                          priority:
+                          timeout: 3.000s
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: "quote.local"
+                              name: ":authority"
+                          prefix: "/backend/"
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_quote_default
+                        redirect:
+                          https_redirect: true
+                  - domains:
+                      - "*.local:8500"
+                    name: listener-8080-*.local:8500
+                    routes:
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: https
+                              name: x-forwarded-proto
+                          prefix: /ambassador/v0/check_ready
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        route:
+                          cluster: cluster_127_0_0_1_8877_default
+                          prefix_rewrite: "/ambassador/v0/check_ready"
+                          priority:
+                          timeout: "10.000s"
+                      - match:
+                          case_sensitive: true
+                          prefix: /ambassador/v0/check_ready
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        redirect:
+                          https_redirect: true
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: https
+                              name: x-forwarded-proto
+                          prefix: /ambassador/v0/check_alive
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        route:
+                          cluster: cluster_127_0_0_1_8877_default
+                          prefix_rewrite: "/ambassador/v0/check_alive"
+                          priority:
+                          timeout: "10.000s"
+                      - match:
+                          case_sensitive: true
+                          prefix: /ambassador/v0/check_alive
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        redirect:
+                          https_redirect: true
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: https
+                              name: x-forwarded-proto
+                          prefix: /ambassador/v0/
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        route:
+                          cluster: cluster_127_0_0_1_8877_default
+                          prefix_rewrite: "/ambassador/v0/"
+                          priority:
+                          timeout: "10.000s"
+                      - match:
+                          case_sensitive: true
+                          prefix: /ambassador/v0/
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        redirect:
+                          https_redirect: true
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: "quote.local:8500"
+                              name: ":authority"
+                            - exact_match: "https"
+                              name: x-forwarded-proto
+                          prefix: "/backend3/"
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_quote3_default
+                        route:
+                          cluster: cluster_quote3_default
+                          prefix_rewrite: "/"
+                          priority:
+                          timeout: 3.000s
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: "quote.local:8500"
+                              name: ":authority"
+                          prefix: "/backend3/"
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_quote3_default
+                        redirect:
+                          https_redirect: true
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - name: ":authority"
+                              suffix_match: ".local:8500"
+                            - exact_match: "https"
+                              name: x-forwarded-proto
+                          prefix: "/backend4/"
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_quote4_default
+                        route:
+                          cluster: cluster_quote4_default
+                          prefix_rewrite: "/"
+                          priority:
+                          timeout: 3.000s
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - name: ":authority"
+                              suffix_match: ".local:8500"
+                          prefix: "/backend4/"
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_quote4_default
+                        redirect:
+                          https_redirect: true
+              server_name: envoy
+              stat_prefix: ingress_http
+              use_remote_address: true
+        name: httphost-shared
+    name: listener-8080
+    traffic_direction: UNSPECIFIED
+  - address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 8443
+        protocol: TCP
+    filter_chains:
+      - filter_chain_match:
+          server_names: ["*.local"]
+          transport_protocol: tls
+        filters:
+          - name: envoy.filters.network.http_connection_manager
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+              access_log:
+                - name: envoy.access_loggers.file
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+                    log_format:
+                      text_format_source:
+                        inline_string: |
+                          ACCESS [%START_TIME%] "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%" "%REQ(USER-AGENT)%" "%REQ(X-REQUEST-ID)%" "%REQ(:AUTHORITY)%" "%UPSTREAM_HOST%"
+
+                    path: "/dev/fd/1"
+              http_filters:
+                - name: envoy.filters.http.cors
+                - name: envoy.filters.http.router
+              http_protocol_options:
+                accept_http_10: false
+              normalize_path: true
+              preserve_external_request_id: false
+              route_config:
+                virtual_hosts:
+                  - domains:
+                      - "*.local"
+                    name: listener-8443-*.local
+                    routes:
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: https
+                              name: x-forwarded-proto
+                          prefix: /ambassador/v0/check_ready
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        route:
+                          cluster: cluster_127_0_0_1_8877_default
+                          prefix_rewrite: "/ambassador/v0/check_ready"
+                          priority:
+                          timeout: "10.000s"
+                      - match:
+                          case_sensitive: true
+                          prefix: /ambassador/v0/check_ready
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        redirect:
+                          https_redirect: true
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: https
+                              name: x-forwarded-proto
+                          prefix: /ambassador/v0/check_alive
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        route:
+                          cluster: cluster_127_0_0_1_8877_default
+                          prefix_rewrite: "/ambassador/v0/check_alive"
+                          priority:
+                          timeout: "10.000s"
+                      - match:
+                          case_sensitive: true
+                          prefix: /ambassador/v0/check_alive
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        redirect:
+                          https_redirect: true
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: https
+                              name: x-forwarded-proto
+                          prefix: /ambassador/v0/
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        route:
+                          cluster: cluster_127_0_0_1_8877_default
+                          prefix_rewrite: "/ambassador/v0/"
+                          priority:
+                          timeout: "10.000s"
+                      - match:
+                          case_sensitive: true
+                          prefix: /ambassador/v0/
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        redirect:
+                          https_redirect: true
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - name: ":authority"
+                              suffix_match: ".local"
+                            - exact_match: "https"
+                              name: x-forwarded-proto
+                          prefix: "/backend2/"
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_quote2_default
+                        route:
+                          cluster: cluster_quote2_default
+                          prefix_rewrite: "/"
+                          priority:
+                          timeout: 3.000s
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - name: ":authority"
+                              suffix_match: ".local"
+                          prefix: "/backend2/"
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_quote2_default
+                        redirect:
+                          https_redirect: true
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: "quote.local"
+                              name: ":authority"
+                            - exact_match: "https"
+                              name: x-forwarded-proto
+                          prefix: "/backend/"
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_quote_default
+                        route:
+                          cluster: cluster_quote_default
+                          prefix_rewrite: "/"
+                          priority:
+                          timeout: 3.000s
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: "quote.local"
+                              name: ":authority"
+                          prefix: "/backend/"
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_quote_default
+                        redirect:
+                          https_redirect: true
+                  - domains:
+                      - "*.local:8500"
+                    name: listener-8443-*.local:8500
+                    routes:
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: https
+                              name: x-forwarded-proto
+                          prefix: /ambassador/v0/check_ready
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        route:
+                          cluster: cluster_127_0_0_1_8877_default
+                          prefix_rewrite: "/ambassador/v0/check_ready"
+                          priority:
+                          timeout: "10.000s"
+                      - match:
+                          case_sensitive: true
+                          prefix: /ambassador/v0/check_ready
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        redirect:
+                          https_redirect: true
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: https
+                              name: x-forwarded-proto
+                          prefix: /ambassador/v0/check_alive
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        route:
+                          cluster: cluster_127_0_0_1_8877_default
+                          prefix_rewrite: "/ambassador/v0/check_alive"
+                          priority:
+                          timeout: "10.000s"
+                      - match:
+                          case_sensitive: true
+                          prefix: /ambassador/v0/check_alive
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        redirect:
+                          https_redirect: true
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: https
+                              name: x-forwarded-proto
+                          prefix: /ambassador/v0/
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        route:
+                          cluster: cluster_127_0_0_1_8877_default
+                          prefix_rewrite: "/ambassador/v0/"
+                          priority:
+                          timeout: "10.000s"
+                      - match:
+                          case_sensitive: true
+                          prefix: /ambassador/v0/
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        redirect:
+                          https_redirect: true
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: "quote.local:8500"
+                              name: ":authority"
+                            - exact_match: "https"
+                              name: x-forwarded-proto
+                          prefix: "/backend3/"
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_quote3_default
+                        route:
+                          cluster: cluster_quote3_default
+                          prefix_rewrite: "/"
+                          priority:
+                          timeout: 3.000s
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: "quote.local:8500"
+                              name: ":authority"
+                          prefix: "/backend3/"
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_quote3_default
+                        redirect:
+                          https_redirect: true
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - name: ":authority"
+                              suffix_match: ".local:8500"
+                            - exact_match: "https"
+                              name: x-forwarded-proto
+                          prefix: "/backend4/"
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_quote4_default
+                        route:
+                          cluster: cluster_quote4_default
+                          prefix_rewrite: "/"
+                          priority:
+                          timeout: 3.000s
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - name: ":authority"
+                              suffix_match: ".local:8500"
+                          prefix: "/backend4/"
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_quote4_default
+                        redirect:
+                          https_redirect: true
+              server_name: envoy
+              stat_prefix: ingress_https
+              use_remote_address: true
+        name: httpshost-minimal-host
+        transport_socket:
+          name: envoy.transport_sockets.tls
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+            common_tls_context:
+              tls_certificates:
+                - certificate_chain:
+                    filename: test.crt
+                  private_key:
+                    filename: test.key
+      - filter_chain_match: {}
+        filters:
+          - name: envoy.filters.network.http_connection_manager
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+              access_log:
+                - name: envoy.access_loggers.file
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+                    log_format:
+                      text_format_source:
+                        inline_string: |
+                          ACCESS [%START_TIME%] "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%" "%REQ(USER-AGENT)%" "%REQ(X-REQUEST-ID)%" "%REQ(:AUTHORITY)%" "%UPSTREAM_HOST%"
+
+                    path: "/dev/fd/1"
+              http_filters:
+                - name: envoy.filters.http.cors
+                - name: envoy.filters.http.router
+              http_protocol_options:
+                accept_http_10: false
+              normalize_path: true
+              preserve_external_request_id: false
+              route_config:
+                virtual_hosts:
+                  - domains:
+                      - "*.local"
+                    name: listener-8443-*.local
+                    routes:
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: https
+                              name: x-forwarded-proto
+                          prefix: /ambassador/v0/check_ready
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        route:
+                          cluster: cluster_127_0_0_1_8877_default
+                          prefix_rewrite: "/ambassador/v0/check_ready"
+                          priority:
+                          timeout: "10.000s"
+                      - match:
+                          case_sensitive: true
+                          prefix: /ambassador/v0/check_ready
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        redirect:
+                          https_redirect: true
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: https
+                              name: x-forwarded-proto
+                          prefix: /ambassador/v0/check_alive
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        route:
+                          cluster: cluster_127_0_0_1_8877_default
+                          prefix_rewrite: "/ambassador/v0/check_alive"
+                          priority:
+                          timeout: "10.000s"
+                      - match:
+                          case_sensitive: true
+                          prefix: /ambassador/v0/check_alive
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        redirect:
+                          https_redirect: true
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: https
+                              name: x-forwarded-proto
+                          prefix: /ambassador/v0/
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        route:
+                          cluster: cluster_127_0_0_1_8877_default
+                          prefix_rewrite: "/ambassador/v0/"
+                          priority:
+                          timeout: "10.000s"
+                      - match:
+                          case_sensitive: true
+                          prefix: /ambassador/v0/
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        redirect:
+                          https_redirect: true
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - name: ":authority"
+                              suffix_match: ".local"
+                            - exact_match: "https"
+                              name: x-forwarded-proto
+                          prefix: "/backend2/"
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_quote2_default
+                        route:
+                          cluster: cluster_quote2_default
+                          prefix_rewrite: "/"
+                          priority:
+                          timeout: 3.000s
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - name: ":authority"
+                              suffix_match: ".local"
+                          prefix: "/backend2/"
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_quote2_default
+                        redirect:
+                          https_redirect: true
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: "quote.local"
+                              name: ":authority"
+                            - exact_match: "https"
+                              name: x-forwarded-proto
+                          prefix: "/backend/"
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_quote_default
+                        route:
+                          cluster: cluster_quote_default
+                          prefix_rewrite: "/"
+                          priority:
+                          timeout: 3.000s
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: "quote.local"
+                              name: ":authority"
+                          prefix: "/backend/"
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_quote_default
+                        redirect:
+                          https_redirect: true
+                  - domains:
+                      - "*.local:8500"
+                    name: listener-8443-*.local:8500
+                    routes:
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: https
+                              name: x-forwarded-proto
+                          prefix: /ambassador/v0/check_ready
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        route:
+                          cluster: cluster_127_0_0_1_8877_default
+                          prefix_rewrite: "/ambassador/v0/check_ready"
+                          priority:
+                          timeout: "10.000s"
+                      - match:
+                          case_sensitive: true
+                          prefix: /ambassador/v0/check_ready
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        redirect:
+                          https_redirect: true
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: https
+                              name: x-forwarded-proto
+                          prefix: /ambassador/v0/check_alive
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        route:
+                          cluster: cluster_127_0_0_1_8877_default
+                          prefix_rewrite: "/ambassador/v0/check_alive"
+                          priority:
+                          timeout: "10.000s"
+                      - match:
+                          case_sensitive: true
+                          prefix: /ambassador/v0/check_alive
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        redirect:
+                          https_redirect: true
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: https
+                              name: x-forwarded-proto
+                          prefix: /ambassador/v0/
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        route:
+                          cluster: cluster_127_0_0_1_8877_default
+                          prefix_rewrite: "/ambassador/v0/"
+                          priority:
+                          timeout: "10.000s"
+                      - match:
+                          case_sensitive: true
+                          prefix: /ambassador/v0/
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+                        redirect:
+                          https_redirect: true
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: "quote.local:8500"
+                              name: ":authority"
+                            - exact_match: "https"
+                              name: x-forwarded-proto
+                          prefix: "/backend3/"
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_quote3_default
+                        route:
+                          cluster: cluster_quote3_default
+                          prefix_rewrite: "/"
+                          priority:
+                          timeout: 3.000s
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - exact_match: "quote.local:8500"
+                              name: ":authority"
+                          prefix: "/backend3/"
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_quote3_default
+                        redirect:
+                          https_redirect: true
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - name: ":authority"
+                              suffix_match: ".local:8500"
+                            - exact_match: "https"
+                              name: x-forwarded-proto
+                          prefix: "/backend4/"
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_quote4_default
+                        route:
+                          cluster: cluster_quote4_default
+                          prefix_rewrite: "/"
+                          priority:
+                          timeout: 3.000s
+                      - match:
+                          case_sensitive: true
+                          headers:
+                            - name: ":authority"
+                              suffix_match: ".local:8500"
+                          prefix: "/backend4/"
+                          runtime_fraction:
+                            default_value:
+                              denominator: "HUNDRED"
+                              numerator: 100
+                            runtime_key: routing.traffic_shift.cluster_quote4_default
+                        redirect:
+                          https_redirect: true
+              server_name: envoy
+              stat_prefix: ingress_https
+              use_remote_address: true
+        name: httphost-shared
+    listener_filters:
+      - name: envoy.filters.listener.tls_inspector
+    name: listener-8443
+    traffic_direction: UNSPECIFIED

--- a/python/tests/utils.py
+++ b/python/tests/utils.py
@@ -6,11 +6,12 @@ import tempfile
 from base64 import b64encode
 from collections import namedtuple
 
+import pytest
 from OpenSSL import crypto
 
 from ambassador import IR, Cache
 from ambassador.compile import Compile
-from ambassador.utils import NullSecretHandler
+from ambassador.utils import NullSecretHandler, parse_bool
 
 logger = logging.getLogger("ambassador")
 
@@ -339,3 +340,12 @@ def create_crl_pem_b64(issuerCert, issuerKey, revokedCerts):
     return b64encode(
         (crypto.dump_crl(crypto.FILETYPE_PEM, crl).decode("utf-8") + "\n").encode("utf-8")
     ).decode("utf-8")
+
+
+def skip_edgestack():
+    isEdgeStack = parse_bool(os.environ.get("EDGE_STACK", "false"))
+
+    return pytest.mark.skipif(
+        isEdgeStack,
+        reason=f"Skipping because EdgeStack behaves differently and tested separately",
+    )

--- a/python/tests/utils.py
+++ b/python/tests/utils.py
@@ -175,7 +175,7 @@ spec:
 
 
 def _require_no_errors(ir: IR):
-    assert ir.aconf.errors == {}
+    assert ir.aconf.errors == {}, f"{repr(ir.aconf.errors)}"
 
 
 def _secret_handler():


### PR DESCRIPTION
## Description

> **Note** - this PR looks to address the broken behavior and not to address developer experience (DX) with the Host.hostname and ports. I think that will take more thought and potentially breaking changes so the goal of this PR is to restore existing behavior users had in v1.Y and to fix broken envoy configuration


When trying to expose a `Host` with a `hostname` that includes a non-standard port such as 'example.com:8500' over a TLS connection, a client would receive a 404 NR's due to Envoy not being able to find a valid route.

For example:
```yaml
apiVersion: getambassador.io/v3alpha1
kind: Host
metadata:
  name: basic-host
  namespace: default
spec:
  hostname: 'example.com:8500'
  tlsSecret:
    name: tls-cert
  tlsContext: 
    name: my-tls-context
---
apiVersion: getambassador.io/v3alpha1
kind: Mapping
metadata:
  name: quote-backend
  namespace: default
spec:
  hostname: "example.com:8500"
  prefix: /backend/
  service: quote
```


In v1.14, emissary would group everything under a single FilterChain with a wildcard virtual_host ("*") and then do :authority header matching using header matches on the Route. This allowed the above configuration to work but had the downside of causing large memory usage and slower route matching due to lumping all routes into a single virtual host.

In v2.Y/ v3.Y, this was addressed by creating separate Filter Chains for each `Host`. A **non-tls** Host would get a single FilterChain with multiple virtual_hosts per `Host`. A Host with TLS will produce a 1-1 FilterChain and virtual_host. This works fine in most cases when downstream clients are connecting over standard ports (80/443) because the dns portion of the `:authority` header matched the `virtual_host.domain`. But, when a client needs to connect on something like
the example above this would effectively generate a Filter Chain that could never match on an incoming request due to the overloaded nature of how we use `Host.hostname`.


### Before Fix (psuedo envoy config):

```yaml
FilterChains:
 - FilterChainMatching:
    server_names: ["example.com:8500"]
    transport_protocol: tls
   FilterChain:
    virtual_hosts:
      - domains: ["example.com:8500"]
        routes:
          - prefix: /backend/
            headers:
              - name: ":authority"
                exact_match: example.com:8500
```
### After Fix

In the **non-tls** scenario there are no changes to what gets generated since we behave similar to v1.y in that we don't have sni to differentiate FilterChains so virtual_hosts per `Host` are generated along with route header matching.

In the **TLS** scenario we now parse the hostname to determine the sni. SNI doesn't not understand ports  which is why the configuration above is effectively dead and no connections would ever be made to that Filter Chain. 


So, `example.com:8500` would become:

- sni=example.com
- hostname=example.com:8500

We now create a Filter Chain per sni value and add a virtual host for the full hostname which will now produce:

```yaml
FilterChains:
 - FilterChainMatching:
    server_names: ["example.com"]
    transport_protocol: tls
   FilterChain:
    virtual_hosts:
      - domains: ["example.com:8500"]
        routes:
          - prefix: /backend/
            headers:
              - name: ":authority"
                exact_match: example.com:8500
```

If a second Host with a `hostname=example.com` is provided then we would have a conflict with the 1 FilterChain to 1 virtual Host design that is used in the TLS scenario. Therefore, we will attempt to merge these into a single Filter Chain with
multiple virtual_host. We can only do this merge when the same TLSContex is used because if we didn't then we  wouldn't know which TLS settings because these are set at the FilterChain level and not the virtual host level. This also means that using `Host.tls` is not supported in this scenario because internally those are translated to implicit TLSContext and would have the same issue where two Host could be in conflict.

```yaml
apiVersion: getambassador.io/v3alpha1
kind: TLSContext
metadata:
  name: my-tls-context
  namespace: default
spec:
  secret: tls-cert
  hosts: ["*.local", "*.local:8500"]
---
apiVersion: getambassador.io/v3alpha1
kind: Host
metadata:
  name: basic-host-2
  namespace: default
spec:
  hostname: 'example.com'
  tlsSecret:
    name: tls-cert
  tlsContext: 
    name: my-tls-context
---
apiVersion: getambassador.io/v3alpha1
kind: Host
metadata:
  name: basic-host
  namespace: default
spec:
  hostname: 'example.com:8500'
  tlsSecret:
    name: tls-cert
  tlsContext: 
    name: my-tls-context
---
apiVersion: getambassador.io/v3alpha1
kind: Mapping
metadata:
  name: quote-backend
  namespace: default
spec:
  hostname: "example.com:8500"
  prefix: /backend/
  service: quote
 ---
apiVersion: getambassador.io/v3alpha1
kind: Mapping
metadata:
  name: quote-backend-2
  namespace: default
spec:
  hostname: "example.com"
  prefix: /backend2/
  service: quote
```


In that scenario we would produce the following:
```yaml
FilterChains:
 - FilterChainMatching:
    server_names: ["example.com"]
    transport_protocol: tls
   FilterChain:
    virtual_hosts:
      - domains: ["example.com:8500"]
        routes:
          - prefix: /backend/
            headers:
              - name: ":authority"
                exact_match: example.com:8500
      - domains: ["example.com"]
        routes:
          - prefix: /backend2/
            headers:
              - name: ":authority"
                exact_match: example.com
```

## Related Issues

- #4791 
- https://github.com/datawire/apro/issues/3108
- maybe #4714

I might be missing some but these capture it mostly.

## Testing
CI is green here and pulled into EdgeStack as well as seen here: https://github.com/datawire/apro/pull/3228

I have added some unit tests that are similar to the existing golden test we had a while back. They allowed for a much faster dev-loop but they may suffer from the same challenges we had before where any touch to the default generated config will require them to be updated. I have left them in place for now but we may want to revisit it if it becomes a pain.

## Checklist

- [ ] **Does my change need to be backported to a previous release?**
- [x] **I made sure to update `CHANGELOG.md`.**
- [x] **This is unlikely to impact how Ambassador performs at scale.**
- [x] **My change is adequately tested.**
- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**
- [x] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
