### PR TITLE
fix: properly handle HTTP/2 connection reuse

### DIFF
--- a/build-aux/lint.mk
+++ b/build-aux/lint.mk
@@ -52,6 +52,12 @@ format/isort: $(OSS_HOME)/venv
 	. $(OSS_HOME)/venv/bin/activate && isort ./python/
 .PHONY: format/isort
 
+format/python: format/black format/isort
+.PHONY: format/python
+
+lint/python: lint/black lint/isort lint/mypy
+.PHONY: lint/python
+
 #
 # Helm
 

--- a/python/tests/unit/test_listener.py
+++ b/python/tests/unit/test_listener.py
@@ -65,92 +65,95 @@ spec:
 
 
 class TestListener:
+    @dataclass
+    class SocketProtocolTestCase:
+        name: str
+        protocol: Optional[str]
+        protocolStack: Optional[List[str]]
+        expectedSocketProtocol: Optional[str]
+
     @pytest.mark.compilertest
-    def test_socket_protocol(self):
-        """ensure that we can identify the listener socket protocol based on the provided protocol and protocolStack"""
-
-        @dataclass
-        class TestCase:
-            name: str
-            protocol: Optional[str]
-            protocolStack: Optional[List[str]]
-            expectedSocketProtocol: Optional[str]
-
-        testcases = [
+    @pytest.mark.parametrize(
+        "case",
+        ids=lambda case: case.name,
+        argvalues=[
             # test with emissary defined protcolStacks via pre-definied protocol enum
-            TestCase(
+            SocketProtocolTestCase(
                 name="http_protocol",
                 protocol="HTTP",
                 protocolStack=None,
                 expectedSocketProtocol="TCP",
             ),
-            TestCase(
+            SocketProtocolTestCase(
                 name="https_protocol",
                 protocol="HTTPS",
                 protocolStack=None,
                 expectedSocketProtocol="TCP",
             ),
-            TestCase(
+            SocketProtocolTestCase(
                 name="httpproxy_protocol",
                 protocol="HTTPPROXY",
                 protocolStack=None,
                 expectedSocketProtocol="TCP",
             ),
-            TestCase(
+            SocketProtocolTestCase(
                 name="httpsproxy_protocol",
                 protocol="HTTPSPROXY",
                 protocolStack=None,
                 expectedSocketProtocol="TCP",
             ),
-            TestCase(
+            SocketProtocolTestCase(
                 name="tcp_protocol",
                 protocol="TCP",
                 protocolStack=None,
                 expectedSocketProtocol="TCP",
             ),
-            TestCase(
+            SocketProtocolTestCase(
                 name="tls_protocol",
                 protocol="TLS",
                 protocolStack=None,
                 expectedSocketProtocol="TCP",
             ),
             # test with custom stacks
-            TestCase(
+            SocketProtocolTestCase(
                 name="tcp_stack",
                 protocol=None,
                 protocolStack=["TLS", "HTTP", "TCP"],
                 expectedSocketProtocol="TCP",
             ),
-            TestCase(
+            SocketProtocolTestCase(
                 name="udp_stack",
                 protocol=None,
                 protocolStack=["TLS", "HTTP", "UDP"],
                 expectedSocketProtocol="UDP",
             ),
-            TestCase(
+            SocketProtocolTestCase(
                 name="invalid_stack",
                 protocol=None,
                 protocolStack=["TLS", "HTTP"],
                 expectedSocketProtocol=None,
             ),
-            TestCase(
+            SocketProtocolTestCase(
                 name="empty_stack", protocol=None, protocolStack=[], expectedSocketProtocol=None
             ),
-        ]
-        for case in testcases:
-            yaml = _generateListener(case.name, case.protocol, case.protocolStack)
+        ],
+    )
+    def test_socket_protocol(self, case: SocketProtocolTestCase):
+        """ensure that we can identify the listener socket protocol based on the provided protocol and protocolStack"""
 
-            compiled_ir = Compile(logger, yaml, k8s=True)
-            result_ir = compiled_ir["ir"]
-            listeners = list(result_ir.listeners.values())
-            errors = result_ir.aconf.errors
+        yaml = _generateListener(case.name, case.protocol, case.protocolStack)
 
-            if case.expectedSocketProtocol == None:
-                assert len(errors) == 1
-                assert len(listeners) == 0
-            else:
-                assert len(listeners) == 1
-                assert listeners[0].socket_protocol == case.expectedSocketProtocol
+        compiled_ir = Compile(logger, yaml, k8s=True)
+        result_ir = compiled_ir["ir"]
+        listeners = list(result_ir.listeners.values())
+        errors = result_ir.aconf.errors
+
+        if case.expectedSocketProtocol == None:
+            assert len(errors) == 1
+            assert len(listeners) == 0
+        else:
+            assert len(listeners) == 1
+            assert listeners[0].socket_protocol == case.expectedSocketProtocol
 
     @pytest.mark.compilertest
     def test_http3_valid_quic_listener(self):
@@ -325,9 +328,44 @@ spec:
 
         _verify_no_added_response_headers(udp_listener)
 
+    @dataclass
+    class FilterChainGenTestCase:
+        # name should match the file name in testdata/listeners (excluding the _out.yaml and _in.yaml suffixes)
+        name: str
+        # description allows developer to provide any information on use-case without having to study the in/out files
+        # as well as displaying it in the pytest output for easier debugging.
+        description: str
+
     @skip_edgestack()
     @pytest.mark.compilertest
-    def test_listener_filterchain_vhost_generation(self):
+    @pytest.mark.parametrize(
+        "case",
+        ids=lambda case: case.name,
+        argvalues=[
+            FilterChainGenTestCase(
+                name="host_missing_tls",
+                description="When applying the quick-start of 8080 and 8443 with a Host that doesn't have tls configured it will generate basically "
+                "the same FilterChain/Vhost/Routes between the two listeners. The HTTPS Listener will not generate a "
+                "Filter Chain checking for matches on TLS and/or SNI. A fallback cert is not used because a Host is configured "
+                "although arguable incorrectly. Ideally, the HTTPS listener (8443) should not attach anything or use the fallback "
+                "cert as-if no Host was provided but since this was existing behavior it has been left that way for now.",
+            ),
+            FilterChainGenTestCase(
+                name="no_host",
+                description="If no Host is provided the http (8080) listener will create the normal 'shared http' filter chain "
+                "and the https (8443) listener will generate two filter chains; a 'shared http' filter chain to catch non-tls traffic "
+                "and a filter chain matching on tls and using the fall-back cert with NO sni matching.",
+            ),
+            FilterChainGenTestCase(
+                name="prefix_wildcard_and_hostname_with_port",
+                description="Properly handle Host with prefix wildcards (*.local) and hosts with portnames (*.local:8500). "
+                "In this scenario both host will be coalesced into the same FilterChain due to matching SNI but "
+                "will get their own virtual hosts due to needing to match on a :authority header. Mappings will "
+                "associate to the most specific vhost based on the Host.hostname and Mapping.hostname fields",
+            ),
+        ],
+    )
+    def test_listener_filterchain_generation(self, case: FilterChainGenTestCase):
         """Ensure that the Listener FilterChain and correct vhosts are generated based on the
         provided Listener, Host and Mappings to ensure mutliple scenarios are covered such as
         clients sending hostname:port and addressing h2/h3 connection re-use on parent domains
@@ -360,56 +398,16 @@ spec:
             os.path.dirname(os.path.abspath(__file__)), "testdata", "listeners"
         )
 
-        @dataclass
-        class TestCase:
-            # name should match the file name in testdata/listeners (excluding the _out.yaml and _in.yaml suffixes)
-            name: str
-            # description allows developer to provide my information on use-case without having to study the in/out files
-            description: str
+        applied_yaml = open(os.path.join(testdata_dir, f"{case.name}_in.yaml"), "r").read()
+        expected = yaml.safe_load(open(os.path.join(testdata_dir, f"{case.name}_out.yaml"), "r"))
 
-        testcases = [
-            TestCase(
-                name="host_missing_tls",
-                description="""
-                    When applying the quick-start of 8080 and 8443 with a Host that doesn't have tls configured it will generate basically
-                    the same FilterChain/Vhost/Routes between the two listeners. The HTTPS Listener will not generate a
-                    Filter Chain checking for matches on TLS and/or SNI. A fallback cert is not used because a Host is configured
-                    although arguable incorrectly. Ideally, the HTTPS listener (8443) should not attach anything or use the fallback
-                    cert as-if no Host was provided but since this was existing behavior it has been left that way for now.
-                """,
-            ),
-            TestCase(
-                name="no_host",
-                description="""
-                    If no Host is provided the http (8080) listener will create the normal "shared http" filter chain
-                    and the https (8443) listener will generate two filter chains; a "shared http" filter chain to catch non-tls traffic
-                    and a filter chain matching on tls and using the fall-back cert with NO sni matching.
-                """,
-            ),
-            TestCase(
-                name="prefix_wildcard_and_hostname_with_port",
-                description="""
-                    Properly handle Host with prefix wildcards (*.local) and hosts with portnames (*.local:8500). In
-                    this scenario both host will be coalesced into the same FilterChain due to matching SNI but
-                    will get their own virtual hosts due to needing to match on a :authority header. Mappings will
-                    associate to the most specific vhost based on the Host.hostname and Mapping.hostname fields
-                """,
-            ),
-        ]
-        for case in testcases:
+        econf = econf_compile(applied_yaml)
+        assert econf
 
-            applied_yaml = open(os.path.join(testdata_dir, f"{case.name}_in.yaml"), "r").read()
-            expected = yaml.safe_load(
-                open(os.path.join(testdata_dir, f"{case.name}_out.yaml"), "r")
-            )
+        expListeners = expected.get("listeners", {})
+        assert expListeners != {}
 
-            econf = econf_compile(applied_yaml)
-            assert econf
+        listeners = econf.get("static_resources", {}).get("listeners", [])
+        _cleanse_secrets(listeners)
 
-            expListeners = expected.get("listeners", {})
-            assert expListeners != {}
-
-            listeners = econf.get("static_resources", {}).get("listeners", [])
-            _cleanse_secrets(listeners)
-
-            assert expListeners == listeners
+        assert expListeners == listeners

--- a/python/tests/unit/testdata/listeners/host_and_tcp_mapping_sharing_tls_context_in.yaml
+++ b/python/tests/unit/testdata/listeners/host_and_tcp_mapping_sharing_tls_context_in.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Listener
+metadata:
+  name: listener-8443
+  namespace: ambassador
+spec:
+  port: 8443
+  protocol: HTTPS
+  securityModel: XFP
+  hostBinding:
+    namespace:
+      from: ALL
+---
+apiVersion: getambassador.io/v3alpha1
+kind: TLSContext
+metadata:
+  name: my-tls-context
+  namespace: default
+spec:
+  secret: tls-cert
+  hosts: ["foo.com", "db.foo.com"]
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: host
+  namespace: default
+spec:
+  hostname: 'foo.com'
+  tlsSecret:
+    name: tls-cert
+  tlsContext: 
+    name: my-tls-context
+---
+apiVersion: getambassador.io/v3alpha1
+kind: TCPMapping
+metadata:
+  name: tcp
+  namespace: default
+spec:
+  host: 'db.foo.com'
+  port: 8443
+  tls: my-tls-context
+  service: db
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: quote-backend
+  namespace: default
+spec:
+  hostname: "foo.com"
+  prefix: /backend/
+  service: quote

--- a/python/tests/unit/testdata/listeners/host_and_tcp_mapping_sharing_tls_context_out.yaml
+++ b/python/tests/unit/testdata/listeners/host_and_tcp_mapping_sharing_tls_context_out.yaml
@@ -1,0 +1,360 @@
+listeners:
+- address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 8443
+      protocol: TCP
+  filter_chains:
+  - filter_chain_match:
+      server_names:
+      - db.foo.com
+      transport_protocol: tls
+    filters:
+    - name: envoy.filters.network.tcp_proxy
+      typed_config:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+        stat_prefix: ingress_https
+        weighted_clusters:
+          clusters:
+          - name: cluster_db_otls_my_tls_context_default
+            weight: 100
+    name: 'tcphost-GROUP: tcp'
+    transport_socket:
+      name: envoy.transport_sockets.tls
+      typed_config:
+        '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+        common_tls_context:
+          tls_certificates:
+          - certificate_chain:
+              filename: test.crt
+            private_key:
+              filename: test.key
+  - filter_chain_match:
+      server_names:
+      - foo.com
+      transport_protocol: tls
+    filters:
+    - name: envoy.filters.network.http_connection_manager
+      typed_config:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        access_log:
+        - name: envoy.access_loggers.file
+          typed_config:
+            '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+            log_format:
+              text_format_source:
+                inline_string: 'ACCESS [%START_TIME%] "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%
+                  %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT%
+                  %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%"
+                  "%REQ(USER-AGENT)%" "%REQ(X-REQUEST-ID)%" "%REQ(:AUTHORITY)%" "%UPSTREAM_HOST%"
+
+                  '
+            path: /dev/fd/1
+        http_filters:
+        - name: envoy.filters.http.cors
+        - name: envoy.filters.http.router
+        http_protocol_options:
+          accept_http_10: false
+        normalize_path: true
+        preserve_external_request_id: false
+        route_config:
+          virtual_hosts:
+          - domains:
+            - foo.com
+            name: listener-8443-foo.com
+            routes:
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /ambassador/v0/check_ready
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              route:
+                cluster: cluster_127_0_0_1_8877_default
+                prefix_rewrite: /ambassador/v0/check_ready
+                priority: null
+                timeout: 10.000s
+            - match:
+                case_sensitive: true
+                prefix: /ambassador/v0/check_ready
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              redirect:
+                https_redirect: true
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /ambassador/v0/check_alive
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              route:
+                cluster: cluster_127_0_0_1_8877_default
+                prefix_rewrite: /ambassador/v0/check_alive
+                priority: null
+                timeout: 10.000s
+            - match:
+                case_sensitive: true
+                prefix: /ambassador/v0/check_alive
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              redirect:
+                https_redirect: true
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /ambassador/v0/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              route:
+                cluster: cluster_127_0_0_1_8877_default
+                prefix_rewrite: /ambassador/v0/
+                priority: null
+                timeout: 10.000s
+            - match:
+                case_sensitive: true
+                prefix: /ambassador/v0/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              redirect:
+                https_redirect: true
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: foo.com
+                  name: :authority
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /backend/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_quote_default
+              route:
+                cluster: cluster_quote_default
+                prefix_rewrite: /
+                priority: null
+                timeout: 3.000s
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: foo.com
+                  name: :authority
+                prefix: /backend/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_quote_default
+              redirect:
+                https_redirect: true
+        server_name: envoy
+        stat_prefix: ingress_https
+        use_remote_address: true
+    name: httpshost-7c49909
+    transport_socket:
+      name: envoy.transport_sockets.tls
+      typed_config:
+        '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+        common_tls_context:
+          tls_certificates:
+          - certificate_chain:
+              filename: test.crt
+            private_key:
+              filename: test.key
+  - filter_chain_match: {}
+    filters:
+    - name: envoy.filters.network.http_connection_manager
+      typed_config:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        access_log:
+        - name: envoy.access_loggers.file
+          typed_config:
+            '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+            log_format:
+              text_format_source:
+                inline_string: 'ACCESS [%START_TIME%] "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%
+                  %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT%
+                  %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%"
+                  "%REQ(USER-AGENT)%" "%REQ(X-REQUEST-ID)%" "%REQ(:AUTHORITY)%" "%UPSTREAM_HOST%"
+
+                  '
+            path: /dev/fd/1
+        http_filters:
+        - name: envoy.filters.http.cors
+        - name: envoy.filters.http.router
+        http_protocol_options:
+          accept_http_10: false
+        normalize_path: true
+        preserve_external_request_id: false
+        route_config:
+          virtual_hosts:
+          - domains:
+            - foo.com
+            name: listener-8443-foo.com
+            routes:
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /ambassador/v0/check_ready
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              route:
+                cluster: cluster_127_0_0_1_8877_default
+                prefix_rewrite: /ambassador/v0/check_ready
+                priority: null
+                timeout: 10.000s
+            - match:
+                case_sensitive: true
+                prefix: /ambassador/v0/check_ready
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              redirect:
+                https_redirect: true
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /ambassador/v0/check_alive
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              route:
+                cluster: cluster_127_0_0_1_8877_default
+                prefix_rewrite: /ambassador/v0/check_alive
+                priority: null
+                timeout: 10.000s
+            - match:
+                case_sensitive: true
+                prefix: /ambassador/v0/check_alive
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              redirect:
+                https_redirect: true
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /ambassador/v0/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              route:
+                cluster: cluster_127_0_0_1_8877_default
+                prefix_rewrite: /ambassador/v0/
+                priority: null
+                timeout: 10.000s
+            - match:
+                case_sensitive: true
+                prefix: /ambassador/v0/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              redirect:
+                https_redirect: true
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: foo.com
+                  name: :authority
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /backend/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_quote_default
+              route:
+                cluster: cluster_quote_default
+                prefix_rewrite: /
+                priority: null
+                timeout: 3.000s
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: foo.com
+                  name: :authority
+                prefix: /backend/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_quote_default
+              redirect:
+                https_redirect: true
+        server_name: envoy
+        stat_prefix: ingress_https
+        use_remote_address: true
+    name: httphost-shared
+  listener_filters:
+  - name: envoy.filters.listener.tls_inspector
+  name: listener-8443
+  traffic_direction: UNSPECIFIED
+- address:
+    socket_address:
+      address: 127.0.0.1
+      port_value: 8006
+      protocol: TCP
+  filter_chains:
+  - filter_chain_match: {}
+    filters:
+    - name: envoy.filters.network.http_connection_manager
+      typed_config:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        http_filters:
+        - name: envoy.filters.http.health_check
+          typed_config:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
+            headers:
+            - exact_match: /ready
+              name: :path
+            pass_through_mode: false
+        - name: envoy.filters.http.router
+        route_config:
+          name: local_route
+        stat_prefix: ready_http
+  name: ambassador-listener-ready-127.0.0.1-8006

--- a/python/tests/unit/testdata/listeners/host_and_tcp_mapping_using_different_tls_contexts_in.yaml
+++ b/python/tests/unit/testdata/listeners/host_and_tcp_mapping_using_different_tls_contexts_in.yaml
@@ -1,0 +1,64 @@
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Listener
+metadata:
+  name: listener-8443
+  namespace: ambassador
+spec:
+  port: 8443
+  protocol: HTTPS
+  securityModel: XFP
+  hostBinding:
+    namespace:
+      from: ALL
+---
+apiVersion: getambassador.io/v3alpha1
+kind: TLSContext
+metadata:
+  name: tls-context-0
+  namespace: default
+spec:
+  secret: tls-cert
+  hosts: ["foo.com"]
+---
+apiVersion: getambassador.io/v3alpha1
+kind: TLSContext
+metadata:
+  name: tls-context-1
+  namespace: default
+spec:
+  secret: tls-cert
+  hosts: ["db.foo.com"]
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: host
+  namespace: default
+spec:
+  hostname: 'foo.com'
+  tlsSecret:
+    name: tls-cert
+  tlsContext: 
+    name: tls-context-0
+---
+apiVersion: getambassador.io/v3alpha1
+kind: TCPMapping
+metadata:
+  name: tcp
+  namespace: default
+spec:
+  host: 'db.foo.com'
+  port: 8443
+  tls: tls-context-1
+  service: db
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: quote-backend
+  namespace: default
+spec:
+  hostname: "foo.com"
+  prefix: /backend/
+  service: quote

--- a/python/tests/unit/testdata/listeners/host_and_tcp_mapping_using_different_tls_contexts_out.yaml
+++ b/python/tests/unit/testdata/listeners/host_and_tcp_mapping_using_different_tls_contexts_out.yaml
@@ -1,0 +1,360 @@
+listeners:
+- address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 8443
+      protocol: TCP
+  filter_chains:
+  - filter_chain_match:
+      server_names:
+      - db.foo.com
+      transport_protocol: tls
+    filters:
+    - name: envoy.filters.network.tcp_proxy
+      typed_config:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+        stat_prefix: ingress_https
+        weighted_clusters:
+          clusters:
+          - name: cluster_db_otls_tls_context_1_default
+            weight: 100
+    name: 'tcphost-GROUP: tcp'
+    transport_socket:
+      name: envoy.transport_sockets.tls
+      typed_config:
+        '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+        common_tls_context:
+          tls_certificates:
+          - certificate_chain:
+              filename: test.crt
+            private_key:
+              filename: test.key
+  - filter_chain_match:
+      server_names:
+      - foo.com
+      transport_protocol: tls
+    filters:
+    - name: envoy.filters.network.http_connection_manager
+      typed_config:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        access_log:
+        - name: envoy.access_loggers.file
+          typed_config:
+            '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+            log_format:
+              text_format_source:
+                inline_string: 'ACCESS [%START_TIME%] "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%
+                  %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT%
+                  %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%"
+                  "%REQ(USER-AGENT)%" "%REQ(X-REQUEST-ID)%" "%REQ(:AUTHORITY)%" "%UPSTREAM_HOST%"
+
+                  '
+            path: /dev/fd/1
+        http_filters:
+        - name: envoy.filters.http.cors
+        - name: envoy.filters.http.router
+        http_protocol_options:
+          accept_http_10: false
+        normalize_path: true
+        preserve_external_request_id: false
+        route_config:
+          virtual_hosts:
+          - domains:
+            - foo.com
+            name: listener-8443-foo.com
+            routes:
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /ambassador/v0/check_ready
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              route:
+                cluster: cluster_127_0_0_1_8877_default
+                prefix_rewrite: /ambassador/v0/check_ready
+                priority: null
+                timeout: 10.000s
+            - match:
+                case_sensitive: true
+                prefix: /ambassador/v0/check_ready
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              redirect:
+                https_redirect: true
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /ambassador/v0/check_alive
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              route:
+                cluster: cluster_127_0_0_1_8877_default
+                prefix_rewrite: /ambassador/v0/check_alive
+                priority: null
+                timeout: 10.000s
+            - match:
+                case_sensitive: true
+                prefix: /ambassador/v0/check_alive
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              redirect:
+                https_redirect: true
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /ambassador/v0/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              route:
+                cluster: cluster_127_0_0_1_8877_default
+                prefix_rewrite: /ambassador/v0/
+                priority: null
+                timeout: 10.000s
+            - match:
+                case_sensitive: true
+                prefix: /ambassador/v0/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              redirect:
+                https_redirect: true
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: foo.com
+                  name: :authority
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /backend/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_quote_default
+              route:
+                cluster: cluster_quote_default
+                prefix_rewrite: /
+                priority: null
+                timeout: 3.000s
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: foo.com
+                  name: :authority
+                prefix: /backend/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_quote_default
+              redirect:
+                https_redirect: true
+        server_name: envoy
+        stat_prefix: ingress_https
+        use_remote_address: true
+    name: httpshost-f29b6dd
+    transport_socket:
+      name: envoy.transport_sockets.tls
+      typed_config:
+        '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+        common_tls_context:
+          tls_certificates:
+          - certificate_chain:
+              filename: test.crt
+            private_key:
+              filename: test.key
+  - filter_chain_match: {}
+    filters:
+    - name: envoy.filters.network.http_connection_manager
+      typed_config:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        access_log:
+        - name: envoy.access_loggers.file
+          typed_config:
+            '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+            log_format:
+              text_format_source:
+                inline_string: 'ACCESS [%START_TIME%] "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%
+                  %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT%
+                  %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%"
+                  "%REQ(USER-AGENT)%" "%REQ(X-REQUEST-ID)%" "%REQ(:AUTHORITY)%" "%UPSTREAM_HOST%"
+
+                  '
+            path: /dev/fd/1
+        http_filters:
+        - name: envoy.filters.http.cors
+        - name: envoy.filters.http.router
+        http_protocol_options:
+          accept_http_10: false
+        normalize_path: true
+        preserve_external_request_id: false
+        route_config:
+          virtual_hosts:
+          - domains:
+            - foo.com
+            name: listener-8443-foo.com
+            routes:
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /ambassador/v0/check_ready
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              route:
+                cluster: cluster_127_0_0_1_8877_default
+                prefix_rewrite: /ambassador/v0/check_ready
+                priority: null
+                timeout: 10.000s
+            - match:
+                case_sensitive: true
+                prefix: /ambassador/v0/check_ready
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              redirect:
+                https_redirect: true
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /ambassador/v0/check_alive
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              route:
+                cluster: cluster_127_0_0_1_8877_default
+                prefix_rewrite: /ambassador/v0/check_alive
+                priority: null
+                timeout: 10.000s
+            - match:
+                case_sensitive: true
+                prefix: /ambassador/v0/check_alive
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              redirect:
+                https_redirect: true
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /ambassador/v0/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              route:
+                cluster: cluster_127_0_0_1_8877_default
+                prefix_rewrite: /ambassador/v0/
+                priority: null
+                timeout: 10.000s
+            - match:
+                case_sensitive: true
+                prefix: /ambassador/v0/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              redirect:
+                https_redirect: true
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: foo.com
+                  name: :authority
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /backend/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_quote_default
+              route:
+                cluster: cluster_quote_default
+                prefix_rewrite: /
+                priority: null
+                timeout: 3.000s
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: foo.com
+                  name: :authority
+                prefix: /backend/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_quote_default
+              redirect:
+                https_redirect: true
+        server_name: envoy
+        stat_prefix: ingress_https
+        use_remote_address: true
+    name: httphost-shared
+  listener_filters:
+  - name: envoy.filters.listener.tls_inspector
+  name: listener-8443
+  traffic_direction: UNSPECIFIED
+- address:
+    socket_address:
+      address: 127.0.0.1
+      port_value: 8006
+      protocol: TCP
+  filter_chains:
+  - filter_chain_match: {}
+    filters:
+    - name: envoy.filters.network.http_connection_manager
+      typed_config:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        http_filters:
+        - name: envoy.filters.http.health_check
+          typed_config:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
+            headers:
+            - exact_match: /ready
+              name: :path
+            pass_through_mode: false
+        - name: envoy.filters.http.router
+        route_config:
+          name: local_route
+        stat_prefix: ready_http
+  name: ambassador-listener-ready-127.0.0.1-8006

--- a/python/tests/unit/testdata/listeners/no_host_out.yaml
+++ b/python/tests/unit/testdata/listeners/no_host_out.yaml
@@ -295,7 +295,7 @@ listeners:
               server_name: envoy
               stat_prefix: ingress_https
               use_remote_address: true
-        name: httpshost-default-host
+        name: httpshost-684888c
         transport_socket:
           name: envoy.transport_sockets.tls
           typed_config:

--- a/python/tests/unit/testdata/listeners/prefix_wildcard_and_hostname_with_port_out.yaml
+++ b/python/tests/unit/testdata/listeners/prefix_wildcard_and_hostname_with_port_out.yaml
@@ -646,7 +646,7 @@ listeners:
               server_name: envoy
               stat_prefix: ingress_https
               use_remote_address: true
-        name: httpshost-minimal-host
+        name: httpshost-7542860
         transport_socket:
           name: envoy.transport_sockets.tls
           typed_config:

--- a/python/tests/unit/testdata/listeners/two_hosts_sharing_tls_context_in.yaml
+++ b/python/tests/unit/testdata/listeners/two_hosts_sharing_tls_context_in.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Listener
+metadata:
+  name: listener-8443
+  namespace: ambassador
+spec:
+  port: 8443
+  protocol: HTTPS
+  securityModel: XFP
+  hostBinding:
+    namespace:
+      from: ALL
+---
+apiVersion: getambassador.io/v3alpha1
+kind: TLSContext
+metadata:
+  name: my-tls-context
+  namespace: default
+spec:
+  secret: tls-cert
+  hosts: ["foo.com", "bar.foo.com"]
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: host-0
+  namespace: default
+spec:
+  hostname: 'foo.com'
+  tlsSecret:
+    name: tls-cert
+  tlsContext: 
+    name: my-tls-context
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: host-1
+  namespace: default
+spec:
+  hostname: 'bar.foo.com'
+  tlsSecret:
+    name: tls-cert
+  tlsContext: 
+    name: my-tls-context
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: quote-backend-0
+  namespace: default
+spec:
+  hostname: "foo.com"
+  prefix: /backend0/
+  service: quote0
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: quote-backend-1
+  namespace: default
+spec:
+  hostname: "bar.foo.com"
+  prefix: /backend1/
+  service: quote1

--- a/python/tests/unit/testdata/listeners/two_hosts_sharing_tls_context_missing_host_in.yaml
+++ b/python/tests/unit/testdata/listeners/two_hosts_sharing_tls_context_missing_host_in.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Listener
+metadata:
+  name: listener-8443
+  namespace: ambassador
+spec:
+  port: 8443
+  protocol: HTTPS
+  securityModel: XFP
+  hostBinding:
+    namespace:
+      from: ALL
+---
+apiVersion: getambassador.io/v3alpha1
+kind: TLSContext
+metadata:
+  name: my-tls-context
+  namespace: default
+spec:
+  secret: tls-cert
+  hosts: ["foo.com"]
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: host-0
+  namespace: default
+spec:
+  hostname: 'foo.com'
+  tlsSecret:
+    name: tls-cert
+  tlsContext: 
+    name: my-tls-context
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: host-1
+  namespace: default
+spec:
+  hostname: 'bar.foo.com'
+  tlsSecret:
+    name: tls-cert
+  tlsContext: 
+    name: my-tls-context
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: quote-backend-0
+  namespace: default
+spec:
+  hostname: "foo.com"
+  prefix: /backend0/
+  service: quote0
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: quote-backend-1
+  namespace: default
+spec:
+  hostname: "bar.foo.com"
+  prefix: /backend1/
+  service: quote1

--- a/python/tests/unit/testdata/listeners/two_hosts_sharing_tls_context_out.yaml
+++ b/python/tests/unit/testdata/listeners/two_hosts_sharing_tls_context_out.yaml
@@ -1,0 +1,563 @@
+listeners:
+- address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 8443
+      protocol: TCP
+  filter_chains:
+  - filter_chain_match:
+      server_names:
+      - bar.foo.com
+      - foo.com
+      transport_protocol: tls
+    filters:
+    - name: envoy.filters.network.http_connection_manager
+      typed_config:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        access_log:
+        - name: envoy.access_loggers.file
+          typed_config:
+            '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+            log_format:
+              text_format_source:
+                inline_string: 'ACCESS [%START_TIME%] "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%
+                  %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT%
+                  %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%"
+                  "%REQ(USER-AGENT)%" "%REQ(X-REQUEST-ID)%" "%REQ(:AUTHORITY)%" "%UPSTREAM_HOST%"
+
+                  '
+            path: /dev/fd/1
+        http_filters:
+        - name: envoy.filters.http.cors
+        - name: envoy.filters.http.router
+        http_protocol_options:
+          accept_http_10: false
+        normalize_path: true
+        preserve_external_request_id: false
+        route_config:
+          virtual_hosts:
+          - domains:
+            - bar.foo.com
+            name: listener-8443-bar.foo.com
+            routes:
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /ambassador/v0/check_ready
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              route:
+                cluster: cluster_127_0_0_1_8877_default
+                prefix_rewrite: /ambassador/v0/check_ready
+                priority: null
+                timeout: 10.000s
+            - match:
+                case_sensitive: true
+                prefix: /ambassador/v0/check_ready
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              redirect:
+                https_redirect: true
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /ambassador/v0/check_alive
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              route:
+                cluster: cluster_127_0_0_1_8877_default
+                prefix_rewrite: /ambassador/v0/check_alive
+                priority: null
+                timeout: 10.000s
+            - match:
+                case_sensitive: true
+                prefix: /ambassador/v0/check_alive
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              redirect:
+                https_redirect: true
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /ambassador/v0/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              route:
+                cluster: cluster_127_0_0_1_8877_default
+                prefix_rewrite: /ambassador/v0/
+                priority: null
+                timeout: 10.000s
+            - match:
+                case_sensitive: true
+                prefix: /ambassador/v0/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              redirect:
+                https_redirect: true
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: bar.foo.com
+                  name: :authority
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /backend1/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_quote1_default
+              route:
+                cluster: cluster_quote1_default
+                prefix_rewrite: /
+                priority: null
+                timeout: 3.000s
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: bar.foo.com
+                  name: :authority
+                prefix: /backend1/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_quote1_default
+              redirect:
+                https_redirect: true
+          - domains:
+            - foo.com
+            name: listener-8443-foo.com
+            routes:
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /ambassador/v0/check_ready
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              route:
+                cluster: cluster_127_0_0_1_8877_default
+                prefix_rewrite: /ambassador/v0/check_ready
+                priority: null
+                timeout: 10.000s
+            - match:
+                case_sensitive: true
+                prefix: /ambassador/v0/check_ready
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              redirect:
+                https_redirect: true
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /ambassador/v0/check_alive
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              route:
+                cluster: cluster_127_0_0_1_8877_default
+                prefix_rewrite: /ambassador/v0/check_alive
+                priority: null
+                timeout: 10.000s
+            - match:
+                case_sensitive: true
+                prefix: /ambassador/v0/check_alive
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              redirect:
+                https_redirect: true
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /ambassador/v0/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              route:
+                cluster: cluster_127_0_0_1_8877_default
+                prefix_rewrite: /ambassador/v0/
+                priority: null
+                timeout: 10.000s
+            - match:
+                case_sensitive: true
+                prefix: /ambassador/v0/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              redirect:
+                https_redirect: true
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: foo.com
+                  name: :authority
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /backend0/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_quote0_default
+              route:
+                cluster: cluster_quote0_default
+                prefix_rewrite: /
+                priority: null
+                timeout: 3.000s
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: foo.com
+                  name: :authority
+                prefix: /backend0/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_quote0_default
+              redirect:
+                https_redirect: true
+        server_name: envoy
+        stat_prefix: ingress_https
+        use_remote_address: true
+    name: httpshost-263c102
+    transport_socket:
+      name: envoy.transport_sockets.tls
+      typed_config:
+        '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+        common_tls_context:
+          tls_certificates:
+          - certificate_chain:
+              filename: test.crt
+            private_key:
+              filename: test.key
+  - filter_chain_match: {}
+    filters:
+    - name: envoy.filters.network.http_connection_manager
+      typed_config:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        access_log:
+        - name: envoy.access_loggers.file
+          typed_config:
+            '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+            log_format:
+              text_format_source:
+                inline_string: 'ACCESS [%START_TIME%] "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%
+                  %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT%
+                  %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%"
+                  "%REQ(USER-AGENT)%" "%REQ(X-REQUEST-ID)%" "%REQ(:AUTHORITY)%" "%UPSTREAM_HOST%"
+
+                  '
+            path: /dev/fd/1
+        http_filters:
+        - name: envoy.filters.http.cors
+        - name: envoy.filters.http.router
+        http_protocol_options:
+          accept_http_10: false
+        normalize_path: true
+        preserve_external_request_id: false
+        route_config:
+          virtual_hosts:
+          - domains:
+            - bar.foo.com
+            name: listener-8443-bar.foo.com
+            routes:
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /ambassador/v0/check_ready
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              route:
+                cluster: cluster_127_0_0_1_8877_default
+                prefix_rewrite: /ambassador/v0/check_ready
+                priority: null
+                timeout: 10.000s
+            - match:
+                case_sensitive: true
+                prefix: /ambassador/v0/check_ready
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              redirect:
+                https_redirect: true
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /ambassador/v0/check_alive
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              route:
+                cluster: cluster_127_0_0_1_8877_default
+                prefix_rewrite: /ambassador/v0/check_alive
+                priority: null
+                timeout: 10.000s
+            - match:
+                case_sensitive: true
+                prefix: /ambassador/v0/check_alive
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              redirect:
+                https_redirect: true
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /ambassador/v0/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              route:
+                cluster: cluster_127_0_0_1_8877_default
+                prefix_rewrite: /ambassador/v0/
+                priority: null
+                timeout: 10.000s
+            - match:
+                case_sensitive: true
+                prefix: /ambassador/v0/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              redirect:
+                https_redirect: true
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: bar.foo.com
+                  name: :authority
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /backend1/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_quote1_default
+              route:
+                cluster: cluster_quote1_default
+                prefix_rewrite: /
+                priority: null
+                timeout: 3.000s
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: bar.foo.com
+                  name: :authority
+                prefix: /backend1/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_quote1_default
+              redirect:
+                https_redirect: true
+          - domains:
+            - foo.com
+            name: listener-8443-foo.com
+            routes:
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /ambassador/v0/check_ready
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              route:
+                cluster: cluster_127_0_0_1_8877_default
+                prefix_rewrite: /ambassador/v0/check_ready
+                priority: null
+                timeout: 10.000s
+            - match:
+                case_sensitive: true
+                prefix: /ambassador/v0/check_ready
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              redirect:
+                https_redirect: true
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /ambassador/v0/check_alive
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              route:
+                cluster: cluster_127_0_0_1_8877_default
+                prefix_rewrite: /ambassador/v0/check_alive
+                priority: null
+                timeout: 10.000s
+            - match:
+                case_sensitive: true
+                prefix: /ambassador/v0/check_alive
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              redirect:
+                https_redirect: true
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /ambassador/v0/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              route:
+                cluster: cluster_127_0_0_1_8877_default
+                prefix_rewrite: /ambassador/v0/
+                priority: null
+                timeout: 10.000s
+            - match:
+                case_sensitive: true
+                prefix: /ambassador/v0/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              redirect:
+                https_redirect: true
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: foo.com
+                  name: :authority
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /backend0/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_quote0_default
+              route:
+                cluster: cluster_quote0_default
+                prefix_rewrite: /
+                priority: null
+                timeout: 3.000s
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: foo.com
+                  name: :authority
+                prefix: /backend0/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_quote0_default
+              redirect:
+                https_redirect: true
+        server_name: envoy
+        stat_prefix: ingress_https
+        use_remote_address: true
+    name: httphost-shared
+  listener_filters:
+  - name: envoy.filters.listener.tls_inspector
+  name: listener-8443
+  traffic_direction: UNSPECIFIED
+- address:
+    socket_address:
+      address: 127.0.0.1
+      port_value: 8006
+      protocol: TCP
+  filter_chains:
+  - filter_chain_match: {}
+    filters:
+    - name: envoy.filters.network.http_connection_manager
+      typed_config:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        http_filters:
+        - name: envoy.filters.http.health_check
+          typed_config:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
+            headers:
+            - exact_match: /ready
+              name: :path
+            pass_through_mode: false
+        - name: envoy.filters.http.router
+        route_config:
+          name: local_route
+        stat_prefix: ready_http
+  name: ambassador-listener-ready-127.0.0.1-8006

--- a/python/tests/unit/testdata/listeners/two_hosts_using_different_tls_contexts_in.yaml
+++ b/python/tests/unit/testdata/listeners/two_hosts_using_different_tls_contexts_in.yaml
@@ -1,0 +1,75 @@
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Listener
+metadata:
+  name: listener-8443
+  namespace: ambassador
+spec:
+  port: 8443
+  protocol: HTTPS
+  securityModel: XFP
+  hostBinding:
+    namespace:
+      from: ALL
+---
+apiVersion: getambassador.io/v3alpha1
+kind: TLSContext
+metadata:
+  name: tls-context-0
+  namespace: default
+spec:
+  secret: tls-cert
+  hosts: ["foo.com"]
+---
+apiVersion: getambassador.io/v3alpha1
+kind: TLSContext
+metadata:
+  name: tls-context-1
+  namespace: default
+spec:
+  secret: tls-cert
+  hosts: ["bar.foo.com"]
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: host-0
+  namespace: default
+spec:
+  hostname: 'foo.com'
+  tlsSecret:
+    name: tls-cert
+  tlsContext: 
+    name: tls-context-0
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: host-1
+  namespace: default
+spec:
+  hostname: 'bar.foo.com'
+  tlsSecret:
+    name: tls-cert
+  tlsContext: 
+    name: tls-context-1
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: quote-backend-0
+  namespace: default
+spec:
+  hostname: "foo.com"
+  prefix: /backend0/
+  service: quote0
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: quote-backend-1
+  namespace: default
+spec:
+  hostname: "bar.foo.com"
+  prefix: /backend1/
+  service: quote1

--- a/python/tests/unit/testdata/listeners/two_hosts_using_different_tls_contexts_out.yaml
+++ b/python/tests/unit/testdata/listeners/two_hosts_using_different_tls_contexts_out.yaml
@@ -1,0 +1,606 @@
+listeners:
+- address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 8443
+      protocol: TCP
+  filter_chains:
+  - filter_chain_match:
+      server_names:
+      - bar.foo.com
+      transport_protocol: tls
+    filters:
+    - name: envoy.filters.network.http_connection_manager
+      typed_config:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        access_log:
+        - name: envoy.access_loggers.file
+          typed_config:
+            '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+            log_format:
+              text_format_source:
+                inline_string: 'ACCESS [%START_TIME%] "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%
+                  %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT%
+                  %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%"
+                  "%REQ(USER-AGENT)%" "%REQ(X-REQUEST-ID)%" "%REQ(:AUTHORITY)%" "%UPSTREAM_HOST%"
+
+                  '
+            path: /dev/fd/1
+        http_filters:
+        - name: envoy.filters.http.cors
+        - name: envoy.filters.http.router
+        http_protocol_options:
+          accept_http_10: false
+        normalize_path: true
+        preserve_external_request_id: false
+        route_config:
+          virtual_hosts:
+          - domains:
+            - bar.foo.com
+            name: listener-8443-bar.foo.com
+            routes:
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /ambassador/v0/check_ready
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              route:
+                cluster: cluster_127_0_0_1_8877_default
+                prefix_rewrite: /ambassador/v0/check_ready
+                priority: null
+                timeout: 10.000s
+            - match:
+                case_sensitive: true
+                prefix: /ambassador/v0/check_ready
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              redirect:
+                https_redirect: true
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /ambassador/v0/check_alive
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              route:
+                cluster: cluster_127_0_0_1_8877_default
+                prefix_rewrite: /ambassador/v0/check_alive
+                priority: null
+                timeout: 10.000s
+            - match:
+                case_sensitive: true
+                prefix: /ambassador/v0/check_alive
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              redirect:
+                https_redirect: true
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /ambassador/v0/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              route:
+                cluster: cluster_127_0_0_1_8877_default
+                prefix_rewrite: /ambassador/v0/
+                priority: null
+                timeout: 10.000s
+            - match:
+                case_sensitive: true
+                prefix: /ambassador/v0/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              redirect:
+                https_redirect: true
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: bar.foo.com
+                  name: :authority
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /backend1/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_quote1_default
+              route:
+                cluster: cluster_quote1_default
+                prefix_rewrite: /
+                priority: null
+                timeout: 3.000s
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: bar.foo.com
+                  name: :authority
+                prefix: /backend1/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_quote1_default
+              redirect:
+                https_redirect: true
+        server_name: envoy
+        stat_prefix: ingress_https
+        use_remote_address: true
+    name: httpshost-1e7d9d3
+    transport_socket:
+      name: envoy.transport_sockets.tls
+      typed_config:
+        '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+        common_tls_context:
+          tls_certificates:
+          - certificate_chain:
+              filename: test.crt
+            private_key:
+              filename: test.key
+  - filter_chain_match: {}
+    filters:
+    - name: envoy.filters.network.http_connection_manager
+      typed_config:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        access_log:
+        - name: envoy.access_loggers.file
+          typed_config:
+            '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+            log_format:
+              text_format_source:
+                inline_string: 'ACCESS [%START_TIME%] "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%
+                  %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT%
+                  %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%"
+                  "%REQ(USER-AGENT)%" "%REQ(X-REQUEST-ID)%" "%REQ(:AUTHORITY)%" "%UPSTREAM_HOST%"
+
+                  '
+            path: /dev/fd/1
+        http_filters:
+        - name: envoy.filters.http.cors
+        - name: envoy.filters.http.router
+        http_protocol_options:
+          accept_http_10: false
+        normalize_path: true
+        preserve_external_request_id: false
+        route_config:
+          virtual_hosts:
+          - domains:
+            - bar.foo.com
+            name: listener-8443-bar.foo.com
+            routes:
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /ambassador/v0/check_ready
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              route:
+                cluster: cluster_127_0_0_1_8877_default
+                prefix_rewrite: /ambassador/v0/check_ready
+                priority: null
+                timeout: 10.000s
+            - match:
+                case_sensitive: true
+                prefix: /ambassador/v0/check_ready
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              redirect:
+                https_redirect: true
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /ambassador/v0/check_alive
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              route:
+                cluster: cluster_127_0_0_1_8877_default
+                prefix_rewrite: /ambassador/v0/check_alive
+                priority: null
+                timeout: 10.000s
+            - match:
+                case_sensitive: true
+                prefix: /ambassador/v0/check_alive
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              redirect:
+                https_redirect: true
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /ambassador/v0/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              route:
+                cluster: cluster_127_0_0_1_8877_default
+                prefix_rewrite: /ambassador/v0/
+                priority: null
+                timeout: 10.000s
+            - match:
+                case_sensitive: true
+                prefix: /ambassador/v0/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              redirect:
+                https_redirect: true
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: bar.foo.com
+                  name: :authority
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /backend1/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_quote1_default
+              route:
+                cluster: cluster_quote1_default
+                prefix_rewrite: /
+                priority: null
+                timeout: 3.000s
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: bar.foo.com
+                  name: :authority
+                prefix: /backend1/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_quote1_default
+              redirect:
+                https_redirect: true
+          - domains:
+            - foo.com
+            name: listener-8443-foo.com
+            routes:
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /ambassador/v0/check_ready
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              route:
+                cluster: cluster_127_0_0_1_8877_default
+                prefix_rewrite: /ambassador/v0/check_ready
+                priority: null
+                timeout: 10.000s
+            - match:
+                case_sensitive: true
+                prefix: /ambassador/v0/check_ready
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              redirect:
+                https_redirect: true
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /ambassador/v0/check_alive
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              route:
+                cluster: cluster_127_0_0_1_8877_default
+                prefix_rewrite: /ambassador/v0/check_alive
+                priority: null
+                timeout: 10.000s
+            - match:
+                case_sensitive: true
+                prefix: /ambassador/v0/check_alive
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              redirect:
+                https_redirect: true
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /ambassador/v0/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              route:
+                cluster: cluster_127_0_0_1_8877_default
+                prefix_rewrite: /ambassador/v0/
+                priority: null
+                timeout: 10.000s
+            - match:
+                case_sensitive: true
+                prefix: /ambassador/v0/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              redirect:
+                https_redirect: true
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: foo.com
+                  name: :authority
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /backend0/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_quote0_default
+              route:
+                cluster: cluster_quote0_default
+                prefix_rewrite: /
+                priority: null
+                timeout: 3.000s
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: foo.com
+                  name: :authority
+                prefix: /backend0/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_quote0_default
+              redirect:
+                https_redirect: true
+        server_name: envoy
+        stat_prefix: ingress_https
+        use_remote_address: true
+    name: httphost-shared
+  - filter_chain_match:
+      server_names:
+      - foo.com
+      transport_protocol: tls
+    filters:
+    - name: envoy.filters.network.http_connection_manager
+      typed_config:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        access_log:
+        - name: envoy.access_loggers.file
+          typed_config:
+            '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+            log_format:
+              text_format_source:
+                inline_string: 'ACCESS [%START_TIME%] "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%
+                  %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT%
+                  %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%"
+                  "%REQ(USER-AGENT)%" "%REQ(X-REQUEST-ID)%" "%REQ(:AUTHORITY)%" "%UPSTREAM_HOST%"
+
+                  '
+            path: /dev/fd/1
+        http_filters:
+        - name: envoy.filters.http.cors
+        - name: envoy.filters.http.router
+        http_protocol_options:
+          accept_http_10: false
+        normalize_path: true
+        preserve_external_request_id: false
+        route_config:
+          virtual_hosts:
+          - domains:
+            - foo.com
+            name: listener-8443-foo.com
+            routes:
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /ambassador/v0/check_ready
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              route:
+                cluster: cluster_127_0_0_1_8877_default
+                prefix_rewrite: /ambassador/v0/check_ready
+                priority: null
+                timeout: 10.000s
+            - match:
+                case_sensitive: true
+                prefix: /ambassador/v0/check_ready
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              redirect:
+                https_redirect: true
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /ambassador/v0/check_alive
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              route:
+                cluster: cluster_127_0_0_1_8877_default
+                prefix_rewrite: /ambassador/v0/check_alive
+                priority: null
+                timeout: 10.000s
+            - match:
+                case_sensitive: true
+                prefix: /ambassador/v0/check_alive
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              redirect:
+                https_redirect: true
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /ambassador/v0/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              route:
+                cluster: cluster_127_0_0_1_8877_default
+                prefix_rewrite: /ambassador/v0/
+                priority: null
+                timeout: 10.000s
+            - match:
+                case_sensitive: true
+                prefix: /ambassador/v0/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_127_0_0_1_8877_default
+              redirect:
+                https_redirect: true
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: foo.com
+                  name: :authority
+                - exact_match: https
+                  name: x-forwarded-proto
+                prefix: /backend0/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_quote0_default
+              route:
+                cluster: cluster_quote0_default
+                prefix_rewrite: /
+                priority: null
+                timeout: 3.000s
+            - match:
+                case_sensitive: true
+                headers:
+                - exact_match: foo.com
+                  name: :authority
+                prefix: /backend0/
+                runtime_fraction:
+                  default_value:
+                    denominator: HUNDRED
+                    numerator: 100
+                  runtime_key: routing.traffic_shift.cluster_quote0_default
+              redirect:
+                https_redirect: true
+        server_name: envoy
+        stat_prefix: ingress_https
+        use_remote_address: true
+    name: httpshost-f29b6dd
+    transport_socket:
+      name: envoy.transport_sockets.tls
+      typed_config:
+        '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+        common_tls_context:
+          tls_certificates:
+          - certificate_chain:
+              filename: test.crt
+            private_key:
+              filename: test.key
+  listener_filters:
+  - name: envoy.filters.listener.tls_inspector
+  name: listener-8443
+  traffic_direction: UNSPECIFIED
+- address:
+    socket_address:
+      address: 127.0.0.1
+      port_value: 8006
+      protocol: TCP
+  filter_chains:
+  - filter_chain_match: {}
+    filters:
+    - name: envoy.filters.network.http_connection_manager
+      typed_config:
+        '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+        http_filters:
+        - name: envoy.filters.http.health_check
+          typed_config:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
+            headers:
+            - exact_match: /ready
+              name: :path
+            pass_through_mode: false
+        - name: envoy.filters.http.router
+        route_config:
+          name: local_route
+        stat_prefix: ready_http
+  name: ambassador-listener-ready-127.0.0.1-8006


### PR DESCRIPTION
## Description

When multiple domains use the same certificate (e.g. the server has a certificate that can be used for domain domain.com and subdomains a.domain.com and b.domain.com) and the server supports HTTP/2, the browser will reuse the same connection for requests to domain.com, a.domain.com, and b.domain.com.

In 1.14 this wasn't an issue because all virtual hosts lived on a single filter chain.

It's a bit different in 2.y and above. To increase host and route matching performance, virtual hosts were split across multiple filter chains, using SNI for server name matching if TLS is available. For the non-TLS case, all virtual hosts are still combined under one filter chain since hostname matching in the filter_chain_match isn't available in the cleartext case.

In more detail, let's say you have the following `Host`s and `TLSContext` configuration:

```yaml
apiVersion: getambassador.io/v3alpha1
kind: TLSContext
metadata:
  name: my-tls-context
  namespace: default
spec:
  secret: tls-cert
  hosts: ["example.com", "foo.example.com"]
---
apiVersion: getambassador.io/v3alpha1
kind: Host
metadata:
  name: basic-host-1
  namespace: default
spec:
  hostname: 'example.com'
  tlsSecret:
    name: tls-cert
  tlsContext: 
    name: my-tls-context
---
apiVersion: getambassador.io/v3alpha1
kind: Host
metadata:
  name: basic-host-2
  namespace: default
spec:
  hostname: 'foo.example.com'
  tlsSecret:
    name: tls-cert
  tlsContext: 
    name: my-tls-context
```

This results in the following filter chain configuration:

```yaml
filter_chains:
- filter_chain_match:
    server_names: ["example.com"]
    transport_protocol: tls
  transport_socket:
    name: envoy.transport_sockets.tls
  filters:
  - name: envoy.filters.network.http_connection_manager
    typed_config:
    "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
    stat_prefix: ingress_https
    route_config:
      virtual_hosts:
      - domains:
        - "example.com"
        routes: []

- filter_chain_match:
    server_names: ["foo.example.com"]
    transport_protocol: tls
  transport_socket:
    name: envoy.transport_sockets.tls
  filters:
  - name: envoy.filters.network.http_connection_manager
    typed_config:
    "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
    stat_prefix: ingress_https
    route_config:
      virtual_hosts:
      - domains:
        - "foo.example.com"
        routes: []
```

Each `Host` is added as a virtual_host in separate filter chains.

This can an issue when reusing TLS connections. A connection is established to the virtual_host that is first visited (e.g. foo.example.com) but that same connection will be reused when visiting the other virtual_host (example.com). Since the virtual_hosts live on separate filter chains, this results in a 404 because it won't be able to find foo.example.com in the route table.

### The Fix
This updates so that Hosts sharing the same TLSContext will be coalesced into a single filter chain with both hosts added as server names for the filter_chain_match.

With the same `Host`s and `TLSContext` configuration above, now the generated filter chain roughly looks like:

```yaml
filter_chains:
- filter_chain_match:
    server_names: ["example.com", "foo.example.com"]
    transport_protocol: tls
  transport_socket:
    name: envoy.transport_sockets.tls
  filters:
  - name: envoy.filters.network.http_connection_manager
    typed_config:
    "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
    stat_prefix: ingress_https
    route_config:
    virtual_hosts:
      - domains:
        - "example.com"
        routes: []
      - domains:
        - "foo.example.com"
        routes: []
``` 

This allows for HTTP/2 connection reuse in the browser.

If a Host and TCPMapping share the same TLSContext then the existing behavior is retained, a separate filter chain is created for each. Same for the inline and implicit tls cases. i.e we do not support connection reuse with `Host.tls` or if only `Host.tlsSecret` is provided without a TLSContext.

### Misc

- Added make targets `format/python`, `lint/python` to run just the python linters and formatters
- Refactored the diagd listener unit tests. Some of those tests run various test cases but because they are all under a single test function, pytest will see it as just one test. This can make debugging failed tests a little cumbersome when trying to figure out which specific test case failed. So refactor to use pytest's parametrize decorator to parametrize those test functions for all of the test cases. This lets pytest know about each test case and will treat them as sub-tests under the main unit test. This also makes it possible to run a specific test case from pytest e.g. `pytest tests/unit/test_listener.py -k '<unit-test-name>[subtest-id]'`.
#### Before
```
pytest -v tests/unit/test_listener.py -k "test_listener_filterchain"           
========================================================================================= test session starts ==========================================================================================
platform linux -- Python 3.10.9, pytest-6.2.5, py-1.11.0, pluggy-1.0.0 -- /home/hamzah/.virtualenvs/ambassador/bin/python
cachedir: .pytest_cache
rootdir: /home/hamzah/src/emissary-ingress/emissary, configfile: pytest.ini
plugins: cov-4.0.0, rerunfailures-11.1.1
collected 6 items / 5 deselected / 1 selected                                                                                                                                                          

tests/unit/test_listener.py::TestListener::test_listener_filterchain_vhost_generation PASSED 
```

#### After
```
pytest -v tests/unit/test_listener.py -k "test_listener_filterchain"
======================================================== test session starts ========================================================
platform linux -- Python 3.10.9, pytest-6.2.5, py-1.11.0, pluggy-1.0.0 -- /home/hamzah/.virtualenvs/ambassador/bin/python
cachedir: .pytest_cache
rootdir: /home/hamzah/src/emissary-ingress/emissary, configfile: pytest.ini
plugins: cov-4.0.0, rerunfailures-11.1.1
collected 22 items / 14 deselected / 8 selected                                                                                     

tests/unit/test_listener.py::TestListener::test_listener_filterchain_generation[host_missing_tls] PASSED                      [ 12%]
tests/unit/test_listener.py::TestListener::test_listener_filterchain_generation[no_host] PASSED                               [ 25%]
tests/unit/test_listener.py::TestListener::test_listener_filterchain_generation[prefix_wildcard_and_hostname_with_port] PASSED [ 37%]
tests/unit/test_listener.py::TestListener::test_listener_filterchain_generation[two_hosts_using_different_tls_contexts] PASSED [ 50%]
tests/unit/test_listener.py::TestListener::test_listener_filterchain_generation[host_and_tcp_mapping_using_different_tls_contexts] PASSED [ 62%]
tests/unit/test_listener.py::TestListener::test_listener_filterchain_generation[two_hosts_sharing_tls_context] PASSED         [ 75%]
tests/unit/test_listener.py::TestListener::test_listener_filterchain_generation[host_and_tcp_mapping_sharing_tls_context] PASSED [ 87%]
tests/unit/test_listener.py::TestListener::test_listener_filterchain_generation[two_hosts_sharing_tls_context_missing_host] PASSED [100%]

```
## Related Issues

fixes https://github.com/emissary-ingress/emissary/issues/2403

## Testing

Added some additional unit test cases testing various scenarios to capture as many corner cases as I can and to ensure backwards compatibility with the existing behavior (hosts sharing tls context, host & tcpmapping sharing tls context, hosts/tcpmappings using different tls contexts, etc.)

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->
- [ ] **Does my change need to be backported to a previous release?**
  - What backport versions were discussed with the Maintainers in the Issue?

- [ ] **I made sure to update `CHANGELOG.md`.**

   Remember, the CHANGELOG needs to mention:
  - Any new features
  - Any changes to our included version of Envoy
  - Any non-backward-compatible changes
  - Any deprecations

- [ ] **This is unlikely to impact how Ambassador performs at scale.**

   Remember, things that might have an impact at scale include:
  - Any significant changes in memory use that might require adjusting the memory limits
  - Any significant changes in CPU use that might require adjusting the CPU limits
  - Anything that might change how many replicas users should use
  - Changes that impact data-plane latency/scalability

- [ ] **My change is adequately tested.**

   Remember when considering testing:
  - Your change needs to be specifically covered by tests.
    - Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
  - You also need to make sure that the _entire area being changed_ has adequate test coverage.
    - If existing tests don't actually cover the entire area being changed, add tests.
    - This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
  - We should lean on the bulk of code being covered by unit tests, but...
  - ... an end-to-end test should cover the integration points

- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**

- [ ] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
