### PR TITLE
Enable go filter testing

### DIFF
--- a/k8s-config/kat-ambassador/values.yaml
+++ b/k8s-config/kat-ambassador/values.yaml
@@ -18,7 +18,7 @@ env:
   AMBASSADOR_ID: «self.path.k8s»
   AMBASSADOR_SNAPSHOT_COUNT: "0"
   AMBASSADOR_CONFIG_BASE_DIR: "/tmp/ambassador"
-  AMBASSADOR_DISABLE_GO_FILTER: true
+  AMBASSADOR_DISABLE_GO_FILTER: false
 envRaw: "- ←«envs»"
 security:
   containerSecurityContext:

--- a/python/tests/integration/manifests/ambassador.yaml
+++ b/python/tests/integration/manifests/ambassador.yaml
@@ -106,7 +106,7 @@ spec:
     - name: AMBASSADOR_CONFIG_BASE_DIR
       value: /tmp/ambassador
     - name: AMBASSADOR_DISABLE_GO_FILTER
-      value: "true"
+      value: "false"
     - name: AMBASSADOR_ID
       value: {self.path.k8s}
     - name: AMBASSADOR_SNAPSHOT_COUNT


### PR DESCRIPTION
## Description

Enable go filter testing by default.

## Related Issues

N/A

## Testing

Local testing. CI testing.

## Checklist

- [ ] **Does my change need to be backported to a previous release?**
- [ ] **I made sure to update `CHANGELOG.md`.**
- [x] **This is unlikely to impact how Ambassador performs at scale.**
- [x] **My change is adequately tested.**
- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**
- [x] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
