### PR TITLE
[v3.7.2] Release PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,14 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
 
 ## RELEASE NOTES
 
+## [3.7.2] July 25, 2023
+[3.7.2]: https://github.com/emissary-ingress/emissary/compare/v3.7.1...v3.7.2
+
+### Emissary-ingress and Ambassador Edge Stack
+
+- Security: This upgrades Emissary-ingress to be built on Envoy v1.26.4 which includes a security
+  fixes for  CVE-2023-35942, CVE-2023-35943,  VE-2023-35944.
+
 ## [3.7.1] July 13, 2023
 [3.7.1]: https://github.com/emissary-ingress/emissary/compare/v3.7.0...v3.7.1
 

--- a/_cxx/envoy.mk
+++ b/_cxx/envoy.mk
@@ -13,8 +13,8 @@ RSYNC_EXTRAS ?=
 
 # IF YOU MESS WITH ANY OF THESE VALUES, YOU MUST RUN `make update-base`.
   ENVOY_REPO ?= $(if $(IS_PRIVATE),git@github.com:datawire/envoy-private.git,https://github.com/datawire/envoy.git)
-  # rebase/release/v1.26.3
-  ENVOY_COMMIT ?= 3480b07639bbfcc41b7c3030091eda48fa6f699b
+  # https://github.com/datawire/envoy/tree/rebase/release/v1.26.4
+  ENVOY_COMMIT ?= bbda92fc3e3d430bd2114aa3458d3191205c9c0e
   ENVOY_COMPILATION_MODE ?= opt
   # Increment BASE_ENVOY_RELVER on changes to `docker/base-envoy/Dockerfile`, or Envoy recipes.
   # You may reset BASE_ENVOY_RELVER when adjusting ENVOY_COMMIT.

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -32,6 +32,16 @@
 
 changelog: https://github.com/emissary-ingress/emissary/blob/$branch$/CHANGELOG.md
 items:
+  - version: 3.7.2
+    prevVersion: 3.7.1
+    date: '2023-07-25'
+    notes:
+      - title: Upgrade to Envoy 1.26.4
+        type: security
+        body: >-
+          This upgrades $productName$ to be built on Envoy v1.26.4 which includes a security fixes for 
+          CVE-2023-35942, CVE-2023-35943,  VE-2023-35944.
+
   - version: 3.7.1
     prevVersion: 3.7.0
     date: '2023-07-13'


### PR DESCRIPTION
## Description

This is the release PR for 3.7.2 to address CVE's annouced by Envoy Proxy. This bumps to the latest 1.26.4 patched version of Envoy Proxy.

## Related Issues

N/A

## Testing

CI is green, no additional tests added.

## Checklist

- [ ] **Does my change need to be backported to a previous release?**
Will land in master later once security release is out the door.

- [x] **I made sure to update `CHANGELOG.md`.**
- [x] **This is unlikely to impact how Ambassador performs at scale.**
- [x] **My change is adequately tested.**
- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**
- [x] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
