### PR TITLE
testing[IRGOFilter]: make slight adjustments to tests

### DIFF
--- a/python/ambassador/ir/irgofilter.py
+++ b/python/ambassador/ir/irgofilter.py
@@ -62,7 +62,7 @@ class IRGOFilter(IRFilter):
     def setup(self, ir: "IR", _: Config) -> bool:
         if ir.edge_stack_allowed:
             if not go_library_exists(GO_FILTER_OBJECT_FILE):
-                self.post_error(f"{GO_FILTER_OBJECT_FILE} not found, disabling Go filter...")
+                self.logger.error("%s not found, disabling Go filter...", GO_FILTER_OBJECT_FILE)
                 return False
             self.config = GOFilterConfig(library_path=GO_FILTER_OBJECT_FILE)
             return True

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,16 +1,8 @@
 import os
-from unittest.mock import patch
 
 import pytest
 
 from ambassador.utils import parse_bool
-
-
-@pytest.fixture(autouse=True)
-def go_library():
-    with patch("ambassador.ir.irgofilter.go_library_exists") as go_library_exists:
-        go_library_exists.return_value = True
-        yield go_library_exists
 
 
 @pytest.fixture(autouse=True)

--- a/python/tests/unit/conftest.py
+++ b/python/tests/unit/conftest.py
@@ -1,0 +1,10 @@
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def go_library():
+    with patch("ambassador.ir.irgofilter.go_library_exists") as go_library_exists:
+        go_library_exists.return_value = True
+        yield go_library_exists

--- a/python/tests/unit/test_gofilter.py
+++ b/python/tests/unit/test_gofilter.py
@@ -110,7 +110,7 @@ def test_go_filter_injected_before_auth_service():
 
 @pytest.mark.compilertest
 @edgestack()
-def test_gofilter_missing_object_file(go_library):
+def test_gofilter_missing_object_file(go_library, caplog):
     go_library.return_value = False
 
     econf = get_envoy_config(MAPPING)
@@ -118,12 +118,7 @@ def test_gofilter_missing_object_file(go_library):
 
     assert len(filters) == 0
 
-    errors = econf.ir.aconf.errors
-    assert "ir.go_filter" in errors
-    assert (
-        errors["ir.go_filter"][0]["error"]
-        == "/ambassador/go_filter.so not found, disabling Go filter..."
-    )
+    assert "/ambassador/go_filter.so not found" in caplog.text
 
 
 @pytest.mark.compilertest
@@ -135,4 +130,4 @@ def test_gofilter_not_injected():
     assert len(filters) == 0
 
     errors = econf.ir.aconf.errors
-    assert "ir.go_filter" not in errors
+    assert len(errors) == 0


### PR DESCRIPTION
## Description

Make slight adjustments to go-filter tests:

- Move the `go_library` fixture to `python/tests/unit`. Don't make the default assumption that the go library file exists for integration tests. Some of the integration tests call `assert_valid_envoy_config` which runs a validation check on the generated xDS inside the base envoy docker container. Because the xDS was generated under the assumption the go library file existed it would cause the validate command to fail due to the file actually not existing inside the container. Making it so that it was injected would require building an object file of the go library and incorporate that into the integration tests which is fairly complicated at this time. So we'll omit it for the time being especially because these integration tests are not testing the go filter specifically and test the go filter with additional integration tests.

- Don't use `post_error` when the go library file is not found. This will cause it to not count as an ir error but it will still log an error level message. This is so that unrelated kat tests pass.

## Related Issues

List related issues.

## Testing

Updating tests, CI, verify in apro that tests pass

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->
- [ ] **Does my change need to be backported to a previous release?**
  - What backport versions were discussed with the Maintainers in the Issue?

- [ ] **I made sure to update `CHANGELOG.md`.**

   Remember, the CHANGELOG needs to mention:
  - Any new features
  - Any changes to our included version of Envoy
  - Any non-backward-compatible changes
  - Any deprecations

- [x] **This is unlikely to impact how Ambassador performs at scale.**

   Remember, things that might have an impact at scale include:
  - Any significant changes in memory use that might require adjusting the memory limits
  - Any significant changes in CPU use that might require adjusting the CPU limits
  - Anything that might change how many replicas users should use
  - Changes that impact data-plane latency/scalability

- [x] **My change is adequately tested.**

   Remember when considering testing:
  - Your change needs to be specifically covered by tests.
    - Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
  - You also need to make sure that the _entire area being changed_ has adequate test coverage.
    - If existing tests don't actually cover the entire area being changed, add tests.
    - This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
  - We should lean on the bulk of code being covered by unit tests, but...
  - ... an end-to-end test should cover the integration points

- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**

- [ ] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
