### PR TITLE
Add Opentelemetry driver support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,14 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
 
 ### Emissary-ingress and Ambassador Edge Stack
 
+- Feature: In Envoy 1.24, experimental support for a native OpenTelemetry tracing driver  was
+  introduced that allows exporting spans in the otlp format. Many  Observability platforms accept
+  that format and is the recommend replacement for the LightStep driver. Emissary-ingress now
+  supports setting the  `TracingService.spec.driver=opentelemetry` to export spans in  otlp
+  format.<br/><br/>
+  Thanks to <a href="https://github.com/psalaberria002">Paul</a> for helping us
+  get this tested and implemented!
+
 - Bugfix: When wanting to expose traffic to clients on ports other than 80/443, users will set a
   port in the Host.hostname (eg.`Host.hostname=example.com:8500`. The config generated allowed
   matching on the :authority header. This worked in v1.Y series due to the way emissary was

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -36,6 +36,19 @@ items:
     prevVersion: 3.4.0
     date: 'TBD'
     notes:
+      - title: TracingService support for native OpenTelemetry driver
+        type: feature
+        body: >-
+          In Envoy 1.24, experimental support for a native OpenTelemetry tracing driver 
+          was introduced that allows exporting spans in the otlp format. Many 
+          Observability platforms accept that format and is the recommend
+          replacement for the LightStep driver. $productName$ now supports setting the 
+          <code>TracingService.spec.driver=opentelemetry</code> to export spans in 
+          otlp format.<br/><br/>
+
+          Thanks to <a href="https://github.com/psalaberria002">Paul</a> for helping us
+          get this tested and implemented!
+
       - title: Fix envoy config generation when including port in Host.hostname
         type: bugfix
         body: >-

--- a/manifests/emissary/emissary-crds.yaml.in
+++ b/manifests/emissary/emissary-crds.yaml.in
@@ -4914,6 +4914,7 @@ spec:
                 - lightstep
                 - zipkin
                 - datadog
+                - opentelemetry
                 type: string
               sampling:
                 properties:
@@ -5042,6 +5043,7 @@ spec:
                 - lightstep
                 - zipkin
                 - datadog
+                - opentelemetry
                 type: string
               sampling:
                 properties:
@@ -5224,6 +5226,7 @@ spec:
                 - lightstep
                 - zipkin
                 - datadog
+                - opentelemetry
                 type: string
               sampling:
                 properties:

--- a/pkg/api/getambassador.io/crds.yaml
+++ b/pkg/api/getambassador.io/crds.yaml
@@ -5257,6 +5257,7 @@ spec:
                 - lightstep
                 - zipkin
                 - datadog
+                - opentelemetry
                 type: string
               sampling:
                 properties:
@@ -5394,6 +5395,7 @@ spec:
                 - lightstep
                 - zipkin
                 - datadog
+                - opentelemetry
                 type: string
               sampling:
                 properties:
@@ -5575,6 +5577,7 @@ spec:
                 - lightstep
                 - zipkin
                 - datadog
+                - opentelemetry
                 type: string
               sampling:
                 properties:

--- a/pkg/api/getambassador.io/v2/crd_tracingservice.go
+++ b/pkg/api/getambassador.io/v2/crd_tracingservice.go
@@ -49,7 +49,7 @@ type TraceConfig struct {
 type TracingServiceSpec struct {
 	AmbassadorID AmbassadorID `json:"ambassador_id,omitempty"`
 
-	// +kubebuilder:validation:Enum={"lightstep","zipkin","datadog"}
+	// +kubebuilder:validation:Enum={"lightstep","zipkin","datadog","opentelemetry"}
 	// +kubebuilder:validation:Required
 	Driver string `json:"driver,omitempty"`
 	// +kubebuilder:validation:Required

--- a/pkg/api/getambassador.io/v3alpha1/crd_tracingservice.go
+++ b/pkg/api/getambassador.io/v3alpha1/crd_tracingservice.go
@@ -87,7 +87,7 @@ type TracingCustomTag struct {
 type TracingServiceSpec struct {
 	AmbassadorID AmbassadorID `json:"ambassador_id,omitempty"`
 
-	// +kubebuilder:validation:Enum={"lightstep","zipkin","datadog"}
+	// +kubebuilder:validation:Enum={"lightstep","zipkin","datadog","opentelemetry"}
 	// +kubebuilder:validation:Required
 	Driver string `json:"driver,omitempty"`
 	// +kubebuilder:validation:Required

--- a/python/ambassador/envoy/v3/v3tracing.py
+++ b/python/ambassador/envoy/v3/v3tracing.py
@@ -52,6 +52,10 @@ class V3Tracing(dict):
             driver_config["@type"] = "type.googleapis.com/envoy.config.trace.v3.DatadogConfig"
             if not driver_config.get("service_name"):
                 driver_config["service_name"] = "ambassador"
+        elif name.lower() == "envoy.opentelemetry":
+            driver_config["@type"] = "type.googleapis.com/envoy.config.trace.v3.OpenTelemetryConfig"
+            if not driver_config.get("service_name"):
+                driver_config["service_name"] = "ambassador"
         else:
             # This should be impossible, because we ought to have validated the input driver
             # in ambassador/pkg/api/getambassador.io/v2/tracingservice_types.go:47

--- a/python/ambassador/ir/irtracing.py
+++ b/python/ambassador/ir/irtracing.py
@@ -80,7 +80,9 @@ class IRTracing(IRResource):
             )
             return False
         if driver == "opentelemetry":
-            ir.logger.warning("The OpenTelemetry tracing driver is work-in-progress. Functionality is incomplete and it is not intended for production use. This extension has an unknown security posture and should only be used in deployments where both the downstream and upstream are trusted.") 
+            ir.logger.warning(
+                "The OpenTelemetry tracing driver is work-in-progress. Functionality is incomplete and it is not intended for production use. This extension has an unknown security posture and should only be used in deployments where both the downstream and upstream are trusted."
+            )
             grpc = True
 
         if driver == "datadog":
@@ -155,9 +157,7 @@ class IRTracing(IRResource):
         # Opentelemetry is the only one that does not use collector_cluster
         if self.driver == "opentelemetry":
             self.driver_config["grpc_service"] = {
-                "envoy_grpc": {
-                    "cluster_name": self.cluster.envoy_name
-                }
+                "envoy_grpc": {"cluster_name": self.cluster.envoy_name}
             }
         else:
             self.driver_config["collector_cluster"] = self.cluster.envoy_name

--- a/python/tests/integration/manifests/crds.yaml
+++ b/python/tests/integration/manifests/crds.yaml
@@ -4914,6 +4914,7 @@ spec:
                 - lightstep
                 - zipkin
                 - datadog
+                - opentelemetry
                 type: string
               sampling:
                 properties:
@@ -5042,6 +5043,7 @@ spec:
                 - lightstep
                 - zipkin
                 - datadog
+                - opentelemetry
                 type: string
               sampling:
                 properties:
@@ -5224,6 +5226,7 @@ spec:
                 - lightstep
                 - zipkin
                 - datadog
+                - opentelemetry
                 type: string
               sampling:
                 properties:

--- a/python/tests/kat/t_tracing.py
+++ b/python/tests/kat/t_tracing.py
@@ -764,10 +764,22 @@ custom_tags:
                 phase=1,
             )
 
-        # ...then ask Jaeger for services and traces.
+        # query-20: ask Jaeger for services and traces.
         yield Query(f"http://{self.jaeger.path.fqdn}:16686/api/services", phase=check_phase)
+
+        # query-21: ask for envoy routing traces
+        router_operation_name = (
+            "router%20tracingtestopentelemetry_http_default_svc_cluster_local%20egress"
+        )
         yield Query(
-            f"http://{self.jaeger.path.fqdn}:16686/api/traces?service=ambassador&limit=20",
+            f"http://{self.jaeger.path.fqdn}:16686/api/traces?service=ambassador&operation={router_operation_name}",
+            phase=check_phase,
+        )
+
+        # query-22: ask for upstream cluster traces
+        cluster_operation_name = "egress%20tracingtestopentelemetry.default.svc.cluster.local"
+        yield Query(
+            f"http://{self.jaeger.path.fqdn}:16686/api/traces?service=ambassador&operation={cluster_operation_name}",
             phase=check_phase,
         )
 
@@ -777,29 +789,23 @@ custom_tags:
             assert result.backend
             assert result.backend.name == self.target.path.k8s
 
+        # verify "ambassador" is the list of services from jaeger
         print(f"self.results[20] = {self.results[20]}")
         assert (
             self.results[20].json is not None and "ambassador" in self.results[20].json["data"]
         ), f"unexpected self.results[20] = {self.results[20]}"
 
-        tracelist = self.results[21].json["data"]
-        assert len(tracelist) == 20, f"tracelist lenght = {len(tracelist)}"
-        # The order of spans in the json response is not deterministic.
-        # One span contains `egress tracingtestopentelemetry.default.svc.cluster.local`
-        # and the other one `router tracingtestopentelemetry_http_default_svc_cluster_local egress`
-        assert any(
-            s
-            for s in tracelist[0]["spans"]
-            if s["operationName"]
-            == "router tracingtestopentelemetry_http_default_svc_cluster_local egress"
-        ), tracelist[0]["spans"]
-        assert any(
-            s
-            for s in tracelist[0]["spans"]
-            if s["operationName"] == "egress tracingtestopentelemetry.default.svc.cluster.local"
-        ), tracelist[0]["spans"]
+        # verify trace spans for "router tracingtestopentelemetry_http_default_svc_cluster_local egress"
+        route_tracelist = self.results[21].json["data"]
+        print(f"route_tracelist = {route_tracelist}")
+        assert len(route_tracelist) == 20, f"route tracelist length = {len(route_tracelist)}"
 
-        for trace in self.results[21].json["data"]:
+        # verify trace spans for "egress tracingtestopentelemetry.default.svc.cluster.local"
+        cluster_tracelist = self.results[22].json["data"]
+        print(f"cluster_tracelist = {cluster_tracelist}")
+        assert len(cluster_tracelist) == 20, f"cluster tracelist length = {len(cluster_tracelist)}"
+
+        for trace in cluster_tracelist:
             for span in trace.get("spans", []):
                 # Check if the egress span contains expected tags.
                 # For some reason the router span isn't resolving the htag request_header,


### PR DESCRIPTION
I added integration tests using a Jaeger OTLP endpoint as the trace endpoint.

The implementation was already done by @AliceProxy , so I built this PR based on her branch.