### PR TITLE
Delete further remnants from KAT_RUN_MODE=local

### DIFF
--- a/.github/workflows/execute-tests-and-promote.yml
+++ b/.github/workflows/execute-tests-and-promote.yml
@@ -145,11 +145,11 @@ jobs:
       matrix:
         test:
           - integration
-          - kat-envoy3-1-of-5
-          - kat-envoy3-2-of-5
-          - kat-envoy3-3-of-5
-          - kat-envoy3-4-of-5
-          - kat-envoy3-5-of-5
+          - kat-1-of-5
+          - kat-2-of-5
+          - kat-3-of-5
+          - kat-4-of-5
+          - kat-5-of-5
     name: pytest-${{ matrix.test }}
     steps:
       - uses: actions/checkout@v3

--- a/build-aux/builder.mk
+++ b/build-aux/builder.mk
@@ -218,7 +218,7 @@ pytest-integration: push-pytest-images
 	$(MAKE) pytest PYTEST_ARGS="$$PYTEST_ARGS python/tests/integration"
 .PHONY: pytest-integration
 
-pytest-kat-envoy3: push-pytest-images # doing this all at once is too much for CI...
+pytest-kat: push-pytest-images # doing this all at once is too much for CI...
 	$(MAKE) pytest PYTEST_ARGS="$$PYTEST_ARGS python/tests/kat"
 # ... so we have a separate rule to run things split up
 build-aux/.pytest-kat.txt.stamp: $(OSS_HOME)/venv push-pytest-images $(tools/kubectl) FORCE
@@ -226,7 +226,7 @@ build-aux/.pytest-kat.txt.stamp: $(OSS_HOME)/venv push-pytest-images $(tools/kub
 build-aux/pytest-kat.txt: build-aux/%: build-aux/.%.stamp $(tools/copy-ifchanged)
 	$(tools/copy-ifchanged) $< $@
 clean: build-aux/.pytest-kat.txt.stamp.rm build-aux/pytest-kat.txt.rm
-pytest-kat-envoy3-%: build-aux/pytest-kat.txt $(tools/py-split-tests)
+pytest-kat-%: build-aux/pytest-kat.txt $(tools/py-split-tests)
 	$(MAKE) pytest PYTEST_ARGS="$$PYTEST_ARGS -k '$$($(tools/py-split-tests) $(subst -of-, ,$*) <build-aux/pytest-kat.txt)' python/tests/kat"
 
 $(OSS_HOME)/venv: python/requirements.txt python/requirements-dev.txt


### PR DESCRIPTION
## Description

> This is on top of https://github.com/emissary-ingress/emissary/pull/4863, go merge that first!

#4863 removed the gold-file machinery (`KAT_RUN_MODE=local`), but the Make targets are still overly verbose, still having the `-envoy` specifier that was originally added to have `-envoy` (non-gold) and `-local` (gold) names.  This drops that `-envoy` bit, but this **will require a minor sibling change in apro.git** to match.

## Related Issues

(none)

## Testing

(none)

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->
- [x] **Does my change need to be backported to a previous release?** - no
  - What backport versions were discussed with the Maintainers in the Issue?

- [x] **I made sure to update `CHANGELOG.md`.** - no applicable changes

   Remember, the CHANGELOG needs to mention:
  - Any new features
  - Any changes to our included version of Envoy
  - Any non-backward-compatible changes
  - Any deprecations

- [x] **This is unlikely to impact how Ambassador performs at scale.** - not a runtime change

   Remember, things that might have an impact at scale include:
  - Any significant changes in memory use that might require adjusting the memory limits
  - Any significant changes in CPU use that might require adjusting the CPU limits
  - Anything that might change how many replicas users should use
  - Changes that impact data-plane latency/scalability

- [x] **My change is adequately tested.** - I'd say so

   Remember when considering testing:
  - Your change needs to be specifically covered by tests.
    - Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
  - You also need to make sure that the _entire area being changed_ has adequate test coverage.
    - If existing tests don't actually cover the entire area being changed, add tests.
    - This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
  - We should lean on the bulk of code being covered by unit tests, but...
  - ... an end-to-end test should cover the integration points

- [x] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.** - no tricksn

- [ ] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
