### PR TITLE
docs(helm): comment to values.yaml on multiple Modules

### DIFF
--- a/charts/emissary-ingress/templates/module.yaml
+++ b/charts/emissary-ingress/templates/module.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
     {{- include "ambassador.labels" . | nindent 4 }}
-    app.kubernetes.io/component: {{ include "ambassador.name" . }}-ratelimit
+    app.kubernetes.io/component: {{ include "ambassador.name" . }}
     product: aes
 spec:
   {{- if .Values.env }}

--- a/charts/emissary-ingress/values.yaml.in
+++ b/charts/emissary-ingress/values.yaml.in
@@ -353,7 +353,10 @@ resolvers: # +doc-gen:break
 # for more info on the available options.
 #
 # Note: The Module can only be named ambassador. There can only be one Module
-# installed per-namespace.
+# object installed per-namespace. To create multiple ambassador Modules in the
+# same Kubernetes namespace, you will need to apply them as annotations with
+# separate ambassador_ids, and set `module: {}` in your Helm values to prevent
+# creation of a Module object.
 module:
   diagnostics:
     enabled: false

--- a/manifests/emissary/emissary-defaultns.yaml.in
+++ b/manifests/emissary/emissary-defaultns.yaml.in
@@ -358,7 +358,7 @@ apiVersion: getambassador.io/v3alpha1
 kind: Module
 metadata:
   labels:
-    app.kubernetes.io/component: emissary-ingress-ratelimit
+    app.kubernetes.io/component: emissary-ingress
     app.kubernetes.io/instance: emissary-ingress
     app.kubernetes.io/managed-by: getambassador.io
     app.kubernetes.io/name: emissary-ingress

--- a/manifests/emissary/emissary-emissaryns.yaml.in
+++ b/manifests/emissary/emissary-emissaryns.yaml.in
@@ -358,7 +358,7 @@ apiVersion: getambassador.io/v3alpha1
 kind: Module
 metadata:
   labels:
-    app.kubernetes.io/component: emissary-ingress-ratelimit
+    app.kubernetes.io/component: emissary-ingress
     app.kubernetes.io/instance: emissary-ingress
     app.kubernetes.io/managed-by: getambassador.io
     app.kubernetes.io/name: emissary-ingress


### PR DESCRIPTION
## Description

- in values.yaml there was a comment for the module values incorrectly stating that "There can only be one Module installed per-namespace". There can indeed only be one Module _object_, but it's possible to add multiple Modules by adding them as `getambassador.io/config` annotations to Emissary Ingress Service objects.
- generated Module, if enabled, had confusing suffix '-ratelimit' for label `app.kubernetes.io/component: {{ include "ambassador.name" . }}-ratelimit`

## Related Issues

None

## Testing

No testing done.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->
- [ ] **Does my change need to be backported to a previous release?**
  - What backport versions were discussed with the Maintainers in the Issue?

- [ ] **I made sure to update `CHANGELOG.md`.**

   Remember, the CHANGELOG needs to mention:
  - Any new features
  - Any changes to our included version of Envoy
  - Any non-backward-compatible changes
  - Any deprecations

- [x] **This is unlikely to impact how Ambassador performs at scale.**

   Remember, things that might have an impact at scale include:
  - Any significant changes in memory use that might require adjusting the memory limits
  - Any significant changes in CPU use that might require adjusting the CPU limits
  - Anything that might change how many replicas users should use
  - Changes that impact data-plane latency/scalability

- [ ] **My change is adequately tested.**

   Remember when considering testing:
  - Your change needs to be specifically covered by tests.
    - Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
  - You also need to make sure that the _entire area being changed_ has adequate test coverage.
    - If existing tests don't actually cover the entire area being changed, add tests.
    - This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
  - We should lean on the bulk of code being covered by unit tests, but...
  - ... an end-to-end test should cover the integration points

- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**

- [ ] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
