### PR TITLE
Refactor the NAME environment variable

### DIFF
--- a/DevDocumentation/DEVELOPING.md
+++ b/DevDocumentation/DEVELOPING.md
@@ -924,14 +924,9 @@ using the `BUILD_ARCH` environment variable (e.g. `BUILD_ARCH=linux/arm64 make i
 
 ### How do I develop on Windows using WSL?
 
-As the Emissary-ingress build system requires docker communication via a UNIX socket, using WSL 1 is not possible.
-Not even with a `DOCKER_HOST` environment variable set. As a result, you have to use WSL 2, including using the
-WSL 2 version of docker-for-windows.
-
-Additionally, if your hostname contains an upper-case character, the build script will break. This is based on the
-`NAME` environment variable, which should contain your hostname. You can solve this issue by doing `export NAME=my-lowercase-host-name`.
-If you do this *after* you've already run `make images` once, you will manually have to clean up the docker images
-that have been created using your upper-case host name.
+- [WSL 2](https://learn.microsoft.com/en-us/windows/wsl/)
+- [Docker Desktop for Windows](https://docs.docker.com/desktop/windows/wsl/)
+- [VS Code](https://code.visualstudio.com/)
 
 ### How do I test using a private Docker repository?
 

--- a/Makefile
+++ b/Makefile
@@ -56,15 +56,16 @@ endif
 
 # Everything else...
 
-NAME ?= emissary
+EMISSARY_NAME ?= emissary
+
 _git_remote_urls := $(shell git remote | xargs -n1 git remote get-url --all)
 IS_PRIVATE ?= $(findstring private,$(_git_remote_urls))
 
 include $(OSS_HOME)/build-aux/ci.mk
 include $(OSS_HOME)/build-aux/deps.mk
 include $(OSS_HOME)/build-aux/main.mk
-include $(OSS_HOME)/build-aux/check.mk
 include $(OSS_HOME)/build-aux/builder.mk
+include $(OSS_HOME)/build-aux/check.mk
 include $(OSS_HOME)/_cxx/envoy.mk
 include $(OSS_HOME)/releng/release.mk
 

--- a/build-aux/builder.mk
+++ b/build-aux/builder.mk
@@ -1,6 +1,6 @@
 BUILDER_HOME := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
-LCNAME := $(shell echo $(NAME) | tr '[:upper:]' '[:lower:]')
+LCNAME := $(shell echo $(EMISSARY_NAME) | tr '[:upper:]' '[:lower:]')
 BUILDER_NAME ?= $(LCNAME)
 
 include $(OSS_HOME)/build-aux/prelude.mk

--- a/build-aux/check.mk
+++ b/build-aux/check.mk
@@ -4,7 +4,7 @@ include build-aux/tools.mk
 # Auxiliary Docker images needed for the tests
 
 # Keep this list in-sync with python/tests/integration/manifests.py
-push-pytest-images: docker/emissary.docker.push.remote
+push-pytest-images: docker/$(LCNAME).docker.push.remote
 push-pytest-images: docker/test-auth.docker.push.remote
 push-pytest-images: docker/test-shadow.docker.push.remote
 push-pytest-images: docker/test-stats.docker.push.remote
@@ -31,7 +31,7 @@ docker/.kat-client.img.tar.stamp: $(tools/ocibuild) docker/base.img.tar docker/k
 	{ $(tools/ocibuild) image build \
 	  --base=docker/base.img.tar \
 	  --config.Cmd='sleep' --config.Cmd='3600' \
-	  --tag=emissary.local/kat-client:latest \
+	  --tag=$(LCNAME).local/kat-client:latest \
 	  <($(tools/ocibuild) layer squash $(filter %.layer.tar,$^)); } > $@
 
 # kat-server.docker
@@ -52,14 +52,14 @@ docker/.kat-server.img.tar.stamp: $(tools/ocibuild) docker/base.img.tar docker/k
 	  --config.Env.append=GRPC_TRACE=tcp,http,api \
 	  --config.WorkingDir='/work' \
 	  --config.Cmd='kat-server' \
-	  --tag=emissary.local/kat-server:latest \
+	  --tag=$(LCNAME).local/kat-server:latest \
 	  <($(tools/ocibuild) layer squash $(filter %.layer.tar,$^)); } > $@
 docker/kat-server.img.tar.clean: docker/kat-server.rm-r
 
 #
 # Helm tests
 
-test-chart-values.yaml: docker/emissary.docker.push.remote build-aux/check.mk
+test-chart-values.yaml: docker/$(LCNAME).docker.push.remote build-aux/check.mk
 	{ \
 	  echo 'test:'; \
 	  echo '  enabled: true'; \


### PR DESCRIPTION
NAME is overly simplistic, not descriptive, and conflicts in some cases with existing environment variables on some systems (i.e. WSL 2), where it represents the local hostname. We should move away from using names like NAME, LCNAME, and BUILDER_NAME. Several hardcoded references to `emissary` exist as well, and some of these cause issues when using a different name (or using an environment where NAME already exists).

## Description

* Renames `NAME` to `EMISSARY_NAME` (although there may be better options here)
* Sets `LCNAME` to reference `EMISSARY_NAME` (it's probably worth renaming `LCNAME` in the near future)
* Arguably it may be worth removing this complexity altogether and just using `emissary` instead.
* Fixes a few places where `emissary` is hardcoded.
* Removes the complexity from the `WSL` documentation. WSL 2 smoothly integrates these days, and does not need too much documentation around it. Additionally, the whole related NAME issue with it just needs to be removed instead of adding to the complexity.
* The CHANGELOG may need updated with this change, just in case (although it's unlikely NAME is being changed often...)

## Related Issues

N/A

## Testing

Copious amounts of local testing. Spot testing in CI.

## Checklist

- [ ] **Does my change need to be backported to a previous release?**
- [ ] **I made sure to update `CHANGELOG.md`.**
- [X] **This is unlikely to impact how Ambassador performs at scale.**
- [X] **My change is adequately tested.**
- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**
- [X] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
