### PR TITLE
python: fix integration test

### DIFF
--- a/python/ambassador/ir/irgofilter.py
+++ b/python/ambassador/ir/irgofilter.py
@@ -63,6 +63,7 @@ class IRGOFilter(IRFilter):
                 self.logger.error(
                     "%s not found, envoy configuration will fail to apply", GO_FILTER_LIBRARY_PATH
                 )
+                return False
             self.config = GOFilterConfig(library_path=GO_FILTER_LIBRARY_PATH)
             return True
         return False

--- a/python/tests/unit/test_gofilter.py
+++ b/python/tests/unit/test_gofilter.py
@@ -116,7 +116,7 @@ def test_gofilter_missing_object_file(go_library, caplog):
     econf = get_envoy_config(MAPPING)
     filters = _get_go_filters(econf.as_dict())
 
-    assert len(filters) == 4
+    assert len(filters) == 0
 
     assert "/ambassador/filter.so not found" in caplog.text
 


### PR DESCRIPTION
## Description

A recent refactor broke integration tests by generating config envoy would reject.

## Related Issues

n/a

## Testing

Adjusted unit test due to change in behavior but no additional testing needed.

## Checklist

- [ ] **Does my change need to be backported to a previous release?**
- [ ] **I made sure to update `CHANGELOG.md`.**
- [x] **This is unlikely to impact how Ambassador performs at scale.**
- [x] **My change is adequately tested.**
- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**
- [x] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
