### PR TITLE
add module support for envoy runtime flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,11 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
 
 ### Emissary-ingress and Ambassador Edge Stack
 
+- Feature: Envoy runtime fields that were provided to mitigate the recent HTTP/2 rapid reset
+  vulnerability can now be configured via the Module resource so the configuration will persist
+  between restarts. This configuration is added to the Envoy bootstrap config, so restarting
+  Emissary is necessary after changing these fields for the configuration to take effect.
+
 ## [3.8.0] August 29, 2023
 [3.8.0]: https://github.com/emissary-ingress/emissary/compare/v3.7.2...v3.8.0
 

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -37,6 +37,14 @@ items:
     date: 'TBD'
     notes:
 
+    - title: Added support for setting specific Envoy runtime flags in the Module
+      type: feature
+      body: >-
+        Envoy runtime fields that were provided to mitigate the recent HTTP/2 rapid reset
+        vulnerability can now be configured via the Module resource so the configuration will
+        persist between restarts. This configuration is added to the Envoy bootstrap config, so
+        restarting Emissary is necessary after changing these fields for the configuration to take effect.
+
   - version: 3.8.0
     prevVersion: 3.7.2
     date: '2023-08-29'

--- a/python/ambassador/envoy/v3/v3bootstrap.py
+++ b/python/ambassador/envoy/v3/v3bootstrap.py
@@ -32,22 +32,7 @@ class V3Bootstrap(dict):
                     "lds_config": {"ads": {}, "resource_api_version": api_version},
                 },
                 "admin": dict(config.admin),
-                "layered_runtime": {
-                    "layers": [
-                        {
-                            "name": "static_layer",
-                            "static_layer": {
-                                "re2.max_program_size.error_level": 200,
-                                # TODO(lance):
-                                # the new default is that all filters are looked up using the @type which currently we exclude on a lot of
-                                # our filters. This will ensure we do not break current config. We can migrate over
-                                # in a minor release. see here: https://www.envoyproxy.io/docs/envoy/v1.22.0/version_history/current#minor-behavior-changes
-                                # The biggest impact of this is ensuring that ambex imports all the types because we will need to import many more
-                                "envoy.reloadable_features.no_extension_lookup_by_name": False,
-                            },
-                        }
-                    ]
-                },
+                "layered_runtime": dict(config.layered_runtime),
             }
         )
 

--- a/python/ambassador/envoy/v3/v3runtime.py
+++ b/python/ambassador/envoy/v3/v3runtime.py
@@ -1,0 +1,94 @@
+# Copyright 2023 Ambassador Labs. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from . import V3Config  # pragma: no cover
+
+
+class V3Runtime(dict):
+    def __init__(self, config: "V3Config") -> None:
+        super().__init__()
+
+        static_runtime_layer = {
+            "re2.max_program_size.error_level": 200,
+            # TODO(lance):
+            # the new default is that all filters are looked up using the @type which currently we exclude on a lot of
+            # our filters. This will ensure we do not break current config. We can migrate over
+            # in a minor release. see here: https://www.envoyproxy.io/docs/envoy/v1.22.0/version_history/current#minor-behavior-changes
+            # The biggest impact of this is ensuring that ambex imports all the types because we will need to import many more
+            "envoy.reloadable_features.no_extension_lookup_by_name": False,
+        }
+
+        user_runtime = config.ir.ambassador_module.get("runtime_flags", None)
+        if user_runtime:
+            max_io_per_cycle = user_runtime.get("http.max_requests_per_io_cycle", None)
+            if max_io_per_cycle:
+                if isinstance(max_io_per_cycle, int) and max_io_per_cycle > 0:
+                    static_runtime_layer["http.max_requests_per_io_cycle"] = max_io_per_cycle
+                else:
+                    config.ir.logger.error(
+                        f"value: {max_io_per_cycle} is invalid for Module field runtime_flags.max_requests_per_io_cycle. must be an integer greater than zero"
+                    )
+
+            rapid_reset_min_stream_lifetime = user_runtime.get(
+                "overload.premature_reset_min_stream_lifetime_seconds", None
+            )
+            if rapid_reset_min_stream_lifetime:
+                if (
+                    isinstance(rapid_reset_min_stream_lifetime, int)
+                    and rapid_reset_min_stream_lifetime > 0
+                ):
+                    static_runtime_layer[
+                        "overload.premature_reset_min_stream_lifetime_seconds"
+                    ] = rapid_reset_min_stream_lifetime
+                else:
+                    config.ir.logger.error(
+                        f"value: {rapid_reset_min_stream_lifetime} is invalid for Module field overload.premature_reset_min_stream_lifetime_seconds. must be an integer greater than zero"
+                    )
+
+            rapid_reset_total_streams = user_runtime.get(
+                "overload.premature_reset_total_stream_count", None
+            )
+            if rapid_reset_total_streams:
+                if isinstance(rapid_reset_total_streams, int) and rapid_reset_total_streams > 0:
+                    static_runtime_layer[
+                        "overload.premature_reset_total_stream_count"
+                    ] = rapid_reset_total_streams
+                else:
+                    config.ir.logger.error(
+                        f"value: {rapid_reset_total_streams} invalid for Module field overload.premature_reset_total_stream_count. must be an integer greater than zero"
+                    )
+
+            use_rapid_reset_goaway = user_runtime.get(
+                "envoy.restart_features.send_goaway_for_premature_rst_streams", None
+            )
+            if use_rapid_reset_goaway:
+                if isinstance(rapid_reset_total_streams, bool):
+                    static_runtime_layer[
+                        "envoy.restart_features.send_goaway_for_premature_rst_streams"
+                    ] = use_rapid_reset_goaway
+                else:
+                    config.ir.logger.error(
+                        f"value: {use_rapid_reset_goaway} is invalid for Module field envoy.restart_features.send_goaway_for_premature_rst_streams. This field must be true/false"
+                    )
+
+        self.update({"layers": [{"name": "static_layer", "static_layer": static_runtime_layer}]})
+
+    @classmethod
+    def generate(cls, config: "V3Config") -> None:
+        config.layered_runtime = config.save_element(
+            "layered_runtime", config.ir.ambassador_module, V3Runtime(config)
+        )

--- a/python/ambassador/ir/irambassador.py
+++ b/python/ambassador/ir/irambassador.py
@@ -61,6 +61,7 @@ class IRAmbassador(IRResource):
         "regex_max_size",
         "regex_type",
         "resolver",
+        "runtime_flags",
         "error_response_overrides",
         "header_case_overrides",
         "server_name",


### PR DESCRIPTION
## Description

Due to the recent HTTP/2 rapid reset vulnerability, setting the runtime flags manually is cumbersome and must be done on every reset. This PR adds support for setting those runtime flags via the Module. I opted for only supporting specific flags instead of just using the field as a raw dict input since I feet that the added safety of not allowing invalid Envoy configs is preferable to supporting any arbitrary field here.


## Testing

This could use some tests but I did a little manual validation to make sure invalid values do not cause an invalid Envoy config to be generated. Here is a screenshot below showing the active runtime flags when valid values are provided:

 

## Checklist
![Screenshot from 2023-11-03 17-26-54](https://github.com/emissary-ingress/emissary/assets/22459179/f7b03b5e-fe61-40c1-90ea-34c160d1ada7)


<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->
- [ ] **Does my change need to be backported to a previous release?**
  - What backport versions were discussed with the Maintainers in the Issue?

- [x] **I made sure to update `CHANGELOG.md`.**

   Remember, the CHANGELOG needs to mention:
  - Any new features
  - Any changes to our included version of Envoy
  - Any non-backward-compatible changes
  - Any deprecations

- [x] **This is unlikely to impact how Ambassador performs at scale.**

   Remember, things that might have an impact at scale include:
  - Any significant changes in memory use that might require adjusting the memory limits
  - Any significant changes in CPU use that might require adjusting the CPU limits
  - Anything that might change how many replicas users should use
  - Changes that impact data-plane latency/scalability

- [ ] **My change is adequately tested.**

   Remember when considering testing:
  - Your change needs to be specifically covered by tests.
    - Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
  - You also need to make sure that the _entire area being changed_ has adequate test coverage.
    - If existing tests don't actually cover the entire area being changed, add tests.
    - This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
  - We should lean on the bulk of code being covered by unit tests, but...
  - ... an end-to-end test should cover the integration points

- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**

- [ ] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
