### PR TITLE
repo: prepare branch for v3.6.0 development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,11 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
 
 ## RELEASE NOTES
 
+## [3.6.0] TBD
+[3.6.0]: https://github.com/emissary-ingress/emissary/compare/v3.5.0...v3.6.0
+
+### Emissary-ingress and Ambassador Edge Stack
+
 ## [3.5.0] February 15, 2023
 [3.5.0]: https://github.com/emissary-ingress/emissary/compare/v3.4.0...v3.5.0
 

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Branches
 (If you are looking at this list on a branch other than `master`, it
 may be out of date.)
 
-- [`master`](https://github.com/emissary-ingress/emissary/tree/master) - branch for Emissary-ingress 3.5.z work (:heavy_check_mark: upcoming release)
-- [`release/v3.4`](https://github.com/emissary-ingress/emissary/tree/release/v3.4) - branch for Emissary-ingress 3.4.z work
+- [`master`](https://github.com/emissary-ingress/emissary/tree/master) - branch for Emissary-ingress 3.6.z work (:heavy_check_mark: upcoming release)
+- [`release/v3.5`](https://github.com/emissary-ingress/emissary/tree/release/v3.5) - branch for Emissary-ingress 3.5.z work
 - [`release/v2.5`](https://github.com/emissary-ingress/emissary/tree/release/v2.5) - branch for Emissary-ingress 2.5.z work (:heavy_check_mark: upcoming release)
 - [`release/v1.14`](https://github.com/emissary-ingress/emissary/tree/release/v1.14) - branch for Emissary-ingress 1.14.z work (:heavy_check_mark: maintenance, supported through September 2022)
 

--- a/charts/emissary-ingress/CHANGELOG.md
+++ b/charts/emissary-ingress/CHANGELOG.md
@@ -3,6 +3,9 @@
 This file documents all notable changes to Ambassador Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v8.6.0 - TBD
+- Upgrade Emissary to v3.6.0 [CHANGELOG](https://github.com/emissary-ingress/emissary/blob/master/CHANGELOG.md)
+
 ## v8.5.0 - 2023-02-15
 
 - Upgrade Emissary to v3.5.0 [CHANGELOG](https://github.com/emissary-ingress/emissary/blob/master/CHANGELOG.md)

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -32,6 +32,11 @@
 
 changelog: https://github.com/emissary-ingress/emissary/blob/$branch$/CHANGELOG.md
 items:
+  - version: 3.6.0
+    prevVersion: 3.5.0
+    date: 'TBD'
+    notes: []
+
   - version: 3.5.0
     prevVersion: 3.4.0
     date: '2023-02-15'


### PR DESCRIPTION
Get main branch ready now that v3.5.0 has been released.

> Note: the check branch is expected to fail. Once this is merged we will tag it with a dev tag `3.6.0-dev`.