### PR TITLE
[CC] charts: add tolerations, nodeSelector, affinity to agent

### DIFF
--- a/charts/emissary-ingress/CHANGELOG.md
+++ b/charts/emissary-ingress/CHANGELOG.md
@@ -4,9 +4,11 @@ This file documents all notable changes to Ambassador Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
 ## v8.6.0 - TBD
+
 - Upgrade Emissary to v3.6.0 [CHANGELOG](https://github.com/emissary-ingress/emissary/blob/master/CHANGELOG.md)
 - Use autoscaling/v2 HorizontalPodAutoscaler if the cluster version is >v1.26 as autoscaling/v2beta2 is deprecated starting v1.23 and removed in v1.26. Thanks to [Elvind Valderhaug](https://github.com/eevdev)
 - Upgrade KubernetesEndpointResolver & ConsulResolver apiVersions to `getambassador.io/v3alpha1`
+- Add support for setting `nodeSelector`, `tolerations` and `affinity` on the Ambassador Agent. Thanks to [Philip Panyukov](https://github.com/ppanyukov).
 
 ## v8.5.1 - 2023-02-23
 

--- a/charts/emissary-ingress/templates/ambassador-agent.yaml
+++ b/charts/emissary-ingress/templates/ambassador-agent.yaml
@@ -234,6 +234,20 @@ spec:
           value: {{ .Values.agent.reportDiagnostics | quote }}
         - name: AES_DIAGNOSTICS_URL
           value: "http://{{ include "ambassador.fullname" . }}-admin.{{ include "ambassador.namespace" . }}:{{ .Values.adminService.port }}/ambassador/v0/diag/?json=true"
+
+      {{- with .Values.agent.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.agent.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.agent.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
   {{ if .Values.progressDeadlines }}
   {{ if hasKey .Values.progressDeadlines "agent" }}
   progressDeadlineSeconds: {{ .Values.progressDeadlines.agent }}

--- a/charts/emissary-ingress/values.yaml.in
+++ b/charts/emissary-ingress/values.yaml.in
@@ -422,6 +422,11 @@ agent:
   # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#securitycontext-v1-core
   # allowPrivilegeEscalation: false
 
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+
 deploymentTool: ''
 
 # configure docker to pull from private registry


### PR DESCRIPTION
CI run for community contribution PR #4880.

I have rebased on Master and also included a change-log entry. See #4880 for details.

Note: I will also port this to the Ambassador Agent repository so that the stand alone chart includes this capability.