### PR TITLE
apiext: set minimum tls version to 1.3

### DIFF
--- a/pkg/apiext/internal/serve.go
+++ b/pkg/apiext/internal/serve.go
@@ -92,6 +92,7 @@ func ServeHTTPS(ctx context.Context, port int, ca *CA, scheme *k8sRuntime.Scheme
 	sc := &dhttp.ServerConfig{
 		Handler: mux,
 		TLSConfig: &tls.Config{
+			MinVersion: tls.VersionTLS13,
 			GetCertificate: func(clientHello *tls.ClientHelloInfo) (*tls.Certificate, error) {
 				return ca.GenServerCert(ctx, clientHello.ServerName)
 			},


### PR DESCRIPTION
## Description

TLS 1.0 support on apiext is flagged by Nessus: https://www.tenable.com/plugins/nessus/104743

Set apiext minimum tls version to 1.3 -- available since Kubernetes 1.13 (https://go.dev/doc/go1.13#tls_1_3)

## Related Issues

List related issues.

## Testing

Built using `make images` and deployed in my dev cluster. 

Verified creating mappings
```bash
echo '---
apiVersion: getambassador.io/v3alpha1
kind:  Mapping
metadata:
  name:  httpbin-mapping
spec:
  prefix: /httpbin/
  service: http://httpbin.org' | kubectl apply -f -
mapping.getambassador.io/httpbin-mapping created

kubectl get mapping httpbin-mapping -o yaml
apiVersion: getambassador.io/v2
kind: Mapping
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"getambassador.io/v3alpha1","kind":"Mapping","metadata":{"annotations":{},"name":"httpbin-mapping","namespace":"emissary-system"},"spec":{"prefix":"/httpbin/","service":"http://httpbin.org"}}
  creationTimestamp: "2023-08-18T18:13:27Z"
  generation: 1
  name: httpbin-mapping
  namespace: emissary-system
  resourceVersion: "1736605387"
  uid: 77aceec1-b0b4-4431-a95e-72c1e79bf8c2
spec:
  ambassador_id:
  - --apiVersion-v3alpha1-only--default
  host: _skip_mapping_with_empty_host_
  prefix: /httpbin/
  service: http://httpbin.org
```


Verified TLSVersion using nmap
```
> kubectl port-forward emissary-apiext-6fbf97fff9-h5mcr 8443
> nmap --script ssl-enum-ciphers 127.0.0.1 -p 8443
Starting Nmap 7.94 ( https://nmap.org ) at 2023-08-18 11:05 PDT
Nmap scan report for localhost (127.0.0.1)
Host is up (0.00015s latency).

PORT     STATE SERVICE
8443/tcp open  https-alt
| ssl-enum-ciphers:
|   TLSv1.3:
|     ciphers:
|       TLS_AKE_WITH_AES_128_GCM_SHA256 (ecdh_x25519) - A
|       TLS_AKE_WITH_AES_256_GCM_SHA384 (ecdh_x25519) - A
|       TLS_AKE_WITH_CHACHA20_POLY1305_SHA256 (ecdh_x25519) - A
|     cipher preference: server
|_  least strength: A

Nmap done: 1 IP address (1 host up) scanned in 1.81 seconds
```


## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->
- [ ] **Does my change need to be backported to a previous release?**
  - What backport versions were discussed with the Maintainers in the Issue?

- [ ] **I made sure to update `CHANGELOG.md`.**

   Remember, the CHANGELOG needs to mention:
  - Any new features
  - Any changes to our included version of Envoy
  - Any non-backward-compatible changes
  - Any deprecations

- [x] **This is unlikely to impact how Ambassador performs at scale.**

   Remember, things that might have an impact at scale include:
  - Any significant changes in memory use that might require adjusting the memory limits
  - Any significant changes in CPU use that might require adjusting the CPU limits
  - Anything that might change how many replicas users should use
  - Changes that impact data-plane latency/scalability

- [ ] **My change is adequately tested.**

   Remember when considering testing:
  - Your change needs to be specifically covered by tests.
    - Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
  - You also need to make sure that the _entire area being changed_ has adequate test coverage.
    - If existing tests don't actually cover the entire area being changed, add tests.
    - This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
  - We should lean on the bulk of code being covered by unit tests, but...
  - ... an end-to-end test should cover the integration points

- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**

- [ ] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
