### PR TITLE
deps: update k3d and k3s

### DIFF
--- a/.github/actions/collect-logs/action.yml
+++ b/.github/actions/collect-logs/action.yml
@@ -47,6 +47,7 @@ runs:
           tools/bin/kubectl cp xfpredirect:/tmp/ambassador/snapshots /tmp/test-logs/cluster/xfpredirect.snapshots || true
         fi
         cp /tmp/*.yaml /tmp/test-logs || true
+        cp /tmp/kat-client-*.log /tmp/test-logs || true
     - name: "Upload Logs"
       uses: actions/upload-artifact@v3
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,13 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
   exist) then it defaults back  to the original behavior. (Thanks to <a
   href="https://github.com/antonu17">Anton Ustyuzhanin</a>!). ([#4809])
 
+- Change: The `emissary-apiext` server is a Kubernetes Conversion Webhook that converts between the 
+  Emissary-ingress CRD versions. On startup, it ensures that a self-signed cert is available so that
+  K8s API Server can talk to the conversion webhook (*TLS is required by K8s*). We  have introduced
+  a startupProbe to ensure that emissary-apiext server has enough time to configure the webhooks
+  before running liveness and readiness probes. This is to ensure  slow startup doesn't cause K8s to
+  needlessly restart the pod.
+
 [fix: hostname port issue]: https://github.com/emissary-ingress/emissary/pull/4816
 [#4809]: https://github.com/emissary-ingress/emissary/pull/4809
 

--- a/build-aux/ci.mk
+++ b/build-aux/ci.mk
@@ -2,7 +2,7 @@ include $(dir $(lastword $(MAKEFILE_LIST)))tools.mk
 
 K3S_VERSION      = 1.22.17-k3s1
 K3D_CLUSTER_NAME =
-K3D_ARGS         = --k3s-arg=--no-deploy=traefik@server:* --k3s-arg=--kubelet-arg=max-pods=255@server:*
+K3D_ARGS         = --k3s-arg=--no-deploy=traefik@server:* --k3s-arg=--kubelet-arg=max-pods=255@server:* --k3s-arg=--egress-selector-mode=disabled@server:*
 # This is modeled after
 # https://github.com/nolar/setup-k3d-k3s/blob/v1.0.7/action.sh#L70-L77 and
 # https://github.com/nolar/setup-k3d-k3s/blob/v1.0.7/action.yaml#L34-L46

--- a/build-aux/ci.mk
+++ b/build-aux/ci.mk
@@ -1,8 +1,8 @@
 include $(dir $(lastword $(MAKEFILE_LIST)))tools.mk
 
-K3S_VERSION      = 1.22.2+k3s1
+K3S_VERSION      = 1.22.17-k3s1
 K3D_CLUSTER_NAME =
-K3D_ARGS         = --k3s-server-arg=--no-deploy=traefik --k3s-server-arg=--kubelet-arg=max-pods=255
+K3D_ARGS         = --k3s-arg=--no-deploy=traefik@server:* --k3s-arg=--kubelet-arg=max-pods=255@server:*
 # This is modeled after
 # https://github.com/nolar/setup-k3d-k3s/blob/v1.0.7/action.sh#L70-L77 and
 # https://github.com/nolar/setup-k3d-k3s/blob/v1.0.7/action.yaml#L34-L46

--- a/build-aux/tools.mk
+++ b/build-aux/tools.mk
@@ -119,7 +119,7 @@ $(tools.bindir)/telepresence: $(tools.mk)
 # k3d is in theory `go get`-able, but... the tests fail when I do
 # that.  IDK.  --lukeshu
 tools/k3d   = $(tools.bindir)/k3d
-K3D_VERSION = 4.4.8
+K3D_VERSION = 5.4.7
 $(tools.bindir)/k3d: $(tools.mk)
 	mkdir -p $(@D)
 	curl -s --fail -L https://github.com/rancher/k3d/releases/download/v$(K3D_VERSION)/k3d-$(GOHOSTOS)-$(GOHOSTARCH) -o $@

--- a/cmd/kat-client/client.go
+++ b/cmd/kat-client/client.go
@@ -853,14 +853,15 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	dlog.Printf(ctx, "processing queries for input file name: %s , saving to: %s", args.input, args.output)
 
 	var data []byte
 
 	// Read input file
 	if args.input == "" {
+		dlog.Printf(ctx, "processing queries from stdin")
 		data, err = io.ReadAll(os.Stdin)
 	} else {
+
 		data, err = os.ReadFile(args.input)
 	}
 	if err != nil {
@@ -893,7 +894,7 @@ func main() {
 				sem.Release()
 			}()
 			if err := ExecuteQuery(ctx, specs[idx]); err != nil {
-				dlog.Errorf(ctx, "an error occurred executing query %d, kat-client is panicing: %s", idx, err.Error())
+				dlog.Errorf(ctx, "an error occurred executing query %d, kat-client will panic: %s", idx, err.Error())
 				panic(err) // TODO: do something better
 			}
 		}(i)
@@ -909,8 +910,10 @@ func main() {
 	if err != nil {
 		dlog.Print(ctx, err)
 	} else if args.output == "" {
+		dlog.Printf(ctx, "writing results to stdout")
 		fmt.Print(string(bytes))
 	} else {
+		dlog.Printf(ctx, "writing results to output file: %s", args.output)
 		err = os.WriteFile(args.output, bytes, 0644)
 		if err != nil {
 			dlog.Print(ctx, err)

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -66,6 +66,16 @@ items:
         - title: "#4809"
           link: https://github.com/emissary-ingress/emissary/pull/4809
 
+      - title: Add starupProbe to emissary-apiext server
+        type: change
+        body: >-
+          The <code>emissary-apiext</code> server is a Kubernetes Conversion Webhook that converts between the 
+          Emissary-ingress CRD versions. On startup, it ensures that a self-signed cert is available
+          so that K8s API Server can talk to the conversion webhook (*TLS is required by K8s*). We 
+          have introduced a startupProbe to ensure that emissary-apiext server has enough time to
+          configure the webhooks before running liveness and readiness probes. This is to ensure 
+          slow startup doesn't cause K8s to needlessly restart the pod.
+
   - version: 3.4.0
     prevVersion: 3.3.0
     date: '2023-01-03'

--- a/manifests/emissary/emissary-crds.yaml.in
+++ b/manifests/emissary/emissary-crds.yaml.in
@@ -5434,11 +5434,23 @@ spec:
               containerPort: 8080
             - name: https
               containerPort: 8443
+          startupProbe:
+            httpGet:
+              path: /probes/live
+              port: 8080
+            failureThreshold: 10
+            periodSeconds: 3
           livenessProbe:
             httpGet:
               scheme: HTTP
               path: /probes/live
               port: 8080
-            initialDelaySeconds: 5
+            periodSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              scheme: HTTP
+              path: /probes/ready
+              port: 8080
             periodSeconds: 3
             failureThreshold: 3

--- a/python/kat/harness.py
+++ b/python/kat/harness.py
@@ -1078,7 +1078,7 @@ def run_queries(name: str, queries: Sequence[Query]) -> Sequence[Result]:
     # run(f"{CLIENT_GO} -input {path_urls} -output {path_results} 2> {path_log}")
     res = ShellCommand.run(
         "Running queries",
-        f"tools/bin/kubectl exec -n default -i kat /work/kat_client < '{path_urls}' > '{path_results}' 2> '{path_log}'",
+        f"tools/bin/kubectl exec -n default -i kat -- /work/kat_client < '{path_urls}' > '{path_results}' 2> '{path_log}'",
         shell=True,
     )
 

--- a/python/kat/harness.py
+++ b/python/kat/harness.py
@@ -1616,6 +1616,15 @@ class Runner:
             ):
                 raise RuntimeError("Failed applying CRDs")
 
+            print("waiting for emissary-apiext server to become available")
+            if os.system(
+                "kubectl wait --timeout=90s --for=condition=available deployment emissary-apiext -n emissary-system > /dev/null 2>&1"
+            ):
+                raise RuntimeError(
+                    "emissary-apiext server did not become available within 90 seconds"
+                )
+            print("emissary-apiext server is available")
+
             tries_left = 10
 
             while (

--- a/python/tests/integration/manifests/crds.yaml
+++ b/python/tests/integration/manifests/crds.yaml
@@ -5435,11 +5435,23 @@ spec:
               containerPort: 8080
             - name: https
               containerPort: 8443
+          startupProbe:
+            httpGet:
+              path: /probes/live
+              port: 8080
+            failureThreshold: 10
+            periodSeconds: 3
           livenessProbe:
             httpGet:
               scheme: HTTP
               path: /probes/live
               port: 8080
-            initialDelaySeconds: 5
+            periodSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              scheme: HTTP
+              path: /probes/ready
+              port: 8080
             periodSeconds: 3
             failureThreshold: 3

--- a/tools/src/fix-crds/apiext.yaml
+++ b/tools/src/fix-crds/apiext.yaml
@@ -164,11 +164,23 @@ spec:
               containerPort: 8080
             - name: https
               containerPort: 8443
+          startupProbe:
+            httpGet:
+              path: /probes/live
+              port: 8080
+            failureThreshold: 10
+            periodSeconds: 3
           livenessProbe:
             httpGet:
               scheme: HTTP
               path: /probes/live
               port: 8080
-            initialDelaySeconds: 5
+            periodSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              scheme: HTTP
+              path: /probes/ready
+              port: 8080
             periodSeconds: 3
             failureThreshold: 3


### PR DESCRIPTION
## Description

This updates k3d to the latest version and fixes args that were renamed in v5 of k3d. Also, updated to the latest minor release of k3s 1.22.Y.

As part of this, I looked into the KAT flakiness that we see. I have landed a few additional fixes to address this:

- introduced startupProbes to `emissary-apiext` to ensure it has time to generate self-signed certificate before running readiness check so that it doesn't needlessly restart pods
- ensure Kat test wait for `emisary-apiext` to be ready before trying to apply yaml
- capture kat-client logs in github actions to help with debugging
- add some additional logs lines
- add `--egress-selector-mode=disabled` to k3d to get around bug in k3s 1.22 (note: 1.23 this is fixed see commit messages for details_)

## Related Issues

General keeping up with the deps updated and improve our QOL of CI and kat test flakiness.

## Testing

Locally tested creating and tearing down cluster. Also, CI is green.

## Checklist

- [x] **Does my change need to be backported to a previous release?**
- [x] **I made sure to update `CHANGELOG.md`.**
- [x] **This is unlikely to impact how Ambassador performs at scale.**
- [x] **My change is adequately tested.**
- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**
- [x] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
