### PR TITLE
deps: reduce noise by ignoring go and python deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "sigs.k8s.io/gateway-api"
+      - dependency-name: "go.opentelemetry.io/proto/otlp"
 
   - package-ecosystem: gomod
     directory: "/tools/src/yq"
@@ -65,6 +68,9 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: pytest
+
   - package-ecosystem: docker
     directory: "/docker/base-python"
     schedule:


### PR DESCRIPTION
## Description

Removing checks for specific deps because they would not get updated easily or would be updated when a
parent dep is updated. This will help reduce PR noise.

Golang:

- sigs.k8s.io/gateway-api --> updating this dependency would require significant investment in the gateway-api support which is not planned at this time.

- go.opentelemetry.io/proto/otlp --> this is pulled in via envoy thus will automatically get bumped to the envoy supported version during Envoy upgrades

Python
- pytest --> Upgrading to the v7.x release has breaking changes that break the KAT suite. Signifcant investment is needed to upgrade this so it is unlikely this will happen anytime soon so disabling.


## Related Issues
N/A

## Testing

No additional testing added.

## Checklist

- [ ] **Does my change need to be backported to a previous release?**
- [ ] **I made sure to update `CHANGELOG.md`.**
- [ ] **This is unlikely to impact how Ambassador performs at scale.**
- [ ] **My change is adequately tested.**
- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**
- [ ] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
