### PR TITLE
deps: bump to Envoy 1.26.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,9 +86,17 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
 ## RELEASE NOTES
 
 ## [3.8.0] TBD
-[3.8.0]: https://github.com/emissary-ingress/emissary/compare/v3.7.1...v3.8.0
+[3.8.0]: https://github.com/emissary-ingress/emissary/compare/v3.7.2...v3.8.0
 
 ### Emissary-ingress and Ambassador Edge Stack
+
+## [3.7.2] July 25, 2023
+[3.7.2]: https://github.com/emissary-ingress/emissary/compare/v3.7.1...v3.7.2
+
+### Emissary-ingress and Ambassador Edge Stack
+
+- Security: This upgrades Emissary-ingress to be built on Envoy v1.26.4 which includes a security
+  fixes for  CVE-2023-35942, CVE-2023-35943,  VE-2023-35944.
 
 ## [3.7.1] July 13, 2023
 [3.7.1]: https://github.com/emissary-ingress/emissary/compare/v3.7.0...v3.7.1

--- a/_cxx/envoy.mk
+++ b/_cxx/envoy.mk
@@ -13,8 +13,8 @@ RSYNC_EXTRAS ?=
 
 # IF YOU MESS WITH ANY OF THESE VALUES, YOU MUST RUN `make update-base`.
   ENVOY_REPO ?= $(if $(IS_PRIVATE),git@github.com:datawire/envoy-private.git,https://github.com/datawire/envoy.git)
-  # rebase/release/v1.26.3
-  ENVOY_COMMIT ?= 3480b07639bbfcc41b7c3030091eda48fa6f699b
+  # https://github.com/datawire/envoy/tree/rebase/release/v1.26.4
+  ENVOY_COMMIT ?= bbda92fc3e3d430bd2114aa3458d3191205c9c0e
   ENVOY_COMPILATION_MODE ?= opt
   # Increment BASE_ENVOY_RELVER on changes to `docker/base-envoy/Dockerfile`, or Envoy recipes.
   # You may reset BASE_ENVOY_RELVER when adjusting ENVOY_COMMIT.

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -33,9 +33,19 @@
 changelog: https://github.com/emissary-ingress/emissary/blob/$branch$/CHANGELOG.md
 items:
   - version: 3.8.0
-    prevVersion: 3.7.1
+    prevVersion: 3.7.2
     date: TBD
     notes: []
+
+  - version: 3.7.2
+    prevVersion: 3.7.1
+    date: '2023-07-25'
+    notes:
+      - title: Upgrade to Envoy 1.26.4
+        type: security
+        body: >-
+          This upgrades $productName$ to be built on Envoy v1.26.4 which includes a security fixes for 
+          CVE-2023-35942, CVE-2023-35943,  VE-2023-35944.
 
   - version: 3.7.1
     prevVersion: 3.7.0


### PR DESCRIPTION

## Description

This already landed in the v3.7.2 release to ensure we got the security release out faster. This PR is just making sure master is in sync.

Bumps to our latest Envoy custom build based on 1.26.4 which addresses the following CVEs:

- CVE-2023-35941 : Not affected but pulled in
- CVE-2023-35942
- CVE-2023-35943
- CVE-2023-35944

## Related Issues

n/a

## Testing

CI is green, no additional testing added.

## Checklist

- [ ] **Does my change need to be backported to a previous release?**
- [x] **I made sure to update `CHANGELOG.md`.**
- [x] **This is unlikely to impact how Ambassador performs at scale.**
- [x] **My change is adequately tested.**
- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**
- [x] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
