### PR TITLE
charts: update rbac

### DIFF
--- a/charts/emissary-ingress/templates/rbac.yaml
+++ b/charts/emissary-ingress/templates/rbac.yaml
@@ -89,7 +89,7 @@ rules:
     - endpoints
     verbs: ["get", "list", "watch"]
 
-  - apiGroups: [ "getambassador.io" ]
+  - apiGroups: [ "getambassador.io", "gateway.getambassador.io" ]
     resources: [ "*" ]
     verbs: ["get", "list", "watch", "update", "patch", "create", "delete" ]
 

--- a/manifests/emissary/emissary-defaultns.yaml.in
+++ b/manifests/emissary/emissary-defaultns.yaml.in
@@ -186,6 +186,7 @@ rules:
   - watch
 - apiGroups:
   - getambassador.io
+  - gateway.getambassador.io
   resources:
   - '*'
   verbs:

--- a/manifests/emissary/emissary-emissaryns.yaml.in
+++ b/manifests/emissary/emissary-emissaryns.yaml.in
@@ -186,6 +186,7 @@ rules:
   - watch
 - apiGroups:
   - getambassador.io
+  - gateway.getambassador.io
   resources:
   - '*'
   verbs:

--- a/python/tests/integration/manifests/rbac_cluster_scope.yaml
+++ b/python/tests/integration/manifests/rbac_cluster_scope.yaml
@@ -96,6 +96,7 @@ rules:
   - watch
 - apiGroups:
   - getambassador.io
+  - gateway.getambassador.io
   resources:
   - '*'
   verbs:

--- a/python/tests/integration/manifests/rbac_namespace_scope.yaml
+++ b/python/tests/integration/manifests/rbac_namespace_scope.yaml
@@ -97,6 +97,7 @@ rules:
   - watch
 - apiGroups:
   - getambassador.io
+  - gateway.getambassador.io
   resources:
   - '*'
   verbs:


### PR DESCRIPTION
## Description

Update rbac to allow fetching gateway.getambassador.io resources. Needed for EdgeStack KAT tests because the manifests including CRDs the KAT tests uses are under python/test/integration/manifests which is generated using helm template from the charts/. 

Unfortunate we have to set it here.

## Related Issues

List related issues.

## Testing

A few sentences describing what testing you've done, e.g., manual tests, automated tests, deployed in production, etc.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->
- [ ] **Does my change need to be backported to a previous release?**
  - What backport versions were discussed with the Maintainers in the Issue?

- [ ] **I made sure to update `CHANGELOG.md`.**

   Remember, the CHANGELOG needs to mention:
  - Any new features
  - Any changes to our included version of Envoy
  - Any non-backward-compatible changes
  - Any deprecations

- [ ] **This is unlikely to impact how Ambassador performs at scale.**

   Remember, things that might have an impact at scale include:
  - Any significant changes in memory use that might require adjusting the memory limits
  - Any significant changes in CPU use that might require adjusting the CPU limits
  - Anything that might change how many replicas users should use
  - Changes that impact data-plane latency/scalability

- [ ] **My change is adequately tested.**

   Remember when considering testing:
  - Your change needs to be specifically covered by tests.
    - Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
  - You also need to make sure that the _entire area being changed_ has adequate test coverage.
    - If existing tests don't actually cover the entire area being changed, add tests.
    - This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
  - We should lean on the bulk of code being covered by unit tests, but...
  - ... an end-to-end test should cover the integration points

- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**

- [ ] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
