### PR TITLE
apiext: set ConversionReviewVersion to v1

### DIFF
--- a/DevDocumentation/ARCHITECTURE.md
+++ b/DevDocumentation/ARCHITECTURE.md
@@ -66,10 +66,10 @@ conversion:
           name: emissary-apiext
           namespace: emissary-system
       conversionReviewVersions:
-      - v1beta1
+      - v1
 ```
 
-This is telling the Kubernetes API Server to call a WebHook using a `Service` within the cluster that is called `emissary-apiext` that can be found in the `emissary-system` namespace. It also states that our server implementation as of writing this guide only supports `v1beta1` of the WebHook so the K8s API Server will send the request and expect the response in the format for `v1beta1`.
+This is telling the Kubernetes API Server to call a WebHook using a `Service` within the cluster that is called `emissary-apiext` that can be found in the `emissary-system` namespace. It also states that our server implementation supports the `v1` version of the WebHook protocol so the K8s API Server will send the request and expect the response in the format for `v1`.
 
 The implementation of the `apiext` server can be found in `cmd/apiext` and it leverages the [controller-runtime](https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.11.2starts) library which is vendored in `vendor/sigs.k8s.io/controller-runtime`. When this process starts up it will do the following:
 

--- a/cmd/apiext/inject.go
+++ b/cmd/apiext/inject.go
@@ -66,7 +66,7 @@ func ConfigureCRDs(
 			// sigs.k8s.io/controller-runtime/pkg/webhook/conversion to implement the
 			// webhook this list should be kept in-sync with what that package supports.
 			ConversionReviewVersions: []string{
-				"v1beta1",
+				"v1",
 			},
 		},
 	}


### PR DESCRIPTION
## Description

When injecting the CA public cert into the CRD definition, the apiext sets the ConversionReviewVersions which overrides what was set in the `fix-crds` tool during release. When we upgraded controller-runtime to the latest libraries we now only support v1 which is also what all current supported k8s version use.

Therefore, this ensures that at runtime we do not override that and use the `v1` apiVersion in our CR definition file.

## Related Issues

n/a

## Testing

CI is green

## Checklist

- [x] **Does my change need to be backported to a previous release?**
- [ ] **I made sure to update `CHANGELOG.md`.**
- [x] **This is unlikely to impact how Ambassador performs at scale.**
- [ ] **My change is adequately tested.**
- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**
- [x] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
