### PR TITLE
deps: bump the rest of the python dependabot deps

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -159,7 +159,7 @@ libraries:
     jsonpointer         2.3       3-clause BSD license
     kubernetes          26.1.0    Apache License 2.0
     oauthlib            3.2.2     3-clause BSD license
-    orjson              3.8.10    Apache License 2.0, MIT license
+    orjson              3.9.1     Apache License 2.0, MIT license
     packaging           21.3      2-clause BSD license, Apache License 2.0
     pep517              0.13.0    MIT license
     pip-tools           6.12.1    3-clause BSD license

--- a/docker/base-python/Dockerfile
+++ b/docker/base-python/Dockerfile
@@ -93,4 +93,4 @@ RUN mkdir /tmp/pyyaml && \
 
 # orjson is also special.  The wheels on PyPI rely on glibc, so we
 # need to use cargo/rustc/patchelf to build a musl-compatible version.
-RUN pip3 install orjson==3.8.10
+RUN pip3 install orjson==3.9.1

--- a/python/ambassador/config/acresource.py
+++ b/python/ambassador/config/acresource.py
@@ -62,7 +62,6 @@ class ACResource(Resource):
         serialization: Optional[str] = None,
         **kwargs
     ) -> None:
-
         if not rkey:
             raise Exception("ACResource requires rkey")
 

--- a/python/ambassador/fetch/ingress.py
+++ b/python/ambassador/fetch/ingress.py
@@ -8,7 +8,6 @@ from .resource import NormalizedResource, ResourceManager
 
 
 class IngressClassProcessor(ManagedKubernetesProcessor):
-
     CONTROLLER: ClassVar[str] = "getambassador.io/ingress-controller"
 
     ingress_classes_dep: IngressClassesDependency
@@ -64,7 +63,6 @@ class IngressClassProcessor(ManagedKubernetesProcessor):
 
 
 class IngressProcessor(ManagedKubernetesProcessor):
-
     service_dep: ServiceDependency
     ingress_classes_dep: IngressClassesDependency
 
@@ -167,7 +165,6 @@ class IngressProcessor(ManagedKubernetesProcessor):
 
             tls_secret = tls.get("secretName", None)
             if tls_secret is not None:
-
                 for host_count, host in enumerate(tls.get("hosts", ["*"])):
                     tls_unique_identifier = f"{obj.name}-{tls_count}-{host_count}"
 

--- a/python/ambassador/fetch/resource.py
+++ b/python/ambassador/fetch/resource.py
@@ -32,7 +32,7 @@ class NormalizedResource:
         version: str = "v3alpha1",
         api_group="getambassador.io",
         labels: Optional[Dict[str, Any]] = None,
-        spec: Dict[str, Any] = None,
+        spec: Dict[str, Any] | None = None,
         errors: Optional[str] = None,
         rkey: Optional[str] = None,
     ) -> NormalizedResource:

--- a/python/ambassador/ir/irambassador.py
+++ b/python/ambassador/ir/irambassador.py
@@ -17,7 +17,6 @@ if TYPE_CHECKING:
 
 
 class IRAmbassador(IRResource):
-
     # All the AModTransparentKeys are copied from the incoming Ambassador resource
     # into the IRAmbassador object partway through IRAmbassador.finalize().
     #

--- a/python/ambassador/ir/irauth.py
+++ b/python/ambassador/ir/irauth.py
@@ -26,7 +26,6 @@ class IRAuth(IRFilter):
         type: Optional[str] = "decoder",
         **kwargs,
     ) -> None:
-
         super().__init__(
             ir=ir,
             aconf=aconf,

--- a/python/ambassador/ir/irbasemappinggroup.py
+++ b/python/ambassador/ir/irbasemappinggroup.py
@@ -125,7 +125,6 @@ class IRBaseMappingGroup(IRResource):
 
             # Now, let's add weight to every weightless mapping and push to normalized_mappings
             for i, weightless_mapping in enumerate(weightless_mappings):
-
                 # We need last mapping's weight to be 100
                 if i == num_weightless_mappings - 1:
                     current_weight = 100

--- a/python/ambassador/ir/irbuffer.py
+++ b/python/ambassador/ir/irbuffer.py
@@ -18,11 +18,9 @@ class IRBuffer(IRFilter):
         kind: str = "IRBuffer",
         **kwargs
     ) -> None:
-
         super().__init__(ir=ir, aconf=aconf, rkey=rkey, kind=kind, name=name, **kwargs)
 
     def setup(self, ir: "IR", aconf: Config) -> bool:
-
         max_request_bytes = self.pop("max_request_bytes", None)
         if max_request_bytes is not None:
             self["max_request_bytes"] = max_request_bytes

--- a/python/ambassador/ir/irerrorresponse.py
+++ b/python/ambassador/ir/irerrorresponse.py
@@ -80,6 +80,7 @@ ENVOY_FMT_TOKEN_REGEX = (
     "\%([A-Za-z0-9_]+?)(\([A-Za-z0-9_.]+?((:|\?)[A-Za-z0-9_.]+?)+\))?(:[A-Za-z0-9_]+?)?\%"
 )
 
+
 # IRErrorResponse implements custom error response bodies using Envoy's HTTP response_map filter.
 #
 # Error responses are configured as an array of rules on the Ambassador module. Rules can be
@@ -90,7 +91,6 @@ ENVOY_FMT_TOKEN_REGEX = (
 # The Ambassador module config isn't subject to strict typing at higher layers, so this IR has
 # to pay special attention to the types and format of the incoming config.
 class IRErrorResponse(IRFilter):
-
     # The list of mappers that will make up the final error response config
     _mappers: Optional[List[Dict[str, Any]]]
 

--- a/python/ambassador/ir/irgzip.py
+++ b/python/ambassador/ir/irgzip.py
@@ -17,7 +17,6 @@ class IRGzip(IRFilter):
         kind: str = "IRGzip",
         **kwargs
     ) -> None:
-
         super().__init__(ir=ir, aconf=aconf, rkey=rkey, kind=kind, name=name, **kwargs)
 
     def setup(self, ir: "IR", aconf: Config) -> bool:

--- a/python/ambassador/ir/irhealthchecks.py
+++ b/python/ambassador/ir/irhealthchecks.py
@@ -9,7 +9,6 @@ if TYPE_CHECKING:
 
 
 class IRHealthChecks(IRResource):
-
     # The list of mappers that will make up the final health checking config
     _mappers: Optional[List[Dict[str, Union[str, int, Dict]]]]
 
@@ -63,7 +62,6 @@ class IRHealthChecks(IRResource):
 
         # Make sure each health check in the list has config for either a grpc health check or an http health check
         for hc in self._ir_config:
-
             health_check_config = hc["health_check"]
 
             # This should never happen but is necessary for the linting type checks

--- a/python/ambassador/ir/irhost.py
+++ b/python/ambassador/ir/irhost.py
@@ -42,7 +42,6 @@ class IRHost(IRResource):
         apiVersion: str = "getambassador.io/v3alpha1",  # Not a typo! See below.
         **kwargs,
     ) -> None:
-
         new_args = {x: kwargs[x] for x in kwargs.keys() if x in IRHost.AllowedKeys}
 
         self.context: Optional[IRTLSContext] = None

--- a/python/ambassador/ir/iripallowdeny.py
+++ b/python/ambassador/ir/iripallowdeny.py
@@ -28,8 +28,8 @@ class IRIPAllowDeny(IRFilter):
         rkey: str = "ir.ipallowdeny",
         name: str = "ir.ipallowdeny",
         kind: str = "IRIPAllowDeny",
-        parent: IRResource = None,
-        action: str = None,
+        parent: IRResource | None = None,
+        action: str | None = None,
         **kwargs,
     ) -> None:
         """

--- a/python/ambassador/ir/irratelimit.py
+++ b/python/ambassador/ir/irratelimit.py
@@ -22,7 +22,6 @@ class IRRateLimit(IRFilter):
         namespace: Optional[str] = None,
         **kwargs,
     ) -> None:
-
         super().__init__(
             ir=ir, aconf=aconf, rkey=rkey, kind=kind, name=name, namespace=namespace, type="decoder"
         )

--- a/python/ambassador/ir/irtlscontext.py
+++ b/python/ambassador/ir/irtlscontext.py
@@ -71,7 +71,6 @@ class IRTLSContext(IRResource):
         is_fallback: Optional[bool] = False,
         **kwargs,
     ) -> None:
-
         new_args = {
             x: kwargs[x]
             for x in kwargs.keys()

--- a/python/ambassador/resource.py
+++ b/python/ambassador/resource.py
@@ -50,7 +50,6 @@ class Resource(Cacheable):
     def __init__(
         self, rkey: str, location: str, *, kind: str, serialization: Optional[str] = None, **kwargs
     ) -> None:
-
         if not rkey:
             raise Exception("Resource requires rkey")
 

--- a/python/ambassador/utils.py
+++ b/python/ambassador/utils.py
@@ -1182,7 +1182,9 @@ class KubewatchSecretHandler(SecretHandler):
 
 # TODO(gsagula): This duplicates code from ircluster.py.
 class ParsedService:
-    def __init__(self, logger, service: str, allow_scheme=True, ctx_name: str = None) -> None:
+    def __init__(
+        self, logger, service: str, allow_scheme=True, ctx_name: str | None = None
+    ) -> None:
         original_service = service
 
         originate_tls = False

--- a/python/ambassador/utils.py
+++ b/python/ambassador/utils.py
@@ -110,7 +110,6 @@ def _load_url_contents(
     try:
         with requests.get(url) as r:
             if r.status_code == 200:
-
                 # All's well, pull the config down.
                 encoded = b""
 

--- a/python/kat/harness.py
+++ b/python/kat/harness.py
@@ -312,7 +312,6 @@ def _argprocess(o):
 
 
 class Node(ABC):
-
     parent: Optional["Node"]
     children: List["Node"]
     name: str
@@ -473,7 +472,6 @@ class Node(ABC):
 
 
 class Test(Node):
-
     results: List["Result"] = []
     pending: List["Query"] = []
     queried: List["Query"] = []
@@ -681,7 +679,6 @@ class Result:
                         self.error,
                     )
                 else:
-
                     if self.query.expected != self.status:
                         self.parent.log_kube_artifacts()
                     assert (

--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -1,7 +1,7 @@
 # Dev requirements
 gitpython
 httpretty
-mypy<0.990
+mypy
 packaging
 pexpect
 pyOpenSSL
@@ -17,6 +17,6 @@ types-orjson
 types-protobuf
 types-pyOpenSSL
 types-pyyaml
-types-requests==2.28.11.12 # Something about the upgrade to 2.28.11.13 breaks `make lint/mypy`
+types-requests
 types-retry
 types-setuptools

--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -9,7 +9,7 @@ pytest==6.2.5
 pytest-cov
 pytest-rerunfailures
 retry
-black==22.10.0
+black==23.3
 isort
 
 # Type stubs

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -77,7 +77,7 @@ rsa==4.9
     # via google-auth
 semantic-version==2.10.0
     # via -r requirements.in
-setuptools==65.6.3
+setuptools==68.0.0
     # via
     #   -r requirements.in
     #   gunicorn

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -48,7 +48,7 @@ markupsafe==2.1.3
     #   werkzeug
 oauthlib==3.2.2
     # via requests-oauthlib
-orjson==3.8.10
+orjson==3.9.1
     # via -r requirements.in
 prometheus-client==0.15.0
     # via -r requirements.in

--- a/python/tests/integration/test_tracing.py
+++ b/python/tests/integration/test_tracing.py
@@ -43,7 +43,6 @@ class MockSecretHandler(SecretHandler):
 
 
 def _get_envoy_config(yaml):
-
     aconf = Config()
     fetcher = ResourceFetcher(logger, aconf)
     fetcher.parse_yaml(default_listener_manifests() + yaml, k8s=True)
@@ -60,7 +59,6 @@ def _get_envoy_config(yaml):
 
 @pytest.mark.compilertest
 def test_tracing_config_v3(tmp_path: Path):
-
     aconf = Config()
 
     yaml = (
@@ -146,7 +144,6 @@ spec:
 
 @pytest.mark.compilertest
 def test_tracing_zipkin_defaults():
-
     yaml = """
 ---
 apiVersion: getambassador.io/v3alpha1
@@ -180,7 +177,6 @@ spec:
 
 @pytest.mark.compilertest
 def test_tracing_cluster_fields():
-
     yaml = """
 ---
 apiVersion: getambassador.io/v3alpha1
@@ -245,7 +241,6 @@ spec:
 
 @pytest.mark.compilertest
 def test_lightstep_not_supported(tmp_path: Path):
-
     yaml = """
 ---
 apiVersion: getambassador.io/v3alpha1

--- a/python/tests/kat/abstract_tests.py
+++ b/python/tests/kat/abstract_tests.py
@@ -393,7 +393,7 @@ class ServiceType(Node):
     use_superpod: bool = True
 
     def __init__(
-        self, service_manifests: str = None, namespace: str = None, *args, **kwargs
+        self, service_manifests: str | None = None, namespace: str | None = None, *args, **kwargs
     ) -> None:
         super().__init__(namespace=namespace, *args, **kwargs)
 
@@ -424,7 +424,7 @@ class ServiceTypeGrpc(Node):
 
     path: Name
 
-    def __init__(self, service_manifests: str = None, *args, **kwargs) -> None:
+    def __init__(self, service_manifests: str | None = None, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self._manifests = service_manifests or integration_manifests.load("backend")
 

--- a/python/tests/kat/abstract_tests.py
+++ b/python/tests/kat/abstract_tests.py
@@ -387,7 +387,6 @@ class AmbassadorTest(Test):
 
 @abstract_test
 class ServiceType(Node):
-
     path: Name
     _manifests: Optional[str]
     use_superpod: bool = True
@@ -421,7 +420,6 @@ class ServiceType(Node):
 
 @abstract_test
 class ServiceTypeGrpc(Node):
-
     path: Name
 
     def __init__(self, service_manifests: str | None = None, *args, **kwargs) -> None:
@@ -575,7 +573,6 @@ class StatsDSink(ServiceType):
 
 @abstract_test
 class MappingTest(Test):
-
     target: ServiceType
     options: Sequence["OptionTest"]
     parent: AmbassadorTest
@@ -591,7 +588,6 @@ class MappingTest(Test):
 
 @abstract_test
 class OptionTest(Test):
-
     VALUES: ClassVar[Any] = None
     value: Any
     parent: Test

--- a/python/tests/kat/t_basics.py
+++ b/python/tests/kat/t_basics.py
@@ -55,7 +55,6 @@ class Empty(AmbassadorTest):
 
 
 class AmbassadorIDTest(AmbassadorTest):
-
     target: ServiceType
 
     def init(self):
@@ -287,7 +286,6 @@ spec:
 
 
 class ServerNameTest(AmbassadorTest):
-
     target: ServiceType
 
     def init(self):
@@ -320,7 +318,6 @@ service: {self.target.path.fqdn}
 
 
 class SafeRegexMapping(AmbassadorTest):
-
     target: ServiceType
 
     def init(self):

--- a/python/tests/kat/t_extauth.py
+++ b/python/tests/kat/t_extauth.py
@@ -7,7 +7,6 @@ from tests.selfsigned import TLSCerts
 
 
 class AuthenticationGRPCTest(AmbassadorTest):
-
     target: ServiceType
     auth: ServiceType
 
@@ -227,7 +226,6 @@ auth_context_extensions:
 
 
 class AuthenticationHTTPPartialBufferTest(AmbassadorTest):
-
     target: ServiceType
     auth: ServiceType
 
@@ -353,7 +351,6 @@ service: {self.target.path.fqdn}
 
 
 class AuthenticationHTTPBufferedTest(AmbassadorTest):
-
     target: ServiceType
     auth: ServiceType
 
@@ -640,7 +637,6 @@ service: {self.target.path.fqdn}
 
 
 class AuthenticationTestV1(AmbassadorTest):
-
     target: ServiceType
     auth: ServiceType
 
@@ -805,7 +801,6 @@ bypass_auth: true
         return (backend_name == self.auth1.path.k8s) or (backend_name == self.auth2.path.k8s)
 
     def check(self):
-
         # [0] Verifies all request headers sent to the authorization server.
         assert self.check_backend_name(self.results[0])
         assert self.results[0].backend
@@ -1114,7 +1109,6 @@ service: {self.target.path.fqdn}
 
 
 class AuthenticationWebsocketTest(AmbassadorTest):
-
     auth: ServiceType
     backend: ServiceType
 
@@ -1158,7 +1152,6 @@ use_websocket: true
 
 
 class AuthenticationGRPCVerTest(AmbassadorTest):
-
     target: ServiceType
     specified_protocol_version: Literal["v2", "v3", "default"]
     expected_protocol_version: Literal["v3", "invalid"]

--- a/python/tests/kat/t_grpc_bridge.py
+++ b/python/tests/kat/t_grpc_bridge.py
@@ -5,7 +5,6 @@ from kat.harness import Query
 
 
 class AcceptanceGrpcBridgeTest(AmbassadorTest):
-
     target: ServiceType
 
     def init(self):

--- a/python/tests/kat/t_grpc_web.py
+++ b/python/tests/kat/t_grpc_web.py
@@ -5,7 +5,6 @@ from kat.harness import Query
 
 
 class AcceptanceGrpcWebTest(AmbassadorTest):
-
     target: ServiceType
 
     def init(self):

--- a/python/tests/kat/t_mappingtests_plain.py
+++ b/python/tests/kat/t_mappingtests_plain.py
@@ -27,7 +27,6 @@ def unique(options):
 
 
 class SimpleMapping(MappingTest):
-
     parent: AmbassadorTest
     target: ServiceType
 
@@ -74,7 +73,6 @@ service: http://{self.target.path.fqdn}
 
 
 class SimpleMappingIngress(MappingTest):
-
     parent: AmbassadorTest
     target: ServiceType
 
@@ -162,7 +160,6 @@ spec:
 
 
 class SimpleIngressWithAnnotations(MappingTest):
-
     parent: AmbassadorTest
     target: ServiceType
 
@@ -227,7 +224,6 @@ spec:
 
 
 class HostHeaderMappingIngress(MappingTest):
-
     parent: AmbassadorTest
 
     @classmethod
@@ -267,7 +263,6 @@ spec:
 
 
 class HostHeaderMapping(MappingTest):
-
     parent: AmbassadorTest
 
     @classmethod
@@ -305,7 +300,6 @@ host: inspector.external
 
 
 class InvalidPortMapping(MappingTest):
-
     parent: AmbassadorTest
 
     @classmethod
@@ -340,7 +334,6 @@ service: http://{self.target.path.fqdn}:80.invalid
 
 
 class WebSocketMapping(MappingTest):
-
     parent: AmbassadorTest
     target: ServiceType
 
@@ -373,7 +366,6 @@ use_websocket: true
 
 
 class TLSOrigination(MappingTest):
-
     parent: AmbassadorTest
     definition: str
 
@@ -551,7 +543,6 @@ redirect_response_code: 308
 
 
 class CanaryMapping(MappingTest):
-
     parent: AmbassadorTest
     target: ServiceType
     canary: ServiceType
@@ -627,7 +618,6 @@ weight: {self.weight}
 
 
 class CanaryDiffMapping(MappingTest):
-
     parent: AmbassadorTest
     target: ServiceType
     canary: ServiceType

--- a/python/tests/kat/t_optiontests.py
+++ b/python/tests/kat/t_optiontests.py
@@ -10,7 +10,6 @@ from kat.harness import Query, Test
 
 
 class AddRequestHeaders(OptionTest):
-
     parent: Test
 
     VALUES: ClassVar[Sequence[Dict[str, Dict[str, Union[str, bool]]]]] = [
@@ -37,7 +36,6 @@ class AddRequestHeaders(OptionTest):
 
 
 class AddResponseHeaders(OptionTest):
-
     parent: Test
 
     VALUES: ClassVar[Sequence[Dict[str, Dict[str, Union[str, bool]]]]] = [
@@ -107,7 +105,6 @@ class CORS(OptionTest):
 
 
 class CaseSensitive(OptionTest):
-
     parent: MappingTest
 
     def config(self) -> Generator[Union[str, Tuple[Node, str]], None, None]:
@@ -122,7 +119,6 @@ class CaseSensitive(OptionTest):
 
 
 class AutoHostRewrite(OptionTest):
-
     parent: MappingTest
 
     def config(self) -> Generator[Union[str, Tuple[Node, str]], None, None]:
@@ -140,7 +136,6 @@ class AutoHostRewrite(OptionTest):
 
 
 class Rewrite(OptionTest):
-
     parent: MappingTest
 
     VALUES = ("/foo", "foo")
@@ -166,7 +161,6 @@ class Rewrite(OptionTest):
 
 
 class RemoveResponseHeaders(OptionTest):
-
     parent: Test
 
     def config(self) -> Generator[Union[str, Tuple[Node, str]], None, None]:

--- a/python/tests/kat/t_redirect.py
+++ b/python/tests/kat/t_redirect.py
@@ -113,7 +113,6 @@ service: {self.target.path.fqdn}
 
 
 class RedirectTestsWithProxyProto(AmbassadorTest):
-
     target: ServiceType
 
     def init(self):

--- a/python/tests/kat/t_tls.py
+++ b/python/tests/kat/t_tls.py
@@ -525,7 +525,6 @@ tls: upstream-files
 
 
 class TLS(AmbassadorTest):
-
     target: ServiceType
 
     def init(self):
@@ -617,7 +616,6 @@ service: {self.target.path.fqdn}
 
 
 class TLSInvalidSecret(AmbassadorTest):
-
     target: ServiceType
 
     def init(self):

--- a/python/tests/unit/test_error_response.py
+++ b/python/tests/unit/test_error_response.py
@@ -184,7 +184,6 @@ def _test_errorresponse_onemapper_onstatuscode_textformat_contenttype(
 def _test_errorresponse_onemapper_onstatuscode_textformat_datasource(
     status_code, text_format, source, content_type
 ):
-
     # in order for tests to pass the files (all located in /tmp) need to exist
     try:
         open(source, "x").close()

--- a/python/tests/unit/test_fetch.py
+++ b/python/tests/unit/test_fetch.py
@@ -231,7 +231,6 @@ class TestLocationManager:
 
 
 class FinalizingKubernetesProcessor(KubernetesProcessor):
-
     finalized: bool = False
 
     def finalize(self):

--- a/python/tests/unit/test_healthchecks.py
+++ b/python/tests/unit/test_healthchecks.py
@@ -47,7 +47,6 @@ def _get_envoy_config(yaml):
 
 @pytest.mark.compilertest
 def test_healthcheck():
-
     baseYaml = """
 ---
 apiVersion: getambassador.io/v3alpha1
@@ -359,7 +358,6 @@ spec:
     ]
 
     for case in testcases:
-
         caseYaml = case["input"]
         testName = case["name"]
         econf = _get_envoy_config(caseYaml)

--- a/python/tests/unit/test_irratelimit.py
+++ b/python/tests/unit/test_irratelimit.py
@@ -63,7 +63,6 @@ def _get_ratelimit_default_conf():
 
 @pytest.mark.compilertest
 def test_irratelimit_defaults():
-
     # Test all defaults
     yaml = """
 apiVersion: getambassador.io/v3alpha1
@@ -92,7 +91,6 @@ spec:
 
 @pytest.mark.compilertest
 def test_irratelimit_grpcsvc_version_v3():
-
     yaml = """
 ---
 apiVersion: getambassador.io/v3alpha1
@@ -118,7 +116,6 @@ spec:
 
 @pytest.mark.compilertest
 def test_irratelimit_cluster_fields():
-
     stats_name = "ratelimitservice"
 
     yaml = """
@@ -154,7 +151,6 @@ spec:
 
 @pytest.mark.compilertest
 def test_irratelimit_grpcsvc_version_v2():
-
     yaml = """
 ---
 apiVersion: getambassador.io/v3alpha1

--- a/python/tests/unit/test_listener.py
+++ b/python/tests/unit/test_listener.py
@@ -397,7 +397,6 @@ spec:
             ),
         ]
         for case in testcases:
-
             applied_yaml = open(os.path.join(testdata_dir, f"{case.name}_in.yaml"), "r").read()
             expected = yaml.safe_load(
                 open(os.path.join(testdata_dir, f"{case.name}_out.yaml"), "r")

--- a/python/tests/unit/test_lookup.py
+++ b/python/tests/unit/test_lookup.py
@@ -49,7 +49,6 @@ class IRTestResource(IRBuffer):
         kind: str = "IRTestResource",
         **kwargs
     ) -> None:
-
         super().__init__(ir=ir, aconf=aconf, rkey=rkey, kind=kind, name=name, **kwargs)
 
         self.default_class = "test_resource"

--- a/tools/src/py-mkopensource/main.go
+++ b/tools/src/py-mkopensource/main.go
@@ -73,7 +73,7 @@ func parseLicenses(name, version, license string) map[License]struct{} {
 
 		// These are packages with non-trivial strings to parse, and
 		// it's easier to just hard-code it.
-		{"orjson", "3.8.10", "Apache-2.0 OR MIT"}:           {Apache2, MIT},
+		{"orjson", "3.9.1", "Apache-2.0 OR MIT"}:            {Apache2, MIT},
 		{"packaging", "21.3", "BSD-2-Clause or Apache-2.0"}: {BSD2, Apache2},
 	}[tuple{name, version, license}]
 	if ok {


### PR DESCRIPTION
## Description

Bumps the remaining python deps to address the dependabot PR's.

## Related Issues

Address the following PR's:

- #5120 
- #5115 
- #5101 
- #4937

## Testing

No testing added, CI is green.

## Checklist

- [ ] **Does my change need to be backported to a previous release?**
- [ ] **I made sure to update `CHANGELOG.md`.**
- [x] **This is unlikely to impact how Ambassador performs at scale.**
- [x] **My change is adequately tested.**
- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**
- [x] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
