### PR TITLE
flynn/dev/4.x - Export kat-client/kat-server/emissary images as tarballs for Github actions/CI

### DIFF
--- a/build-aux/builder.mk
+++ b/build-aux/builder.mk
@@ -435,6 +435,14 @@ release/ga-check:
 	  --source-registry=$(RELEASE_REGISTRY) \
 	  --image-name=$(LCNAME); }
 
+_save-dev-images = $(LCNAME) kat-client kat-server
+save-dev: FORCE inspect-image-cache images-build
+	@for image in $(_save-dev-images); do \
+		printf '$(CYN)==> $(GRN)saving image %s as tarball: $(BLU)%s.tar$(GRN)...$(END)\n' $$image $$image; \
+		docker image save --output $$image.tar $$(cat docker/$$image.docker); \
+	done
+.PHONY: save-dev
+
 AMBASSADOR_DOCKER_IMAGE = $(shell sed -n 2p docker/$(LCNAME).docker.push.remote 2>/dev/null)
 export AMBASSADOR_DOCKER_IMAGE
 


### PR DESCRIPTION
## Description

Based off of what was discussed in this [thread](https://cloud-native.slack.com/archives/C070Q6YHL2C/p1713798653374599), this PR introduces a new command `save-dev` that saves the currently-built docker images of `kat-client` , `kat-server`, `emissary` into tarballs that will eventually be uploaded as GitHub Actions artifacts to be used for e2e test suites/other test suites. 

## Related Issues

List related issues.

## Testing

Ran `make save-dev` locally

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->
- [x] **Does my change need to be backported to a previous release?** No

- [ ] **I made sure to update `CHANGELOG.md`.**

   Remember, the CHANGELOG needs to mention:
  - Any new features
  - Any changes to our included version of Envoy
  - Any non-backward-compatible changes
  - Any deprecations

- [x] **This is unlikely to impact how Ambassador performs at scale.**

   Remember, things that might have an impact at scale include:
  - Any significant changes in memory use that might require adjusting the memory limits
  - Any significant changes in CPU use that might require adjusting the CPU limits
  - Anything that might change how many replicas users should use
  - Changes that impact data-plane latency/scalability

- [x] **My change is adequately tested.**

   Remember when considering testing:
  - Your change needs to be specifically covered by tests.
    - Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
  - You also need to make sure that the _entire area being changed_ has adequate test coverage.
    - If existing tests don't actually cover the entire area being changed, add tests.
    - This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
  - We should lean on the bulk of code being covered by unit tests, but...
  - ... an end-to-end test should cover the integration points

- [x] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.** No changes should be required here. 

- [ ] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
