### PR TITLE
Remove legacy TODO/FIXME comments from CRDs

### DIFF
--- a/manifests/emissary/emissary-crds.yaml.in
+++ b/manifests/emissary/emissary-crds.yaml.in
@@ -255,9 +255,6 @@ spec:
               add_linkerd_headers:
                 type: boolean
               allow_request_body:
-                description: 'TODO(lukeshu): In v3alpha2, drop allow_request_body
-                  in favor of include_body. allow_request_body has been deprecated
-                  for a long time.'
                 type: boolean
               allowed_authorization_headers:
                 items:
@@ -270,15 +267,11 @@ spec:
               ambassador_id:
                 description: "AmbassadorID declares which Ambassador instances should
                   pay attention to this resource. If no value is provided, the default
-                  is: \n ambassador_id: - \"default\" \n TODO(lukeshu): In v3alpha2,
-                  consider renaming all of the `ambassador_id` (singular) fields to
-                  `ambassador_ids` (plural)."
+                  is: \n ambassador_id: - \"default\""
                 items:
                   type: string
                 type: array
               auth_service:
-                description: 'TODO(lukeshu): In v3alpha2, consider renameing `auth_service`
-                  to just `service`, for consistency with the other resource types.'
                 type: string
               circuit_breakers:
                 items:
@@ -327,9 +320,6 @@ spec:
               stats_name:
                 type: string
               status_on_error:
-                description: 'TODO(lukeshu): In v3alpha2, consider getting rid of
-                  this struct type in favor of just using an int (i.e. `statusOnError:
-                  500` instead of the current `statusOnError: { code: 500 }`).'
                 properties:
                   code:
                     type: integer
@@ -510,9 +500,7 @@ spec:
               ambassador_id:
                 description: "AmbassadorID declares which Ambassador instances should
                   pay attention to this resource. If no value is provided, the default
-                  is: \n ambassador_id: - \"default\" \n TODO(lukeshu): In v3alpha2,
-                  consider renaming all of the `ambassador_id` (singular) fields to
-                  `ambassador_ids` (plural)."
+                  is: \n ambassador_id: - \"default\""
                 items:
                   type: string
                 type: array
@@ -812,9 +800,7 @@ spec:
               ambassador_id:
                 description: "AmbassadorID declares which Ambassador instances should
                   pay attention to this resource. If no value is provided, the default
-                  is: \n ambassador_id: - \"default\" \n TODO(lukeshu): In v3alpha2,
-                  consider renaming all of the `ambassador_id` (singular) fields to
-                  `ambassador_ids` (plural)."
+                  is: \n ambassador_id: - \"default\""
                 items:
                   type: string
                 type: array
@@ -1367,9 +1353,8 @@ spec:
                     type: object
                 type: object
               selector:
-                description: "DEPRECATED: Selector by which we can find further configuration.
-                  Use MappingSelector instead. \n TODO(lukeshu): In v3alpha2, figure
-                  out how to get rid of HostSpec.DeprecatedSelector."
+                description: 'DEPRECATED: Selector by which we can find further configuration.
+                  Use MappingSelector instead.'
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -1648,9 +1633,7 @@ spec:
               ambassador_id:
                 description: "AmbassadorID declares which Ambassador instances should
                   pay attention to this resource. If no value is provided, the default
-                  is: \n ambassador_id: - \"default\" \n TODO(lukeshu): In v3alpha2,
-                  consider renaming all of the `ambassador_id` (singular) fields to
-                  `ambassador_ids` (plural)."
+                  is: \n ambassador_id: - \"default\""
                 items:
                   type: string
                 type: array
@@ -1771,9 +1754,7 @@ spec:
               ambassador_id:
                 description: "AmbassadorID declares which Ambassador instances should
                   pay attention to this resource. If no value is provided, the default
-                  is: \n ambassador_id: - \"default\" \n TODO(lukeshu): In v3alpha2,
-                  consider renaming all of the `ambassador_id` (singular) fields to
-                  `ambassador_ids` (plural)."
+                  is: \n ambassador_id: - \"default\""
                 items:
                   type: string
                 type: array
@@ -1847,9 +1828,7 @@ spec:
               ambassador_id:
                 description: "AmbassadorID declares which Ambassador instances should
                   pay attention to this resource. If no value is provided, the default
-                  is: \n ambassador_id: - \"default\" \n TODO(lukeshu): In v3alpha2,
-                  consider renaming all of the `ambassador_id` (singular) fields to
-                  `ambassador_ids` (plural)."
+                  is: \n ambassador_id: - \"default\""
                 items:
                   type: string
                 type: array
@@ -2157,9 +2136,7 @@ spec:
               ambassador_id:
                 description: "AmbassadorID declares which Ambassador instances should
                   pay attention to this resource. If no value is provided, the default
-                  is: \n ambassador_id: - \"default\" \n TODO(lukeshu): In v3alpha2,
-                  consider renaming all of the `ambassador_id` (singular) fields to
-                  `ambassador_ids` (plural)."
+                  is: \n ambassador_id: - \"default\""
                 items:
                   type: string
                 type: array
@@ -2189,10 +2166,6 @@ spec:
               flush_interval_time:
                 type: integer
               grpc:
-                description: 'TODO(lukeshu): In v3alpha2, drop this LogService.spec.grpc.  Due
-                  to sloppy implementation it is required to be present, and required
-                  to be ''true''.  It is silly to have a required field with only
-                  one valid value, we should just remove the thing.'
                 type: boolean
               protocol_version:
                 description: ProtocolVersion is the envoy api transport protocol version
@@ -3278,9 +3251,7 @@ spec:
               ambassador_id:
                 description: "AmbassadorID declares which Ambassador instances should
                   pay attention to this resource. If no value is provided, the default
-                  is: \n ambassador_id: - \"default\" \n TODO(lukeshu): In v3alpha2,
-                  consider renaming all of the `ambassador_id` (singular) fields to
-                  `ambassador_ids` (plural)."
+                  is: \n ambassador_id: - \"default\""
                 items:
                   type: string
                 type: array
@@ -3539,16 +3510,13 @@ spec:
                   Hostname. \n If both Host and Hostname are set, an error is logged,
                   Host is ignored, and Hostname is used. \n DEPRECATED: Host is either
                   an exact match or a regex, depending on HostRegex. Use HostName
-                  instead. \n TODO(lukeshu): In v3alpha2, get rid of MappingSpec.host
-                  and MappingSpec.host_regex in favor of a MappingSpec.deprecated_hostname_regex."
+                  instead."
                 type: string
               host_redirect:
                 type: boolean
               host_regex:
-                description: "DEPRECATED: Host is either an exact match or a regex,
-                  depending on HostRegex. Use HostName instead. \n TODO(lukeshu):
-                  In v3alpha2, get rid of MappingSpec.host and MappingSpec.host_regex
-                  in favor of a MappingSpec.deprecated_hostname_regex."
+                description: 'DEPRECATED: Host is either an exact match or a regex,
+                  depending on HostRegex. Use HostName instead.'
                 type: boolean
               host_rewrite:
                 type: string
@@ -3799,9 +3767,8 @@ spec:
               tls:
                 type: string
               use_websocket:
-                description: "use_websocket is deprecated, and is equivlaent to setting
-                  `allow_upgrade: [\"websocket\"]` \n TODO(lukeshu): In v3alpha2,
-                  get rid of MappingSpec.DeprecatedUseWebsocket."
+                description: 'use_websocket is deprecated, and is equivlaent to setting
+                  `allow_upgrade: ["websocket"]`'
                 type: boolean
               v2BoolHeaders:
                 items:
@@ -3992,23 +3959,15 @@ spec:
           metadata:
             type: object
           spec:
-            description: 'TODO(lukeshu): In v3alpha2, get rid of unnecessary nesting
-              and move `ModuleSpec.config.*` to `ModuleSpec.*`.'
             properties:
               ambassador_id:
                 description: "AmbassadorID declares which Ambassador instances should
                   pay attention to this resource. If no value is provided, the default
-                  is: \n ambassador_id: - \"default\" \n TODO(lukeshu): In v3alpha2,
-                  consider renaming all of the `ambassador_id` (singular) fields to
-                  `ambassador_ids` (plural)."
+                  is: \n ambassador_id: - \"default\""
                 items:
                   type: string
                 type: array
               config:
-                description: "TODO(lukeshu): In v3alpha2, change the default from
-                  `diagnostics.enabled=true` to `diagnostics.enabled=false`.  This
-                  needs conversion support in apiext.  See the related comment in
-                  irambassador.py. \n TODO(lukeshu): Structurally type ModuleSpec.Config."
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
             required:
@@ -4315,7 +4274,6 @@ spec:
               host:
                 type: string
               idle_timeout_ms:
-                description: 'FIXME(lukeshu): Surely this should be an ''int''?'
                 type: string
               port:
                 description: Port isn't a pointer because it's required.
@@ -4385,7 +4343,6 @@ spec:
               host:
                 type: string
               idle_timeout_ms:
-                description: 'FIXME(lukeshu): Surely this should be an ''int''?'
                 type: string
               port:
                 description: Port isn't a pointer because it's required.
@@ -4431,9 +4388,7 @@ spec:
               ambassador_id:
                 description: "AmbassadorID declares which Ambassador instances should
                   pay attention to this resource. If no value is provided, the default
-                  is: \n ambassador_id: - \"default\" \n TODO(lukeshu): In v3alpha2,
-                  consider renaming all of the `ambassador_id` (singular) fields to
-                  `ambassador_ids` (plural)."
+                  is: \n ambassador_id: - \"default\""
                 items:
                   type: string
                 type: array
@@ -4464,7 +4419,6 @@ spec:
               host:
                 type: string
               idle_timeout_ms:
-                description: 'FIXME(lukeshu): Surely this should be an ''int''?'
                 type: string
               port:
                 description: Port isn't a pointer because it's required.
@@ -4734,9 +4688,7 @@ spec:
               ambassador_id:
                 description: "AmbassadorID declares which Ambassador instances should
                   pay attention to this resource. If no value is provided, the default
-                  is: \n ambassador_id: - \"default\" \n TODO(lukeshu): In v3alpha2,
-                  consider renaming all of the `ambassador_id` (singular) fields to
-                  `ambassador_ids` (plural)."
+                  is: \n ambassador_id: - \"default\""
                 items:
                   type: string
                 type: array
@@ -5104,9 +5056,7 @@ spec:
               ambassador_id:
                 description: "AmbassadorID declares which Ambassador instances should
                   pay attention to this resource. If no value is provided, the default
-                  is: \n ambassador_id: - \"default\" \n TODO(lukeshu): In v3alpha2,
-                  consider renaming all of the `ambassador_id` (singular) fields to
-                  `ambassador_ids` (plural)."
+                  is: \n ambassador_id: - \"default\""
                 items:
                   type: string
                 type: array

--- a/pkg/api/getambassador.io/crds.yaml
+++ b/pkg/api/getambassador.io/crds.yaml
@@ -276,9 +276,6 @@ spec:
               add_linkerd_headers:
                 type: boolean
               allow_request_body:
-                description: 'TODO(lukeshu): In v3alpha2, drop allow_request_body
-                  in favor of include_body. allow_request_body has been deprecated
-                  for a long time.'
                 type: boolean
               allowed_authorization_headers:
                 items:
@@ -291,15 +288,11 @@ spec:
               ambassador_id:
                 description: "AmbassadorID declares which Ambassador instances should
                   pay attention to this resource. If no value is provided, the default
-                  is: \n ambassador_id: - \"default\" \n TODO(lukeshu): In v3alpha2,
-                  consider renaming all of the `ambassador_id` (singular) fields to
-                  `ambassador_ids` (plural)."
+                  is: \n ambassador_id: - \"default\""
                 items:
                   type: string
                 type: array
               auth_service:
-                description: 'TODO(lukeshu): In v3alpha2, consider renameing `auth_service`
-                  to just `service`, for consistency with the other resource types.'
                 type: string
               circuit_breakers:
                 items:
@@ -348,9 +341,6 @@ spec:
               stats_name:
                 type: string
               status_on_error:
-                description: 'TODO(lukeshu): In v3alpha2, consider getting rid of
-                  this struct type in favor of just using an int (i.e. `statusOnError:
-                  500` instead of the current `statusOnError: { code: 500 }`).'
                 properties:
                   code:
                     type: integer
@@ -544,9 +534,7 @@ spec:
               ambassador_id:
                 description: "AmbassadorID declares which Ambassador instances should
                   pay attention to this resource. If no value is provided, the default
-                  is: \n ambassador_id: - \"default\" \n TODO(lukeshu): In v3alpha2,
-                  consider renaming all of the `ambassador_id` (singular) fields to
-                  `ambassador_ids` (plural)."
+                  is: \n ambassador_id: - \"default\""
                 items:
                   type: string
                 type: array
@@ -859,9 +847,7 @@ spec:
               ambassador_id:
                 description: "AmbassadorID declares which Ambassador instances should
                   pay attention to this resource. If no value is provided, the default
-                  is: \n ambassador_id: - \"default\" \n TODO(lukeshu): In v3alpha2,
-                  consider renaming all of the `ambassador_id` (singular) fields to
-                  `ambassador_ids` (plural)."
+                  is: \n ambassador_id: - \"default\""
                 items:
                   type: string
                 type: array
@@ -1426,9 +1412,8 @@ spec:
                     type: object
                 type: object
               selector:
-                description: "DEPRECATED: Selector by which we can find further configuration.
-                  Use MappingSelector instead. \n TODO(lukeshu): In v3alpha2, figure
-                  out how to get rid of HostSpec.DeprecatedSelector."
+                description: 'DEPRECATED: Selector by which we can find further configuration.
+                  Use MappingSelector instead.'
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -1722,9 +1707,7 @@ spec:
               ambassador_id:
                 description: "AmbassadorID declares which Ambassador instances should
                   pay attention to this resource. If no value is provided, the default
-                  is: \n ambassador_id: - \"default\" \n TODO(lukeshu): In v3alpha2,
-                  consider renaming all of the `ambassador_id` (singular) fields to
-                  `ambassador_ids` (plural)."
+                  is: \n ambassador_id: - \"default\""
                 items:
                   type: string
                 type: array
@@ -1860,9 +1843,7 @@ spec:
               ambassador_id:
                 description: "AmbassadorID declares which Ambassador instances should
                   pay attention to this resource. If no value is provided, the default
-                  is: \n ambassador_id: - \"default\" \n TODO(lukeshu): In v3alpha2,
-                  consider renaming all of the `ambassador_id` (singular) fields to
-                  `ambassador_ids` (plural)."
+                  is: \n ambassador_id: - \"default\""
                 items:
                   type: string
                 type: array
@@ -1931,9 +1912,7 @@ spec:
               ambassador_id:
                 description: "AmbassadorID declares which Ambassador instances should
                   pay attention to this resource. If no value is provided, the default
-                  is: \n ambassador_id: - \"default\" \n TODO(lukeshu): In v3alpha2,
-                  consider renaming all of the `ambassador_id` (singular) fields to
-                  `ambassador_ids` (plural)."
+                  is: \n ambassador_id: - \"default\""
                 items:
                   type: string
                 type: array
@@ -2254,9 +2233,7 @@ spec:
               ambassador_id:
                 description: "AmbassadorID declares which Ambassador instances should
                   pay attention to this resource. If no value is provided, the default
-                  is: \n ambassador_id: - \"default\" \n TODO(lukeshu): In v3alpha2,
-                  consider renaming all of the `ambassador_id` (singular) fields to
-                  `ambassador_ids` (plural)."
+                  is: \n ambassador_id: - \"default\""
                 items:
                   type: string
                 type: array
@@ -2286,10 +2263,6 @@ spec:
               flush_interval_time:
                 type: integer
               grpc:
-                description: 'TODO(lukeshu): In v3alpha2, drop this LogService.spec.grpc.  Due
-                  to sloppy implementation it is required to be present, and required
-                  to be ''true''.  It is silly to have a required field with only
-                  one valid value, we should just remove the thing.'
                 type: boolean
               protocol_version:
                 description: ProtocolVersion is the envoy api transport protocol version
@@ -3526,9 +3499,7 @@ spec:
               ambassador_id:
                 description: "AmbassadorID declares which Ambassador instances should
                   pay attention to this resource. If no value is provided, the default
-                  is: \n ambassador_id: - \"default\" \n TODO(lukeshu): In v3alpha2,
-                  consider renaming all of the `ambassador_id` (singular) fields to
-                  `ambassador_ids` (plural)."
+                  is: \n ambassador_id: - \"default\""
                 items:
                   type: string
                 type: array
@@ -3787,16 +3758,13 @@ spec:
                   Hostname. \n If both Host and Hostname are set, an error is logged,
                   Host is ignored, and Hostname is used. \n DEPRECATED: Host is either
                   an exact match or a regex, depending on HostRegex. Use HostName
-                  instead. \n TODO(lukeshu): In v3alpha2, get rid of MappingSpec.host
-                  and MappingSpec.host_regex in favor of a MappingSpec.deprecated_hostname_regex."
+                  instead."
                 type: string
               host_redirect:
                 type: boolean
               host_regex:
-                description: "DEPRECATED: Host is either an exact match or a regex,
-                  depending on HostRegex. Use HostName instead. \n TODO(lukeshu):
-                  In v3alpha2, get rid of MappingSpec.host and MappingSpec.host_regex
-                  in favor of a MappingSpec.deprecated_hostname_regex."
+                description: 'DEPRECATED: Host is either an exact match or a regex,
+                  depending on HostRegex. Use HostName instead.'
                 type: boolean
               host_rewrite:
                 type: string
@@ -4047,9 +4015,8 @@ spec:
               tls:
                 type: string
               use_websocket:
-                description: "use_websocket is deprecated, and is equivlaent to setting
-                  `allow_upgrade: [\"websocket\"]` \n TODO(lukeshu): In v3alpha2,
-                  get rid of MappingSpec.DeprecatedUseWebsocket."
+                description: 'use_websocket is deprecated, and is equivlaent to setting
+                  `allow_upgrade: ["websocket"]`'
                 type: boolean
               v2BoolHeaders:
                 items:
@@ -4253,23 +4220,15 @@ spec:
           metadata:
             type: object
           spec:
-            description: 'TODO(lukeshu): In v3alpha2, get rid of unnecessary nesting
-              and move `ModuleSpec.config.*` to `ModuleSpec.*`.'
             properties:
               ambassador_id:
                 description: "AmbassadorID declares which Ambassador instances should
                   pay attention to this resource. If no value is provided, the default
-                  is: \n ambassador_id: - \"default\" \n TODO(lukeshu): In v3alpha2,
-                  consider renaming all of the `ambassador_id` (singular) fields to
-                  `ambassador_ids` (plural)."
+                  is: \n ambassador_id: - \"default\""
                 items:
                   type: string
                 type: array
               config:
-                description: "TODO(lukeshu): In v3alpha2, change the default from
-                  `diagnostics.enabled=true` to `diagnostics.enabled=false`.  This
-                  needs conversion support in apiext.  See the related comment in
-                  irambassador.py. \n TODO(lukeshu): Structurally type ModuleSpec.Config."
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
             required:
@@ -4596,7 +4555,6 @@ spec:
               host:
                 type: string
               idle_timeout_ms:
-                description: 'FIXME(lukeshu): Surely this should be an ''int''?'
                 type: string
               port:
                 description: Port isn't a pointer because it's required.
@@ -4679,7 +4637,6 @@ spec:
               host:
                 type: string
               idle_timeout_ms:
-                description: 'FIXME(lukeshu): Surely this should be an ''int''?'
                 type: string
               port:
                 description: Port isn't a pointer because it's required.
@@ -4728,9 +4685,7 @@ spec:
               ambassador_id:
                 description: "AmbassadorID declares which Ambassador instances should
                   pay attention to this resource. If no value is provided, the default
-                  is: \n ambassador_id: - \"default\" \n TODO(lukeshu): In v3alpha2,
-                  consider renaming all of the `ambassador_id` (singular) fields to
-                  `ambassador_ids` (plural)."
+                  is: \n ambassador_id: - \"default\""
                 items:
                   type: string
                 type: array
@@ -4761,7 +4716,6 @@ spec:
               host:
                 type: string
               idle_timeout_ms:
-                description: 'FIXME(lukeshu): Surely this should be an ''int''?'
                 type: string
               port:
                 description: Port isn't a pointer because it's required.
@@ -5044,9 +4998,7 @@ spec:
               ambassador_id:
                 description: "AmbassadorID declares which Ambassador instances should
                   pay attention to this resource. If no value is provided, the default
-                  is: \n ambassador_id: - \"default\" \n TODO(lukeshu): In v3alpha2,
-                  consider renaming all of the `ambassador_id` (singular) fields to
-                  `ambassador_ids` (plural)."
+                  is: \n ambassador_id: - \"default\""
                 items:
                   type: string
                 type: array
@@ -5427,9 +5379,7 @@ spec:
               ambassador_id:
                 description: "AmbassadorID declares which Ambassador instances should
                   pay attention to this resource. If no value is provided, the default
-                  is: \n ambassador_id: - \"default\" \n TODO(lukeshu): In v3alpha2,
-                  consider renaming all of the `ambassador_id` (singular) fields to
-                  `ambassador_ids` (plural)."
+                  is: \n ambassador_id: - \"default\""
                 items:
                   type: string
                 type: array

--- a/pkg/api/getambassador.io/v2/common.go
+++ b/pkg/api/getambassador.io/v2/common.go
@@ -43,8 +43,7 @@ import (
 //      type: "string"
 //
 // but if we're going to use just vanilla controller-gen, we're forced to
-// be dumb and say `+kubebuilder:validation:Type=""`, to define its schema
-// as
+// say `+kubebuilder:validation:Type=""`, to define its schema as
 //
 //    # no `type:` setting because of the +kubebuilder marker
 //    items:
@@ -58,31 +57,29 @@ import (
 //
 //  > Aside: Some recent work in controller-gen[2] *strongly* suggests that
 //  > setting `+kubebuilder:validation:Type=Any` instead of `:Type=""` is
-//  > the proper thing to do.  But, um, it doesn't work... kubectl would
+//  > the proper thing to do.  But, it doesn't work... kubectl would
 //  > say things like:
 //  >
 //  >    Invalid value: "array": spec.ambassador_id in body must be of type Any: "array"
 //
-// But honestly that's dumb, and we can do better than that.
-//
 // So, option one choice would be to send the controller-tools folks a PR
 // to support the openapi-gen methods to allow that customization.  That's
 // probably the Right Thing, but that seemed like more work than option
-// two.  FIXME(lukeshu): Send the controller-tools folks a PR.
+// two.
 //
 // Option two: Say something nonsensical like
 // `+kubebuilder:validation:Type="d6e-union"`, and teach the `fix-crds`
 // script to notice that and delete that nonsensical `type`, replacing it
 // with the appropriate `oneOf: [type: A, type: B]` (note that the version
 // of JSONSchema that OpenAPI/Kubernetes uses doesn't support type being an
-// array).  And so that's what I did.
+// array).
 //
-// FIXME(lukeshu): But all of that is still terrible.  Because the very
-// structure of our data inherently means that we must have a
+// Because the very structure of our data inherently means that we must have a
 // non-structural[3] schema.  With "apiextensions.k8s.io/v1beta1" CRDs,
 // non-structural schemas disable several features; and in v1 CRDs,
-// non-structural schemas are entirely forbidden.  I mean it doesn't
-// _really_ matter right now, because we give out v1beta1 CRDs anyway
+// non-structural schemas are entirely forbidden.
+//
+// It doesn't really matter right now, because we give out v1beta1 CRDs anyway
 // because v1 only became available in Kubernetes 1.16 and we still support
 // down to Kubernetes 1.11; but I don't think that we want to lock
 // ourselves out from v1 forever.  So I guess that means when it comes time

--- a/pkg/api/getambassador.io/v2/crd_tcpmapping.go
+++ b/pkg/api/getambassador.io/v2/crd_tcpmapping.go
@@ -38,7 +38,6 @@ type TCPMappingSpec struct {
 	EnableIPv6      *bool            `json:"enable_ipv6,omitempty"`
 	CircuitBreakers []CircuitBreaker `json:"circuit_breakers,omitempty"`
 
-	// FIXME(lukeshu): Surely this should be an 'int'?
 	IdleTimeoutMs string `json:"idle_timeout_ms,omitempty"`
 
 	Resolver string `json:"resolver,omitempty"`

--- a/pkg/api/getambassador.io/v3alpha1/common.go
+++ b/pkg/api/getambassador.io/v3alpha1/common.go
@@ -175,9 +175,6 @@ type GRPCHealthCheck struct {
 //
 //	ambassador_id:
 //	- "default"
-//
-// TODO(lukeshu): In v3alpha2, consider renaming all of the `ambassador_id` (singular) fields to
-// `ambassador_ids` (plural).
 type AmbassadorID []string
 
 func (aid AmbassadorID) Matches(envVar string) bool {
@@ -197,9 +194,6 @@ func (aid AmbassadorID) Matches(envVar string) bool {
 	return false
 }
 
-// TODO(lukeshu): In v3alpha2, change all of the `{foo}_ms`/`MillisecondDuration` fields to
-// `{foo}`/`metav1.Duration`.
-//
 // +kubebuilder:validation:Type="integer"
 type MillisecondDuration struct {
 	time.Duration `json:"-"`
@@ -223,9 +217,6 @@ func (d MillisecondDuration) MarshalJSON() ([]byte, error) {
 	return json.Marshal(d.Milliseconds())
 }
 
-// TODO(lukeshu): In v3alpha2, change all of the `{foo}s`/`SecondDuration` fields to
-// `{foo}`/`metav1.Duration`.
-//
 // +kubebuilder:validation:Type="integer"
 type SecondDuration struct {
 	time.Duration `json:"-"`

--- a/pkg/api/getambassador.io/v3alpha1/crd_authservice.go
+++ b/pkg/api/getambassador.io/v3alpha1/crd_authservice.go
@@ -32,8 +32,6 @@ type AuthServiceIncludeBody struct {
 	AllowPartial bool `json:"allow_partial,omitempty"`
 }
 
-// TODO(lukeshu): In v3alpha2, consider getting rid of this struct type in favor of just using an
-// int (i.e. `statusOnError: 500` instead of the current `statusOnError: { code: 500 }`).
 type AuthServiceStatusOnError struct {
 	Code int `json:"code,omitempty"`
 }
@@ -42,9 +40,6 @@ type AuthServiceStatusOnError struct {
 type AuthServiceSpec struct {
 	AmbassadorID AmbassadorID `json:"ambassador_id,omitempty"`
 
-	// TODO(lukeshu): In v3alpha2, consider renameing `auth_service` to just `service`, for
-	// consistency with the other resource types.
-	//
 	// +kubebuilder:validation:Required
 	AuthService string `json:"auth_service,omitempty"`
 	PathPrefix  string `json:"path_prefix,omitempty"`
@@ -55,8 +50,7 @@ type AuthServiceSpec struct {
 	AllowedRequestHeaders       []string             `json:"allowed_request_headers,omitempty"`
 	AllowedAuthorizationHeaders []string             `json:"allowed_authorization_headers,omitempty"`
 	AddAuthHeaders              map[string]string    `json:"add_auth_headers,omitempty"`
-	// TODO(lukeshu): In v3alpha2, drop allow_request_body in favor of
-	// include_body. allow_request_body has been deprecated for a long time.
+
 	AllowRequestBody  *bool                     `json:"allow_request_body,omitempty"`
 	AddLinkerdHeaders *bool                     `json:"add_linkerd_headers,omitempty"`
 	FailureModeAllow  *bool                     `json:"failure_mode_allow,omitempty"`

--- a/pkg/api/getambassador.io/v3alpha1/crd_host.go
+++ b/pkg/api/getambassador.io/v3alpha1/crd_host.go
@@ -88,8 +88,6 @@ type HostSpec struct {
 	Hostname string `json:"hostname,omitempty"`
 
 	// DEPRECATED: Selector by which we can find further configuration. Use MappingSelector instead.
-	//
-	// TODO(lukeshu): In v3alpha2, figure out how to get rid of HostSpec.DeprecatedSelector.
 	DeprecatedSelector *metav1.LabelSelector `json:"selector,omitempty"`
 
 	// Selector for Mappings we'll associate with this Host. At the moment, Selector and

--- a/pkg/api/getambassador.io/v3alpha1/crd_logservice.go
+++ b/pkg/api/getambassador.io/v3alpha1/crd_logservice.go
@@ -51,9 +51,6 @@ type LogServiceSpec struct {
 	FlushIntervalTime     *SecondDuration `json:"flush_interval_time,omitempty"`
 	FlushIntervalByteSize *int            `json:"flush_interval_byte_size,omitempty"`
 
-	// TODO(lukeshu): In v3alpha2, drop this LogService.spec.grpc.  Due to sloppy implementation
-	// it is required to be present, and required to be 'true'.  It is silly to have a required
-	// field with only one valid value, we should just remove the thing.
 	GRPC *bool `json:"grpc,omitempty"`
 
 	StatsName string `json:"stats_name,omitempty"`

--- a/pkg/api/getambassador.io/v3alpha1/crd_mapping.go
+++ b/pkg/api/getambassador.io/v3alpha1/crd_mapping.go
@@ -84,8 +84,6 @@ type MappingSpec struct {
 
 	// use_websocket is deprecated, and is equivlaent to setting
 	// `allow_upgrade: ["websocket"]`
-	//
-	// TODO(lukeshu): In v3alpha2, get rid of MappingSpec.DeprecatedUseWebsocket.
 	DeprecatedUseWebsocket *bool `json:"use_websocket,omitempty"`
 
 	// A case-insensitive list of the non-HTTP protocols to allow
@@ -132,14 +130,8 @@ type MappingSpec struct {
 	// used.
 	//
 	// DEPRECATED: Host is either an exact match or a regex, depending on HostRegex. Use HostName instead.
-	//
-	// TODO(lukeshu): In v3alpha2, get rid of MappingSpec.host and MappingSpec.host_regex in
-	// favor of a MappingSpec.deprecated_hostname_regex.
 	DeprecatedHost string `json:"host,omitempty"`
 	// DEPRECATED: Host is either an exact match or a regex, depending on HostRegex. Use HostName instead.
-	//
-	// TODO(lukeshu): In v3alpha2, get rid of MappingSpec.host and MappingSpec.host_regex in
-	// favor of a MappingSpec.deprecated_hostname_regex.
 	DeprecatedHostRegex *bool `json:"host_regex,omitempty"`
 	// Hostname is a DNS glob specifying the hosts to which this Mapping applies.
 	//

--- a/pkg/api/getambassador.io/v3alpha1/crd_module.go
+++ b/pkg/api/getambassador.io/v3alpha1/crd_module.go
@@ -23,17 +23,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// TODO(lukeshu): In v3alpha2, get rid of unnecessary nesting and move `ModuleSpec.config.*` to
-// `ModuleSpec.*`.
 type ModuleSpec struct {
 	AmbassadorID AmbassadorID `json:"ambassador_id,omitempty"`
 
-	// TODO(lukeshu): In v3alpha2, change the default from `diagnostics.enabled=true` to
-	// `diagnostics.enabled=false`.  This needs conversion support in apiext.  See the related
-	// comment in irambassador.py.
-	//
-	// TODO(lukeshu): Structurally type ModuleSpec.Config.
-	//
 	// +kubebuilder:validation:Required
 	Config UntypedDict `json:"config,omitempty"`
 }
@@ -195,8 +187,7 @@ type AmbassadorConfigSpec struct {
 }
 
 // AmbassadorConfigStatus defines the observed state of AmbassadorConfig
-type AmbassadorConfigStatus struct {
-}
+type AmbassadorConfigStatus struct{}
 
 /*
 // AmbassadorConfig is the Schema for the ambassadorconfigs API
@@ -222,5 +213,5 @@ type AmbassadorConfigList struct {
 
 func init() {
 	SchemeBuilder.Register(&Module{}, &ModuleList{})
-	//SchemeBuilder.Register(&AmbassadorConfig{}, &AmbassadorConfigList{})
+	// SchemeBuilder.Register(&AmbassadorConfig{}, &AmbassadorConfigList{})
 }

--- a/pkg/api/getambassador.io/v3alpha1/crd_tcpmapping.go
+++ b/pkg/api/getambassador.io/v3alpha1/crd_tcpmapping.go
@@ -38,7 +38,6 @@ type TCPMappingSpec struct {
 	EnableIPv6      *bool            `json:"enable_ipv6,omitempty"`
 	CircuitBreakers []CircuitBreaker `json:"circuit_breakers,omitempty"`
 
-	// FIXME(lukeshu): Surely this should be an 'int'?
 	IdleTimeoutMs string `json:"idle_timeout_ms,omitempty"`
 
 	Resolver   string `json:"resolver,omitempty"`

--- a/python/tests/integration/manifests/crds.yaml
+++ b/python/tests/integration/manifests/crds.yaml
@@ -255,9 +255,6 @@ spec:
               add_linkerd_headers:
                 type: boolean
               allow_request_body:
-                description: 'TODO(lukeshu): In v3alpha2, drop allow_request_body
-                  in favor of include_body. allow_request_body has been deprecated
-                  for a long time.'
                 type: boolean
               allowed_authorization_headers:
                 items:
@@ -270,15 +267,11 @@ spec:
               ambassador_id:
                 description: "AmbassadorID declares which Ambassador instances should
                   pay attention to this resource. If no value is provided, the default
-                  is: \n ambassador_id: - \"default\" \n TODO(lukeshu): In v3alpha2,
-                  consider renaming all of the `ambassador_id` (singular) fields to
-                  `ambassador_ids` (plural)."
+                  is: \n ambassador_id: - \"default\""
                 items:
                   type: string
                 type: array
               auth_service:
-                description: 'TODO(lukeshu): In v3alpha2, consider renameing `auth_service`
-                  to just `service`, for consistency with the other resource types.'
                 type: string
               circuit_breakers:
                 items:
@@ -327,9 +320,6 @@ spec:
               stats_name:
                 type: string
               status_on_error:
-                description: 'TODO(lukeshu): In v3alpha2, consider getting rid of
-                  this struct type in favor of just using an int (i.e. `statusOnError:
-                  500` instead of the current `statusOnError: { code: 500 }`).'
                 properties:
                   code:
                     type: integer
@@ -510,9 +500,7 @@ spec:
               ambassador_id:
                 description: "AmbassadorID declares which Ambassador instances should
                   pay attention to this resource. If no value is provided, the default
-                  is: \n ambassador_id: - \"default\" \n TODO(lukeshu): In v3alpha2,
-                  consider renaming all of the `ambassador_id` (singular) fields to
-                  `ambassador_ids` (plural)."
+                  is: \n ambassador_id: - \"default\""
                 items:
                   type: string
                 type: array
@@ -812,9 +800,7 @@ spec:
               ambassador_id:
                 description: "AmbassadorID declares which Ambassador instances should
                   pay attention to this resource. If no value is provided, the default
-                  is: \n ambassador_id: - \"default\" \n TODO(lukeshu): In v3alpha2,
-                  consider renaming all of the `ambassador_id` (singular) fields to
-                  `ambassador_ids` (plural)."
+                  is: \n ambassador_id: - \"default\""
                 items:
                   type: string
                 type: array
@@ -1367,9 +1353,8 @@ spec:
                     type: object
                 type: object
               selector:
-                description: "DEPRECATED: Selector by which we can find further configuration.
-                  Use MappingSelector instead. \n TODO(lukeshu): In v3alpha2, figure
-                  out how to get rid of HostSpec.DeprecatedSelector."
+                description: 'DEPRECATED: Selector by which we can find further configuration.
+                  Use MappingSelector instead.'
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -1648,9 +1633,7 @@ spec:
               ambassador_id:
                 description: "AmbassadorID declares which Ambassador instances should
                   pay attention to this resource. If no value is provided, the default
-                  is: \n ambassador_id: - \"default\" \n TODO(lukeshu): In v3alpha2,
-                  consider renaming all of the `ambassador_id` (singular) fields to
-                  `ambassador_ids` (plural)."
+                  is: \n ambassador_id: - \"default\""
                 items:
                   type: string
                 type: array
@@ -1771,9 +1754,7 @@ spec:
               ambassador_id:
                 description: "AmbassadorID declares which Ambassador instances should
                   pay attention to this resource. If no value is provided, the default
-                  is: \n ambassador_id: - \"default\" \n TODO(lukeshu): In v3alpha2,
-                  consider renaming all of the `ambassador_id` (singular) fields to
-                  `ambassador_ids` (plural)."
+                  is: \n ambassador_id: - \"default\""
                 items:
                   type: string
                 type: array
@@ -1847,9 +1828,7 @@ spec:
               ambassador_id:
                 description: "AmbassadorID declares which Ambassador instances should
                   pay attention to this resource. If no value is provided, the default
-                  is: \n ambassador_id: - \"default\" \n TODO(lukeshu): In v3alpha2,
-                  consider renaming all of the `ambassador_id` (singular) fields to
-                  `ambassador_ids` (plural)."
+                  is: \n ambassador_id: - \"default\""
                 items:
                   type: string
                 type: array
@@ -2157,9 +2136,7 @@ spec:
               ambassador_id:
                 description: "AmbassadorID declares which Ambassador instances should
                   pay attention to this resource. If no value is provided, the default
-                  is: \n ambassador_id: - \"default\" \n TODO(lukeshu): In v3alpha2,
-                  consider renaming all of the `ambassador_id` (singular) fields to
-                  `ambassador_ids` (plural)."
+                  is: \n ambassador_id: - \"default\""
                 items:
                   type: string
                 type: array
@@ -2189,10 +2166,6 @@ spec:
               flush_interval_time:
                 type: integer
               grpc:
-                description: 'TODO(lukeshu): In v3alpha2, drop this LogService.spec.grpc.  Due
-                  to sloppy implementation it is required to be present, and required
-                  to be ''true''.  It is silly to have a required field with only
-                  one valid value, we should just remove the thing.'
                 type: boolean
               protocol_version:
                 description: ProtocolVersion is the envoy api transport protocol version
@@ -3278,9 +3251,7 @@ spec:
               ambassador_id:
                 description: "AmbassadorID declares which Ambassador instances should
                   pay attention to this resource. If no value is provided, the default
-                  is: \n ambassador_id: - \"default\" \n TODO(lukeshu): In v3alpha2,
-                  consider renaming all of the `ambassador_id` (singular) fields to
-                  `ambassador_ids` (plural)."
+                  is: \n ambassador_id: - \"default\""
                 items:
                   type: string
                 type: array
@@ -3539,16 +3510,13 @@ spec:
                   Hostname. \n If both Host and Hostname are set, an error is logged,
                   Host is ignored, and Hostname is used. \n DEPRECATED: Host is either
                   an exact match or a regex, depending on HostRegex. Use HostName
-                  instead. \n TODO(lukeshu): In v3alpha2, get rid of MappingSpec.host
-                  and MappingSpec.host_regex in favor of a MappingSpec.deprecated_hostname_regex."
+                  instead."
                 type: string
               host_redirect:
                 type: boolean
               host_regex:
-                description: "DEPRECATED: Host is either an exact match or a regex,
-                  depending on HostRegex. Use HostName instead. \n TODO(lukeshu):
-                  In v3alpha2, get rid of MappingSpec.host and MappingSpec.host_regex
-                  in favor of a MappingSpec.deprecated_hostname_regex."
+                description: 'DEPRECATED: Host is either an exact match or a regex,
+                  depending on HostRegex. Use HostName instead.'
                 type: boolean
               host_rewrite:
                 type: string
@@ -3799,9 +3767,8 @@ spec:
               tls:
                 type: string
               use_websocket:
-                description: "use_websocket is deprecated, and is equivlaent to setting
-                  `allow_upgrade: [\"websocket\"]` \n TODO(lukeshu): In v3alpha2,
-                  get rid of MappingSpec.DeprecatedUseWebsocket."
+                description: 'use_websocket is deprecated, and is equivlaent to setting
+                  `allow_upgrade: ["websocket"]`'
                 type: boolean
               v2BoolHeaders:
                 items:
@@ -3992,23 +3959,15 @@ spec:
           metadata:
             type: object
           spec:
-            description: 'TODO(lukeshu): In v3alpha2, get rid of unnecessary nesting
-              and move `ModuleSpec.config.*` to `ModuleSpec.*`.'
             properties:
               ambassador_id:
                 description: "AmbassadorID declares which Ambassador instances should
                   pay attention to this resource. If no value is provided, the default
-                  is: \n ambassador_id: - \"default\" \n TODO(lukeshu): In v3alpha2,
-                  consider renaming all of the `ambassador_id` (singular) fields to
-                  `ambassador_ids` (plural)."
+                  is: \n ambassador_id: - \"default\""
                 items:
                   type: string
                 type: array
               config:
-                description: "TODO(lukeshu): In v3alpha2, change the default from
-                  `diagnostics.enabled=true` to `diagnostics.enabled=false`.  This
-                  needs conversion support in apiext.  See the related comment in
-                  irambassador.py. \n TODO(lukeshu): Structurally type ModuleSpec.Config."
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
             required:
@@ -4315,7 +4274,6 @@ spec:
               host:
                 type: string
               idle_timeout_ms:
-                description: 'FIXME(lukeshu): Surely this should be an ''int''?'
                 type: string
               port:
                 description: Port isn't a pointer because it's required.
@@ -4385,7 +4343,6 @@ spec:
               host:
                 type: string
               idle_timeout_ms:
-                description: 'FIXME(lukeshu): Surely this should be an ''int''?'
                 type: string
               port:
                 description: Port isn't a pointer because it's required.
@@ -4431,9 +4388,7 @@ spec:
               ambassador_id:
                 description: "AmbassadorID declares which Ambassador instances should
                   pay attention to this resource. If no value is provided, the default
-                  is: \n ambassador_id: - \"default\" \n TODO(lukeshu): In v3alpha2,
-                  consider renaming all of the `ambassador_id` (singular) fields to
-                  `ambassador_ids` (plural)."
+                  is: \n ambassador_id: - \"default\""
                 items:
                   type: string
                 type: array
@@ -4464,7 +4419,6 @@ spec:
               host:
                 type: string
               idle_timeout_ms:
-                description: 'FIXME(lukeshu): Surely this should be an ''int''?'
                 type: string
               port:
                 description: Port isn't a pointer because it's required.
@@ -4734,9 +4688,7 @@ spec:
               ambassador_id:
                 description: "AmbassadorID declares which Ambassador instances should
                   pay attention to this resource. If no value is provided, the default
-                  is: \n ambassador_id: - \"default\" \n TODO(lukeshu): In v3alpha2,
-                  consider renaming all of the `ambassador_id` (singular) fields to
-                  `ambassador_ids` (plural)."
+                  is: \n ambassador_id: - \"default\""
                 items:
                   type: string
                 type: array
@@ -5104,9 +5056,7 @@ spec:
               ambassador_id:
                 description: "AmbassadorID declares which Ambassador instances should
                   pay attention to this resource. If no value is provided, the default
-                  is: \n ambassador_id: - \"default\" \n TODO(lukeshu): In v3alpha2,
-                  consider renaming all of the `ambassador_id` (singular) fields to
-                  `ambassador_ids` (plural)."
+                  is: \n ambassador_id: - \"default\""
                 items:
                   type: string
                 type: array


### PR DESCRIPTION
Various `TODO` and `FIXME` comments in our public APIs are being inadvertently added to the generated manifests.  It's not the intention to have these comments in our user-facing manifests. These design notes are out-of-date at this point, and any necessary design updates will be handled differently in the future.