### PR TITLE
Allow Ingress annotation to set bypass_auth:true

### DIFF
--- a/python/ambassador/fetch/ingress.py
+++ b/python/ambassador/fetch/ingress.py
@@ -196,6 +196,7 @@ class IngressProcessor(ManagedKubernetesProcessor):
         default_backend = obj.spec.get("defaultBackend", obj.spec.get("backend", {}))
         db_service_name = default_backend.get("serviceName", None)
         db_service_port = default_backend.get("servicePort", None)
+
         if db_service_name is not None and db_service_port is not None:
             db_mapping_identifier = f"{obj.name}-default-backend"
 
@@ -254,6 +255,7 @@ class IngressProcessor(ManagedKubernetesProcessor):
                 # For cases where `pathType: Exact`,
                 # otherwise `Prefix` and `ImplementationSpecific` are handled as regular Mapping prefixes
                 is_exact_prefix = True if path_type == "Exact" else False
+                do_bypass_auth = True if obj.annotations.get("getambassador.io/bypass-auth", "false") == "true" else False
 
                 spec = {
                     "ambassador_id": obj.ambassador_id,
@@ -263,6 +265,7 @@ class IngressProcessor(ManagedKubernetesProcessor):
                     if is_exact_prefix
                     else 0,  # Make sure exact paths are evaluated before prefix
                     "service": f"{service_name}.{obj.namespace}:{service_port}",
+                    "bypass_auth": do_bypass_auth,
                 }
 
                 if rule_host is not None:


### PR DESCRIPTION
## Description

With this PR the `IngressProcessor` component of `diagd` looks for the annotation `getambassador.io/bypass-auth` to set the appropriate `bypass_auth` value to the translated `Mapping`. The default is to `false`.

I don't know exactly where is the right place to put a couple of tests about the feature. If you can provide some insights, I can also add the tests.

## Related Issues

[Issue](https://github.com/emissary-ingress/emissary/issues/5034)

## Testing

I've built the Emissary image and deployed in a development cluster with Emissary configured with: 
```
apiVersion: getambassador.io/v3alpha1
kind: Listener
metadata:
  name: my-listener
  namespace: emissary
spec:
  port: 8080
  protocol: HTTPS  
  securityModel: XFP
  hostBinding:
    namespace:
      from: ALL   
---
apiVersion: getambassador.io/v3alpha1
kind: Host
metadata:
  name: my-host
  namespace: emissary
spec:
  hostname: "*"
---
apiVersion: getambassador.io/v3alpha1
kind: AuthService
metadata:
  name: authentication
  namespace: emissary
spec:
  auth_service: "auth-service.default:3000"
  path_prefix: "/extauth"
  proto: http
```

Then created a couple of resources like the following:

```
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  annotations:
    getambassador.io/bypass-auth: "true"
  name: upstream-service-noauth
  namespace: default
spec:
  ingressClassName: ambassador
  rules:
  - http:
      paths:
      - backend:
          service:
            name: upstream-service
            port:
              number: 8080
        path: /no-auth/
        pathType: Prefix
---
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  annotations:
    getambassador.io/bypass-auth: "false"
  name: upstream-service-with-auth
  namespace: default
spec:
  ingressClassName: ambassador
  rules:
  - http:
      paths:
      - backend:
          service:
            name: upstream-service
            port:
              number: 8080
        path: /with-auth/
        pathType: Prefix
```

From the DiagUI the mapping where correctly configured and hitting the ingress with `curl` requests demonstrated that 
`http://${HOST}/no-auth/` requests were bypassing the AuthService.


## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->
- [ ] **Does my change need to be backported to a previous release?**
  - What backport versions were discussed with the Maintainers in the Issue?

- [ ] **I made sure to update `CHANGELOG.md`.**

   Remember, the CHANGELOG needs to mention:
  - Any new features
  - Any changes to our included version of Envoy
  - Any non-backward-compatible changes
  - Any deprecations

- [x] **This is unlikely to impact how Ambassador performs at scale.**

   Remember, things that might have an impact at scale include:
  - Any significant changes in memory use that might require adjusting the memory limits
  - Any significant changes in CPU use that might require adjusting the CPU limits
  - Anything that might change how many replicas users should use
  - Changes that impact data-plane latency/scalability

- [ ] **My change is adequately tested.**

   Remember when considering testing:
  - Your change needs to be specifically covered by tests.
    - Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
  - You also need to make sure that the _entire area being changed_ has adequate test coverage.
    - If existing tests don't actually cover the entire area being changed, add tests.
    - This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
  - We should lean on the bulk of code being covered by unit tests, but...
  - ... an end-to-end test should cover the integration points

- [x] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**

- [x] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
