### PR TITLE
apiext: add rbac for updating crd statuses

### DIFF
--- a/manifests/emissary/emissary-crds.yaml.in
+++ b/manifests/emissary/emissary-crds.yaml.in
@@ -5238,7 +5238,7 @@ rules:
     resources: [ "customresourcedefinitions" ]
     verbs: [ "list", "watch" ]
   - apiGroups: [ "apiextensions.k8s.io" ]
-    resources: [ "customresourcedefinitions" ]
+    resources: [ "customresourcedefinitions", "customresourcedefinitions/status" ]
     resourceNames:
       - authservices.getambassador.io
       - consulresolvers.getambassador.io

--- a/python/tests/integration/manifests/crds.yaml
+++ b/python/tests/integration/manifests/crds.yaml
@@ -5239,7 +5239,7 @@ rules:
     resources: [ "customresourcedefinitions" ]
     verbs: [ "list", "watch" ]
   - apiGroups: [ "apiextensions.k8s.io" ]
-    resources: [ "customresourcedefinitions" ]
+    resources: [ "customresourcedefinitions", "customresourcedefinitions/status" ]
     resourceNames:
       - authservices.getambassador.io
       - consulresolvers.getambassador.io

--- a/tools/src/fix-crds/apiext.yaml
+++ b/tools/src/fix-crds/apiext.yaml
@@ -42,7 +42,7 @@ rules:
     resources: [ "customresourcedefinitions" ]
     verbs: [ "list", "watch" ]
   - apiGroups: [ "apiextensions.k8s.io" ]
-    resources: [ "customresourcedefinitions" ]
+    resources: [ "customresourcedefinitions", "customresourcedefinitions/status" ]
     resourceNames:
       {{- range $crdName := .CRDNames }}
       - {{ $crdName }}


### PR DESCRIPTION
## Description

On some locked down clusters, the status update for CRD's will fail due to missing RBAC. This updates the fix-crds tool so that it includes `customresourcedefinitions/status` in the RBAC permissions when updating CRDs. AFAIK, it seems like it will report an error but still update status in our CI tests which is why we didn't catch this.

This supersedes https://github.com/emissary-ingress/emissary/pull/5449 because the file changed in that PR is generated and would get overridden as soon as make generate was called again. The file is generated via the `tools/src/fix-crds` using the template defined here: `tools/src/fix-crds/apiext.yaml` so that has been updated so that `make generate` is clean now.

## Related Issues

Fixes https://github.com/emissary-ingress/emissary/issues/5436

## Testing

CI Tests are still passing. Manually testing from user as noted here: https://github.com/emissary-ingress/emissary/pull/5449#issue-2002048514

## Checklist

- [ ] **Does my change need to be backported to a previous release?**
- [x] **I made sure to update `CHANGELOG.md`.**
- [x] **This is unlikely to impact how Ambassador performs at scale.**
- [x] **My change is adequately tested.**
- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**
- [x] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
