### PR TITLE
bug: make canary groups take into account host mappingSelector labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,15 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
 
 ### Emissary-ingress and Ambassador Edge Stack
 
+- Bugfix: As of v2.2.2, if two mappings were associated with different Hosts through host
+  mappingSelector labels but share the same prefix, the labels were not taken into account which
+  would cause one Mapping to be correctly routed but the other not.
+  This change fixes this issue so
+  that Mappings sharing the same prefix but associated with different Hosts will be correctly
+  routed. ([Canary grouping must take labels into account])
+
+[Canary grouping must take labels into account]: https://github.com/emissary-ingress/emissary/issues/4170
+
 ## [3.7.2] July 25, 2023
 [3.7.2]: https://github.com/emissary-ingress/emissary/compare/v3.7.1...v3.7.2
 

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -35,7 +35,19 @@ items:
   - version: 3.8.0
     prevVersion: 3.7.2
     date: TBD
-    notes: []
+    notes:
+      - title: Account for matchLabels when associating mappings with the same prefix to different Hosts
+        type: bugfix
+        body: >-
+          As of v2.2.2, if two mappings were associated with different Hosts through host
+          mappingSelector labels but share the same prefix, the labels were not taken into
+          account which would cause one Mapping to be correctly routed but the other not.
+
+          This change fixes this issue so that Mappings sharing the same prefix but associated
+          with different Hosts will be correctly routed.
+        github:
+          - title: "Canary grouping must take labels into account"
+            link: https://github.com/emissary-ingress/emissary/issues/4170
 
   - version: 3.7.2
     prevVersion: 3.7.1

--- a/python/ambassador/ir/irhttpmappinggroup.py
+++ b/python/ambassador/ir/irhttpmappinggroup.py
@@ -366,8 +366,6 @@ class IRHTTPMappingGroup(IRBaseMappingGroup):
             add_request_headers.update(mapping.get("add_request_headers", {}))
             add_response_headers.update(mapping.get("add_response_headers", {}))
 
-            # Should we have higher weights win over lower if there are conflicts?
-            # Should we disallow conflicts?
             metadata_labels.update(mapping.get("metadata_labels") or {})
 
         if add_request_headers:

--- a/python/tests/unit/test_mapping_canary_group.py
+++ b/python/tests/unit/test_mapping_canary_group.py
@@ -1,0 +1,65 @@
+import json
+import os
+from dataclasses import dataclass
+from typing import List, Optional
+
+import pytest
+import yaml
+
+from tests.utils import compile_with_cachecheck
+
+
+@dataclass
+class MappingGroupTestOutput:
+    group_id: str
+    host: Optional[str]
+    prefix: str
+    mappings: List[str]
+
+
+test_cases = [
+    "mapping_selector",
+    "mapping_selector_and_authority",
+    "mapping_selector_and_hostname",
+    "mapping_selector_and_host",
+    "mapping_selector_to_multiple_hosts",
+    "mapping_selector_irrelevant_labels",
+]
+
+
+@pytest.mark.compilertest
+@pytest.mark.parametrize("test_case", test_cases)
+def test_mapping_canary_group_selectors(test_case):
+    testdata_dir = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "testdata", "canary_groups"
+    )
+
+    with open(os.path.join(testdata_dir, f"{test_case}_in.yaml"), "r") as f:
+        test_yaml = f.read()
+
+    r = compile_with_cachecheck(test_yaml, errors_ok=True)
+
+    ir = r["ir"]
+
+    errors = ir.aconf.errors
+    assert len(errors) == 0, "Expected no errors but got %s" % (
+        json.dumps(errors, sort_keys=True, indent=4)
+    )
+
+    mapping_groups = []
+    for g in ir.groups.values():
+        if g.prefix.startswith("/ambassador"):
+            continue
+
+        mg = MappingGroupTestOutput(
+            group_id=g.group_id, host=g.host, prefix=g.prefix, mappings=[m.name for m in g.mappings]
+        )
+        mapping_groups.append(mg)
+
+    with open(os.path.join(testdata_dir, f"{test_case}_out.yaml"), "r") as f:
+        out = yaml.safe_load(f)
+
+    expected_output = [MappingGroupTestOutput(**group_yaml) for group_yaml in out["mapping_groups"]]
+    assert sorted(mapping_groups, key=lambda g: g.group_id) == sorted(
+        expected_output, key=lambda g: g.group_id
+    )

--- a/python/tests/unit/testdata/canary_groups/mapping_selector_and_authority_in.yaml
+++ b/python/tests/unit/testdata/canary_groups/mapping_selector_and_authority_in.yaml
@@ -1,0 +1,47 @@
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: foo-host
+  namespace: default
+spec:
+  hostname: foo.example.com
+  mappingSelector:
+    matchLabels:
+      host: foo
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: bar-host
+  namespace: default
+spec:
+  hostname: bar.example.com
+  mappingSelector:
+    matchLabels:
+      host: bar
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: star-backend-foo
+  namespace: default
+  labels:
+    host: foo
+spec:
+  prefix: /test/
+  service: star
+  headers:
+    ":authority": foo.example.com
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: star-backend-bar
+  namespace: default
+  labels:
+    host: bar
+spec:
+  prefix: /test/
+  service: star
+  headers:
+    ":authority": bar.example.com

--- a/python/tests/unit/testdata/canary_groups/mapping_selector_and_authority_out.yaml
+++ b/python/tests/unit/testdata/canary_groups/mapping_selector_and_authority_out.yaml
@@ -1,0 +1,12 @@
+mapping_groups:
+- group_id: '1a5a176cc92a69ab669ac332644324fe7813e889'
+  host: 'foo.example.com'
+  prefix: /test/
+  mappings:
+  - star-backend-foo
+
+- group_id: '71cf9a8de7cec920d057da6ae1a1d304dc599a05'
+  host: 'bar.example.com'
+  prefix: /test/
+  mappings:
+  - star-backend-bar

--- a/python/tests/unit/testdata/canary_groups/mapping_selector_and_host_in.yaml
+++ b/python/tests/unit/testdata/canary_groups/mapping_selector_and_host_in.yaml
@@ -1,0 +1,45 @@
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: foo-host
+  namespace: default
+spec:
+  hostname: foo.example.com
+  mappingSelector:
+    matchLabels:
+      host: foo
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: bar-host
+  namespace: default
+spec:
+  hostname: bar.example.com
+  mappingSelector:
+    matchLabels:
+      host: bar
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: star-backend-foo
+  namespace: default
+  labels:
+    host: foo
+spec:
+  prefix: /test/
+  service: star
+  host: foo.example.com
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: star-backend-bar
+  namespace: default
+  labels:
+    host: bar
+spec:
+  prefix: /test/
+  service: star
+  host: bar.example.com

--- a/python/tests/unit/testdata/canary_groups/mapping_selector_and_host_out.yaml
+++ b/python/tests/unit/testdata/canary_groups/mapping_selector_and_host_out.yaml
@@ -1,0 +1,12 @@
+mapping_groups:
+- group_id: '1a5a176cc92a69ab669ac332644324fe7813e889'
+  host: foo.example.com
+  prefix: /test/
+  mappings:
+  - star-backend-foo
+
+- group_id: '71cf9a8de7cec920d057da6ae1a1d304dc599a05'
+  host: bar.example.com
+  prefix: /test/
+  mappings:
+  - star-backend-bar

--- a/python/tests/unit/testdata/canary_groups/mapping_selector_and_hostname_in.yaml
+++ b/python/tests/unit/testdata/canary_groups/mapping_selector_and_hostname_in.yaml
@@ -1,0 +1,45 @@
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: foo-host
+  namespace: default
+spec:
+  hostname: foo.example.com
+  mappingSelector:
+    matchLabels:
+      host: foo
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: bar-host
+  namespace: default
+spec:
+  hostname: bar.example.com
+  mappingSelector:
+    matchLabels:
+      host: bar
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: star-backend-foo
+  namespace: default
+  labels:
+    host: foo
+spec:
+  prefix: /test/
+  service: star
+  hostname: foo.example.com
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: star-backend-bar
+  namespace: default
+  labels:
+    host: bar
+spec:
+  prefix: /test/
+  service: star
+  hostname: bar.example.com

--- a/python/tests/unit/testdata/canary_groups/mapping_selector_and_hostname_out.yaml
+++ b/python/tests/unit/testdata/canary_groups/mapping_selector_and_hostname_out.yaml
@@ -1,0 +1,12 @@
+mapping_groups:
+- group_id: '1a5a176cc92a69ab669ac332644324fe7813e889'
+  host: foo.example.com
+  prefix: /test/
+  mappings:
+  - star-backend-foo
+
+- group_id: '71cf9a8de7cec920d057da6ae1a1d304dc599a05'
+  host: bar.example.com
+  prefix: /test/
+  mappings:
+  - star-backend-bar

--- a/python/tests/unit/testdata/canary_groups/mapping_selector_in.yaml
+++ b/python/tests/unit/testdata/canary_groups/mapping_selector_in.yaml
@@ -1,0 +1,43 @@
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: foo-host
+  namespace: default
+spec:
+  hostname: foo.example.com
+  mappingSelector:
+    matchLabels:
+      host: foo
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: bar-host
+  namespace: default
+spec:
+  hostname: bar.example.com
+  mappingSelector:
+    matchLabels:
+      host: bar
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: star-backend-foo
+  namespace: default
+  labels:
+    host: foo
+spec:
+  prefix: /test/
+  service: star
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: star-backend-bar
+  namespace: default
+  labels:
+    host: bar
+spec:
+  prefix: /test/
+  service: star

--- a/python/tests/unit/testdata/canary_groups/mapping_selector_irrelevant_labels_in.yaml
+++ b/python/tests/unit/testdata/canary_groups/mapping_selector_irrelevant_labels_in.yaml
@@ -1,0 +1,35 @@
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: foo-host
+  namespace: default
+spec:
+  hostname: foo.example.com
+  mappingSelector:
+    matchLabels:
+      host: foo
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: star-backend-foo
+  namespace: default
+  labels:
+    host: foo
+    irrelevant-label: 1
+spec:
+  prefix: /test/
+  service: star
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: star-test-backend-foo
+  namespace: default
+  labels:
+    host: foo
+    irrelevant-label: 2
+spec:
+  prefix: /test/
+  service: star-test
+  weight: 10

--- a/python/tests/unit/testdata/canary_groups/mapping_selector_irrelevant_labels_out.yaml
+++ b/python/tests/unit/testdata/canary_groups/mapping_selector_irrelevant_labels_out.yaml
@@ -1,0 +1,7 @@
+mapping_groups:
+- group_id: '3d04d59d417131b3e4b017d21216c109eda6ab65'
+  host: null
+  prefix: /test/
+  mappings:
+  - star-test-backend-foo
+  - star-backend-foo

--- a/python/tests/unit/testdata/canary_groups/mapping_selector_out.yaml
+++ b/python/tests/unit/testdata/canary_groups/mapping_selector_out.yaml
@@ -1,0 +1,12 @@
+mapping_groups:
+- group_id: '3d04d59d417131b3e4b017d21216c109eda6ab65'
+  host: null
+  prefix: /test/
+  mappings:
+  - star-backend-foo
+
+- group_id: '22b4856cf2489452367a139b4d5dd7f5112e400b'
+  host: null
+  prefix: /test/
+  mappings:
+  - star-backend-bar

--- a/python/tests/unit/testdata/canary_groups/mapping_selector_to_multiple_hosts_in.yaml
+++ b/python/tests/unit/testdata/canary_groups/mapping_selector_to_multiple_hosts_in.yaml
@@ -1,0 +1,32 @@
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: foo-host
+  namespace: default
+spec:
+  hostname: foo.example.com
+  mappingSelector:
+    matchLabels:
+      service: star
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: bar-host
+  namespace: default
+spec:
+  hostname: bar.example.com
+  mappingSelector:
+    matchLabels:
+      service: star
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: star-backend
+  namespace: default
+  labels:
+    service: star
+spec:
+  prefix: /test/
+  service: star

--- a/python/tests/unit/testdata/canary_groups/mapping_selector_to_multiple_hosts_out.yaml
+++ b/python/tests/unit/testdata/canary_groups/mapping_selector_to_multiple_hosts_out.yaml
@@ -1,0 +1,6 @@
+mapping_groups:
+- group_id: '75dd21c08e54514a335bf2d46a0ece5cbf738b0d'
+  host: null
+  prefix: /test/
+  mappings:
+  - star-backend


### PR DESCRIPTION
## Description

If two mappings have different host labels but share the same prefix, then they should not be placed in the same canary group. Previously, labels were not taken into account when grouping mappings into canary groups, which caused mappings sharing the same prefix to be part of the same canary group when using host labels (hostname or host field was not specified in the mapping).

In order to solve this, we update the mapping group_id logic to incorporate host selector labels. This means that the mappings are grouped based on the following criteria:
- HTTP method
- Prefix
- Headers
- Query parameters
- Host labels
- Precedence

Because this affects only how mappings are grouped, the following behavior is retained:
- hostname, host, and :authority header fields take precendence over host labels for the purposes of grouping.
- If hostname, host, and/or :authority header fields are specified along with host labels, then they must match before they can be associated.
- A canary group can be associated with multiple Hosts based on selector labels. 

## Related Issues

#4170.

## Testing

Added additional unit tests for canary grouping.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->
- [ ] **Does my change need to be backported to a previous release?**
  - What backport versions were discussed with the Maintainers in the Issue?

- [ ] **I made sure to update `CHANGELOG.md`.**

   Remember, the CHANGELOG needs to mention:
  - Any new features
  - Any changes to our included version of Envoy
  - Any non-backward-compatible changes
  - Any deprecations

- [x] **This is unlikely to impact how Ambassador performs at scale.**

   Remember, things that might have an impact at scale include:
  - Any significant changes in memory use that might require adjusting the memory limits
  - Any significant changes in CPU use that might require adjusting the CPU limits
  - Anything that might change how many replicas users should use
  - Changes that impact data-plane latency/scalability

- [ ] **My change is adequately tested.**

   Remember when considering testing:
  - Your change needs to be specifically covered by tests.
    - Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
  - You also need to make sure that the _entire area being changed_ has adequate test coverage.
    - If existing tests don't actually cover the entire area being changed, add tests.
    - This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
  - We should lean on the bulk of code being covered by unit tests, but...
  - ... an end-to-end test should cover the integration points

- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**

- [ ] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
