### PR TITLE
Fix broken HTTPSPROXY

### DIFF
--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -42,6 +42,8 @@ items:
           This upgrades $productName$ to be built on Envoy v1.25.3. This provides $productName$ with the latest
           security patches, performances enhancments, and features offered by the envoy proxy.
 
+          Fixed longstanding issue with HTTPSPROXY not working.
+
   - version: 3.5.0
     prevVersion: 3.4.0
     date: '2023-02-15'

--- a/python/ambassador/ir/irlistener.py
+++ b/python/ambassador/ir/irlistener.py
@@ -47,7 +47,7 @@ class IRListener(IRResource):
         # HTTPPROXY: accepts cleartext HTTP/1.1 sessions using the HAProxy PROXY protocol over TCP.
         "HTTPPROXY": ["PROXY", "HTTP", "TCP"],
         # HTTPSPROXY: accepts encrypted HTTP/1.1 or HTTP/2 sessions using the HAProxy PROXY protocol over TLS over TCP.
-        "HTTPSPROXY": ["TLS", "PROXY", "HTTP", "TCP"],
+        "HTTPSPROXY": ["PROXY", "TLS", "HTTP", "TCP"],
         # TCP: accepts raw TCP sessions.
         "TCP": ["TCP"],
         # TLS: accepts TLS over TCP.


### PR DESCRIPTION
## Description

Fixes problem where Emissary tries to parse TLS before parsing HAproxy protocol

## Related Issues

https://github.com/emissary-ingress/emissary/issues/4968
https://github.com/emissary-ingress/emissary/issues/4153

## Testing

Tested on AWS cluster

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->
- [] **Does my change need to be backported to a previous release?**

- [X] **I made sure to update `CHANGELOG.md`.**

- [X] **This is unlikely to impact how Ambassador performs at scale.**

- [X] **My change is adequately tested.**

- [X] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**

- [X] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
