### PR TITLE
envoy: upgrade to 1.24.2

### DIFF
--- a/_cxx/envoy.mk
+++ b/_cxx/envoy.mk
@@ -13,12 +13,12 @@ RSYNC_EXTRAS ?=
 
 # IF YOU MESS WITH ANY OF THESE VALUES, YOU MUST RUN `make update-base`.
   ENVOY_REPO ?= $(if $(IS_PRIVATE),git@github.com:datawire/envoy-private.git,https://github.com/datawire/envoy.git)
-  # rebase/release/v1.24.1
-	ENVOY_COMMIT ?= dcc3afef1680c1c4f932c73e0c9bca8b0b5db484
+  # rebase/release/v1.24.2 - with boringSSL cve patch and c-ares dep update
+	ENVOY_COMMIT ?= 5a4aed880cb9b76df21448e75d42fe95a77c3893
   ENVOY_COMPILATION_MODE ?= opt
   # Increment BASE_ENVOY_RELVER on changes to `docker/base-envoy/Dockerfile`, or Envoy recipes.
   # You may reset BASE_ENVOY_RELVER when adjusting ENVOY_COMMIT.
-  BASE_ENVOY_RELVER ?= 0
+  BASE_ENVOY_RELVER ?= 1
 
   # Set to non-empty to enable compiling Envoy in FIPS mode.
   FIPS_MODE ?=
@@ -210,6 +210,7 @@ $(OSS_HOME)/docker/base-envoy/envoy-static: $(ENVOY_BASH.deps) FORCE
 	            exit 1; \
 	        fi; \
 	        $(call ENVOY_BASH.cmd, \
+							$(ENVOY_DOCKER_EXEC) git config --global --add safe.directory /root/envoy; \
 	            $(ENVOY_DOCKER_EXEC) bazel build $(if $(FIPS_MODE), --define boringssl=fips) --verbose_failures -c $(ENVOY_COMPILATION_MODE) --config=clang //source/exe:envoy-static; \
 	            rsync -a$(RSYNC_EXTRAS) --partial --blocking-io -e 'docker exec -i' $$(cat $(OSS_HOME)/_cxx/envoy-build-container.txt):/root/envoy/bazel-bin/source/exe/envoy-static $@; \
 	        ); \

--- a/docker/base-envoy/Dockerfile.stripped
+++ b/docker/base-envoy/Dockerfile.stripped
@@ -16,7 +16,7 @@
 # If you have to change this file, you _must_ update BASE_ENVOY_RELVER
 # in the Makefile, then run "make update-base" to build and push the
 # new image.
-FROM frolvlad/alpine-glibc:alpine-3.17_glibc-2.32
+FROM frolvlad/alpine-glibc:alpine-3.17_glibc-2.34
 
 # We use rsync to move things in and out of the container.
 RUN apk add rsync


### PR DESCRIPTION
## Description
Pulls in the envoy upgrade that landed in the patch release 3.4.1 into master.

> IMPORTANT: I had to rebuild the base-envoy container because in the release/3.4 branch we were using alpine 3.12 but since then we have bumped to alpine 3.17. So, I needed to rebuild envoy to ensure we don't have any mismatches. To ensure we had a unique tag I bumped the `BASE_ENVOY_RELVER` and pushed all of these up to the mirrors.

Updates to the latest release of envoy 1.24.2. It includes two notable changes which are it pulls in a patch for boringssl CVE-2023-0286 that has the potential of affecting users that use Certificate Revocation List (CRL). To be vulnerability one would have to allow end users to provide input to the CRL list where a bad actor could provide malicious certs to take advantage of the vulnerability. If you do not use CRL's or you don't allow external user to provide them directly then it wasn't an issue. AFAIK we know these use cases are niche from our user base but we want to make sure we mitigate this either way.

The 1.24.2 was able to pull in a dependency update for c-ares which will resolve upstream dns cname wildcard resolution issues.

Other items:
- bumps base alpine image used for static envoy layer to frolvlad/alpine-glibc:alpine-3.17_glibc-2.34 to match base-python.
- fixes envoy build so that it sets the /root/envoy as a safe directory in git when doing build to fix build error.

## Related Issues

None

## Testing
CI and we also smoked tested and shipped it as part of 3.4.1.

## Checklist

- [x] **Does my change need to be backported to a previous release?**
It has already landed in 3.4.1 so no action but just checking for visibility. It was landed on the `release/v3.4 branch`.

- [ ] **I made sure to update `CHANGELOG.md`.**
- [x] **This is unlikely to impact how Ambassador performs at scale.**
- [ ] **My change is adequately tested.**
- [x] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**
- [x] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
