### PR TITLE
envoy config: switch to `append_action` when adding headers

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -158,7 +158,7 @@ libraries:
     jsonpointer         2.3        3-clause BSD license
     kubernetes          21.7.0     Apache License 2.0
     oauthlib            3.2.2      3-clause BSD license
-    orjson              3.6.6      Apache License 2.0, MIT license
+    orjson              3.8.10     Apache License 2.0, MIT license
     packaging           21.3       2-clause BSD license, Apache License 2.0
     pep517              0.13.0     MIT license
     pip-tools           6.12.1     3-clause BSD license

--- a/docker/base-python/Dockerfile
+++ b/docker/base-python/Dockerfile
@@ -86,11 +86,11 @@ RUN curl --fail -L https://dl.google.com/go/go1.20.3.linux-amd64.tar.gz | tar -C
 # Download, build, and install PyYAML.
 RUN mkdir /tmp/pyyaml && \
   cd /tmp/pyyaml && \
-  curl -o pyyaml-5.4.1.1.tar.gz -L https://github.com/yaml/pyyaml/archive/refs/tags/5.4.1.1.tar.gz && \
-  tar xzf pyyaml-5.4.1.1.tar.gz && \
-  cd pyyaml-5.4.1.1 && \
+  curl -o pyyaml-6.0.tar.gz -L https://github.com/yaml/pyyaml/archive/refs/tags/6.0.tar.gz && \
+  tar xzf pyyaml-6.0.tar.gz && \
+  cd pyyaml-6.0 && \
   python3 setup.py --with-libyaml install
 
 # orjson is also special.  The wheels on PyPI rely on glibc, so we
 # need to use cargo/rustc/patchelf to build a musl-compatible version.
-RUN pip3 install orjson==3.6.6
+RUN pip3 install orjson==3.8.10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,4 +4,16 @@ line-length = 100
 [tool.isort]
 profile = "black"
 line_length = 100
-src_paths = [ "./python/", "./python/tests/kat/" ]
+src_paths = ["./python/", "./python/tests/kat/"]
+
+[tool.pytest.ini_options]
+pythonpath = ["python"]
+filterwarnings = [
+  "ignore:.*The metaschema specified by \\$schema was not found.*:DeprecationWarning",
+  "ignore:.*Call to deprecated create function Descriptor.*:DeprecationWarning",
+  "ignore:.*Call to deprecated create function FileDescriptor.*:DeprecationWarning",
+  "ignore:.*Call to deprecated create function FieldDescriptor.*:DeprecationWarning",
+]
+testpaths = ["python/tests"]
+norecursedirs = "docs"
+markers = "compilertest"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,9 +1,0 @@
-[pytest]
-testpaths = python/tests
-norecursedirs = docs
-markers = compilertest
-filterwarnings =
-    ignore:.*The metaschema specified by \$schema was not found.*:DeprecationWarning
-    ignore:.*Call to deprecated create function Descriptor.*:DeprecationWarning
-    ignore:.*Call to deprecated create function FileDescriptor.*:DeprecationWarning
-    ignore:.*Call to deprecated create function FieldDescriptor.*:DeprecationWarning

--- a/python/kat/harness.py
+++ b/python/kat/harness.py
@@ -1029,11 +1029,13 @@ class Runner:
     def __call__(self):
         assert False, "this is here for py.test discovery purposes only"
 
-    def setup(self, selected):
+    def setup_method(self, selected):
+        print(f"setup_method-done: {self.done}")
         if not self.done:
             if not DOCTEST:
                 print()
 
+            print(f"setup_method-selected: {selected}")
             expanded_up = set(selected)
 
             for s in selected:

--- a/python/kat/harness.py
+++ b/python/kat/harness.py
@@ -1026,8 +1026,8 @@ class Runner:
         self.__func__ = test
         self.__test__ = True
 
-    def __call__(self):
-        assert False, "this is here for py.test discovery purposes only"
+    # def __call__(self):
+    #     assert False, "this is here for py.test discovery purposes only"
 
     def setup_method(self, selected):
         print(f"setup_method-done: {self.done}")

--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -4,7 +4,7 @@ mypy<0.990
 packaging
 pexpect
 pyOpenSSL
-pytest==6.2.5
+pytest
 pytest-cov
 pytest-rerunfailures
 retry

--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -7,6 +7,7 @@ pyOpenSSL
 pytest
 pytest-cov
 pytest-rerunfailures
+pyyaml
 retry
 black==22.10.0
 isort

--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -1,5 +1,4 @@
 # Dev requirements
-gitpython
 httpretty
 mypy<0.990
 packaging

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -46,7 +46,7 @@ markupsafe==2.1.1
     #   werkzeug
 oauthlib==3.2.2
     # via requests-oauthlib
-orjson==3.6.6
+orjson==3.8.10
     # via -r requirements.in
 prometheus-client==0.15.0
     # via -r requirements.in

--- a/tools/src/py-mkopensource/main.go
+++ b/tools/src/py-mkopensource/main.go
@@ -73,8 +73,7 @@ func parseLicenses(name, version, license string) map[License]struct{} {
 
 		// These are packages with non-trivial strings to parse, and
 		// it's easier to just hard-code it.
-		{"orjson", "3.3.1", "Apache-2.0 OR MIT"}:            {Apache2, MIT},
-		{"orjson", "3.6.6", "Apache-2.0 OR MIT"}:            {Apache2, MIT},
+		{"orjson", "3.8.10", "Apache-2.0 OR MIT"}:           {Apache2, MIT},
 		{"packaging", "21.3", "BSD-2-Clause or Apache-2.0"}: {BSD2, Apache2},
 	}[tuple{name, version, license}]
 	if ok {


### PR DESCRIPTION
## Description

WIP - testing some python deps updates and then will be pushing a change to switch over to `append_action`. This should allow us to drop one of our custom commits from Envoy.

## Related Issues

List related issues.

## Testing

A few sentences describing what testing you've done, e.g., manual tests, automated tests, deployed in production, etc.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->
- [ ] **Does my change need to be backported to a previous release?**
  - What backport versions were discussed with the Maintainers in the Issue?

- [ ] **I made sure to update `CHANGELOG.md`.**

   Remember, the CHANGELOG needs to mention:
  - Any new features
  - Any changes to our included version of Envoy
  - Any non-backward-compatible changes
  - Any deprecations

- [ ] **This is unlikely to impact how Ambassador performs at scale.**

   Remember, things that might have an impact at scale include:
  - Any significant changes in memory use that might require adjusting the memory limits
  - Any significant changes in CPU use that might require adjusting the CPU limits
  - Anything that might change how many replicas users should use
  - Changes that impact data-plane latency/scalability

- [ ] **My change is adequately tested.**

   Remember when considering testing:
  - Your change needs to be specifically covered by tests.
    - Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
  - You also need to make sure that the _entire area being changed_ has adequate test coverage.
    - If existing tests don't actually cover the entire area being changed, add tests.
    - This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
  - We should lean on the bulk of code being covered by unit tests, but...
  - ... an end-to-end test should cover the integration points

- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**

- [ ] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
