### PR TITLE
Fix go filter disable flag

### DIFF
--- a/python/ambassador/ir/irgofilter.py
+++ b/python/ambassador/ir/irgofilter.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from .ir import IR  # pragma: no cover
 
 GO_FILTER_LIBRARY_PATH = "/ambassador/filter.so"
-AMBASSADOR_DISABLE_GO_FILTER = os.getenv("AMBASSADOR_DISABLE_GO_FILTER", False)
+AMBASSADOR_DISABLE_GO_FILTER = os.getenv("AMBASSADOR_DISABLE_GO_FILTER", "false")
 
 
 def go_library_exists(go_library_path: str) -> bool:
@@ -62,7 +62,7 @@ class IRGOFilter(IRFilter):
     # We want to enable this filter only in Edge Stack
     def setup(self, ir: "IR", _: Config) -> bool:
         if ir.edge_stack_allowed:
-            if AMBASSADOR_DISABLE_GO_FILTER:
+            if AMBASSADOR_DISABLE_GO_FILTER.lower() in ("true", "yes", "1"):
                 self.logger.info(
                     "AMBASSADOR_DISABLE_GO_FILTER=%s, disabling Go filter...",
                     AMBASSADOR_DISABLE_GO_FILTER,


### PR DESCRIPTION
The AMBASSADOR_DISABLE_GO_FILTER is a standard string environment variable. The previous boolean check would not function correctly and has been changed to evaluate against string values instead. Alternately, this could be cast to a bool instead, but there is value in handling multiple truthy string values.

## Description

Evaluates `AMBASSADOR_DISABLE_GO_FILTER` against string values instead of as a boolean.

## Related Issues

N/A

## Testing

Integration test suite.

## Checklist

- [ ] **Does my change need to be backported to a previous release?**
- [ ] **I made sure to update `CHANGELOG.md`.**
- [x] **This is unlikely to impact how Ambassador performs at scale.**
- [x] **My change is adequately tested.**
- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**
- [x] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
