### PR TITLE
Fix `make lint`: requirements-dev.txt: Pin to older types-requests

### DIFF
--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -17,6 +17,6 @@ types-orjson
 types-protobuf
 types-pyOpenSSL
 types-pyyaml
-types-requests
+types-requests==2.28.11.12 # Something about the upgrade to 2.28.11.13 breaks `make lint/mypy`
 types-retry
 types-setuptools


### PR DESCRIPTION
## Description

Apparently the upgrade to 2.28.11.13 (and 2.28.11.14) breaks `make lint/mypy` and I don't really care to investigate it more than that right now.

## Related Issues

(none)

## Testing

I verified that `make lint/mypy` works again.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->
- [ ] **Does my change need to be backported to a previous release?** - maybe?
  - What backport versions were discussed with the Maintainers in the Issue?

- [x] **I made sure to update `CHANGELOG.md`.** - no applicable changes

   Remember, the CHANGELOG needs to mention:
  - Any new features
  - Any changes to our included version of Envoy
  - Any non-backward-compatible changes
  - Any deprecations

- [x] **This is unlikely to impact how Ambassador performs at scale.** - not a runtime change

   Remember, things that might have an impact at scale include:
  - Any significant changes in memory use that might require adjusting the memory limits
  - Any significant changes in CPU use that might require adjusting the CPU limits
  - Anything that might change how many replicas users should use
  - Changes that impact data-plane latency/scalability

- [x] **My change is adequately tested.** - yes

   Remember when considering testing:
  - Your change needs to be specifically covered by tests.
    - Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
  - You also need to make sure that the _entire area being changed_ has adequate test coverage.
    - If existing tests don't actually cover the entire area being changed, add tests.
    - This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
  - We should lean on the bulk of code being covered by unit tests, but...
  - ... an end-to-end test should cover the integration points

- [x] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.** - no tricks

- [ ] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
