### PR TITLE
deps: update to golang 1.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,10 +85,13 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
 
 ## RELEASE NOTES
 
-## [3.5.0] TBD
+## [3.5.0] February 15, 2023
 [3.5.0]: https://github.com/emissary-ingress/emissary/compare/v3.4.0...v3.5.0
 
 ### Emissary-ingress and Ambassador Edge Stack
+
+- Security: Upgrading to the latest release of Golang as part of our general dependency upgrade
+  process. This includes security fixes for CVE-2022-41725, CVE-2022-41723.
 
 - Feature: In Envoy 1.24, experimental support for a native OpenTelemetry tracing driver  was
   introduced that allows exporting spans in the otlp format. Many  Observability platforms accept
@@ -121,9 +124,6 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
   a startupProbe to ensure that emissary-apiext server has enough time to configure the webhooks
   before running liveness and readiness probes. This is to ensure  slow startup doesn't cause K8s to
   needlessly restart the pod.
-
-- Change: Upgrading to the latest release of Golang as part of our general dependency upgrade
-  process.
 
 [fix: hostname port issue]: https://github.com/emissary-ingress/emissary/pull/4816
 [#4809]: https://github.com/emissary-ingress/emissary/pull/4809

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -3,7 +3,7 @@ following Free and Open Source software:
 
     Name                                                                                       Version                                      License(s)
     ----                                                                                       -------                                      ----------
-    the Go language standard library ("std")                                                   v1.20                                        3-clause BSD license
+    the Go language standard library ("std")                                                   v1.20.1                                      3-clause BSD license
     cloud.google.com/go/compute                                                                v1.2.0                                       Apache License 2.0
     github.com/Azure/go-ansiterm                                                               v0.0.0-20210617225240-d185dfc1b5a1           MIT license
     github.com/Azure/go-autorest                                                               v14.2.0+incompatible                         Apache License 2.0

--- a/charts/emissary-ingress/CHANGELOG.md
+++ b/charts/emissary-ingress/CHANGELOG.md
@@ -3,7 +3,7 @@
 This file documents all notable changes to Ambassador Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
-## v8.5.0 - TBD
+## v8.5.0 - 2023-02-15
 
 - Upgrade Emissary to v3.5.0 [CHANGELOG](https://github.com/emissary-ingress/emissary/blob/master/CHANGELOG.md)
 - Adds support for configuring a startupProbe on the emissary-ingress deployments. This is useful when a larger number of resources

--- a/docker/base-python/Dockerfile
+++ b/docker/base-python/Dockerfile
@@ -78,7 +78,7 @@ RUN apk --no-cache add \
 # Pinning build version due to missing license info from pip show in newer versions
 RUN pip3 install pip-tools==6.12.1 build==0.9.0
 
-RUN curl --fail -L https://dl.google.com/go/go1.20.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+RUN curl --fail -L https://dl.google.com/go/go1.20.1.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 
 RUN curl --fail -L https://storage.googleapis.com/kubernetes-release/release/v1.23.3/bin/linux/amd64/kubectl -o /usr/bin/kubectl && \
   chmod a+x /usr/bin/kubectl

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -34,8 +34,14 @@ changelog: https://github.com/emissary-ingress/emissary/blob/$branch$/CHANGELOG.
 items:
   - version: 3.5.0
     prevVersion: 3.4.0
-    date: 'TBD'
+    date: '2023-02-15'
     notes:
+      - title: Update to golang 1.20.1
+        type: security
+        body: >-
+          Upgrading to the latest release of Golang as part of our general dependency upgrade process. This includes
+          security fixes for CVE-2022-41725, CVE-2022-41723.
+
       - title: TracingService support for native OpenTelemetry driver
         type: feature
         body: >-
@@ -89,10 +95,6 @@ items:
           configure the webhooks before running liveness and readiness probes. This is to ensure 
           slow startup doesn't cause K8s to needlessly restart the pod.
       
-      - title: Update to golang 1.20
-        type: change
-        body: >-
-          Upgrading to the latest release of Golang as part of our general dependency upgrade process.
 
   - version: 3.4.0
     prevVersion: 3.3.0


### PR DESCRIPTION
## Description

Pulls in security release fixes for CVE-2022-41725, CVE-2022-41723.

## Related Issues

N/A

## Testing

CI is green

## Checklist

- [x] **Does my change need to be backported to a previous release?**
- [x] **I made sure to update `CHANGELOG.md`.**
- [x] **This is unlikely to impact how Ambassador performs at scale.**
- [x] **My change is adequately tested.**
- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**
- [x] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
