### PR TITLE
deps: bump pyaml and orjson

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -158,7 +158,7 @@ libraries:
     jsonpointer         2.3        3-clause BSD license
     kubernetes          21.7.0     Apache License 2.0
     oauthlib            3.2.2      3-clause BSD license
-    orjson              3.6.6      Apache License 2.0, MIT license
+    orjson              3.8.10     Apache License 2.0, MIT license
     packaging           21.3       2-clause BSD license, Apache License 2.0
     pep517              0.13.0     MIT license
     pip-tools           6.12.1     3-clause BSD license

--- a/docker/base-python/Dockerfile
+++ b/docker/base-python/Dockerfile
@@ -86,11 +86,11 @@ RUN curl --fail -L https://dl.google.com/go/go1.20.3.linux-amd64.tar.gz | tar -C
 # Download, build, and install PyYAML.
 RUN mkdir /tmp/pyyaml && \
   cd /tmp/pyyaml && \
-  curl -o pyyaml-5.4.1.1.tar.gz -L https://github.com/yaml/pyyaml/archive/refs/tags/5.4.1.1.tar.gz && \
-  tar xzf pyyaml-5.4.1.1.tar.gz && \
-  cd pyyaml-5.4.1.1 && \
+  curl -o pyyaml-6.0.tar.gz -L https://github.com/yaml/pyyaml/archive/refs/tags/6.0.tar.gz && \
+  tar xzf pyyaml-6.0.tar.gz && \
+  cd pyyaml-6.0 && \
   python3 setup.py --with-libyaml install
 
 # orjson is also special.  The wheels on PyPI rely on glibc, so we
 # need to use cargo/rustc/patchelf to build a musl-compatible version.
-RUN pip3 install orjson==3.6.6
+RUN pip3 install orjson==3.8.10

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -46,7 +46,7 @@ markupsafe==2.1.1
     #   werkzeug
 oauthlib==3.2.2
     # via requests-oauthlib
-orjson==3.6.6
+orjson==3.8.10
     # via -r requirements.in
 prometheus-client==0.15.0
     # via -r requirements.in

--- a/tools/src/py-mkopensource/main.go
+++ b/tools/src/py-mkopensource/main.go
@@ -73,8 +73,7 @@ func parseLicenses(name, version, license string) map[License]struct{} {
 
 		// These are packages with non-trivial strings to parse, and
 		// it's easier to just hard-code it.
-		{"orjson", "3.3.1", "Apache-2.0 OR MIT"}:            {Apache2, MIT},
-		{"orjson", "3.6.6", "Apache-2.0 OR MIT"}:            {Apache2, MIT},
+		{"orjson", "3.8.10", "Apache-2.0 OR MIT"}:           {Apache2, MIT},
 		{"packaging", "21.3", "BSD-2-Clause or Apache-2.0"}: {BSD2, Apache2},
 	}[tuple{name, version, license}]
 	if ok {


### PR DESCRIPTION
## Description

This bumps pyyaml added in the base-python image to match the dependency that is pulled in via the `requirements.txt`

Also, bumping orjson which now has wheels for mac osx so it builds faster on m1's now. Adjusted license allow list to ensure the new version gets populated in the dependencies.md file properly.

## Related Issues

General dep updates.

## Testing

CI and local runs of `make` commands.

Verified it looks good in apro.git as well. https://github.com/datawire/apro/pull/3295

## Checklist

- [ ] **Does my change need to be backported to a previous release?**
- [ ] **I made sure to update `CHANGELOG.md`.**
- [ ] **This is unlikely to impact how Ambassador performs at scale.**
- [ ] **My change is adequately tested.**
- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**
- [ ] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
