### PR TITLE
CI: k8s acceptance test matrix

### DIFF
--- a/.github/workflows/k8s-e2e.yml
+++ b/.github/workflows/k8s-e2e.yml
@@ -1,0 +1,73 @@
+name: k8s-e2e
+
+"on":
+  pull_request: {}
+  schedule:
+    - cron: "0 7 * * *" # at 7am UTC everyday
+  workflow_dispatch:
+
+jobs:
+  acceptance_tests:
+    runs-on: ubuntu-latest
+    env:
+      # See docker/base-python.docker.gen
+      BASE_PYTHON_REPO: ${{ secrets.BASE_PYTHON_REPO }}
+      # See pkg/kubeapply/resource_kubeapply.go
+      DEV_USE_IMAGEPULLSECRET: ${{ secrets.DEV_USE_IMAGEPULLSECRET }}
+      DOCKER_BUILD_USERNAME: ${{ secrets.GH_DOCKER_BUILD_USERNAME }}
+      DOCKER_BUILD_PASSWORD: ${{ secrets.GH_DOCKER_BUILD_TOKEN }}
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s:
+          [
+            { k3s: 1.25.9+k3s1, kubectl: 1.25.9 },
+            { k3s: 1.26.4+k3s1, kubectl: 1.26.4 },
+          ]
+        test:
+          - integration-tests
+          - kat-envoy3-tests-1-of-5
+          - kat-envoy3-tests-2-of-5
+          - kat-envoy3-tests-3-of-5
+          - kat-envoy3-tests-4-of-5
+          - kat-envoy3-tests-5-of-5
+    name: ${{matrix.k8s.kubectl}}-${{ matrix.test }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Install Deps
+        uses: ./.github/actions/setup-deps
+      - name: "Docker Login"
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ (!startsWith(secrets.DEV_REGISTRY, 'docker.io/')) && secrets.DEV_REGISTRY || null }}
+          username: ${{ secrets.GH_DOCKER_BUILD_USERNAME }}
+          password: ${{ secrets.GH_DOCKER_BUILD_TOKEN }}
+      - name: Create integration test cluster
+        env:
+          K3S_VERSION: ${{matrix.k8s.k3s}}
+          KUBECTL_VERSION: ${{matrix.k8s.kubectl}}
+        run: |
+          sudo sysctl -w fs.file-max=1600000
+          sudo sysctl -w fs.inotify.max_user_instances=4096
+
+          make ci/setup-k3d
+      - name: Setup integration test environment
+        run: |
+          export DEV_KUBE_NO_PVC=yes
+          export KAT_REQ_LIMIT=900
+          export DEV_KUBECONFIG=~/.kube/config
+          export DEV_REGISTRY=${{ secrets.DEV_REGISTRY }}
+          make python-integration-test-environment
+      - name: Run ${{ matrix.test }}
+        run: |
+          export DEV_KUBE_NO_PVC=yes
+          export KAT_REQ_LIMIT=900
+          export DEV_KUBECONFIG=~/.kube/config
+          export DEV_REGISTRY=${{ secrets.DEV_REGISTRY }}
+          make pytest-${{ matrix.test }}
+      - uses: ./.github/actions/after-job
+        if: always()
+        with:
+          jobname: check-pytest-${{ matrix.test }}

--- a/build-aux/check.mk
+++ b/build-aux/check.mk
@@ -1,6 +1,6 @@
 include build-aux/tools.mk
 
-#
+#
 # Auxiliary Docker images needed for the tests
 
 # Keep this list in-sync with python/tests/integration/manifests.py
@@ -56,7 +56,7 @@ docker/.kat-server.img.tar.stamp: $(tools/ocibuild) docker/base.img.tar docker/k
 	  <($(tools/ocibuild) layer squash $(filter %.layer.tar,$^)); } > $@
 docker/kat-server.img.tar.clean: docker/kat-server.rm-r
 
-#
+#
 # Helm tests
 
 test-chart-values.yaml: docker/$(LCNAME).docker.push.remote build-aux/check.mk
@@ -83,7 +83,7 @@ endif
 	cd $(chart_dir) && KUBECONFIG=$(DEV_KUBECONFIG) $(abspath $(tools/ct)) install --config=./ct.yaml
 .PHONY: test-chart
 
-#
+#
 # Other
 
 clean: .pytest_cache.rm-r .coverage.rm

--- a/build-aux/ci.mk
+++ b/build-aux/ci.mk
@@ -1,8 +1,8 @@
 include $(dir $(lastword $(MAKEFILE_LIST)))tools.mk
 
-K3S_VERSION      = 1.22.17-k3s1
+K3S_VERSION      ?= 1.22.17-k3s1
 K3D_CLUSTER_NAME =
-K3D_ARGS         = --k3s-arg=--no-deploy=traefik@server:* --k3s-arg=--kubelet-arg=max-pods=255@server:* --k3s-arg=--egress-selector-mode=disabled@server:*
+K3D_ARGS         = --k3s-arg=--disable=traefik@server:* --k3s-arg=--kubelet-arg=max-pods=255@server:* --k3s-arg=--egress-selector-mode=disabled@server:*
 # This is modeled after
 # https://github.com/nolar/setup-k3d-k3s/blob/v1.0.7/action.sh#L70-L77 and
 # https://github.com/nolar/setup-k3d-k3s/blob/v1.0.7/action.yaml#L34-L46

--- a/build-aux/main.mk
+++ b/build-aux/main.mk
@@ -1,7 +1,7 @@
 include build-aux/tools.mk
 include build-aux/var.mk
 
-#
+#
 # Utility rules
 
 # Assume that any rule ending with '.clean' is phony.
@@ -41,7 +41,7 @@ clean: $(foreach img,$(_ocibuild-images),docker/$(img).img.tar.clean)
 %.img.tar.clean: %.docker.clean
 	rm -f $*.img.tar $(*D)/.$(*F).img.tar.stamp $(*D)/$(*F).*.layer.tar
 
-#
+#
 # Specific rules
 
 # For images we can either write rules for
@@ -180,7 +180,7 @@ endif
 	  mkdir -p $(dir $(dst))$(NL)\
 	  sed -e 's/\$$version\$$/$*/g' -e 's/\$$quoteVersion$$/0.4.1/g' <$(src) >$(dst)$(NL)))
 
-#
+#
 # Destructive rules
 
 clobber: clean

--- a/build-aux/tools.mk
+++ b/build-aux/tools.mk
@@ -144,7 +144,7 @@ $(tools.bindir)/protoc-gen-grpc-web: $(tools.mk)
 	chmod 755 $@
 
 tools/kubectl = $(tools.bindir)/kubectl
-KUBECTL_VERSION = 1.21.6
+KUBECTL_VERSION ?= 1.22.17
 $(tools.bindir)/kubectl: $(tools.mk)
 	mkdir -p $(@D)
 	curl -o $@ -L --fail https://storage.googleapis.com/kubernetes-release/release/v$(KUBECTL_VERSION)/bin/$(GOHOSTOS)/$(GOHOSTARCH)/kubectl


### PR DESCRIPTION
## Description

Introduces new workflow that can be run ad-hoc on any branch and also will run nightly to verify all Integration and KAT tests run against multiple versions of k8s.

The matrix currently includes v1.25 and v1.26 with the v1.22 already running as part of the normal PR process.

Here is an example of what we will see: https://github.com/emissary-ingress/emissary/actions/runs/4852062044

> Note: The CI duplication should be improved and probably broke out into composite actions but for the sake of speed, I just did a copy/paste from the main workflow. During next cooldown, I can spend some additional time improving the dryness.


## Related Issues

N/A - improving test coverage.

## Testing

A few sentences describing what testing you've done, e.g., manual tests, automated tests, deployed in production, etc.

## Checklist

- [ ] **Does my change need to be backported to a previous release?**
- [ ] **I made sure to update `CHANGELOG.md`.**
- [x] **This is unlikely to impact how Ambassador performs at scale.**
- [x] **My change is adequately tested.**
- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**
- [ ] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
