### PR TITLE
agent: bump to latest z-patch

### DIFF
--- a/charts/emissary-ingress/CHANGELOG.md
+++ b/charts/emissary-ingress/CHANGELOG.md
@@ -6,6 +6,8 @@ numbering uses [semantic versioning](http://semver.org).
 ## v8.8.0 - TBD
 
 - Upgrade Emissary to v3.8.0 [CHANGELOG](https://github.com/emissary-ingress/emissary/blob/master/CHANGELOG.md)
+- Fix: Ambassador Agent RBAC so that it can properly find cloud connect tokens in a secret
+- Upgrade Ambassador Agent to the latest z-path of 1.0.14.
 
 ## v8.7.1 - 2023-07-13
 

--- a/charts/emissary-ingress/values.yaml.in
+++ b/charts/emissary-ingress/values.yaml.in
@@ -410,7 +410,7 @@ agent:
   createArgoRBAC: true
   image:
     # Leave blank to use image.repository and image.tag
-    tag: 1.0.3
+    tag: 1.0.14
     repository: docker.io/ambassador/ambassador-agent
     pullPolicy: IfNotPresent
 

--- a/manifests/emissary/emissary-defaultns.yaml.in
+++ b/manifests/emissary/emissary-defaultns.yaml.in
@@ -642,7 +642,7 @@ spec:
           value: "true"
         - name: AES_DIAGNOSTICS_URL
           value: http://emissary-ingress-admin.default:8877/ambassador/v0/diag/?json=true
-        image: docker.io/ambassador/ambassador-agent:1.0.3
+        image: docker.io/ambassador/ambassador-agent:1.0.14
         imagePullPolicy: IfNotPresent
         name: agent
         ports:

--- a/manifests/emissary/emissary-emissaryns.yaml.in
+++ b/manifests/emissary/emissary-emissaryns.yaml.in
@@ -642,7 +642,7 @@ spec:
           value: "true"
         - name: AES_DIAGNOSTICS_URL
           value: http://emissary-ingress-admin.emissary:8877/ambassador/v0/diag/?json=true
-        image: docker.io/ambassador/ambassador-agent:1.0.3
+        image: docker.io/ambassador/ambassador-agent:1.0.14
         imagePullPolicy: IfNotPresent
         name: agent
         ports:


### PR DESCRIPTION
## Description

This bumps the default ambassador agent to be `1.0.14` which addresses some smaller bug fixes.

In the future, we should transition to not maintaining our own templates and instead sub-chart the official charts https://github.com/datawire/ambassador-agent.

## Related Issues
n/a

## Testing

No additional testing, just current CI.

## Checklist

- [ ] **Does my change need to be backported to a previous release?**
- [x] **I made sure to update `CHANGELOG.md`.**
- [x] **This is unlikely to impact how Ambassador performs at scale.**
- [x] **My change is adequately tested.**
- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**
- [x] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
