### PR TITLE
deps: update to Golang 1.20.10

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -3,7 +3,7 @@ following Free and Open Source software:
 
     Name                                                                              Version                                License(s)
     ----                                                                              -------                                ----------
-    the Go language standard library ("std")                                          v1.20.9                                3-clause BSD license
+    the Go language standard library ("std")                                          v1.20.10                               3-clause BSD license
     github.com/Azure/go-ansiterm                                                      v0.0.0-20210617225240-d185dfc1b5a1     MIT license
     github.com/MakeNowJust/heredoc                                                    v1.0.0                                 MIT license
     github.com/Masterminds/goutils                                                    v1.1.1                                 Apache License 2.0

--- a/docker/base-python/Dockerfile
+++ b/docker/base-python/Dockerfile
@@ -77,7 +77,7 @@ RUN apk --no-cache add \
 # Pinning build version due to missing license info from pip show in newer versions
 RUN pip3 install "Cython<3.0" pip-tools==6.12.1 build==0.9.0
 
-RUN curl --fail -L https://dl.google.com/go/go1.20.9.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+RUN curl --fail -L https://dl.google.com/go/go1.20.10.linux-amd64.tar.gz | tar -C /usr/local -xzf -
 
 # The YAML parser is... special. To get the C version, we need to install Cython and libyaml, then
 # build it locally -- just using pip won't work.


### PR DESCRIPTION
## Description

Bump to latest z-patch to address CVE-2023-39325.

## Related Issues

N/A 

## Testing

CI is green, no additional testing needed.

## Checklist


- [ ] **Does my change need to be backported to a previous release?**
- [ ] **I made sure to update `CHANGELOG.md`.**
- [x] **This is unlikely to impact how Ambassador performs at scale.**
- [x] **My change is adequately tested.**
- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**
- [x] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
