### PR TITLE
feat(helm): autoscaling - allow setting behaviors for HPA

### DIFF
--- a/charts/emissary-ingress/CHANGELOG.md
+++ b/charts/emissary-ingress/CHANGELOG.md
@@ -5,6 +5,7 @@ numbering uses [semantic versioning](http://semver.org).
 ## v8.9.0
 
 - Upgrade Emissary to v3.9.0 [CHANGELOG](https://github.com/emissary-ingress/emissary/blob/master/CHANGELOG.md)
+- Feature: configure autoscaling behaviors for HorizontalPodAutoscaler in `.Values.autoscaling.behavior`
 - Fix: wrong autoscaling apiVersion on EKS due to EKS not following semver (see https://github.com/aws/containers-roadmap/issues/1404, https://github.com/helm/helm/issues/10375, https://github.com/helm/helm/issues/12053)
 
 ## v8.8.0

--- a/charts/emissary-ingress/CHANGELOG.md
+++ b/charts/emissary-ingress/CHANGELOG.md
@@ -5,6 +5,7 @@ numbering uses [semantic versioning](http://semver.org).
 ## v8.9.0
 
 - Upgrade Emissary to v3.9.0 [CHANGELOG](https://github.com/emissary-ingress/emissary/blob/master/CHANGELOG.md)
+- Fix: wrong autoscaling apiVersion on EKS due to EKS not following semver (see https://github.com/aws/containers-roadmap/issues/1404, https://github.com/helm/helm/issues/10375, https://github.com/helm/helm/issues/12053)
 
 ## v8.8.0
 
@@ -23,7 +24,7 @@ numbering uses [semantic versioning](http://semver.org).
 ## v8.6.0 - 2023-04-17
 
 - Upgrade Emissary to v3.6.0 [CHANGELOG](https://github.com/emissary-ingress/emissary/blob/master/CHANGELOG.md)
-- Use autoscaling/v2 HorizontalPodAutoscaler if the cluster version is >v1.26 as autoscaling/v2beta2 is deprecated starting v1.23 and removed in v1.26. Thanks to [Elvind Valderhaug](https://github.com/eevdev)
+- Use autoscaling/v2 HorizontalPodAutoscaler if the cluster version is >=v1.23 as autoscaling/v2beta2 is deprecated starting v1.23 and removed in v1.26. Thanks to [Eivind Valderhaug](https://github.com/eevdev)
 - Upgrade KubernetesEndpointResolver & ConsulResolver apiVersions to `getambassador.io/v3alpha1`
 - Add support for setting `nodeSelector`, `tolerations` and `affinity` on the Ambassador Agent. Thanks to [Philip Panyukov](https://github.com/ppanyukov).
 

--- a/charts/emissary-ingress/templates/hpa.yaml
+++ b/charts/emissary-ingress/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.autoscaling.enabled (not .Values.daemonSet) }}
-apiVersion: autoscaling/v2{{- if semverCompare "<1.23" .Capabilities.KubeVersion.Version }}beta2{{- end }}
+apiVersion: autoscaling/v2{{- if not (.Capabilities.APIVersions.Has "autoscaling/v2") }}beta2{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "ambassador.fullname" . }}

--- a/charts/emissary-ingress/templates/hpa.yaml
+++ b/charts/emissary-ingress/templates/hpa.yaml
@@ -16,4 +16,8 @@ spec:
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:
     {{- toYaml .Values.autoscaling.metrics | nindent 4 }}
+  {{- with .Values.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/emissary-ingress/values.yaml.in
+++ b/charts/emissary-ingress/values.yaml.in
@@ -62,6 +62,7 @@ autoscaling: # +doc-gen:break
       target:
         type: Utilization
         averageUtilization: 300
+  behavior: {}
 
 
 podDisruptionBudget: {}


### PR DESCRIPTION
## Description

Allow setting autoscaling/HorizontalPodAutoscaler (HPA) behaviors in chart.

Example Helm values:
```yaml
autoscaling:
  behavior:
    scaleDown:
      stabilizationWindowSeconds: 300
      policies:
        - periodSeconds: 60
          type: Pods
          value: 1
    scaleUp:
      stabilizationWindowSeconds: 300
      policies:
        - periodSeconds: 60
          type: Pods
          value: 1
```

## Related Issues

#5217

## Testing

Manually tested.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->
- [ ] **Does my change need to be backported to a previous release?**
  - What backport versions were discussed with the Maintainers in the Issue?

- [x] **I made sure to update `CHANGELOG.md`.**

   Remember, the CHANGELOG needs to mention:
  - Any new features
  - Any changes to our included version of Envoy
  - Any non-backward-compatible changes
  - Any deprecations

- [x] **This is unlikely to impact how Ambassador performs at scale.**

   Remember, things that might have an impact at scale include:
  - Any significant changes in memory use that might require adjusting the memory limits
  - Any significant changes in CPU use that might require adjusting the CPU limits
  - Anything that might change how many replicas users should use
  - Changes that impact data-plane latency/scalability

- [ ] **My change is adequately tested.**

   Remember when considering testing:
  - Your change needs to be specifically covered by tests.
    - Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
  - You also need to make sure that the _entire area being changed_ has adequate test coverage.
    - If existing tests don't actually cover the entire area being changed, add tests.
    - This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
  - We should lean on the bulk of code being covered by unit tests, but...
  - ... an end-to-end test should cover the integration points

- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**

- [ ] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
