### PR TITLE
[v3.7.1]: bump envoy to v1.26.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,14 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
 
 ## RELEASE NOTES
 
+## [3.7.1] July 13, 2023
+[3.7.1]: https://github.com/emissary-ingress/emissary/compare/v3.7.0...v3.7.1
+
+### Emissary-ingress and Ambassador Edge Stack
+
+- Security: This upgrades Emissary-ingress to be built on Envoy v1.26.3 which includes a security
+  fix for CVE-2023-35945.
+
 ## [3.7.0] June 20, 2023
 [3.7.0]: https://github.com/emissary-ingress/emissary/compare/v3.6.0...v3.7.0
 

--- a/_cxx/envoy.mk
+++ b/_cxx/envoy.mk
@@ -13,12 +13,12 @@ RSYNC_EXTRAS ?=
 
 # IF YOU MESS WITH ANY OF THESE VALUES, YOU MUST RUN `make update-base`.
   ENVOY_REPO ?= $(if $(IS_PRIVATE),git@github.com:datawire/envoy-private.git,https://github.com/datawire/envoy.git)
-  # rebase/release/v1.26.1
-  ENVOY_COMMIT ?= ea206542ed81559f2e0571610f4008daa27ec167
+  # rebase/release/v1.26.3
+  ENVOY_COMMIT ?= 3480b07639bbfcc41b7c3030091eda48fa6f699b
   ENVOY_COMPILATION_MODE ?= opt
   # Increment BASE_ENVOY_RELVER on changes to `docker/base-envoy/Dockerfile`, or Envoy recipes.
   # You may reset BASE_ENVOY_RELVER when adjusting ENVOY_COMMIT.
-  BASE_ENVOY_RELVER ?= 2
+  BASE_ENVOY_RELVER ?= 0
 
   # Set to non-empty to enable compiling Envoy in FIPS mode.
   FIPS_MODE ?=

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -32,6 +32,15 @@
 
 changelog: https://github.com/emissary-ingress/emissary/blob/$branch$/CHANGELOG.md
 items:
+  - version: 3.7.1
+    prevVersion: 3.7.0
+    date: '2023-07-13'
+    notes:
+      - title: Upgrade to Envoy 1.26.3
+        type: security
+        body: >-
+          This upgrades $productName$ to be built on Envoy v1.26.3 which includes a security fix for CVE-2023-35945.
+
   - version: 3.7.0
     prevVersion: 3.6.0
     date: '2023-06-20'


### PR DESCRIPTION
## Description

This is the release PR for the upcoming v3.7.1 patch release to address [CVE-2023-35945](https://github.com/envoyproxy/envoy/security/advisories/GHSA-jfxv-29pc-x22r).

## Related Issues

https://github.com/envoyproxy/envoy/pull/28361

## Testing

Successfully built and test our custom Envoy based on the v1.26.3 release with CVE fix.

## Checklist

- [x] **Does my change need to be backported to a previous release?**
 Sort of, for sake of speed we will land on release branch first. But, will ensure this lands on master as well.

- [x] **I made sure to update `CHANGELOG.md`.**
- [x] **This is unlikely to impact how Ambassador performs at scale.**
- [x] **My change is adequately tested.**
- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**
- [x] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
