### PR TITLE
fix(charts): update 4-year outdated kubectl image

### DIFF
--- a/charts/emissary-ingress/templates/deployment-canary.yaml
+++ b/charts/emissary-ingress/templates/deployment-canary.yaml
@@ -113,7 +113,7 @@ spec:
       initContainers:
       {{- if and .Values.waitForApiext (eq .Values.waitForApiext.enabled true) }}
       - name: wait-for-apiext
-        image: istio/kubectl:1.5.10
+        image: public.ecr.aws/bitnami/kubectl:1.30.0
         imagePullPolicy: IfNotPresent
         {{- with .Values.waitForApiext.securityContext }}
         securityContext:
@@ -122,6 +122,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
+            set -eu
             deployment_name={{ .Values.waitForApiext.deploymentName | default "emissary-apiext" | quote }}
             deployment_namespace={{ .Values.waitForApiext.deploymentNamespace | default "emissary-system" | quote }}
             while true; do
@@ -135,7 +136,7 @@ spec:
                   while true; do
                   desired_replicas=$(kubectl get deployment $deployment_name -n $deployment_namespace -o jsonpath='{.spec.replicas}')
                   current_replicas=$(kubectl get deployment $deployment_name -n $deployment_namespace -o jsonpath='{.status.replicas}')
-                  if [[ $current_replicas != $desired_replicas ]]; then
+                  if [ $current_replicas != $desired_replicas ]; then
                     echo "$deployment_name.$deployment_namespace is in the process of restarting. Have: $current_replicas, want $desired_replicas"
                     sleep 3
                   else

--- a/charts/emissary-ingress/templates/deployment.yaml
+++ b/charts/emissary-ingress/templates/deployment.yaml
@@ -134,7 +134,7 @@ spec:
       initContainers:
       {{- if and .Values.waitForApiext (eq .Values.waitForApiext.enabled true) }}
       - name: wait-for-apiext
-        image: istio/kubectl:1.5.10
+        image: public.ecr.aws/bitnami/kubectl:1.30.0
         imagePullPolicy: IfNotPresent
         {{- with .Values.waitForApiext.securityContext }}
         securityContext:
@@ -143,6 +143,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
+            set -eu
             deployment_name={{ .Values.waitForApiext.deploymentName | default "emissary-apiext" | quote }}
             deployment_namespace={{ .Values.waitForApiext.deploymentNamespace | default "emissary-system" | quote }}
             while true; do
@@ -156,7 +157,7 @@ spec:
                   while true; do
                   desired_replicas=$(kubectl get deployment $deployment_name -n $deployment_namespace -o jsonpath='{.spec.replicas}')
                   current_replicas=$(kubectl get deployment $deployment_name -n $deployment_namespace -o jsonpath='{.status.replicas}')
-                  if [[ $current_replicas != $desired_replicas ]]; then
+                  if [ $current_replicas != $desired_replicas ]; then
                     echo "$deployment_name.$deployment_namespace is in the process of restarting. Have: $current_replicas, want $desired_replicas"
                     sleep 3
                   else

--- a/manifests/emissary/emissary-defaultns.yaml.in
+++ b/manifests/emissary/emissary-defaultns.yaml.in
@@ -321,6 +321,7 @@ spec:
       initContainers:
       - args:
         - |
+          set -eu
           deployment_name="emissary-apiext"
           deployment_namespace="emissary-system"
           while true; do
@@ -334,7 +335,7 @@ spec:
                 while true; do
                 desired_replicas=$(kubectl get deployment $deployment_name -n $deployment_namespace -o jsonpath='{.spec.replicas}')
                 current_replicas=$(kubectl get deployment $deployment_name -n $deployment_namespace -o jsonpath='{.status.replicas}')
-                if [[ $current_replicas != $desired_replicas ]]; then
+                if [ $current_replicas != $desired_replicas ]; then
                   echo "$deployment_name.$deployment_namespace is in the process of restarting. Have: $current_replicas, want $desired_replicas"
                   sleep 3
                 else
@@ -354,7 +355,7 @@ spec:
         command:
         - /bin/sh
         - -c
-        image: istio/kubectl:1.5.10
+        image: public.ecr.aws/bitnami/kubectl:1.30.0
         imagePullPolicy: IfNotPresent
         name: wait-for-apiext
         securityContext:

--- a/manifests/emissary/emissary-emissaryns.yaml.in
+++ b/manifests/emissary/emissary-emissaryns.yaml.in
@@ -321,6 +321,7 @@ spec:
       initContainers:
       - args:
         - |
+          set -eu
           deployment_name="emissary-apiext"
           deployment_namespace="emissary-system"
           while true; do
@@ -334,7 +335,7 @@ spec:
                 while true; do
                 desired_replicas=$(kubectl get deployment $deployment_name -n $deployment_namespace -o jsonpath='{.spec.replicas}')
                 current_replicas=$(kubectl get deployment $deployment_name -n $deployment_namespace -o jsonpath='{.status.replicas}')
-                if [[ $current_replicas != $desired_replicas ]]; then
+                if [ $current_replicas != $desired_replicas ]; then
                   echo "$deployment_name.$deployment_namespace is in the process of restarting. Have: $current_replicas, want $desired_replicas"
                   sleep 3
                 else
@@ -354,7 +355,7 @@ spec:
         command:
         - /bin/sh
         - -c
-        image: istio/kubectl:1.5.10
+        image: public.ecr.aws/bitnami/kubectl:1.30.0
         imagePullPolicy: IfNotPresent
         name: wait-for-apiext
         securityContext:

--- a/python/tests/integration/manifests/ambassador.yaml
+++ b/python/tests/integration/manifests/ambassador.yaml
@@ -189,6 +189,7 @@ spec:
   initContainers:
   - args:
     - |
+      set -eu
       deployment_name="emissary-apiext"
       deployment_namespace="emissary-system"
       while true; do
@@ -202,7 +203,7 @@ spec:
             while true; do
             desired_replicas=$(kubectl get deployment $deployment_name -n $deployment_namespace -o jsonpath='{.spec.replicas}')
             current_replicas=$(kubectl get deployment $deployment_name -n $deployment_namespace -o jsonpath='{.status.replicas}')
-            if [[ $current_replicas != $desired_replicas ]]; then
+            if [ $current_replicas != $desired_replicas ]; then
               echo "$deployment_name.$deployment_namespace is in the process of restarting. Have: $current_replicas, want $desired_replicas"
               sleep 3
             else
@@ -222,7 +223,7 @@ spec:
     command:
     - /bin/sh
     - -c
-    image: istio/kubectl:1.5.10
+    image: public.ecr.aws/bitnami/kubectl:1.30.0
     imagePullPolicy: IfNotPresent
     name: wait-for-apiext
     securityContext:


### PR DESCRIPTION
## Description

* The `istio/kubectl` image is [not maintained](https://hub.docker.com/r/istio/kubectl/tags), replaced it by [bitnami/kubectl](https://gallery.ecr.aws/bitnami/kubectl)
* `[[` is not supported by POSIX shell (`/bin/sh: 14: [[: not found`) (this part of the script never worked I believe)

## Related Issues

## Testing

Manually deployed in a Kubernetes cluster

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->
- [ ] **Does my change need to be backported to a previous release?**
  - What backport versions were discussed with the Maintainers in the Issue?

- [ ] **I made sure to update `CHANGELOG.md`.**

   Remember, the CHANGELOG needs to mention:
  - Any new features
  - Any changes to our included version of Envoy
  - Any non-backward-compatible changes
  - Any deprecations

- [ ] **This is unlikely to impact how Ambassador performs at scale.**

   Remember, things that might have an impact at scale include:
  - Any significant changes in memory use that might require adjusting the memory limits
  - Any significant changes in CPU use that might require adjusting the CPU limits
  - Anything that might change how many replicas users should use
  - Changes that impact data-plane latency/scalability

- [ ] **My change is adequately tested.**

   Remember when considering testing:
  - Your change needs to be specifically covered by tests.
    - Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
  - You also need to make sure that the _entire area being changed_ has adequate test coverage.
    - If existing tests don't actually cover the entire area being changed, add tests.
    - This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
  - We should lean on the bulk of code being covered by unit tests, but...
  - ... an end-to-end test should cover the integration points

- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**

- [ ] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
