### PR TITLE
host: add warning for unsupported previewURL field

### DIFF
--- a/python/ambassador/ir/irhost.py
+++ b/python/ambassador/ir/irhost.py
@@ -44,6 +44,14 @@ class IRHost(IRResource):
     ) -> None:
         new_args = {x: kwargs[x] for x in kwargs.keys() if x in IRHost.AllowedKeys}
 
+        if "previewUrl" in kwargs:
+            ir.logger.warn(
+                f"previewURL found set in {name}, "
+                "this is no longer supported and will be ignored. "
+                "see https://www.getambassador.io/docs/telepresence for more information "
+                "on previewUrls."
+            )
+
         self.context: Optional[IRTLSContext] = None
 
         super().__init__(


### PR DESCRIPTION
## Description

The `Host.spec.previewURL` is a hold over from when the previewURL feature was previously apart of the old ambassador and telepresence 1. Documentation and support for this has long been removed.

But just in case someone is still using this and is upgrading from older versions then we want to provide user feedback.

## Related Issues

N/A

## Testing

CI is green

## Checklist

- [ ] **Does my change need to be backported to a previous release?**
- [ ] **I made sure to update `CHANGELOG.md`.**
- [x] **This is unlikely to impact how Ambassador performs at scale.**
- [x] **My change is adequately tested.**
- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**
- [ ] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
