### PR TITLE
Clean up outdated cache files during make images

### DIFF
--- a/build-aux/builder.mk
+++ b/build-aux/builder.mk
@@ -151,16 +151,16 @@ clean: docker/$(LCNAME).docker.clean
 
 REPO=$(BUILDER_NAME)
 
-_inspect-images = base base-envoy base-pip base-python
-images-inspect: $(foreach i,$(_inspect-images), docker/$i.docker.inspect)
-.PHONY: images-inspect
+_inspect-images = base base-envoy base-pip base-python $(LCNAME) kat-client kat-server test-auth test-shadow test-stats
+inspect-image-cache: $(foreach i,$(_inspect-images), docker/$i.docker.inspect.image.cache)
+.PHONY: inspect-image-cache
 
 images-build: docker/$(LCNAME).docker.tag.local
 images-build: docker/kat-client.docker.tag.local
 images-build: docker/kat-server.docker.tag.local
 .PHONY: images-build
 
-images: FORCE images-inspect images-build
+images: FORCE inspect-image-cache images-build
 .PHONY: images
 
 REGISTRY_ERR  = $(RED)
@@ -173,7 +173,7 @@ images-push: docker/kat-client.docker.push.remote
 images-push: docker/kat-server.docker.push.remote
 .PHONY: images-push
 
-push: FORCE images-inspect images-push
+push: FORCE inspect-image-cache images-push
 .PHONY: push
 
 # `make push-dev` is meant to be run by CI.

--- a/build-aux/builder.mk
+++ b/build-aux/builder.mk
@@ -151,9 +151,16 @@ clean: docker/$(LCNAME).docker.clean
 
 REPO=$(BUILDER_NAME)
 
-images: docker/$(LCNAME).docker.tag.local
-images: docker/kat-client.docker.tag.local
-images: docker/kat-server.docker.tag.local
+_inspect-images = base base-envoy base-pip base-python
+images-inspect: $(foreach i,$(_inspect-images), docker/$i.docker.inspect)
+.PHONY: images-inspect
+
+images-build: docker/$(LCNAME).docker.tag.local
+images-build: docker/kat-client.docker.tag.local
+images-build: docker/kat-server.docker.tag.local
+.PHONY: images-build
+
+images: FORCE images-inspect images-build
 .PHONY: images
 
 REGISTRY_ERR  = $(RED)
@@ -161,9 +168,12 @@ REGISTRY_ERR += $(NL)ERROR: please set the DEV_REGISTRY make/env variable to the
 REGISTRY_ERR += $(NL)       you would like to use for development
 REGISTRY_ERR += $(END)
 
-push: docker/$(LCNAME).docker.push.remote
-push: docker/kat-client.docker.push.remote
-push: docker/kat-server.docker.push.remote
+images-push: docker/$(LCNAME).docker.push.remote
+images-push: docker/kat-client.docker.push.remote
+images-push: docker/kat-server.docker.push.remote
+.PHONY: images-push
+
+push: FORCE images-inspect images-push
 .PHONY: push
 
 # `make push-dev` is meant to be run by CI.

--- a/build-aux/main.mk
+++ b/build-aux/main.mk
@@ -51,7 +51,7 @@ clean: $(foreach img,$(_ocibuild-images),docker/$(img).img.tar.clean)
 # Note that there are a few images used by the test suite that are
 # defined in check.mk, rather than here.
 
-# base: Base OS; none of our specific stuff.  Used for auxiliar test images
+# base: Base OS; none of our specific stuff.  Used for auxiliary test images
 # that don't need Emissary-specific stuff.
 docker/.base.img.tar.stamp: FORCE $(tools/crane) docker/base-python/Dockerfile
 	$(tools/crane) pull $(shell gawk '$$1 == "FROM" { print $$2; quit; }' < docker/base-python/Dockerfile) $@ || test -e $@
@@ -64,23 +64,13 @@ clobber: docker/base.img.tar.clean
 #
 # At the moment, it also includes some other stuff too (kubectl...),
 # but including those things at such an early stage should be
-# understood to be debt from a previous build system, and not
-# something we're actually happy with.
-#
-# In the long-run, this will likely always be a `docker build` rather
-# than an `ocibuild`, in order to do truly base-OS-specific setup
-# (`apk add`, libc-specific compilation...).
+# understood to be debt from a previous build system.
 docker/.base-python.docker.stamp: FORCE docker/base-python/Dockerfile docker/base-python.docker.gen
 	docker/base-python.docker.gen >$@
 clean: docker/base-python.docker.clean
 clobber: docker/base-python.docker.clean
 
 # base-pip: base-python, but with requirements.txt installed.
-#
-# Mixed feelings about this one; it kinda wants to not be a separate
-# image and just be part of the main emissary Dockerfile.  But that
-# would create problems for generate.mk's `pip freeze` step.  Perhaps
-# it will get to go away with `ocibuild`.
 #
 # TODO(lukeshu): Figure out a `py-list-deps`-based workflow for
 # updating requirements-dev.txt.

--- a/build-aux/tools.mk
+++ b/build-aux/tools.mk
@@ -95,8 +95,8 @@ $(tools.bindir)/.%.stamp: $(tools.srcdir)/%/main.go FORCE
 # packages.  In CI, (as long as `vendor/` is checked in to git) this
 # means that they would be empty for the first `make generate` and
 # non-empty for the second `make generate`, which would (rightfully)
-# trip copy-ifchanged's "this should not happen in CI" checks.  I
-# don't have the time to kill off `vendor/` yet, so for now this is
+# trip copy-ifchanged's "this should not happen in CI" checks.
+# Vendoring should be removed when possible, but for now this is
 # addressed by explicitly setting `-mod=mod`.
 	cd $(<D) && GOOS= GOARCH= go build -mod=mod -o $(abspath $@) .
 $(tools.bindir)/%: $(tools.bindir)/.%.stamp $(tools/copy-ifchanged)
@@ -116,8 +116,6 @@ $(tools.bindir)/telepresence: $(tools.mk)
 	curl -s --fail -L https://app.getambassador.io/download/tel2/$(GOHOSTOS)/$(GOHOSTARCH)/$(TELEPRESENCE_VERSION)/telepresence -o $@
 	chmod a+x $@
 
-# k3d is in theory `go get`-able, but... the tests fail when I do
-# that.  IDK.  --lukeshu
 tools/k3d   = $(tools.bindir)/k3d
 K3D_VERSION = 5.4.7
 $(tools.bindir)/k3d: $(tools.mk)


### PR DESCRIPTION
Adds automated support for inspecting images based on the internal cache files, and cleans up any outdated files that would cause `make images` to subsequently fail.

Previously, the existing caching mechanism would prevent `make images` from functioning if the referenced images no longer exist. While both `make clean` and `make clobber` would allow `make images` to function again under those circumstances, this should not be required, and makes the build system cumbersome. With these changes in place, `make images` should function more smoothly under more circumstances, and should largely default to recreating images if necessary.

## Description

`make images`, `make push`, and `make deploy` (indirectly) will now inspect the docker images referenced in the internal cache files to determine if the images exist. If not, it will now remove the outdated cache files, and rebuild images as normal instead of outright failing.

## Related Issues

#4987

## Testing

Local environment testing focused primarily on the build system.

## Checklist

- [ ] **Does my change need to be backported to a previous release?**
- [ ] **I made sure to update `CHANGELOG.md`.**
- [x] **This is unlikely to impact how Ambassador performs at scale.**
- [x] **My change is adequately tested.**
- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**
- [x] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
