### PR TITLE
Ensure make clean always removes build artifacts

### DIFF
--- a/build-aux/builder.mk
+++ b/build-aux/builder.mk
@@ -131,6 +131,7 @@ docker/.base-envoy.docker.stamp: FORCE
 	  fi; \
 	  echo $(ENVOY_DOCKER_TAG) >$@; \
 	}
+clean: docker/base-envoy.docker.clean
 clobber: docker/base-envoy.docker.clean
 
 docker/.$(LCNAME).docker.stamp: %/.$(LCNAME).docker.stamp: %/base.docker.tag.local %/base-envoy.docker.tag.local %/base-pip.docker.tag.local python/ambassador.version $(BUILDER_HOME)/Dockerfile $(OSS_HOME)/build-aux/py-version.txt $(tools/dsum) vendor FORCE

--- a/build-aux/main.mk
+++ b/build-aux/main.mk
@@ -55,6 +55,7 @@ clean: $(foreach img,$(_ocibuild-images),docker/$(img).img.tar.clean)
 # that don't need Emissary-specific stuff.
 docker/.base.img.tar.stamp: FORCE $(tools/crane) docker/base-python/Dockerfile
 	$(tools/crane) pull $(shell gawk '$$1 == "FROM" { print $$2; quit; }' < docker/base-python/Dockerfile) $@ || test -e $@
+clean: docker/base.img.tar.clean
 clobber: docker/base.img.tar.clean
 
 # base-python: Base OS, plus some Emissary-specific setup of
@@ -71,6 +72,7 @@ clobber: docker/base.img.tar.clean
 # (`apk add`, libc-specific compilation...).
 docker/.base-python.docker.stamp: FORCE docker/base-python/Dockerfile docker/base-python.docker.gen
 	docker/base-python.docker.gen >$@
+clean: docker/base-python.docker.clean
 clobber: docker/base-python.docker.clean
 
 # base-pip: base-python, but with requirements.txt installed.
@@ -102,6 +104,7 @@ docker/base-pip/requirements.txt: python/requirements.txt $(tools/copy-ifchanged
 clean: docker/base-pip/requirements.txt.rm
 docker/.base-pip.docker.stamp: docker/.%.docker.stamp: docker/%/Dockerfile docker/%/requirements.txt docker/base-python.docker.tag.local
 	docker build --platform="$(BUILD_ARCH)" --build-arg=from="$$(sed -n 2p docker/base-python.docker.tag.local)" --iidfile=$@ $(<D)
+clean: docker/base-pip.docker.clean
 clobber: docker/base-pip.docker.clean
 
 # The Helm chart


### PR DESCRIPTION
Keeping with the current system, adds additional clean targets as necessary to ensure a make images / make clean cycle always functions properly.

## Description

Adds additional `clean` targets to match existing `clobber` targets. Personally, I'd prefer a split between having the `clean` targets only clean up the internal artifacts, and having `clobber` also remove the images from the registry. But that change would need to be applied systemically/separately, and it's somewhat opinionated.

## Related Issues

#4986 

## Testing

Local build testing.

## Checklist
- [ ] **Does my change need to be backported to a previous release?**
- [ ] **I made sure to update `CHANGELOG.md`.**
- [x] **This is unlikely to impact how Ambassador performs at scale.**
- [x] **My change is adequately tested.**
- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**
- [x] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
