### PR TITLE
Adding typed_json log format

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -162,7 +162,7 @@ libraries:
 
     Name                Version    License(s)
     ----                -------    ----------
-    Cython              0.29.36    Apache License 2.0
+    Cython              0.29.37    Apache License 2.0
     Flask               3.0.0      3-clause BSD license
     Jinja2              3.1.2      3-clause BSD license
     MarkupSafe          2.1.3      3-clause BSD license

--- a/pkg/api/getambassador.io/v3alpha1/crd_module.go
+++ b/pkg/api/getambassador.io/v3alpha1/crd_module.go
@@ -141,7 +141,7 @@ type AmbassadorConfigSpec struct {
 	// run a custom lua script on every request. see below for more details.
 	LuaScripts string `json:"lua_scripts,omitempty"`
 
-	// +kubebuilder:validation:Enum={"text", "json"}
+	// +kubebuilder:validation:Enum={"text", "json", "typed_json"}
 	EnvoyLogType string `json:"envoy_log_type,omitempty"`
 
 	// envoy_log_path defines the path of log envoy will use. By default this is standard output

--- a/python/ambassador/envoy/v3/v3listener.py
+++ b/python/ambassador/envoy/v3/v3listener.py
@@ -380,8 +380,7 @@ class V3Listener:
             if tracing_config and tracing_config.driver == "envoy.tracers.datadog":
                 log_format["dd.trace_id"] = "%REQ(X-DATADOG-TRACE-ID)%"
                 log_format["dd.span_id"] = "%REQ(X-DATADOG-PARENT-ID)%"
-
-            return log_format
+        return log_format
 
     # access_log constructs the access_log configuration for this V3Listener
     def access_log(self) -> List[dict]:
@@ -434,6 +433,7 @@ class V3Listener:
                     },
                 }
             )
+
         # Use sane access log spec in Typed JSON
         elif self.config.ir.ambassador_module.envoy_log_type.lower() == "typed_json":
             log_format = V3Listener.json_helper(self)

--- a/python/ambassador/envoy/v3/v3listener.py
+++ b/python/ambassador/envoy/v3/v3listener.py
@@ -430,6 +430,50 @@ class V3Listener:
                     },
                 }
             )
+            # Use sane access log spec in JSON
+        elif self.config.ir.ambassador_module.envoy_log_type.lower() == "typed_json":
+            log_format = self.config.ir.ambassador_module.get("envoy_log_format", None)
+            if log_format is None:
+                log_format = {
+                    "start_time": "%START_TIME%",
+                    "method": "%REQ(:METHOD)%",
+                    "path": "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%",
+                    "protocol": "%PROTOCOL%",
+                    "response_code": "%RESPONSE_CODE%",
+                    "response_flags": "%RESPONSE_FLAGS%",
+                    "bytes_received": "%BYTES_RECEIVED%",
+                    "bytes_sent": "%BYTES_SENT%",
+                    "duration": "%DURATION%",
+                    "upstream_service_time": "%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%",
+                    "x_forwarded_for": "%REQ(X-FORWARDED-FOR)%",
+                    "user_agent": "%REQ(USER-AGENT)%",
+                    "request_id": "%REQ(X-REQUEST-ID)%",
+                    "authority": "%REQ(:AUTHORITY)%",
+                    "upstream_host": "%UPSTREAM_HOST%",
+                    "upstream_cluster": "%UPSTREAM_CLUSTER%",
+                    "upstream_local_address": "%UPSTREAM_LOCAL_ADDRESS%",
+                    "downstream_local_address": "%DOWNSTREAM_LOCAL_ADDRESS%",
+                    "downstream_remote_address": "%DOWNSTREAM_REMOTE_ADDRESS%",
+                    "requested_server_name": "%REQUESTED_SERVER_NAME%",
+                    "istio_policy_status": "%DYNAMIC_METADATA(istio.mixer:status)%",
+                    "upstream_transport_failure_reason": "%UPSTREAM_TRANSPORT_FAILURE_REASON%",
+                }
+
+                tracing_config = self.config.ir.tracing
+                if tracing_config and tracing_config.driver == "envoy.tracers.datadog":
+                    log_format["dd.trace_id"] = "%REQ(X-DATADOG-TRACE-ID)%"
+                    log_format["dd.span_id"] = "%REQ(X-DATADOG-PARENT-ID)%"
+
+            access_log.append(
+                {
+                    "name": "envoy.access_loggers.file",
+                    "typed_config": {
+                        "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+                        "path": self.config.ir.ambassador_module.envoy_log_path,
+                        "typed_json_format": log_format,
+                    },
+                }
+            )
         else:
             # Use a sane access log spec
             log_format = self.config.ir.ambassador_module.get("envoy_log_format", None)

--- a/python/ambassador/envoy/v3/v3ready.py
+++ b/python/ambassador/envoy/v3/v3ready.py
@@ -152,6 +152,49 @@ class V3Ready(dict):
                     },
                 }
             )
+        elif config.ir.ambassador_module.envoy_log_type.lower() == "typed_json":
+            log_format = config.ir.ambassador_module.get("envoy_log_format", None)
+            if log_format is None:
+                log_format = {
+                    "start_time": "%START_TIME%",
+                    "method": "%REQ(:METHOD)%",
+                    "path": "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%",
+                    "protocol": "%PROTOCOL%",
+                    "response_code": "%RESPONSE_CODE%",
+                    "response_flags": "%RESPONSE_FLAGS%",
+                    "bytes_received": "%BYTES_RECEIVED%",
+                    "bytes_sent": "%BYTES_SENT%",
+                    "duration": "%DURATION%",
+                    "upstream_service_time": "%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%",
+                    "x_forwarded_for": "%REQ(X-FORWARDED-FOR)%",
+                    "user_agent": "%REQ(USER-AGENT)%",
+                    "request_id": "%REQ(X-REQUEST-ID)%",
+                    "authority": "%REQ(:AUTHORITY)%",
+                    "upstream_host": "%UPSTREAM_HOST%",
+                    "upstream_cluster": "%UPSTREAM_CLUSTER%",
+                    "upstream_local_address": "%UPSTREAM_LOCAL_ADDRESS%",
+                    "downstream_local_address": "%DOWNSTREAM_LOCAL_ADDRESS%",
+                    "downstream_remote_address": "%DOWNSTREAM_REMOTE_ADDRESS%",
+                    "requested_server_name": "%REQUESTED_SERVER_NAME%",
+                    "istio_policy_status": "%DYNAMIC_METADATA(istio.mixer:status)%",
+                    "upstream_transport_failure_reason": "%UPSTREAM_TRANSPORT_FAILURE_REASON%",
+                }
+
+                tracing_config = config.ir.tracing
+                if tracing_config and tracing_config.driver == "envoy.tracers.datadog":
+                    log_format["dd.trace_id"] = "%REQ(X-DATADOG-TRACE-ID)%"
+                    log_format["dd.span_id"] = "%REQ(X-DATADOG-PARENT-ID)%"
+
+            access_log.append(
+                {
+                    "name": "envoy.access_loggers.file",
+                    "typed_config": {
+                        "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+                        "path": config.ir.ambassador_module.envoy_log_path,
+                        "typed_json_format": log_format,
+                    },
+                }
+            )
         else:
             # Use a sane access log spec
             log_format = config.ir.ambassador_module.get("envoy_log_format", None)

--- a/python/ambassador/envoy/v3/v3ready.py
+++ b/python/ambassador/envoy/v3/v3ready.py
@@ -141,7 +141,6 @@ class V3Ready(dict):
                 if tracing_config and tracing_config.driver == "envoy.tracers.datadog":
                     log_format["dd.trace_id"] = "%REQ(X-DATADOG-TRACE-ID)%"
                     log_format["dd.span_id"] = "%REQ(X-DATADOG-PARENT-ID)%"
-
             access_log.append(
                 {
                     "name": "envoy.access_loggers.file",
@@ -152,6 +151,7 @@ class V3Ready(dict):
                     },
                 }
             )
+        # Use sane access log spec in Typed JSON
         elif config.ir.ambassador_module.envoy_log_type.lower() == "typed_json":
             log_format = config.ir.ambassador_module.get("envoy_log_format", None)
             if log_format is None:

--- a/python/ambassador/ir/irambassador.py
+++ b/python/ambassador/ir/irambassador.py
@@ -382,9 +382,20 @@ class IRAmbassador(IRResource):
                 )
                 self["envoy_log_format"] = {}
                 return False
+        elif self.get("envoy_log_type") == "typed_json":
+            if self.get("envoy_log_format", None) is not None and not isinstance(
+                self.get("envoy_log_format"), dict
+            ):
+                self.post_error(
+                    "envoy_log_type 'typed_json' requires a dictionary in envoy_log_format: {}, invalidating...".format(
+                        self.get("envoy_log_format")
+                    )
+                )
+                self["envoy_log_format"] = {}
+                return False
         else:
             self.post_error(
-                "Invalid log_type specified: {}. Supported: json, text".format(
+                "Invalid log_type specified: {}. Supported: json, text, typed_json".format(
                     self.get("envoy_log_type")
                 )
             )

--- a/python/tests/kat/t_envoy_logs.py
+++ b/python/tests/kat/t_envoy_logs.py
@@ -83,3 +83,41 @@ config:
             assert access_log_entry_regex.match(
                 line
             ), f"{line} does not match {access_log_entry_regex}"
+
+
+class EnvoyLogTypeJSONTest(AmbassadorTest):
+    target: ServiceType
+    log_path: str
+
+    def init(self):
+        self.target = HTTP()
+        self.log_path = "/tmp/ambassador/ambassador.log"
+
+    def config(self) -> Generator[Union[str, Tuple[Node, str]], None, None]:
+        yield self, self.format(
+            """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Module
+name: ambassador
+ambassador_id: [{self.ambassador_id}]
+config:
+  envoy_log_path: {self.log_path}
+  envoy_log_format:
+    protocol: "%PROTOCOL%"
+    duration: "%DURATION%"
+  envoy_log_type: typed_json
+"""
+        )
+
+    def check(self):
+        access_log_entry_regex = re.compile('^({"duration":|{"protocol":)')
+
+        cmd = ShellCommand("tools/bin/kubectl", "exec", self.path.k8s, "cat", self.log_path)
+        if not cmd.check("check envoy access log"):
+            pytest.exit("envoy access log does not exist")
+
+        for line in cmd.stdout.splitlines():
+            assert access_log_entry_regex.match(
+                line
+            ), f"{line} does not match {access_log_entry_regex}"


### PR DESCRIPTION
## Description

The purpose of this PR is to add `typed_json` log format as an option for envoy logging. 

## Related Issues
https://github.com/datawire/apro/issues/3408

## Testing

All testing was done locally. I compared logs between standard json and the new typed_json. 

This was the module I applied:
```
apiVersion: getambassador.io/v3alpha1
kind:  Module
metadata:
  name: ambassador
spec:
  config:
    envoy_log_type: typed_json
    envoy_log_format:
      {
        "protocol": "%PROTOCOL%",
        "duration": "%DURATION%"
      }
```

When looking at the logs after some simple curls, this is what I see:
![Screen Shot 2023-08-30 at 10 57 07 AM](https://github.com/emissary-ingress/emissary/assets/92330484/4b43111d-e647-4daf-b385-1c146b57a34d)

Note the `duration` values are ints rather than strings. 

When looking at the logs with the same Module but `json` log type:
![Screen Shot 2023-08-30 at 10 57 49 AM](https://github.com/emissary-ingress/emissary/assets/92330484/7b15f718-5267-4712-a2ca-c0ed0d3ea939)

The `duration` values are strings. 

If no `envoy_log_format` is provided, the default format is the same as `json`'s. Here is a full log line without any `envoy_log_format`:

```
{"requested_server_name":null,"user_agent":"curl/7.79.1","method":"GET","response_flags":"-","upstream_local_address":"10.42.0.12:55614","duration":0,"upstream_cluster":"quote_default","start_time":"2023-08-30T15:22:44.539Z","response_code":200,"downstream_local_address":"10.42.0.12:8443","upstream_service_time":"0","downstream_remote_address":"10.42.0.1:40191","x_forwarded_for":"10.42.0.1","upstream_transport_failure_reason":null,"path":"/backend/","authority":"34.133.232.144","istio_policy_status":null,"protocol":"HTTP/1.1","bytes_sent":220,"upstream_host":"10.43.1.125:80","request_id":"ae2e5f5f-d14d-4714-b138-37b3c4aefa70","bytes_received":0}
```

Note that the values are still formatted as expected. 
- `null` instead of `"-"`
- `int` values where expected such as duration, response_code, bytes_sent, bytes_received, etc

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->
- [ ] **Does my change need to be backported to a previous release?**
  - What backport versions were discussed with the Maintainers in the Issue?

- [ ] **I made sure to update `CHANGELOG.md`.**

   Remember, the CHANGELOG needs to mention:
  - Any new features
  - Any changes to our included version of Envoy
  - Any non-backward-compatible changes
  - Any deprecations

- [ ] **This is unlikely to impact how Ambassador performs at scale.**

   Remember, things that might have an impact at scale include:
  - Any significant changes in memory use that might require adjusting the memory limits
  - Any significant changes in CPU use that might require adjusting the CPU limits
  - Anything that might change how many replicas users should use
  - Changes that impact data-plane latency/scalability

- [ ] **My change is adequately tested.**

   Remember when considering testing:
  - Your change needs to be specifically covered by tests.
    - Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
  - You also need to make sure that the _entire area being changed_ has adequate test coverage.
    - If existing tests don't actually cover the entire area being changed, add tests.
    - This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
  - We should lean on the bulk of code being covered by unit tests, but...
  - ... an end-to-end test should cover the integration points

- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**

- [ ] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
