### PR TITLE
Dont specify a default cpu limits

### DIFF
--- a/charts/emissary-ingress/values.yaml.in
+++ b/charts/emissary-ingress/values.yaml.in
@@ -300,7 +300,6 @@ deploymentAnnotations: {}
 resources: # +doc-gen:break
   # Recommended resource requests and limits for Ambassador
   limits:
-    cpu: 1000m
     memory: 600Mi
   requests:
     cpu: 200m


### PR DESCRIPTION
Cpu limits might be necessary or helpful in certain multi tenant environments, but I think its far more common for emissary to be running on k8s nodes where the extra cpu cycles should be used instead of limiting cpu by default.   As such this pr removes the default cpu limit