### PR TITLE
[v3.4.1] release pr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,15 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
 
 ## RELEASE NOTES
 
+## [3.4.1] February 07, 2023
+[3.4.1]: https://github.com/emissary-ingress/emissary/compare/v3.4.0...v3.4.1
+
+### Emissary-ingress and Ambassador Edge Stack
+
+- Security: This upgrades emissary-ingress to be built on Envoy v1.24.2. This captures a  patch to
+  boringssl to address CVE-2023-0286. It also includes an update to c-ares dependency to address
+  issue with cname wildcard dns resolution for upstream clusters.
+
 ## [3.4.0] January 03, 2023
 [3.4.0]: https://github.com/emissary-ingress/emissary/compare/v3.3.0...v3.4.0
 

--- a/_cxx/envoy.mk
+++ b/_cxx/envoy.mk
@@ -13,8 +13,8 @@ RSYNC_EXTRAS ?=
 
 # IF YOU MESS WITH ANY OF THESE VALUES, YOU MUST RUN `make update-base`.
   ENVOY_REPO ?= $(if $(IS_PRIVATE),git@github.com:datawire/envoy-private.git,https://github.com/datawire/envoy.git)
-  # rebase/release/v1.24.1
-	ENVOY_COMMIT ?= dcc3afef1680c1c4f932c73e0c9bca8b0b5db484
+  # rebase/release/v1.24.2 - with boringSSL cve patch and c-ares dep update
+	ENVOY_COMMIT ?= 5a4aed880cb9b76df21448e75d42fe95a77c3893
   ENVOY_COMPILATION_MODE ?= opt
   # Increment BASE_ENVOY_RELVER on changes to `docker/base-envoy/Dockerfile`, or Envoy recipes.
   # You may reset BASE_ENVOY_RELVER when adjusting ENVOY_COMMIT.

--- a/charts/emissary-ingress/CHANGELOG.md
+++ b/charts/emissary-ingress/CHANGELOG.md
@@ -3,7 +3,11 @@
 This file documents all notable changes to Ambassador Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
-## v8.4.0 - 2022-01-03
+## v8.4.1 - 2023-02-07
+
+- Upgrade Emissary to v3.4.1 [CHANGELOG](https://github.com/emissary-ingress/emissary/blob/master/CHANGELOG.md)
+
+## v8.4.0 - 2023-01-03
 
 - Upgrade Emissary to v3.4.0 [CHANGELOG](https://github.com/emissary-ingress/emissary/blob/master/CHANGELOG.md)
 

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -32,6 +32,17 @@
 
 changelog: https://github.com/emissary-ingress/emissary/blob/$branch$/CHANGELOG.md
 items:
+  - version: 3.4.1
+    date: '2023-02-07'
+    notes:
+      - title: Upgrade to Envoy 1.24.2
+        type: security
+        body: >-
+          This upgrades emissary-ingress to be built on Envoy v1.24.2. This captures a 
+          patch to boringssl to address CVE-2023-0286. It also includes an update to c-ares
+          dependency to address issue with cname wildcard dns resolution for upstream clusters.
+        docs: https://www.envoyproxy.io/docs/envoy/v1.24.2/version_history/v1.24/v1.24.2
+
   - version: 3.4.0
     prevVersion: 3.3.0
     date: '2023-01-03'


### PR DESCRIPTION
## Description

This pulls in latest z patch for Envoy 1.24.2 which incudes a patch for the BoringSSL and also includes an update to the c-ares dependency to address an issue with upstream wildcard dns resolution.

## Related Issues

N/A

## Testing

CI and smoke testing.

## Checklist

- [x] **Does my change need to be backported to a previous release?**
Not a direct backport but we need to make sure this lands in master and also need to research if v2.5 needs patching too.

- [x] **I made sure to update `CHANGELOG.md`.**
- [x] **This is unlikely to impact how Ambassador performs at scale.**
- [x] **My change is adequately tested.**
- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**
- [x] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
