### PR TITLE
Remove kubectl dependency from images

### DIFF
--- a/build-aux/Dockerfile
+++ b/build-aux/Dockerfile
@@ -128,7 +128,6 @@ RUN adduser ambassador -u 8888 -G root -D -H -s /bin/false
 # External stuff that should change infrequently
 RUN apk --no-cache add bash curl python3=${py_version} libcap htop
 RUN apk upgrade --no-cache
-COPY --from=artifacts /usr/bin/kubectl /usr/bin/kubectl
 COPY --from=artifacts /usr/lib/libyaml* /usr/lib/
 
 # Other installers

--- a/docker/base-python/Dockerfile
+++ b/docker/base-python/Dockerfile
@@ -80,9 +80,6 @@ RUN pip3 install pip-tools==6.12.1 build==0.9.0
 
 RUN curl --fail -L https://dl.google.com/go/go1.20.1.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 
-RUN curl --fail -L https://storage.googleapis.com/kubernetes-release/release/v1.23.3/bin/linux/amd64/kubectl -o /usr/bin/kubectl && \
-  chmod a+x /usr/bin/kubectl
-
 # The YAML parser is... special. To get the C version, we need to install Cython and libyaml, then
 # build it locally -- just using pip won't work.
 #


### PR DESCRIPTION
Removes all use of kubectl from images.

## Description

Including the `kubectl` binary in the Emissary image is no longer necessary, and it would be better to remove it completely.

## Related Issues

## Testing

* Built and deployed the full environment locally. Confirmed the local environment was fully functional.
* Manually confirmed that the `kubectl` binary was no longer present in the Emissary image. 
* Ran the full suite of tests.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->
- [X] **Does my change need to be backported to a previous release?**

  No.

- [X] **I made sure to update `CHANGELOG.md`.** 

  Unnecessary for this change.

- [X] **This is unlikely to impact how Ambassador performs at scale.**

  This change will not impact performance in any way.

- [X] **My change is adequately tested.**

- [X] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**

  Unnecessary for this change.

- [X] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**