### PR TITLE
deps(python): address multiple dependabot python dep updates

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -134,48 +134,48 @@ following Free and Open Source software:
 The Emissary-ingress Python code makes use of the following Free and Open Source
 libraries:
 
-    Name                Version    License(s)
-    ----                -------    ----------
-    Cython              0.29.32    Apache License 2.0
-    Flask               2.3.2      3-clause BSD license
-    Jinja2              3.1.2      3-clause BSD license
-    MarkupSafe          2.1.3      3-clause BSD license
-    PyYAML              6.0        MIT license
-    Werkzeug            2.3.6      3-clause BSD license
-    blinker             1.6.2      MIT license
-    build               0.9.0      MIT license
-    cachetools          5.3.0      MIT license
-    certifi             2022.12.7  Mozilla Public License 2.0
-    charset-normalizer  3.1.0      MIT license
-    click               8.1.3      3-clause BSD license
-    dpath               2.1.4      MIT license
-    durationpy          0.5        MIT license
-    expiringdict        1.2.2      Apache License 2.0
-    google-auth         2.16.1     Apache License 2.0
-    gunicorn            20.1.0     MIT license
-    idna                3.4        3-clause BSD license
-    itsdangerous        2.1.2      3-clause BSD license
-    jsonpatch           1.33       3-clause BSD license
-    jsonpointer         2.3        3-clause BSD license
-    kubernetes          26.1.0     Apache License 2.0
-    oauthlib            3.2.2      3-clause BSD license
-    orjson              3.8.10     Apache License 2.0, MIT license
-    packaging           21.3       2-clause BSD license, Apache License 2.0
-    pep517              0.13.0     MIT license
-    pip-tools           6.12.1     3-clause BSD license
-    prometheus-client   0.15.0     Apache License 2.0
-    pyasn1              0.4.8      2-clause BSD license
-    pyasn1-modules      0.2.8      2-clause BSD license
-    pyparsing           3.0.9      MIT license
-    python-dateutil     2.8.2      3-clause BSD license, Apache License 2.0
-    python-json-logger  2.0.7      2-clause BSD license
-    requests            2.31.0     Apache License 2.0
-    requests-oauthlib   1.3.1      ISC license
-    retrying            1.3.3      Apache License 2.0
-    rsa                 4.9        Apache License 2.0
-    semantic-version    2.10.0     2-clause BSD license
-    six                 1.16.0     MIT license
-    tomli               2.0.1      MIT license
-    typing_extensions   4.7.1      Python Software Foundation license
-    urllib3             1.26.13    MIT license
-    websocket-client    1.4.2      Apache License 2.0
+    Name                Version   License(s)
+    ----                -------   ----------
+    Cython              0.29.32   Apache License 2.0
+    Flask               2.3.2     3-clause BSD license
+    Jinja2              3.1.2     3-clause BSD license
+    MarkupSafe          2.1.3     3-clause BSD license
+    PyYAML              6.0       MIT license
+    Werkzeug            2.3.6     3-clause BSD license
+    blinker             1.6.2     MIT license
+    build               0.9.0     MIT license
+    cachetools          5.3.0     MIT license
+    certifi             2023.5.7  Mozilla Public License 2.0
+    charset-normalizer  3.1.0     MIT license
+    click               8.1.3     3-clause BSD license
+    dpath               2.1.4     MIT license
+    durationpy          0.5       MIT license
+    expiringdict        1.2.2     Apache License 2.0
+    google-auth         2.16.1    Apache License 2.0
+    gunicorn            20.1.0    MIT license
+    idna                3.4       3-clause BSD license
+    itsdangerous        2.1.2     3-clause BSD license
+    jsonpatch           1.33      3-clause BSD license
+    jsonpointer         2.3       3-clause BSD license
+    kubernetes          26.1.0    Apache License 2.0
+    oauthlib            3.2.2     3-clause BSD license
+    orjson              3.8.10    Apache License 2.0, MIT license
+    packaging           21.3      2-clause BSD license, Apache License 2.0
+    pep517              0.13.0    MIT license
+    pip-tools           6.12.1    3-clause BSD license
+    prometheus-client   0.15.0    Apache License 2.0
+    pyasn1              0.4.8     2-clause BSD license
+    pyasn1-modules      0.2.8     2-clause BSD license
+    pyparsing           3.0.9     MIT license
+    python-dateutil     2.8.2     3-clause BSD license, Apache License 2.0
+    python-json-logger  2.0.7     2-clause BSD license
+    requests            2.31.0    Apache License 2.0
+    requests-oauthlib   1.3.1     ISC license
+    retrying            1.3.3     Apache License 2.0
+    rsa                 4.9       Apache License 2.0
+    semantic-version    2.10.0    2-clause BSD license
+    six                 1.16.0    MIT license
+    tomli               2.0.1     MIT license
+    typing_extensions   4.7.1     Python Software Foundation license
+    urllib3             1.26.13   MIT license
+    websocket-client    1.4.2     Apache License 2.0

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -155,7 +155,7 @@ libraries:
     gunicorn            20.1.0     MIT license
     idna                3.4        3-clause BSD license
     itsdangerous        2.1.2      3-clause BSD license
-    jsonpatch           1.32       3-clause BSD license
+    jsonpatch           1.33       3-clause BSD license
     jsonpointer         2.3        3-clause BSD license
     kubernetes          26.1.0     Apache License 2.0
     oauthlib            3.2.2      3-clause BSD license

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -176,6 +176,6 @@ libraries:
     semantic-version    2.10.0     2-clause BSD license
     six                 1.16.0     MIT license
     tomli               2.0.1      MIT license
-    typing_extensions   4.4.0      Python Software Foundation license
+    typing_extensions   4.7.1      Python Software Foundation license
     urllib3             1.26.13    MIT license
     websocket-client    1.4.2      Apache License 2.0

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -168,7 +168,7 @@ libraries:
     pyasn1-modules      0.2.8      2-clause BSD license
     pyparsing           3.0.9      MIT license
     python-dateutil     2.8.2      3-clause BSD license, Apache License 2.0
-    python-json-logger  2.0.4      2-clause BSD license
+    python-json-logger  2.0.7      2-clause BSD license
     requests            2.31.0     Apache License 2.0
     requests-oauthlib   1.3.1      ISC license
     retrying            1.3.3      Apache License 2.0

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -139,7 +139,7 @@ libraries:
     Cython              0.29.32    Apache License 2.0
     Flask               2.3.2      3-clause BSD license
     Jinja2              3.1.2      3-clause BSD license
-    MarkupSafe          2.1.1      3-clause BSD license
+    MarkupSafe          2.1.3      3-clause BSD license
     PyYAML              6.0        MIT license
     Werkzeug            2.3.6      3-clause BSD license
     blinker             1.6.2      MIT license

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -146,7 +146,7 @@ libraries:
     build               0.9.0      MIT license
     cachetools          5.3.0      MIT license
     certifi             2022.12.7  Mozilla Public License 2.0
-    charset-normalizer  2.1.1      MIT license
+    charset-normalizer  3.1.0      MIT license
     click               8.1.3      3-clause BSD license
     dpath               2.1.4      MIT license
     durationpy          0.5        MIT license
@@ -169,7 +169,7 @@ libraries:
     pyparsing           3.0.9      MIT license
     python-dateutil     2.8.2      3-clause BSD license, Apache License 2.0
     python-json-logger  2.0.4      2-clause BSD license
-    requests            2.29.0     Apache License 2.0
+    requests            2.31.0     Apache License 2.0
     requests-oauthlib   1.3.1      ISC license
     retrying            1.3.3      Apache License 2.0
     rsa                 4.9        Apache License 2.0

--- a/docker/test-shadow/requirements.txt
+++ b/docker/test-shadow/requirements.txt
@@ -6,4 +6,4 @@ jinja2==3.1.2             # via flask
 markupsafe==2.1.3         # via jinja2
 typing-extensions==4.7.1  # via importlib-metadata
 werkzeug==2.3.6           # via flask
-zipp==3.10.0               # via importlib-metadata
+zipp==3.15.0               # via importlib-metadata

--- a/docker/test-shadow/requirements.txt
+++ b/docker/test-shadow/requirements.txt
@@ -4,6 +4,6 @@ importlib-metadata==6.0.0 # via click
 itsdangerous==2.1.2       # via flask
 jinja2==3.1.2             # via flask
 markupsafe==2.1.2         # via jinja2
-typing-extensions==4.5.0  # via importlib-metadata
+typing-extensions==4.7.1  # via importlib-metadata
 werkzeug==2.3.6           # via flask
 zipp==3.10.0               # via importlib-metadata

--- a/docker/test-shadow/requirements.txt
+++ b/docker/test-shadow/requirements.txt
@@ -3,7 +3,7 @@ flask==2.3.2
 importlib-metadata==6.7.0 # via click
 itsdangerous==2.1.2       # via flask
 jinja2==3.1.2             # via flask
-markupsafe==2.1.2         # via jinja2
+markupsafe==2.1.3         # via jinja2
 typing-extensions==4.7.1  # via importlib-metadata
 werkzeug==2.3.6           # via flask
 zipp==3.10.0               # via importlib-metadata

--- a/docker/test-shadow/requirements.txt
+++ b/docker/test-shadow/requirements.txt
@@ -1,6 +1,6 @@
 click==8.1.3              # via flask
 flask==2.3.2
-importlib-metadata==6.0.0 # via click
+importlib-metadata==6.7.0 # via click
 itsdangerous==2.1.2       # via flask
 jinja2==3.1.2             # via flask
 markupsafe==2.1.2         # via jinja2

--- a/docker/test-stats/requirements.txt
+++ b/docker/test-stats/requirements.txt
@@ -2,5 +2,5 @@ click==8.1.3            # via flask
 flask==2.3.2
 itsdangerous==2.1.2     # via flask
 jinja2==3.1.2           # via flask
-markupsafe==2.1.2       # via jinja2
+markupsafe==2.1.3       # via jinja2
 werkzeug==2.3.6         # via flask

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -8,7 +8,7 @@ blinker==1.6.2
     # via flask
 cachetools==5.3.0
     # via google-auth
-certifi==2022.12.7
+certifi==2023.5.7
     # via
     #   kubernetes
     #   requests

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -87,7 +87,7 @@ six==1.16.0
     #   google-auth
     #   kubernetes
     #   python-dateutil
-typing-extensions==4.4.0
+typing-extensions==4.7.1
     # via -r requirements.in
 urllib3==1.26.13
     # via

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -12,7 +12,7 @@ certifi==2022.12.7
     # via
     #   kubernetes
     #   requests
-charset-normalizer==2.1.1
+charset-normalizer==3.1.0
     # via requests
 click==8.1.3
     # via
@@ -66,7 +66,7 @@ pyyaml==6.0
     # via
     #   -r requirements.in
     #   kubernetes
-requests==2.29.0
+requests==2.31.0
     # via
     #   -r requirements.in
     #   kubernetes

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -60,7 +60,7 @@ pyasn1-modules==0.2.8
     # via google-auth
 python-dateutil==2.8.2
     # via kubernetes
-python-json-logger==2.0.4
+python-json-logger==2.0.7
     # via -r requirements.in
 pyyaml==6.0
     # via

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -42,7 +42,7 @@ jsonpointer==2.3
     # via jsonpatch
 kubernetes==26.1.0
     # via -r requirements.in
-markupsafe==2.1.1
+markupsafe==2.1.3
     # via
     #   jinja2
     #   werkzeug

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -36,7 +36,7 @@ itsdangerous==2.1.2
     # via flask
 jinja2==3.1.2
     # via flask
-jsonpatch==1.32
+jsonpatch==1.33
     # via -r requirements.in
 jsonpointer==2.3
     # via jsonpatch

--- a/tools/src/py-mkopensource/main.go
+++ b/tools/src/py-mkopensource/main.go
@@ -65,7 +65,7 @@ func parseLicenses(name, version, license string) map[License]struct{} {
 		{"semantic-version", "2.10.0", "BSD"}:          {BSD2},
 		{"smmap", "3.0.4", "BSD"}:                      {BSD3},
 		{"tomli", "2.0.1", ""}:                         {MIT},
-		{"typing_extensions", "4.4.0", ""}:             {PSF},
+		{"typing_extensions", "4.7.1", ""}:             {PSF},
 		{"webencodings", "0.5.1", "BSD"}:               {BSD3},
 		{"websocket-client", "0.57.0", "BSD"}:          {BSD3},
 		{"websocket-client", "1.2.3", "Apache-2.0"}:    {Apache2},

--- a/tools/src/py-mkopensource/main.go
+++ b/tools/src/py-mkopensource/main.go
@@ -47,7 +47,7 @@ func parseLicenses(name, version, license string) map[License]struct{} {
 		{"importlib-metadata", "5.1.0", "None"}:        {Apache2},
 		{"importlib-resources", "5.4.0", "UNKNOWN"}:    {Apache2},
 		{"itsdangerous", "1.1.0", "BSD"}:               {BSD3},
-		{"jsonpatch", "1.32", "Modified BSD License"}:  {BSD3},
+		{"jsonpatch", "1.33", "Modified BSD License"}:  {BSD3},
 		{"jsonpointer", "2.3", "Modified BSD License"}: {BSD3},
 		{"jsonschema", "3.2.0", "UNKNOWN"}:             {MIT},
 		{"lockfile", "0.12.2", "UNKNOWN"}:              {MIT},

--- a/tools/src/py-mkopensource/main.go
+++ b/tools/src/py-mkopensource/main.go
@@ -61,7 +61,7 @@ func parseLicenses(name, version, license string) map[License]struct{} {
 		{"pyparsing", "3.0.9", ""}:                     {MIT},
 		{"python-dateutil", "2.8.1", "Dual License"}:   {BSD3, Apache2},
 		{"python-dateutil", "2.8.2", "Dual License"}:   {BSD3, Apache2},
-		{"python-json-logger", "2.0.4", "BSD"}:         {BSD2},
+		{"python-json-logger", "2.0.7", "BSD"}:         {BSD2},
 		{"semantic-version", "2.10.0", "BSD"}:          {BSD2},
 		{"smmap", "3.0.4", "BSD"}:                      {BSD3},
 		{"tomli", "2.0.1", ""}:                         {MIT},


### PR DESCRIPTION
## Description

This bumps multiple deps for python to clean out the dependabot backlog. 

## Related Issues

> To reduce merge conflicts on the dependency.md, multiple PR's have been consolidated.

This consolidates the following PRs:

- #5134 
- #5133 
- #5123 
- #5111 
- #5090 
- #5089 
- #5061 
- #4909 
- #4905
- #4889
- #4743

## Testing

No additional testing needed, CI is green.

## Checklist

- [ ] **Does my change need to be backported to a previous release?**
- [ ] **I made sure to update `CHANGELOG.md`.**
- [x] **This is unlikely to impact how Ambassador performs at scale.**
- [x] **My change is adequately tested.**
- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**
- [x] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
