### PR TITLE
helm-chart: Flexibility to add extra custom relabelling config for `serviceMonitor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,7 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
 ### Emissary-ingress and Ambassador Edge Stack
 
 - Feature: This upgrades Emissary-ingress to be built on Envoy v1.28.0 which provides security,
-  performance  and feature enhancements. You can read more about them here:  <a
+  performance and feature enhancements. You can read more about them here: <a
   href="https://www.envoyproxy.io/docs/envoy/v1.28.0/version_history/version_history">Envoy Proxy
   1.28.0 Release Notes</a>
 
@@ -103,37 +103,40 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
 - Change: Upgraded Emissary-ingress to the latest release of Golang as part of our general
   dependency upgrade process.
 
+- Feature: Helm chart extra variable in values.yaml metrics.serviceMonitor.relabelings and
+  templating toggle in the serviceMonitor template This will allow us to add extra labels to
+  prometheus metrics exposed by addition to scrape_config for the job
+
 ## [3.9.0] November 13, 2023
 [3.9.0]: https://github.com/emissary-ingress/emissary/compare/v3.8.0...v3.9.0
 
 ### Emissary-ingress and Ambassador Edge Stack
 
 - Feature: This upgrades Emissary-ingress to be built on Envoy v1.27.2 which provides security,
-  performance  and feature enhancements. You can read more about them here:  <a
+  performance and feature enhancements. You can read more about them here: <a
   href="https://www.envoyproxy.io/docs/envoy/v1.27.2/version_history/version_history">Envoy Proxy
   1.27.2 Release Notes</a>
 
-- Feature: By default, Emissary-ingress will return an `UNAVAILABLE` code when a request using gRPC 
+- Feature: By default, Emissary-ingress will return an `UNAVAILABLE` code when a request using gRPC
   is rate limited. The `RateLimitService` resource now exposes a new
-  `grpc.use_resource_exhausted_code`  field that when set to `true`, Emissary-ingress will return a
-  `RESOURCE_EXHAUSTED` gRPC code instead.  Thanks to <a href="https://github.com/jeromefroe">Jerome
+  `grpc.use_resource_exhausted_code` field that when set to `true`, Emissary-ingress will return a
+  `RESOURCE_EXHAUSTED` gRPC code instead. Thanks to <a href="https://github.com/jeromefroe">Jerome
   Froelich</a> for contributing this feature!
 
 - Feature: Envoy runtime fields that were provided to mitigate the recent HTTP/2 rapid reset
-  vulnerability  can now be configured via the Module resource so the configuration will persist
-  between restarts.  This configuration is added to the Envoy bootstrap config, so restarting
-  Emissary is necessary after  changing these fields for the configuration to take effect.
+  vulnerability can now be configured via the Module resource so the configuration will persist
+  between restarts. This configuration is added to the Envoy bootstrap config, so restarting
+  Emissary is necessary after changing these fields for the configuration to take effect.
 
 - Change: APIExt would previously allow for TLS 1.0 connections. We have updated it to now only use
-  a minimum  TLS version of 1.3 to resolve security concerns.
+  a minimum TLS version of 1.3 to resolve security concerns.
 
 - Change: - Update default image to Emissary-ingress v3.9.0. <br/>
 
 - Bugfix: The APIExt server provides CRD conversion between the stored version v2 and the version
-  watched for  by Emissary-ingress v3alpha1. Since this component is required to operate
-  Emissary-ingress, we have  introduced an init container that will ensure it is available before
-  starting. This will help address  some of the intermittent issues seen during install and
-  upgrades.
+  watched for by Emissary-ingress v3alpha1. Since this component is required to operate
+  Emissary-ingress, we have introduced an init container that will ensure it is available before
+  starting. This will help address some of the intermittent issues seen during install and upgrades.
 
 ## [3.8.0] August 29, 2023
 [3.8.0]: https://github.com/emissary-ingress/emissary/compare/v3.7.2...v3.8.0

--- a/charts/emissary-ingress/templates/servicemonitor.yaml
+++ b/charts/emissary-ingress/templates/servicemonitor.yaml
@@ -19,6 +19,10 @@ spec:
       {{- with .Values.metrics.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ . }}
       {{- end }}
+      {{- if .Values.metrics.serviceMonitor.relabelings }}
+      relabelings:
+      {{- toYaml .Values.metrics.serviceMonitor.relabelings | nindent 8 }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ include "ambassador.namespace" . }}

--- a/charts/emissary-ingress/values.yaml.in
+++ b/charts/emissary-ingress/values.yaml.in
@@ -340,6 +340,7 @@ metrics:
     # interval: 30s
     # scrapeTimeout: 30s
     # selector: {}
+    relabelings: []
 
 # Resolvers are used to configure the discovery service strategy for Ambasador
 # See: https://www.getambassador.io/docs/edge-stack/latest/topics/running/resolvers/

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -35,15 +35,15 @@ items:
   - version: 3.10.0
     prevVersion: 3.9.0
     date: 'TBD'
-    notes: 
+    notes:
       - title: Upgrade to Envoy 1.28.0
         type: feature
         body: >-
-          This upgrades $productName$ to be built on Envoy v1.28.0 which provides security, performance 
-          and feature enhancements. You can read more about them here: 
+          This upgrades $productName$ to be built on Envoy v1.28.0 which provides security, performance
+          and feature enhancements. You can read more about them here:
           <a href="https://www.envoyproxy.io/docs/envoy/v1.28.0/version_history/version_history">Envoy Proxy 1.28.0 Release Notes</a>
         docs: https://www.envoyproxy.io/docs/envoy/v1.28.0/version_history/version_history
-        
+
       - title: Remove Ambassador Agent from published YAML Manifest
         type: change
         body: >-
@@ -51,12 +51,17 @@ items:
           This is an optional component that provides additional features on top of $productName$ and we recommend
           installing it using the instructions found in the <a href="https://github.com/datawire/ambassador-agenty">Ambassador Agent Repo</a>.
         docs: https://github.com/datawire/ambassador-agent
-      
+
       - title: Update to golang 1.21.5
         type: change
         body: >-
           Upgraded $productName$ to the latest release of Golang as part of our general dependency upgrade process.
-      
+
+      - title: Add relabeling support for ServiceMonitor
+        type: feature
+        body: >-
+          Helm chart extra variable in values.yaml metrics.serviceMonitor.relabelings and templating toggle in the serviceMonitor template
+          This will allow us to add extra labels to prometheus metrics exposed by addition to scrape_config for the job
 
 
   - version: 3.9.0
@@ -66,34 +71,34 @@ items:
       - title: Upgrade to Envoy 1.27.2
         type: feature
         body: >-
-          This upgrades $productName$ to be built on Envoy v1.27.2 which provides security, performance 
-          and feature enhancements. You can read more about them here: 
+          This upgrades $productName$ to be built on Envoy v1.27.2 which provides security, performance
+          and feature enhancements. You can read more about them here:
           <a href="https://www.envoyproxy.io/docs/envoy/v1.27.2/version_history/version_history">Envoy Proxy 1.27.2 Release Notes</a>
         docs: https://www.envoyproxy.io/docs/envoy/v1.27.2/version_history/version_history
 
       - title: Added support for RESOURCE_EXHAUSTED responses to grpc clients when rate limited
         type: feature
         body: >-
-          By default, $productName$ will return an <code>UNAVAILABLE</code> code when a request using gRPC 
-          is rate limited. The <code>RateLimitService</code> resource now exposes a new <code>grpc.use_resource_exhausted_code</code> 
-          field that when set to <code>true</code>, $productName$ will return a <code>RESOURCE_EXHAUSTED</code> gRPC code instead. 
+          By default, $productName$ will return an <code>UNAVAILABLE</code> code when a request using gRPC
+          is rate limited. The <code>RateLimitService</code> resource now exposes a new <code>grpc.use_resource_exhausted_code</code>
+          field that when set to <code>true</code>, $productName$ will return a <code>RESOURCE_EXHAUSTED</code> gRPC code instead.
           Thanks to <a href="https://github.com/jeromefroe">Jerome Froelich</a> for contributing this feature!
 
       - title: Added support for setting specific Envoy runtime flags in the Module
         type: feature
         body: >-
-          Envoy runtime fields that were provided to mitigate the recent HTTP/2 rapid reset vulnerability 
-          can now be configured via the Module resource so the configuration will persist between restarts. 
-          This configuration is added to the Envoy bootstrap config, so restarting Emissary is necessary after 
+          Envoy runtime fields that were provided to mitigate the recent HTTP/2 rapid reset vulnerability
+          can now be configured via the Module resource so the configuration will persist between restarts.
+          This configuration is added to the Envoy bootstrap config, so restarting Emissary is necessary after
           changing these fields for the configuration to take effect.
 
       - title: Update APIExt minimum TLS version
         type: change
         body: >-
-          APIExt would previously allow for TLS 1.0 connections. We have updated it to now only use a minimum 
+          APIExt would previously allow for TLS 1.0 connections. We have updated it to now only use a minimum
           TLS version of 1.3 to resolve security concerns.
         docs: https://www.tenable.com/plugins/nessus/104743
-      
+
       - title: Shipped Helm chart v8.9.0
         type: change
         body: >-
@@ -103,9 +108,9 @@ items:
       - title: Ensure APIExt server is available before starting Emissary-ingress
         type: bugfix
         body: >-
-          The APIExt server provides CRD conversion between the stored version v2 and the version watched for 
-          by $productName$ v3alpha1. Since this component is required to operate $productName$, we have 
-          introduced an init container that will ensure it is available before starting. This will help address 
+          The APIExt server provides CRD conversion between the stored version v2 and the version watched for
+          by $productName$ v3alpha1. Since this component is required to operate $productName$, we have
+          introduced an init container that will ensure it is available before starting. This will help address
           some of the intermittent issues seen during install and upgrades.
         docs: https://artifacthub.io/packages/helm/datawire/edge-stack/$emissaryChartVersion$
 


### PR DESCRIPTION
## Description
helm-chart update
Extra variable in `values.yaml` `metrics.serviceMonitor.relabelings` and templating toggle in the `serviceMonitor` template
This will allow us to add extra labels to prometheus metrics exposed by addition to `scrape_config` for the job

Fixes: #5510 

## Related Issues

Ability to use custom relabelling for all prometheus metrics exported by emissary. 
Since we use the upstream chart and just customise it using the values.yaml

## Testing

As per the documentation 
```bash
make test
make gotest
make pytest
make lint
```

## additional 

Also updated the `CHANGELOG.md ` with `make generate`

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->
- [ ] **Does my change need to be backported to a previous release?**
  - What backport versions were discussed with the Maintainers in the Issue?

- [x] **I made sure to update `CHANGELOG.md`.**

   Remember, the CHANGELOG needs to mention:
  - Any new features
  - Any changes to our included version of Envoy
  - Any non-backward-compatible changes
  - Any deprecations

- [x] **This is unlikely to impact how Ambassador performs at scale.**

   Remember, things that might have an impact at scale include:
  - Any significant changes in memory use that might require adjusting the memory limits
  - Any significant changes in CPU use that might require adjusting the CPU limits
  - Anything that might change how many replicas users should use
  - Changes that impact data-plane latency/scalability

- [x] **My change is adequately tested.**

   Remember when considering testing:
  - Your change needs to be specifically covered by tests.
    - Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
  - You also need to make sure that the _entire area being changed_ has adequate test coverage.
    - If existing tests don't actually cover the entire area being changed, add tests.
    - This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
  - We should lean on the bulk of code being covered by unit tests, but...
  - ... an end-to-end test should cover the integration points

- [x] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**

- [x] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
