### PR TITLE
feat: add go_filter

### DIFF
--- a/python/ambassador/ir/ir.py
+++ b/python/ambassador/ir/ir.py
@@ -31,6 +31,7 @@ from .irbasemappinggroup import IRBaseMappingGroup
 from .ircluster import IRCluster
 from .irerrorresponse import IRErrorResponse
 from .irfilter import IRFilter
+from .irgofilter import IRGOFilter
 from .irhost import HostFactory, IRHost
 from .irhttpmapping import IRHTTPMapping
 from .irlistener import IRListener, ListenerFactory
@@ -408,11 +409,14 @@ class IR:
 
         # After the Ambassador and TLS modules are done, we need to set up the
         # filter chains. Note that order of the filters matters. Start with CORS,
-        # so that preflights will work even for things behind auth.
+        # so that preflights will work for all filters.
 
         self.save_filter(
             IRFilter(ir=self, aconf=aconf, rkey="ir.cors", kind="ir.cors", name="cors", config={})
         )
+
+        # We always add the Go filter calling to our filter plugin service if applicable before auth
+        self.save_filter(IRGOFilter(ir=self, aconf=aconf))
 
         # Next is auth...
         self.save_filter(IRAuth(self, aconf))

--- a/python/ambassador/ir/irgofilter.py
+++ b/python/ambassador/ir/irgofilter.py
@@ -1,0 +1,77 @@
+# Copyright 2023 Datawire. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+import os
+from dataclasses import asdict, dataclass
+from typing import TYPE_CHECKING, Any, Dict, Optional
+
+from ..config import Config
+from .irfilter import IRFilter
+
+if TYPE_CHECKING:
+    from .ir import IR  # pragma: no cover
+
+GO_FILTER_OBJECT_FILE: str = os.getenv("GO_FILTER_OBJECT_FILE", "/ambassador/go_filter.so")
+
+
+def go_library_exists(go_library_path: str) -> bool:
+    if os.path.exists(go_library_path):
+        return True
+    return False
+
+
+@dataclass
+class GOFilterConfig:
+    library_path: str
+
+
+class IRGOFilter(IRFilter):
+    config: GOFilterConfig
+
+    def __init__(
+        self,
+        ir: "IR",
+        aconf: Config,
+        rkey: str = "ir.go_filter",
+        kind: str = "IRGOFilter",
+        name: str = "go_filter",
+        namespace: Optional[str] = None,
+    ) -> None:
+        super().__init__(
+            ir=ir,
+            aconf=aconf,
+            rkey=rkey,
+            kind=kind,
+            name=name,
+            namespace=namespace,
+            type="decoder",
+        )
+
+    # We want to enable this filter only in Edge Stack
+    def setup(self, ir: "IR", _: Config) -> bool:
+        if ir.edge_stack_allowed:
+            if not go_library_exists(GO_FILTER_OBJECT_FILE):
+                self.post_error(f"{GO_FILTER_OBJECT_FILE} not found, disabling Go filter...")
+                return False
+            self.config = GOFilterConfig(library_path=GO_FILTER_OBJECT_FILE)
+            return True
+        return False
+
+    def config_dict(self) -> Optional[Dict[str, Any]]:
+        return asdict(self.config) if self.config else None
+
+    def as_dict(self) -> Dict[str, Any]:
+        d = super(IRGOFilter, self).as_dict()
+        d["config"] = self.config_dict() if self.config else {}
+        return d

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,0 +1,18 @@
+import os
+from unittest.mock import patch
+
+import pytest
+
+from ambassador.utils import parse_bool
+
+
+@pytest.fixture(autouse=True)
+def go_library():
+    with patch("ambassador.ir.irgofilter.go_library_exists") as go_library_exists:
+        go_library_exists.return_value = True
+        yield go_library_exists
+
+
+@pytest.fixture(autouse=True)
+def edgestack():
+    return parse_bool(os.environ.get("EDGE_STACK", "false"))

--- a/python/tests/unit/test_gofilter.py
+++ b/python/tests/unit/test_gofilter.py
@@ -1,0 +1,138 @@
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+from unittest.mock import patch
+
+import pytest
+
+from tests.utils import edgestack, get_envoy_config, skip_edgestack
+
+MAPPING = """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: test
+  namespace: ambassador
+spec:
+  prefix: /test/
+  service: test
+  hostname: '*'
+"""
+
+AUTH_SERVICE = """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: AuthService
+metadata:
+  name:  myauthservice
+  namespace: default
+spec:
+  auth_service: someservice
+  proto: grpc
+  protocol_version: "v3"
+"""
+
+
+@dataclass(frozen=True)
+class HTTPFilterResult:
+    listener_name: Optional[str]
+    filter_chain_name: Optional[str]
+    http_filter: Dict[str, Any]
+    prev_http_filter_name: Optional[str] = None
+    next_http_filter_name: Optional[str] = None
+
+
+def _get_go_filters(config: Dict[str, Any]) -> list[HTTPFilterResult]:
+    found_filters: list[HTTPFilterResult] = []
+
+    listener: Dict[str, Any]
+    for listener in config["static_resources"]["listeners"]:
+        listener_name = listener.get("name")
+
+        filter_chain: Dict[str, Any]
+        for filter_chain in listener["filter_chains"]:
+            filter_chain_name = filter_chain.get("name")
+
+            filter: Dict[str, Any]
+            for filter in filter_chain["filters"]:
+                http_filters = filter["typed_config"]["http_filters"]
+                for i, http_filter in enumerate(filter["typed_config"]["http_filters"]):
+                    if http_filter["name"] == "envoy.filters.http.golang":
+                        prev_http_filter_name: Optional[str] = None
+                        if i > 0:
+                            prev_http_filter_name = http_filters[i - 1]["name"]
+
+                        next_http_filter_name: Optional[str] = None
+                        if i < len(http_filters) - 1:
+                            next_http_filter_name = http_filters[i + 1]["name"]
+
+                        found_filter = HTTPFilterResult(
+                            listener_name=listener_name,
+                            filter_chain_name=filter_chain_name,
+                            http_filter=http_filter,
+                            prev_http_filter_name=prev_http_filter_name,
+                            next_http_filter_name=next_http_filter_name,
+                        )
+                        found_filters.append(found_filter)
+    return found_filters
+
+
+@pytest.mark.compilertest
+@edgestack()
+def test_gofilter_injected():
+    econf = get_envoy_config(MAPPING)
+    filters = _get_go_filters(econf.as_dict())
+    # Two listeners - ports 8080 and 8443 - each with an HTTP and HTTPS filterchain
+    assert len(filters) == 4
+
+    errors = econf.ir.aconf.errors
+    assert "ir.go_filter" not in errors
+
+    for filter in filters:
+        assert "envoy.filters.http.cors" == filter.prev_http_filter_name
+
+
+@pytest.mark.compilertest
+@edgestack()
+def test_go_filter_injected_before_auth_service():
+    econf = get_envoy_config(f"{MAPPING}\n{AUTH_SERVICE}")
+    filters = _get_go_filters(econf.as_dict())
+    # Two listeners - ports 8080 and 8443 - each with an HTTP and HTTPS filterchain
+    assert len(filters) == 4
+
+    errors = econf.ir.aconf.errors
+    assert "ir.go_filter" not in errors
+
+    for filter in filters:
+        assert "envoy.filters.http.cors" == filter.prev_http_filter_name
+        assert "envoy.filters.http.ext_authz" == filter.next_http_filter_name
+
+
+@pytest.mark.compilertest
+@edgestack()
+def test_gofilter_missing_object_file(go_library):
+    go_library.return_value = False
+
+    econf = get_envoy_config(MAPPING)
+    filters = _get_go_filters(econf.as_dict())
+
+    assert len(filters) == 0
+
+    errors = econf.ir.aconf.errors
+    assert "ir.go_filter" in errors
+    assert (
+        errors["ir.go_filter"][0]["error"]
+        == "/ambassador/go_filter.so not found, disabling Go filter..."
+    )
+
+
+@pytest.mark.compilertest
+@skip_edgestack()
+def test_gofilter_not_injected():
+    econf = get_envoy_config(MAPPING)
+    filters = _get_go_filters(econf.as_dict())
+
+    assert len(filters) == 0
+
+    errors = econf.ir.aconf.errors
+    assert "ir.go_filter" not in errors

--- a/tools/src/py-list-deps.py
+++ b/tools/src/py-list-deps.py
@@ -49,10 +49,12 @@ import argparse
 import ast
 import importlib
 import os
+import re
 import sys
 import sysconfig
 from typing import List, NamedTuple, Optional, Set
 
+DEV_PY_FILES = r'|'.join(['setup.py', 'conftest.py', '/tests/', '/kat/', 'test_.*.py',])
 
 def parse_members(filepath: str) -> Set[str]:
     """parse_members parses a .py file and returns a set of all of the
@@ -276,14 +278,11 @@ def main(inputdirs: List[str], include_dev: bool = False) -> Set[str]:
                 dirnames.remove('dist')
             if '__pycache__' in dirnames:
                 dirnames.remove('__pycache__')
-            build_rules: List[str] = []
             for filename in sorted(filenames):
                 filepath = os.path.join(dirpath, filename)
                 if filename.endswith('.py'):
                     if not include_dev:
-                        if ('/tests/' in filepath) or ('/kat/' in filepath) or filename.startswith('test_'):
-                            continue
-                        if filename == 'setup.py':
+                        if re.search(DEV_PY_FILES, filepath):
                             continue
                     deps = deps.union(deps_for_pyfile(inputdir, filepath))
     return deps


### PR DESCRIPTION
## Description

Inject a go filter for EdgeStack. When running pure Emissary, the go filter is not injected. 
The go library will reach out to a filter plugin service to handle things like WAF. The Go filter runs after CORS (so that preflights can continue to work) but before the ext_authz filter so that WAF can run before OAuth.

Note that we will need to update our Envoy build to include the go-filter

## Related Issues

List related issues.

## Testing

Added unit tests. The unit tests test that the go filter is being injected into the xDS. Because the go filter is meant to be injected only when the `EDGE_STACK` env var is set to true, some test cases are marked as `edgestack` and would run in apro CI which will be handled separately

I've confirmed that the unit tests do pass with both settings for the `EDGE_STACK` flag:
![image](https://github.com/emissary-ingress/emissary/assets/29347317/77501572-43a6-42eb-913f-8a06f5f939fc)


Full Integration and E2E tests will be added in a separate PR.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->
- [ ] **Does my change need to be backported to a previous release?**
  - What backport versions were discussed with the Maintainers in the Issue?

- [ ] **I made sure to update `CHANGELOG.md`.**

   Remember, the CHANGELOG needs to mention:
  - Any new features
  - Any changes to our included version of Envoy
  - Any non-backward-compatible changes
  - Any deprecations

- [x] **This is unlikely to impact how Ambassador performs at scale.**

   Remember, things that might have an impact at scale include:
  - Any significant changes in memory use that might require adjusting the memory limits
  - Any significant changes in CPU use that might require adjusting the CPU limits
  - Anything that might change how many replicas users should use
  - Changes that impact data-plane latency/scalability

- [x] **My change is adequately tested.**

Note that integration and E2E tests will be added in a separate PR

- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**

- [ ] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
