### PR TITLE
envoy: switch route to use HeaderValueOption.append_action field

### DIFF
--- a/python/ambassador/envoy/v3/v3route.py
+++ b/python/ambassador/envoy/v3/v3route.py
@@ -767,16 +767,22 @@ class V3Route(Cacheable):
     def generate_headers_to_add(header_dict: dict) -> List[dict]:
         headers = []
         for k, v in header_dict.items():
-            append = True
+            # Default as-if append == True, this ensures it matches previous usage of the deprecated
+            # `append` field.
+            append_action = "APPEND_IF_EXISTS_OR_ADD"
             if isinstance(v, dict):
                 if "append" in v:
                     append = bool(v["append"])
-                headers.append({"header": {"key": k, "value": v["value"]}, "append": append})
+                if append == False:
+                    append_action = "OVERWRITE_IF_EXISTS_OR_ADD"
+                headers.append(
+                    {"header": {"key": k, "value": v["value"]}, "append_action": append_action}
+                )
             else:
                 headers.append(
                     {
                         "header": {"key": k, "value": v},
-                        "append": append,  # Default append True, for backward compatability
+                        "append_action": append_action,
                     }
                 )
         return headers

--- a/python/tests/unit/test_route.py
+++ b/python/tests/unit/test_route.py
@@ -1,5 +1,6 @@
 import pytest
 
+from ambassador.envoy.v3.v3route import V3Route
 from tests.utils import econf_compile, econf_foreach_hcm, module_and_mapping_manifests
 
 
@@ -60,3 +61,40 @@ def test_timeout_ms_both():
     # If we set a default on the Module, it should override the usual default of 3000ms.
     yaml = module_and_mapping_manifests(["cluster_request_timeout_ms: 9000"], ["timeout_ms: 5001"])
     _test_route(yaml, expectations={"timeout": "5.001s"})
+
+
+@pytest.mark.compilertest
+def test_generate_headers_to_add():
+    input_headers = {
+        "x-test-proto": "%PROTOCOL%",
+        "x-test-ip": "%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%",
+        "x-test-static": "This is a test header",
+        "x-test-append": {"append": False, "value": "this will not append header if already exist"},
+        "x-test-no-append": {"append": True, "value": "this will allow appending if header exist"},
+    }
+
+    expected = [
+        {"header": {"key": "x-test-proto", "value": "%PROTOCOL%"}, "append": True},
+        {
+            "header": {"key": "x-test-ip", "value": "%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%"},
+            "append": True,
+        },
+        {"header": {"key": "x-test-static", "value": "This is a test header"}, "append": True},
+        {
+            "header": {
+                "key": "x-test-append",
+                "value": "this will not append header if already exist",
+            },
+            "append": False,
+        },
+        {
+            "header": {
+                "key": "x-test-no-append",
+                "value": "this will allow appending if header exist",
+            },
+            "append": True,
+        },
+    ]
+
+    result = V3Route.generate_headers_to_add(input_headers)
+    assert expected == result

--- a/python/tests/unit/test_route.py
+++ b/python/tests/unit/test_route.py
@@ -74,25 +74,31 @@ def test_generate_headers_to_add():
     }
 
     expected = [
-        {"header": {"key": "x-test-proto", "value": "%PROTOCOL%"}, "append": True},
+        {
+            "header": {"key": "x-test-proto", "value": "%PROTOCOL%"},
+            "append_action": "APPEND_IF_EXISTS_OR_ADD",
+        },
         {
             "header": {"key": "x-test-ip", "value": "%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%"},
-            "append": True,
+            "append_action": "APPEND_IF_EXISTS_OR_ADD",
         },
-        {"header": {"key": "x-test-static", "value": "This is a test header"}, "append": True},
+        {
+            "header": {"key": "x-test-static", "value": "This is a test header"},
+            "append_action": "APPEND_IF_EXISTS_OR_ADD",
+        },
         {
             "header": {
                 "key": "x-test-append",
                 "value": "this will not append header if already exist",
             },
-            "append": False,
+            "append_action": "OVERWRITE_IF_EXISTS_OR_ADD",
         },
         {
             "header": {
                 "key": "x-test-no-append",
                 "value": "this will allow appending if header exist",
             },
-            "append": True,
+            "append_action": "APPEND_IF_EXISTS_OR_ADD",
         },
     ]
 


### PR DESCRIPTION
## Description

The usage of the `HeaderValueOption.append` field is deprecated and it is suggested to use `append_action` which is more explicit in its behavior.

This PR adds a unit test to verify existing behavior and then switch Route configuration to generate config using `HeaderValueOption.append_action`.

- `append = True` becomes `append_action = APPEND_IF_EXISTS_OR_ADD`

- `append = False` becomes `append_action = OVERWRITE_IF_EXISTS_OR_ADD`


See Envoy docs for details:
https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/base.proto#config-core-v3-headervalueoption

Note: this is transparent to the end user and leverages the current settings from the `AddHeader` struct of the Mapping CRD as seen here: https://github.com/emissary-ingress/emissary/blob/0cbb16a3c930ec4b1fe326301bb4e353d53f5210/pkg/api/getambassador.io/v3alpha1/crd_mapping.go#L272

## Related Issues

List related issues.

## Testing

Add new unit tests and current KAT tests cover headers.

## Checklist

- [ ] **Does my change need to be backported to a previous release?**
- [ ] **I made sure to update `CHANGELOG.md`.**
- [x] **This is unlikely to impact how Ambassador performs at scale.**
- [x] **My change is adequately tested.**
- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**
- [x] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
