### PR TITLE
apiext: adjust log levels and remove extra log lines

### DIFF
--- a/pkg/apiext/internal/ca/authority.go
+++ b/pkg/apiext/internal/ca/authority.go
@@ -74,13 +74,13 @@ func (a *apiextCertificateAuthority) SetCACert(caCert *CACert) {
 
 // GetCertificate implements CertificateAuthority.
 func (a *apiextCertificateAuthority) GetCertificate(clientHello *tls.ClientHelloInfo) (*tls.Certificate, error) {
-	a.logger.Info("receivedGetCertificate call", zap.Any("clientHello", clientHello))
+	a.logger.Debug("receivedGetCertificate call", zap.Any("clientHello", clientHello))
 	if clientHello == nil {
 		return nil, InvalidClientHelloErr
 	}
 	cachedCert := a.getCachedCert(clientHello.ServerName)
 	if cachedCert != nil {
-		a.logger.Info("reusing cached server cert", zap.String("serverName", clientHello.ServerName))
+		a.logger.Debug("reusing cached server cert", zap.String("serverName", clientHello.ServerName))
 		return cachedCert, nil
 	}
 

--- a/pkg/apiext/internal/controller/cacert/controller.go
+++ b/pkg/apiext/internal/controller/cacert/controller.go
@@ -66,7 +66,7 @@ func (c *caCertController) SetupWithManager(mgr manager.Manager) error {
 
 // Reconcile implements reconcile.Reconciler to watch for CA Cert Secret changes and to update the CertificateAuthority
 func (c *caCertController) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	c.logger.Info("Secret reconcile triggered by object",
+	c.logger.Info("ca cert reconcile triggered",
 		zap.String("namespace", request.Namespace),
 		zap.String("name", request.Name),
 	)
@@ -94,8 +94,6 @@ func (c *caCertController) Reconcile(ctx context.Context, request reconcile.Requ
 		c.certificateAuthority.SetCACert(nil)
 		return reconcile.Result{}, nil
 	}
-
-	c.logger.Info("CA cert being set", zap.Any("caCert", caCert))
 
 	c.certificateAuthority.SetCACert(&caCert)
 	return reconcile.Result{}, nil

--- a/pkg/apiext/internal/controller/crd/controller.go
+++ b/pkg/apiext/internal/controller/crd/controller.go
@@ -72,7 +72,7 @@ func (c *crdPatchController) SetupWithManager(mgr manager.Manager) error {
 
 // Reconcile implements reconcile.Reconciler.
 func (c *crdPatchController) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	c.logger.Info("CustomResourceDefinition reconcile triggered by object", zap.String("namespace", request.Namespace), zap.String("name", request.Name))
+	c.logger.Info("CustomResourceDefinition reconcile triggered", zap.String("namespace", request.Namespace), zap.String("name", request.Name))
 
 	crDefKey := types.NamespacedName{
 		Name:      request.Name,
@@ -203,7 +203,9 @@ func enqueueCRDForCASecretChanges(k8sclient client.Reader, logger *zap.Logger) h
 			})
 		}
 
-		logger.Info("enqueued multipie request items", zap.Int("items", len(requests)))
+		if len(requests) > 0 {
+			logger.Info("ca cert secret changed trigger CustomResourceDefinition reconcile requests", zap.Int("items", len(requests)))
+		}
 
 		return requests
 	}


### PR DESCRIPTION
## Description

This removes some log lines that were in place for debugging and swithes some to Debug. This will ensure we are not logging CA Cert private keys unless the user wants to see debug logs.

## Related Issues

List related issues.

## Testing

A few sentences describing what testing you've done, e.g., manual tests, automated tests, deployed in production, etc.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->
- [ ] **Does my change need to be backported to a previous release?**
  - What backport versions were discussed with the Maintainers in the Issue?

- [ ] **I made sure to update `CHANGELOG.md`.**

   Remember, the CHANGELOG needs to mention:
  - Any new features
  - Any changes to our included version of Envoy
  - Any non-backward-compatible changes
  - Any deprecations

- [ ] **This is unlikely to impact how Ambassador performs at scale.**

   Remember, things that might have an impact at scale include:
  - Any significant changes in memory use that might require adjusting the memory limits
  - Any significant changes in CPU use that might require adjusting the CPU limits
  - Anything that might change how many replicas users should use
  - Changes that impact data-plane latency/scalability

- [ ] **My change is adequately tested.**

   Remember when considering testing:
  - Your change needs to be specifically covered by tests.
    - Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
  - You also need to make sure that the _entire area being changed_ has adequate test coverage.
    - If existing tests don't actually cover the entire area being changed, add tests.
    - This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
  - We should lean on the bulk of code being covered by unit tests, but...
  - ... an end-to-end test should cover the integration points

- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**

- [ ] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
