### PR TITLE
bug: Fixing Header/QueryParameter Value Duplication 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,14 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
   that Mappings sharing the same prefix but associated with different Hosts will be correctly
   routed. ([Canary grouping must take labels into account])
 
+- Bugfix: In previous versions, if multiple Headers/QueryParameters where used in a v3alpha1
+  mapping, these values would duplicate and cause all the Headers/QueryParameters to have the same
+  value. This is no longer the case and the expected values for unique Headers/QueryParameters will
+  apply.
+  This issue was only present in v3alpha1 Mappings. For users who may have this issue, please
+  be sure to re-apply any v3alpha1 Mappings in order to update the stored v2 Mapping and resolve the
+  issue.
+
 [Canary grouping must take labels into account]: https://github.com/emissary-ingress/emissary/issues/4170
 
 ## [3.7.2] July 25, 2023

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -48,6 +48,16 @@ items:
         github:
           - title: "Canary grouping must take labels into account"
             link: https://github.com/emissary-ingress/emissary/issues/4170
+      - title: Duplication of values when using multiple Headers/QueryParameters in Mappings
+        type: bugfix
+        body: >-
+          In previous versions, if multiple Headers/QueryParameters where used in a v3alpha1 mapping,
+          these values would duplicate and cause all the Headers/QueryParameters to have the same value.
+          This is no longer the case and the expected values for unique Headers/QueryParameters will apply.
+
+          This issue was only present in v3alpha1 Mappings. For users who may have this issue, please
+          be sure to re-apply any v3alpha1 Mappings in order to update the stored v2 Mapping and resolve the
+          issue.
 
   - version: 3.7.2
     prevVersion: 3.7.1

--- a/pkg/api/getambassador.io/v2/handwritten.conversion.go
+++ b/pkg/api/getambassador.io/v2/handwritten.conversion.go
@@ -543,6 +543,28 @@ func Convert_v3alpha1_MappingSpec_To_v2_MappingSpec(in *v3alpha1.MappingSpec, ou
 		in.Hostname = "_skip_mapping_with_empty_host_"
 	}
 
+	// INFO: in.Headers opted out of conversion generation via +k8s:conversion-gen=false
+	if in.Headers != nil {
+		if out.Headers == nil {
+			out.Headers = make(map[string]BoolOrString)
+		}
+		for inKey, inVal := range in.Headers {
+			inVal := inVal
+			out.Headers[inKey] = BoolOrString{String: &inVal}
+		}
+	}
+
+	// INFO: in.QueryParameters opted out of conversion generation via +k8s:conversion-gen=false
+	if in.QueryParameters != nil {
+		if out.QueryParameters == nil {
+			out.QueryParameters = make(map[string]BoolOrString)
+		}
+		for inKey, inVal := range in.QueryParameters {
+			inVal := inVal
+			out.QueryParameters[inKey] = BoolOrString{String: &inVal}
+		}
+	}
+
 	if err := autoConvert_v3alpha1_MappingSpec_To_v2_MappingSpec(in, out, s); err != nil {
 		return err
 	}

--- a/pkg/api/getambassador.io/v2/zz_generated.conversion.go
+++ b/pkg/api/getambassador.io/v2/zz_generated.conversion.go
@@ -4326,29 +4326,7 @@ func autoConvert_v3alpha1_MappingSpec_To_v2_MappingSpec(in *v3alpha1.MappingSpec
 		in, out := &in.Hostname, &out.Host
 		*out = *in
 	}
-	if true {
-		in, out := &in.Headers, &out.Headers
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = make(map[string]BoolOrString, len(*in))
-			for inKey, inVal := range *in {
-				outKey := new(string)
-				if true {
-					in, out := &inKey, outKey
-					*out = *in
-				}
-				outVal := new(BoolOrString)
-				if true {
-					in, out := &inVal, outVal
-					if err := Convert_string_To_v2_BoolOrString(in, out, s); err != nil {
-						return err
-					}
-				}
-				(*out)[*outKey] = *outVal
-			}
-		}
-	}
+	// INFO: in.Headers opted out of conversion generation via +k8s:conversion-gen=false
 	if true {
 		in, out := &in.RegexHeaders, &out.RegexHeaders
 		*out = *in
@@ -4383,29 +4361,7 @@ func autoConvert_v3alpha1_MappingSpec_To_v2_MappingSpec(in *v3alpha1.MappingSpec
 			}
 		}
 	}
-	if true {
-		in, out := &in.QueryParameters, &out.QueryParameters
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = make(map[string]BoolOrString, len(*in))
-			for inKey, inVal := range *in {
-				outKey := new(string)
-				if true {
-					in, out := &inKey, outKey
-					*out = *in
-				}
-				outVal := new(BoolOrString)
-				if true {
-					in, out := &inVal, outVal
-					if err := Convert_string_To_v2_BoolOrString(in, out, s); err != nil {
-						return err
-					}
-				}
-				(*out)[*outKey] = *outVal
-			}
-		}
-	}
+	// INFO: in.QueryParameters opted out of conversion generation via +k8s:conversion-gen=false
 	if true {
 		in, out := &in.RegexQueryParameters, &out.RegexQueryParameters
 		*out = *in

--- a/pkg/api/getambassador.io/v3alpha1/crd_mapping.go
+++ b/pkg/api/getambassador.io/v3alpha1/crd_mapping.go
@@ -151,11 +151,13 @@ type MappingSpec struct {
 	// used.
 	Hostname string `json:"hostname,omitempty"`
 
-	Headers              map[string]string `json:"headers,omitempty"`
-	RegexHeaders         map[string]string `json:"regex_headers,omitempty"`
-	Labels               DomainMap         `json:"labels,omitempty"`
-	EnvoyOverride        *UntypedDict      `json:"envoy_override,omitempty"`
-	LoadBalancer         *LoadBalancer     `json:"load_balancer,omitempty"`
+	// +k8s:conversion-gen=false
+	Headers       map[string]string `json:"headers,omitempty"`
+	RegexHeaders  map[string]string `json:"regex_headers,omitempty"`
+	Labels        DomainMap         `json:"labels,omitempty"`
+	EnvoyOverride *UntypedDict      `json:"envoy_override,omitempty"`
+	LoadBalancer  *LoadBalancer     `json:"load_balancer,omitempty"`
+	// +k8s:conversion-gen=false
 	QueryParameters      map[string]string `json:"query_parameters,omitempty"`
 	RegexQueryParameters map[string]string `json:"regex_query_parameters,omitempty"`
 	StatsName            string            `json:"stats_name,omitempty"`

--- a/pkg/api/getambassador.io/v3alpha1/testdata/mappings.yaml
+++ b/pkg/api/getambassador.io/v3alpha1/testdata/mappings.yaml
@@ -609,3 +609,20 @@
     - on_status_code: 503
       body:
         json_format: {}
+- apiVersion: getambassador.io/v3alpha1
+  kind: Mapping
+  metadata:
+    creationTimestamp: null
+    name:  multiple-headers-shouldnt-duplicate-values
+  spec:
+    hostname: "*"
+    prefix: /backend/
+    service: quote
+    query_parameters:
+      this-is-a: test1
+      this-is-a2: test2
+      this-is-a3: test3
+    headers:
+      this-is-a: test1
+      this-is-a2: test2
+      this-is-a3: test3


### PR DESCRIPTION
## Description

The auto conversion from v3alpha1 -> v2 for Headers and QueryParameters was causing the same value to be assigned to all the keys. See below for examples of the behavior before and after. 

This PR removes the auto conversion from v3alpha1 -> v2 for Headers and QueryParameters and adds a simple handwritten conversion to resolve the issue. 

A few other things to note: 
- The translation from v2 -> v3alpha1 is already handwritten and works as expected and thus this issue would not appear for anyone using v2 mappings
- Because the incorrect v2 mappings might be stored, anyone running into this issue would have to re-apply their mappings

## Related Issues
https://github.com/datawire/apro/issues/3382

## Testing

The following was all tested and confirmed locally. 
**Example current behavior:** 
```
apiVersion: getambassador.io/v3alpha1
kind:  Mapping
metadata:
  name:  quote-backend
spec:
  hostname: "*"
  prefix: /backend/
  service: quote
  headers:
    this-is-a: test1
    this-is-a2: test2
    this-is-a3: test3
```
Applying the above mapping will result in the duplicated values for the keys, resulting in something similar to the below output. 
```
kubectl get mappings quote-backend -o yaml
apiVersion: getambassador.io/v2
kind: Mapping
metadata:
  name: quote-backend
  namespace: default
spec:
  ambassador_id:
  - --apiVersion-v3alpha1-only--default
  headers:
    this-is-a: test3
    this-is-a2: test3
    this-is-a3: test3
  prefix: /backend/
  service: quote
```

**New behavior:** 
The same mapping will now result in the correct expected output.
```
kubectl get mappings quote-backend -o yaml
apiVersion: getambassador.io/v2
kind: Mapping
metadata:
  name: quote-backend
  namespace: default
spec:
  ambassador_id:
  - --apiVersion-v3alpha1-only--default
  headers:
    this-is-a: test1
    this-is-a2: test2
    this-is-a3: test3
  prefix: /backend/
  service: quote
```

```
curl -Lik http://34.133.232.144/backend/ -H "this-is-a:test1" -H "this-is-a2:test2" -H "this-is-a3:test3"
HTTP/1.1 301 Moved Permanently
location: https://34.133.232.144/backend/
date: Tue, 15 Aug 2023 20:08:27 GMT
server: envoy
content-length: 0

HTTP/1.1 200 OK
content-type: application/json
date: Tue, 15 Aug 2023 20:08:27 GMT
content-length: 140
x-envoy-upstream-service-time: 0
server: envoy

{
    "server": "mushy-pomegranate-u65ooa62",
    "quote": "668: The Neighbor of the Beast.",
    "time": "2023-08-15T20:08:27.534204805Z"
}%       
```

_Note: Although not outlined in the examples, query_parameters have the same behavior/fix._ 

## More Testing
Added a Mapping to the test cases as well. As we can see in the below test output, the tests fail before, but pass as expected after the changes are implemented. 

_Note: I truncated large sections of the output with "..."_

**BEFORE**
```
Running tool: /usr/local/bin/go test -timeout 3000s -run ^TestConvert$ github.com/emissary-ingress/emissary/v3/pkg/api/getambassador.io

=== RUN   TestConvert
...
    /Users/tenshinhigashi/Documents/GitHub/emissary/pkg/api/getambassador.io/conversion_test.go:160: Not equal
        --- Expected
        +++ Actual
        @@ -874,16 +874,16 @@
                        },
                        "spec": {
                                "headers": {
        -                               "this-is-a": "test1",
        -                               "this-is-a2": "test2",
        +                               "this-is-a": "test3",
        +                               "this-is-a2": "test3",
                                        "this-is-a3": "test3"
                                },
                                "hostname": "*",
                                "prefix": "/backend/",
                                "query_parameters": {
        -                               "this-is-a": "test1",
        +                               "this-is-a": "test2",
                                        "this-is-a2": "test2",
        -                               "this-is-a3": "test3"
        +                               "this-is-a3": "test2"
                                },
                                "service": "quote"
                        }
--- FAIL: TestConvert/RoundTrip/mappings/v3alpha1_through_v2 (0.09s)
...
    /Users/tenshinhigashi/Documents/GitHub/emissary/pkg/api/getambassador.io/conversion_test.go:160: Not equal
        --- Expected
        +++ Actual
        @@ -874,16 +874,16 @@
                        },
                        "spec": {
                                "headers": {
        -                               "this-is-a": "test1",
        -                               "this-is-a2": "test2",
        +                               "this-is-a": "test3",
        +                               "this-is-a2": "test3",
                                        "this-is-a3": "test3"
                                },
                                "hostname": "*",
                                "prefix": "/backend/",
                                "query_parameters": {
        -                               "this-is-a": "test1",
        +                               "this-is-a": "test2",
                                        "this-is-a2": "test2",
        -                               "this-is-a3": "test3"
        +                               "this-is-a3": "test2"
                                },
                                "service": "quote"
                        }
--- FAIL: TestConvert/RoundTrip/mappings/v3alpha1_through_v1 (0.11s)
...
--- FAIL: TestConvert/RoundTrip/mappings (0.00s)
--- FAIL: TestConvert/RoundTrip (0.00s)
--- FAIL: TestConvert (0.00s)
FAIL
FAIL    github.com/emissary-ingress/emissary/v3/pkg/api/getambassador.io        0.876s


> Test run finished at 8/16/2023, 11:31:27 AM <

```

**AFTER**
```
Running tool: /usr/local/bin/go test -timeout 3000s -run ^TestConvert$ github.com/emissary-ingress/emissary/v3/pkg/api/getambassador.io

=== RUN   TestConvert
...
--- PASS: TestConvert/RoundTrip/mappings/v3alpha1_through_v2 (0.14s)
...
--- PASS: TestConvert/RoundTrip/mappings/v3alpha1_through_v1 (0.17s)
...
--- PASS: TestConvert/RoundTrip (0.00s)
--- PASS: TestConvert (0.00s)
PASS
ok      github.com/emissary-ingress/emissary/v3/pkg/api/getambassador.io        1.062s


> Test run finished at 8/16/2023, 11:26:49 AM <
```

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->
- [ ] **Does my change need to be backported to a previous release?**
  - What backport versions were discussed with the Maintainers in the Issue?

- [x] **I made sure to update `CHANGELOG.md`.**

   Remember, the CHANGELOG needs to mention:
  - Any new features
  - Any changes to our included version of Envoy
  - Any non-backward-compatible changes
  - Any deprecations

- [x] **This is unlikely to impact how Ambassador performs at scale.**

   Remember, things that might have an impact at scale include:
  - Any significant changes in memory use that might require adjusting the memory limits
  - Any significant changes in CPU use that might require adjusting the CPU limits
  - Anything that might change how many replicas users should use
  - Changes that impact data-plane latency/scalability

- [x] **My change is adequately tested.**

   Remember when considering testing:
  - Your change needs to be specifically covered by tests.
    - Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
  - You also need to make sure that the _entire area being changed_ has adequate test coverage.
    - If existing tests don't actually cover the entire area being changed, add tests.
    - This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
  - We should lean on the bulk of code being covered by unit tests, but...
  - ... an end-to-end test should cover the integration points

- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**

- [ ] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
