### PR TITLE
chart: update resolver apiVersions to v3alpha1

### DIFF
--- a/charts/emissary-ingress/CHANGELOG.md
+++ b/charts/emissary-ingress/CHANGELOG.md
@@ -6,6 +6,7 @@ numbering uses [semantic versioning](http://semver.org).
 ## v8.6.0 - TBD
 - Upgrade Emissary to v3.6.0 [CHANGELOG](https://github.com/emissary-ingress/emissary/blob/master/CHANGELOG.md)
 - Use autoscaling/v2 HorizontalPodAutoscaler if the cluster version is >v1.26 as autoscaling/v2beta2 is deprecated starting v1.23 and removed in v1.26. Thanks to [Elvind Valderhaug](https://github.com/eevdev)
+- Upgrade KubernetesEndpointResolver & ConsulResolver apiVersions to `getambassador.io/v3alpha1`
 
 ## v8.5.1 - 2023-02-23
 

--- a/charts/emissary-ingress/templates/resolvers.yaml
+++ b/charts/emissary-ingress/templates/resolvers.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.resolvers.endpoint.create }}
 ---
-apiVersion: getambassador.io/v2
+apiVersion: getambassador.io/v3alpha1
 kind: KubernetesEndpointResolver
 metadata:
   name: {{ .Values.resolvers.endpoint.name }}
@@ -10,12 +10,13 @@ metadata:
     {{- include "ambassador.labels" . | nindent 4 }}
 {{- if hasKey .Values.env "AMBASSADOR_ID" }}
 spec:
-  ambassador_id: {{ .Values.env.AMBASSADOR_ID | quote }}
+  ambassador_id:
+  - {{ .Values.env.AMBASSADOR_ID | quote }}
 {{- end }}
 {{- end }}
 {{- if .Values.resolvers.consul.create }}
 ---
-apiVersion: getambassador.io/v2
+apiVersion: getambassador.io/v3alpha1
 kind: ConsulResolver
 metadata:
   name: {{ .Values.resolvers.consul.name }}
@@ -25,7 +26,8 @@ metadata:
     {{- include "ambassador.labels" . | nindent 4 }}
 spec:
   {{- if hasKey .Values.env "AMBASSADOR_ID" }}
-  ambassador_id: {{ .Values.env.AMBASSADOR_ID | quote }}
+  ambassador_id:
+  - {{ .Values.env.AMBASSADOR_ID | quote }}
   {{- end }}
   {{- toYaml .Values.resolvers.consul.spec | nindent 2 }}
 {{- end }}


### PR DESCRIPTION
## Description

Upgrade KubernetesEndpointResolver & ConsulResolver apiVersions to `getambassador.io/v3alpha1` so that all emissary resources in the chart are using `v3alpha1`.

## Related Issues

N/A

## Testing

Since our CI is not very good testing the helm chart, I installed the chart manually with the KubernetesEndpointResolver enabled and confirmed that the resolvers pass CRD validation and I can get a quick mapping going.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->
- [ ] **Does my change need to be backported to a previous release?**
  - What backport versions were discussed with the Maintainers in the Issue?

- [x] **I made sure to update `CHANGELOG.md`.**

   Remember, the CHANGELOG needs to mention:
  - Any new features
  - Any changes to our included version of Envoy
  - Any non-backward-compatible changes
  - Any deprecations

- [x] **This is unlikely to impact how Ambassador performs at scale.**

   Remember, things that might have an impact at scale include:
  - Any significant changes in memory use that might require adjusting the memory limits
  - Any significant changes in CPU use that might require adjusting the CPU limits
  - Anything that might change how many replicas users should use
  - Changes that impact data-plane latency/scalability

- [ ] **My change is adequately tested.**

   Remember when considering testing:
  - Your change needs to be specifically covered by tests.
    - Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
  - You also need to make sure that the _entire area being changed_ has adequate test coverage.
    - If existing tests don't actually cover the entire area being changed, add tests.
    - This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
  - We should lean on the bulk of code being covered by unit tests, but...
  - ... an end-to-end test should cover the integration points

- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**

- [ ] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
