### PR TITLE
Replace rsync --mkpath with mkdir

### DIFF
--- a/_cxx/envoy.mk
+++ b/_cxx/envoy.mk
@@ -260,7 +260,8 @@ envoy-shell: $(ENVOY_BASH.deps)
 
 # Raw Envoy protobufs
 $(OSS_HOME)/api/envoy $(addprefix $(OSS_HOME)/api/,$(envoy-api-contrib)): $(OSS_HOME)/api/%: $(OSS_HOME)/_cxx/envoy
-	rsync --recursive --delete --delete-excluded --prune-empty-dirs --mkpath --include='*/' --include='*.proto' --exclude='*' $</api/$*/ $@
+	mkdir -p $@
+	rsync --recursive --delete --delete-excluded --prune-empty-dirs --include='*/' --include='*.proto' --exclude='*' $</api/$*/ $@
 
 # Go generated from the protobufs
 $(OSS_HOME)/_cxx/envoy/build_go: $(ENVOY_BASH.deps) FORCE


### PR DESCRIPTION
Removes the use of the `rsync` `--mkpath` options in favor of creating the target folder with `mkdir` instead. The `--mkpath` option is only available in later versions of `rsync`, which are not generally available on some platforms. While in most cases, it's better to rely upon (and insist upon) the latest versions, upgrading `rsync` is relatively prohibitive, and it would be better to not have this barrier to open source use.

## Description

The `rsync` `--mkpath` option was added in [3.2.3](https://download.samba.org/pub/rsync/NEWS#3.2.3).

As an example using Ubuntu:
* Ubuntu 20.04 LTS uses [3.1.3](https://packages.ubuntu.com/focal/rsync)
* Ubuntu 22.04 LTS uses [3.2.7](https://packages.ubuntu.com/jammy/rsync)

Ubuntu 20.04 LTS should still be considered an acceptable distribution to use, based on the [Ubuntu release cycle](https://ubuntu.com/about/release-cycle).

And while in most cases, upgrading manually to the latest versions should be the preference, `rsync` has made no effort in modern releases, documentation, or website(s), and none of the unofficial release processes should be recommended or documented as part of the Emissary build system.

## Related Issues

N/A

## Testing

Local build testing.

## Checklist

- [ ] **Does my change need to be backported to a previous release?**
- [ ] **I made sure to update `CHANGELOG.md`.**
- [ ] **This is unlikely to impact how Ambassador performs at scale.**
- [x] **My change is adequately tested.**
- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**
- [x] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
