### PR TITLE
Update docs links and CNCF Slack links

### DIFF
--- a/Community/MEETING_SCHEDULE.md
+++ b/Community/MEETING_SCHEDULE.md
@@ -1,12 +1,5 @@
 # Community Meeting Schedule
 
-## Weekly Troubleshooting
-
-We hold troubleshooting sessions once a week on Thursdays, at 2:30 pm Eastern.  These sessions are a way to connect in person with project maintainers and get help with any problems you might be encountering while using Emissary-ingress.
-
-**Zoom Meeting Link**: https://us02web.zoom.us/j/83032365622
-
-
 ## Monthly Contributors Meeting
 
 The Emissary-ingress Contributors Meeting is held on the first Wednesday of every month at 3:30pm Eastern.  The focus of this meeting is discussion of technical issues related to development of Emissary-ingress.

--- a/DevDocumentation/DEVELOPING.md
+++ b/DevDocumentation/DEVELOPING.md
@@ -8,7 +8,7 @@ This document is intended for developers looking to contribute to the Emissary-i
 
 > Looking for end user guides for Emissary-ingress? You can check out the end user guides at <https://www.getambassador.io/docs/emissary/>.
 
-After reading this document if you have questions we encourage you to join us on our [Slack channel](https://d6e.co/slack) in the [#emissary-dev](https://datawire-oss.slack.com/archives/CB46TNG83) channel.
+After reading this document if you have questions we encourage you to join us on our [Slack channel](https://communityinviter.com/apps/cloud-native/cncf) in the #emissary-ingress channel.
 
 - [Code of Conduct](../Community/CODE_OF_CONDUCT.md)
 - [Governance](../Community/GOVERNANCE.md)
@@ -617,7 +617,7 @@ and tests on a RAM disk (see the `/etc/fstab` line above).
    Emissary does not claim to be FIPS compliant or certified.
    See [here](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/security/ssl#fips-140-2) for more information on FIPS and Envoy.
 
-> _NOTE:_ FIPS_MODE is NOT supported by the emissary-ingress maintainers but we provide this for developers as convience 
+> _NOTE:_ FIPS_MODE is NOT supported by the emissary-ingress maintainers but we provide this for developers as convience
 
 #### 3. Hacking on Envoy
 
@@ -643,12 +643,12 @@ Multiple Phony targets are provided so that developers can run the steps they ar
 
 #### 5. Test Devloop
 
-Running the Envoy test suite will compile all the test targets. This is a slow process and can use lots of disk space. 
+Running the Envoy test suite will compile all the test targets. This is a slow process and can use lots of disk space.
 
 The Envoy Inner Devloop for build and testing:
 
 - You can make a change to Envoy code and run the whole test by just calling `make check-envoy`
-- You can run a specific test instead of the whole test suite by setting the `ENVOY_TEST_LABEL` environment variable. 
+- You can run a specific test instead of the whole test suite by setting the `ENVOY_TEST_LABEL` environment variable.
   - For example, to run just the unit tests in `test/common/network/listener_impl_test.cc`, you should run:
 
    ```shell
@@ -693,7 +693,7 @@ The Envoy changes with Emissary-ingress:
 
 #### 6. Protobuf changes
 
-If you made any changes to the Protocol Buffer files or if you bumped versions of Envoy then you 
+If you made any changes to the Protocol Buffer files or if you bumped versions of Envoy then you
 should make sure that you are re-compiling the Protobufs so that they are available and checked-in
 to the emissary.git repository.
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ For other common questions, view this [FAQ page](https://www.getambassador.io/do
 
 You can also use Helm to install Emissary. For more information, see the instructions in the [Helm installation documentation](https://www.getambassador.io/docs/emissary/latest/topics/install/helm/)
 
-Check out full the [Emissary
+Check out the full [Emissary
 documentation](https://www.getambassador.io/docs/emissary/) at
 www.getambassador.io/docs/open-source.
 

--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ Emissary-ingress
 [badge-docker-img]: https://img.shields.io/docker/pulls/emissaryingress/emissary
 [badge-docker-link]: https://hub.docker.com/r/emissaryingress/emissary
 [badge-slack-img]: https://img.shields.io/badge/slack-join-orange.svg
-[badge-slack-link]: https://a8r.io/slack
+[badge-slack-link]: https://communityinviter.com/apps/cloud-native/cncf
 [badge-cii-img]: https://bestpractices.coreinfrastructure.org/projects/1852/badge
 [badge-cii-link]: https://bestpractices.coreinfrastructure.org/projects/1852
 
 <!-- Links are (mostly) at the end of this document, for legibility. -->
 
-[Emissary-Ingress](https://www.getambassador.io) is an open-source Kubernetes-native API Gateway +
+[Emissary-Ingress](https://www.getambassador.io/docs/open-source) is an open-source Kubernetes-native API Gateway +
 Layer 7 load balancer + Kubernetes Ingress built on [Envoy Proxy](https://www.envoyproxy.io).
 Emissary-ingress is a CNCF incubation project (and was formerly known as Ambassador API Gateway).
 
@@ -32,7 +32,7 @@ Emissary-ingress enables its users to:
 * Connect service meshes including [Consul], [Linkerd], and [Istio]
 * [Knative serverless integration]
 
-See the full list of [features](https://www.getambassador.io/features/) here.
+See the full list of [features](https://www.getambassador.io/docs/emissary) here.
 
 Branches
 ========
@@ -64,7 +64,7 @@ You can also use Helm to install Emissary. For more information, see the instruc
 
 Check out full the [Emissary
 documentation](https://www.getambassador.io/docs/emissary/) at
-www.getambassador.io.
+www.getambassador.io/docs/open-source.
 
 Community
 =========
@@ -82,8 +82,8 @@ the way the community is run, including:
    regular trouble-shooting meetings and contributor meetings
  - how to get [`SUPPORT.md`](Community/SUPPORT.md).
 
-The best way to join the community is to join our [Slack
-channel](https://a8r.io/slack).
+The best way to join the community is to join the [CNCF Slack](https://communityinviter.com/apps/cloud-native/cncf)
+#emissary-ingress channel.
 
 Check out the [`DevDocumentation/`](DevDocumentation/) directory for
 information on the technicals of Emissary, most notably the


### PR DESCRIPTION
## Description

Slack is moving to the CNCF Slack.  Updating links