### PR TITLE
deps: bump orjson to 3.9.7

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -183,7 +183,7 @@ libraries:
     jsonpointer         2.4        3-clause BSD license
     kubernetes          28.1.0     Apache License 2.0
     oauthlib            3.2.2      3-clause BSD license
-    orjson              3.9.1      Apache License 2.0, MIT license
+    orjson              3.9.7      Apache License 2.0, MIT license
     packaging           21.3       2-clause BSD license, Apache License 2.0
     pep517              0.13.0     MIT license
     pip-tools           6.12.1     3-clause BSD license

--- a/docker/base-python/Dockerfile
+++ b/docker/base-python/Dockerfile
@@ -92,4 +92,4 @@ RUN mkdir /tmp/pyyaml && \
 
 # orjson is also special.  The wheels on PyPI rely on glibc, so we
 # need to use cargo/rustc/patchelf to build a musl-compatible version.
-RUN pip3 install orjson==3.9.1
+RUN pip3 install orjson==3.9.7

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -50,7 +50,7 @@ oauthlib==3.2.2
     # via
     #   kubernetes
     #   requests-oauthlib
-orjson==3.9.1
+orjson==3.9.7
     # via -r requirements.in
 prometheus-client==0.17.1
     # via -r requirements.in

--- a/tools/src/py-mkopensource/main.go
+++ b/tools/src/py-mkopensource/main.go
@@ -74,7 +74,7 @@ func parseLicenses(name, version, license string) map[License]struct{} {
 
 		// These are packages with non-trivial strings to parse, and
 		// it's easier to just hard-code it.
-		{"orjson", "3.9.1", "Apache-2.0 OR MIT"}:            {Apache2, MIT},
+		{"orjson", "3.9.7", "Apache-2.0 OR MIT"}:            {Apache2, MIT},
 		{"packaging", "21.3", "BSD-2-Clause or Apache-2.0"}: {BSD2, Apache2},
 	}[tuple{name, version, license}]
 	if ok {


### PR DESCRIPTION
## Description

Bumps to latest z-patch of orjson

## Related Issues

N/A - general dep upgrades

## Testing

No additional testing added.

## Checklist


- [ ] **Does my change need to be backported to a previous release?**
- [ ] **I made sure to update `CHANGELOG.md`.**
- [x] **This is unlikely to impact how Ambassador performs at scale.**
- [x] **My change is adequately tested.**
- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**
- [x] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
