### PR TITLE
fix(helm): missing annotation for IngressClass

### DIFF
--- a/charts/emissary-ingress/templates/controller-ingressclass.yaml
+++ b/charts/emissary-ingress/templates/controller-ingressclass.yaml
@@ -8,9 +8,14 @@ apiVersion: networking.k8s.io/v1beta1
 kind: IngressClass
 metadata:
   name: {{ .Values.ingressClassResource.name }}
-{{- if .Values.ingressClassResource.default }}
+{{- if or .Values.ingressClassResource.default (hasKey .Values.env "AMBASSADOR_ID") }}
   annotations:
+  {{- if hasKey .Values.env "AMBASSADOR_ID" }}
+    getambassador.io/ambassador-id: {{ .Values.env.AMBASSADOR_ID | quote }}
+  {{- end }}
+  {{- if .Values.ingressClassResource.default }}
     ingressclass.kubernetes.io/is-default-class: "true"
+  {{- end }}
 {{- end }}
 spec:
   controller: {{ .Values.ingressClassResource.controllerValue }}


### PR DESCRIPTION
## Description

Fixes point 1 in #4691.

> Helm - generated IngressClass is missing the required getambassador.io/ambassador-id annotation
If AMBASSADOR_ID is set then the annotation getambassador.io/ambassador-id should be included in the IngressClass generated by the Helm chart, otherwise the IngressClass will be ignored ([source](https://github.com/emissary-ingress/emissary/blob/507bf91f95e489d7d5cb437ca7cd1d8f320d4a81/python/ambassador/fetch/ingress.py#L37-L41)).

## Related Issues

#4691 

## Testing

Manually tested.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->
- [ ] **Does my change need to be backported to a previous release?**
  - What backport versions were discussed with the Maintainers in the Issue?

- [x] **I made sure to update `CHANGELOG.md`.**

   Remember, the CHANGELOG needs to mention:
  - Any new features
  - Any changes to our included version of Envoy
  - Any non-backward-compatible changes
  - Any deprecations

- [x] **This is unlikely to impact how Ambassador performs at scale.**

   Remember, things that might have an impact at scale include:
  - Any significant changes in memory use that might require adjusting the memory limits
  - Any significant changes in CPU use that might require adjusting the CPU limits
  - Anything that might change how many replicas users should use
  - Changes that impact data-plane latency/scalability

- [ ] **My change is adequately tested.**

   Remember when considering testing:
  - Your change needs to be specifically covered by tests.
    - Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
  - You also need to make sure that the _entire area being changed_ has adequate test coverage.
    - If existing tests don't actually cover the entire area being changed, add tests.
    - This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
  - We should lean on the bulk of code being covered by unit tests, but...
  - ... an end-to-end test should cover the integration points

- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**

- [ ] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
