### PR TITLE
testing[go-filter]: fix disable go filter tests

### DIFF
--- a/python/ambassador/ir/irgofilter.py
+++ b/python/ambassador/ir/irgofilter.py
@@ -27,9 +27,11 @@ AMBASSADOR_DISABLE_GO_FILTER = os.getenv("AMBASSADOR_DISABLE_GO_FILTER", "false"
 
 
 def go_library_exists(go_library_path: str) -> bool:
-    if os.path.exists(go_library_path):
-        return True
-    return False
+    return os.path.exists(go_library_path)
+
+
+def go_filter_disabled() -> str:
+    return AMBASSADOR_DISABLE_GO_FILTER
 
 
 @dataclass
@@ -62,7 +64,7 @@ class IRGOFilter(IRFilter):
     # We want to enable this filter only in Edge Stack
     def setup(self, ir: "IR", _: Config) -> bool:
         if ir.edge_stack_allowed:
-            if AMBASSADOR_DISABLE_GO_FILTER.lower() in ("true", "yes", "1"):
+            if go_filter_disabled().lower() in ("true", "yes", "1"):
                 self.logger.info(
                     "AMBASSADOR_DISABLE_GO_FILTER=%s, disabling Go filter...",
                     AMBASSADOR_DISABLE_GO_FILTER,

--- a/python/tests/unit/conftest.py
+++ b/python/tests/unit/conftest.py
@@ -11,8 +11,15 @@ def go_library():
         yield go_library_exists
 
 
-@pytest.fixture()
-def disable_go_filter():
-    with patch("ambassador.ir.irgofilter.AMBASSADOR_DISABLE_GO_FILTER") as disable_go_filter:
-        disable_go_filter.return_value = True
-        yield disable_go_filter
+@pytest.fixture(params=["true", "yes", "1", "True", "YES"])
+def disable_go_filter(request):
+    with patch("ambassador.ir.irgofilter.go_filter_disabled") as go_filter_disabled:
+        go_filter_disabled.return_value = request.param
+        yield go_filter_disabled
+
+
+@pytest.fixture(params=["false", "no", "0"])
+def enable_go_filter(request):
+    with patch("ambassador.ir.irgofilter.go_filter_disabled") as go_filter_disabled:
+        go_filter_disabled.return_value = request.param
+        yield go_filter_disabled

--- a/python/tests/unit/test_gofilter.py
+++ b/python/tests/unit/test_gofilter.py
@@ -123,11 +123,24 @@ def test_gofilter_missing_object_file(go_library, caplog):
 
 @pytest.mark.compilertest
 @edgestack()
-def test_gofilter_disable(disable_go_filter, caplog):
+def test_gofilter_disable(disable_go_filter):
     econf = get_envoy_config(MAPPING)
     filters = _get_go_filters(econf.as_dict())
 
     assert len(filters) == 0
+
+
+@pytest.mark.compilertest
+@edgestack()
+def test_gofilter_enable(enable_go_filter):
+    econf = get_envoy_config(MAPPING)
+    filters = _get_go_filters(econf.as_dict())
+
+    # Two listeners - ports 8080 and 8443 - each with an HTTP and HTTPS filterchain
+    assert len(filters) == 4
+
+    errors = econf.ir.aconf.errors
+    assert "ir.go_filter" not in errors
 
 
 @pytest.mark.compilertest


### PR DESCRIPTION
## Description

Fix unit tests for disabling go filter to account for str values from the AMBASSADOR_DISABLE_GO_FILTER env var:
- Wrap accessing the env var in a function call. This makes it easier to mock
- Parametrize the fixtures for various str values that would enable or disable the go filter
- Add a unit test where we explicity set AMBASSADOR_DISABLE_GO_FILTER to different false values to enable the filter

## Related Issues

List related issues.

## Testing

CI + ran unit tests with the EDGE_STACK var set:
```
EDGE_STACK=true pytest -vv tests/unit/test_gofilter.py
=========================================================== test session starts ============================================================
platform linux -- Python 3.10.9, pytest-6.2.5, py-1.11.0, pluggy-1.0.0 -- xxxxxxxxxxxxxxxx
cachedir: .pytest_cache
rootdir: xxxxxxxxxxxxxx, configfile: pytest.ini
plugins: icdiff-0.6, cov-4.0.0, rerunfailures-11.1.1
collected 12 items                                                                                                                         

tests/unit/test_gofilter.py::test_gofilter_injected PASSED                                                                           [  8%]
tests/unit/test_gofilter.py::test_go_filter_injected_before_auth_service PASSED                                                      [ 16%]
tests/unit/test_gofilter.py::test_gofilter_missing_object_file PASSED                                                                [ 25%]
tests/unit/test_gofilter.py::test_gofilter_disable[true] PASSED                                                                      [ 33%]
tests/unit/test_gofilter.py::test_gofilter_disable[yes] PASSED                                                                       [ 41%]
tests/unit/test_gofilter.py::test_gofilter_disable[1] PASSED                                                                         [ 50%]
tests/unit/test_gofilter.py::test_gofilter_disable[True] PASSED                                                                      [ 58%]
tests/unit/test_gofilter.py::test_gofilter_disable[YES] PASSED                                                                       [ 66%]
tests/unit/test_gofilter.py::test_gofilter_enable[false] PASSED                                                                      [ 75%]
tests/unit/test_gofilter.py::test_gofilter_enable[no] PASSED                                                                         [ 83%]
tests/unit/test_gofilter.py::test_gofilter_enable[0] PASSED                                                                          [ 91%]
tests/unit/test_gofilter.py::test_gofilter_not_injected SKIPPED (Skipping because EdgeStack behaves differently and tested separ...) [100%]

====================================================== 11 passed, 1 skipped in 0.11s =======================================================

```

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->
- [x] **Does my change need to be backported to a previous release?**
  - Should go in v3.7.0 release

- [ ] **I made sure to update `CHANGELOG.md`.**

   Remember, the CHANGELOG needs to mention:
  - Any new features
  - Any changes to our included version of Envoy
  - Any non-backward-compatible changes
  - Any deprecations

- [x] **This is unlikely to impact how Ambassador performs at scale.**

   Remember, things that might have an impact at scale include:
  - Any significant changes in memory use that might require adjusting the memory limits
  - Any significant changes in CPU use that might require adjusting the CPU limits
  - Anything that might change how many replicas users should use
  - Changes that impact data-plane latency/scalability

- [x] **My change is adequately tested.**

   Remember when considering testing:
  - Your change needs to be specifically covered by tests.
    - Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
  - You also need to make sure that the _entire area being changed_ has adequate test coverage.
    - If existing tests don't actually cover the entire area being changed, add tests.
    - This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
  - We should lean on the bulk of code being covered by unit tests, but...
  - ... an end-to-end test should cover the integration points

- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**

- [ ] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
