### PR TITLE
deps: bump to envoy 1.27.2

### DIFF
--- a/_cxx/envoy.mk
+++ b/_cxx/envoy.mk
@@ -11,12 +11,12 @@ export ENVOY_TEST_LABEL
 
 # IF YOU MESS WITH ANY OF THESE VALUES, YOU MUST RUN `make update-base`.
 ENVOY_REPO ?= https://github.com/datawire/envoy.git
-# https://github.com/datawire/envoy/tree/rebase/release/v1.27.1
-ENVOY_COMMIT ?= 444b62bf9c71bd6137b3fe6dd539ef306294e4b3
+# https://github.com/datawire/envoy/tree/rebase/release/v1.27.2
+ENVOY_COMMIT ?= 6637fd1bab315774420f3c3d97488fedb7fc710f
 ENVOY_COMPILATION_MODE ?= opt
 # Increment BASE_ENVOY_RELVER on changes to `docker/base-envoy/Dockerfile`, or Envoy recipes.
 # You may reset BASE_ENVOY_RELVER when adjusting ENVOY_COMMIT.
-BASE_ENVOY_RELVER ?= 1
+BASE_ENVOY_RELVER ?= 0
 
 # Set to non-empty to enable compiling Envoy in FIPS mode.
 FIPS_MODE ?=


### PR DESCRIPTION
## Description

Update to the latest Envoy v1.27.2 with our custom commits and backported go-filter memory leak fixes.

See release notes here: https://www.envoyproxy.io/docs/envoy/v1.27.2/version_history/v1.27/v1.27.2

One to call out is the fix for Datadog span names for folks that are using Datadog for collecting Traces.


## Related Issues

N/A

## Testing

No additional testing added.

## Checklist

- [ ] **Does my change need to be backported to a previous release?**
- [ ] **I made sure to update `CHANGELOG.md`.**
- [x] **This is unlikely to impact how Ambassador performs at scale.**
- [x] **My change is adequately tested.**
- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**
- [x] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
