### PR TITLE
go-filter: replace GO_FILTER_OBJECT_FILE env var with disable flag

### DIFF
--- a/k8s-config/kat-ambassador/values.yaml
+++ b/k8s-config/kat-ambassador/values.yaml
@@ -18,6 +18,7 @@ env:
   AMBASSADOR_ID: «self.path.k8s»
   AMBASSADOR_SNAPSHOT_COUNT: "0"
   AMBASSADOR_CONFIG_BASE_DIR: "/tmp/ambassador"
+  AMBASSADOR_DISABLE_GO_FILTER: true
 envRaw: "- ←«envs»"
 security:
   containerSecurityContext:

--- a/python/ambassador/ir/irgofilter.py
+++ b/python/ambassador/ir/irgofilter.py
@@ -22,7 +22,8 @@ from .irfilter import IRFilter
 if TYPE_CHECKING:
     from .ir import IR  # pragma: no cover
 
-GO_FILTER_OBJECT_FILE: str = os.getenv("GO_FILTER_OBJECT_FILE", "/ambassador/go_filter.so")
+GO_FILTER_LIBRARY_PATH = "/ambassador/filter.so"
+AMBASSADOR_DISABLE_GO_FILTER = os.getenv("AMBASSADOR_DISABLE_GO_FILTER", False)
 
 
 def go_library_exists(go_library_path: str) -> bool:
@@ -61,10 +62,16 @@ class IRGOFilter(IRFilter):
     # We want to enable this filter only in Edge Stack
     def setup(self, ir: "IR", _: Config) -> bool:
         if ir.edge_stack_allowed:
-            if not go_library_exists(GO_FILTER_OBJECT_FILE):
-                self.logger.error("%s not found, disabling Go filter...", GO_FILTER_OBJECT_FILE)
+            if AMBASSADOR_DISABLE_GO_FILTER:
+                self.logger.info(
+                    "AMBASSADOR_DISABLE_GO_FILTER=%s, disabling Go filter...",
+                    AMBASSADOR_DISABLE_GO_FILTER,
+                )
                 return False
-            self.config = GOFilterConfig(library_path=GO_FILTER_OBJECT_FILE)
+            if not go_library_exists(GO_FILTER_LIBRARY_PATH):
+                self.logger.error("%s not found, disabling Go filter...", GO_FILTER_LIBRARY_PATH)
+                return False
+            self.config = GOFilterConfig(library_path=GO_FILTER_LIBRARY_PATH)
             return True
         return False
 

--- a/python/tests/integration/manifests/ambassador.yaml
+++ b/python/tests/integration/manifests/ambassador.yaml
@@ -105,6 +105,8 @@ spec:
       value: {self.path.k8s}-agent-cloud-token
     - name: AMBASSADOR_CONFIG_BASE_DIR
       value: /tmp/ambassador
+    - name: AMBASSADOR_DISABLE_GO_FILTER
+      value: "true"
     - name: AMBASSADOR_ID
       value: {self.path.k8s}
     - name: AMBASSADOR_SNAPSHOT_COUNT

--- a/python/tests/unit/conftest.py
+++ b/python/tests/unit/conftest.py
@@ -1,3 +1,4 @@
+import os
 from unittest.mock import patch
 
 import pytest
@@ -8,3 +9,10 @@ def go_library():
     with patch("ambassador.ir.irgofilter.go_library_exists") as go_library_exists:
         go_library_exists.return_value = True
         yield go_library_exists
+
+
+@pytest.fixture()
+def disable_go_filter():
+    with patch("ambassador.ir.irgofilter.AMBASSADOR_DISABLE_GO_FILTER") as disable_go_filter:
+        disable_go_filter.return_value = True
+        yield disable_go_filter

--- a/python/tests/unit/test_gofilter.py
+++ b/python/tests/unit/test_gofilter.py
@@ -118,7 +118,16 @@ def test_gofilter_missing_object_file(go_library, caplog):
 
     assert len(filters) == 0
 
-    assert "/ambassador/go_filter.so not found" in caplog.text
+    assert "/ambassador/filter.so not found" in caplog.text
+
+
+@pytest.mark.compilertest
+@edgestack()
+def test_gofilter_disable(disable_go_filter, caplog):
+    econf = get_envoy_config(MAPPING)
+    filters = _get_go_filters(econf.as_dict())
+
+    assert len(filters) == 0
 
 
 @pytest.mark.compilertest


### PR DESCRIPTION
## Description

AMBASSADOR_DISABLE_GO_FILTER is an env var flag to disable injecting the go filter when running in EdgeStack mode. When running pure Emissary, the go-filter is not injected anyway. the library path is now kept hardcoded since there's no reason to really expose it to be configurable and was causing some confusion on naming.

Due to the presence of this flag now, we add it to the KAT/integration test manifests so that the go-filter isn't injected during those tests. This is fine for now because those tests are not testing any functionality from the go-filter. Future work will include overhauling the E2E test suite.

Also change the filter library path to `/ambassador/filter.so` since that's where the filter library file is located in the edgestack image.

## Related Issues

List related issues.

## Testing

CI

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->
- [ ] **Does my change need to be backported to a previous release?**
  - What backport versions were discussed with the Maintainers in the Issue?

- [ ] **I made sure to update `CHANGELOG.md`.**

   Remember, the CHANGELOG needs to mention:
  - Any new features
  - Any changes to our included version of Envoy
  - Any non-backward-compatible changes
  - Any deprecations

- [ ] **This is unlikely to impact how Ambassador performs at scale.**

   Remember, things that might have an impact at scale include:
  - Any significant changes in memory use that might require adjusting the memory limits
  - Any significant changes in CPU use that might require adjusting the CPU limits
  - Anything that might change how many replicas users should use
  - Changes that impact data-plane latency/scalability

- [ ] **My change is adequately tested.**

   Remember when considering testing:
  - Your change needs to be specifically covered by tests.
    - Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
  - You also need to make sure that the _entire area being changed_ has adequate test coverage.
    - If existing tests don't actually cover the entire area being changed, add tests.
    - This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
  - We should lean on the bulk of code being covered by unit tests, but...
  - ... an end-to-end test should cover the integration points

- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**

- [ ] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
