### PR TITLE
fix(helm): remove CPU limits

### DIFF
--- a/charts/emissary-ingress/values.yaml.in
+++ b/charts/emissary-ingress/values.yaml.in
@@ -301,7 +301,7 @@ deploymentAnnotations: {}
 resources: # +doc-gen:break
   # Recommended resource requests and limits for Ambassador
   limits:
-    cpu: 1000m
+    # cpu: 1000m
     memory: 600Mi
   requests:
     cpu: 200m

--- a/charts/emissary-ingress/values.yaml.in
+++ b/charts/emissary-ingress/values.yaml.in
@@ -301,7 +301,6 @@ deploymentAnnotations: {}
 resources: # +doc-gen:break
   # Recommended resource requests and limits for Ambassador
   limits:
-    # cpu: 1000m
     memory: 600Mi
   requests:
     cpu: 200m


### PR DESCRIPTION
## Description

Remove the CPU limit from the Helm chart as it is generally not recommended to enforce CPU limits.

## Related Issues

Fixes #4808.