### PR TITLE
[BREAKING CHANGE] 4.x chart mod

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -14,7 +14,7 @@ before:
     - rm -rf python/ambassador.version
     - make VERSION=v{{ .Version }} python/ambassador.version
     # Make the chart as part of the build process.
-    - make VERSION={{ .Version }} CHART_VERSION={{ .Version }} chart
+    - make VERSION=v{{ .Version }} chart
 
 builds:
   - id: busyambassador

--- a/Makefile
+++ b/Makefile
@@ -27,16 +27,21 @@ ifneq ($(MAKECMDGOALS),$(OSS_HOME)/build-aux/go-version.txt)
   endif
 
   VERSION := $(or $(VERSION),$(shell go run ./tools/src/goversion))
-  $(if $(or $(filter v3.%,$(VERSION)),$(filter v0.0.0-%,$(VERSION))),\
-    ,$(error VERSION variable is invalid: It must be v3.* or v0.0.0-$$tag, but is '$(VERSION)'))
+  $(if $(or $(filter v4.%,$(VERSION)),$(filter v0.0.0-%,$(VERSION))),\
+    ,$(error VERSION variable is invalid: It must be v4.* or v0.0.0-$$tag, but is '$(VERSION)'))
   $(if $(findstring +,$(VERSION)),\
     $(error VERSION variable is invalid: It must not contain + characters, but is '$(VERSION)'),)
   export VERSION
 
-  CHART_VERSION := $(or $(CHART_VERSION),$(shell go run ./tools/src/goversion --dir-prefix=chart))
-  $(if $(or $(filter v8.%,$(CHART_VERSION)),$(filter v0.0.0-%,$(CHART_VERSION))),\
-    ,$(error CHART_VERSION variable is invalid: It must be v8.* or v0.0.0-$$tag, but is '$(CHART_VERSION)'))
+  # This is a bit hackish, at the moment, but let's run with it for now
+  # and see how far we get.
+  CHART_VERSION := $(VERSION)
   export CHART_VERSION
+
+#   CHART_VERSION := $(or $(CHART_VERSION),$(shell go run ./tools/src/goversion --dir-prefix=chart))
+#   $(if $(or $(filter v4.%,$(CHART_VERSION)),$(filter v0.0.0-%,$(CHART_VERSION))),\
+#     ,$(error CHART_VERSION variable is invalid: It must be v4.* or v0.0.0-$$tag, but is '$(CHART_VERSION)'))
+#   export CHART_VERSION
 
   $(info [make] VERSION=$(VERSION))
   $(info [make] CHART_VERSION=$(CHART_VERSION))

--- a/build-aux/generate.mk
+++ b/build-aux/generate.mk
@@ -162,7 +162,7 @@ $(OSS_HOME)/_generate.tmp/crds: $(tools/controller-gen) build-aux/copyright-boil
 		crd \
 		paths=./pkg/api/getambassador.io/... \
 		output:crd:dir=./_generate.tmp/crds
-	
+
 $(OSS_HOME)/%/zz_generated.conversion.go: $(tools/conversion-gen) build-aux/copyright-boilerplate.go.txt FORCE
 	rm -f $@ $(@D)/*.scaffold.go
 	GOPATH= GOFLAGS=-mod=mod $(tools/conversion-gen) \

--- a/charts/emissary-ingress/readme.tpl
+++ b/charts/emissary-ingress/readme.tpl
@@ -5,34 +5,14 @@
 ## TL;DR;
 
 ```console
-$ helm repo add {{ .Repository.Name }} {{ .Repository.URL }}
-$ helm repo update
-$ helm install {{ .Release.Name }} --devel {{ .Repository.Name }}/{{ .Chart.Name }} -n {{ .Release.Namespace }}{{ with .Chart.Version }} --version={{.}}{{ end }}
+$ helm install {{ .Release.Name }} -n {{ .Release.Namespace }} \
+    oci://ghcr.io/{{ .Repository.Name }}/{{ .Chart.Name }} \
+    --version={{ .Chart.Version }}
 ```
 
 ## Introduction
 
 This chart deploys {{ .Project.App }} on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
-
-This chart is used to install the 2.0 release line of {{ .Project.App }}. 
-
-Versions in the older 1.0 release line of Emissary Ingress and Ambassador Edge Stack share a
-single chart that can be found in this repository under the branch for the specific release, e.g.
-[the release/v1.14 branch] for the latest 1.14 chart, [release/v1.13] for 1.13, and so on.
-
-> Note that for 1.0 releases, the `enableAES` helm value is used to control installing Edge Stack or
-  Emissary Ingress.
-
-As of version 2.0, Emissary Ingress and Ambassador Edge Stack have separate charts. The helm chart
-for Ambassador Edge Stack 2.0 lives in the [Ambassador Edge Stack chart repository].
-
-See the [Ambassador Edge Stack FAQ] for more information about the differences between Emissary
-Ingress and Ambassador Edge Stack.
-
-[the release/v1.14 branch]: https://github.com/emissary-ingress/emissary/tree/release/v1.14/charts/ambassador 
-[release/v1.13]: https://github.com/emissary-ingress/emissary/tree/release/v1.13/charts/ambassador 
-[Ambassador Edge Stack chart repository]: https://github.com/datawire/edge-stack/tree/main/charts/edge-stack
-[Ambassador Edge Stack FAQ]: https://www.getambassador.io/docs/edge-stack/latest/about/faq/#whats-the-difference-between-ossproductname-and-aesproductname
 
 ## Prerequisites
 {{ range .Prerequisites }}
@@ -44,12 +24,12 @@ Ingress and Ambassador Edge Stack.
 To install the chart with the release name `{{ .Release.Name }}`:
 
 ```console
-$ helm install {{ .Release.Name }} --devel {{ .Repository.Name }}/{{ .Chart.Name }} -n {{ .Release.Namespace }}{{ with .Chart.Version }} --version={{.}}{{ end }}
+$ helm install {{ .Release.Name }} -n {{ .Release.Namespace }} \
+    oci://ghcr.io/{{ .Repository.Name }}/{{ .Chart.Name }} \
+    --version={{ .Chart.Version }}
 ```
 
 The command deploys {{ .Project.App }} on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
-
-> **Tip**: List all releases using `helm list`
 
 ## Uninstalling the Chart
 
@@ -75,13 +55,19 @@ The following table lists the configurable parameters of the `{{ .Chart.Name }}`
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 
 ```console
-$ helm install {{ .Release.Name }} --devel {{ .Repository.Name }}/{{ .Chart.Name }} -n {{ .Release.Namespace }}{{ with .Chart.Version }} --version={{.}}{{ end }} --set {{ .Chart.ValuesExample }}
+$ helm install {{ .Release.Name }} -n {{ .Release.Namespace }} \
+    oci://ghcr.io/{{ .Repository.Name }}/{{ .Chart.Name }} \
+    --version={{ .Chart.Version }} \
+    --set {{ .Chart.ValuesExample }}
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```console
-$ helm install {{ .Release.Name }} --devel {{ .Repository.Name }}/{{ .Chart.Name }} -n {{ .Release.Namespace }}{{ with .Chart.Version }} --version={{.}}{{ end }} --values values.yaml
+$ helm install {{ .Release.Name }} -n {{ .Release.Namespace }} \
+    oci://ghcr.io/{{ .Repository.Name }}/{{ .Chart.Name }} \
+    --version={{ .Chart.Version }}
+    --values values.yaml
 ```
 {{- end }}

--- a/charts/emissary-ingress/templates/_helpers.tpl
+++ b/charts/emissary-ingress/templates/_helpers.tpl
@@ -3,10 +3,12 @@
 Expand the name of the chart.
 */}}
 {{- define "ambassador.name" -}}
-{{- if contains "ambassador" .Release.Name -}}
+{{- if contains "emissary" .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else if contains "ambassador" .Release.Name -}}
 {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- default "emissary-ingress" .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
 
@@ -19,10 +21,12 @@ If release name contains chart name it will be used as a full name.
 {{- if .Values.fullnameOverride -}}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- $name := default "emissary-ingress" .Values.nameOverride -}}
 {{- if contains $name .Release.Name -}}
 {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- else if contains "ambassador" .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else if contains "emissary" .Release.Name -}}
 {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}

--- a/charts/emissary-ingress/templates/admin-service.yaml
+++ b/charts/emissary-ingress/templates/admin-service.yaml
@@ -10,16 +10,8 @@ metadata:
     # Hard-coded label for Prometheus Operator ServiceMonitor
     service: ambassador-admin
     product: aes
-  annotations:
-    a8r.io/owner: "Ambassador Labs"
-    a8r.io/repository: github.com/datawire/ambassador
-    a8r.io/description: "The Ambassador Edge Stack admin service for internal use and health checks."
-    a8r.io/documentation: https://www.getambassador.io/docs/edge-stack/latest/
-    a8r.io/chat: http://a8r.io/Slack
-    a8r.io/bugs: https://github.com/datawire/ambassador/issues
-    a8r.io/support: https://www.getambassador.io/about-us/support/
-    a8r.io/dependencies: "None"
   {{- with .Values.adminService.annotations }}
+  annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:

--- a/charts/emissary-ingress/templates/deployment-canary.yaml
+++ b/charts/emissary-ingress/templates/deployment-canary.yaml
@@ -178,7 +178,7 @@ spec:
           resources:
             {{- toYaml .Values.prometheusExporter.resources | nindent 12 }}
         {{- end }}
-        - name: {{ if .Values.containerNameOverride }}{{ .Values.containerNameOverride }}{{ else }}{{ .Chart.Name }}{{ end }}
+        - name: {{ if .Values.containerNameOverride }}{{ .Values.containerNameOverride }}{{ else }}emissary-ingress{{ end }}
           {{- if ne (include "ambassador.canaryImage" .)  "" }}
           image: {{ include "ambassador.canaryImage" . }}
           {{- else }}

--- a/charts/emissary-ingress/templates/deployment.yaml
+++ b/charts/emissary-ingress/templates/deployment.yaml
@@ -199,7 +199,7 @@ spec:
           resources:
             {{- toYaml .Values.prometheusExporter.resources | nindent 12 }}
         {{- end }}
-        - name: {{ if .Values.containerNameOverride }}{{ .Values.containerNameOverride }}{{ else }}{{ .Chart.Name }}{{ end }}
+        - name: {{ if .Values.containerNameOverride }}{{ .Values.containerNameOverride }}{{ else }}emissary-ingress{{ end }}
           image: {{ include "ambassador.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:

--- a/charts/emissary-ingress/templates/service-canary.yaml
+++ b/charts/emissary-ingress/templates/service-canary.yaml
@@ -14,16 +14,8 @@ metadata:
     {{- include "ambassador.labels" . | nindent 4 }}
     app.kubernetes.io/component: ambassador-service
     product: aes
-  annotations:
-    a8r.io/owner: "Ambassador Labs"
-    a8r.io/repository: github.com/datawire/ambassador
-    a8r.io/description: "The Ambassador Edge Stack goes beyond traditional API Gateways and Ingress Controllers with the advanced edge features needed to support developer self-service and full-cycle development."
-    a8r.io/documentation: https://www.getambassador.io/docs/edge-stack/latest/
-    a8r.io/chat: http://a8r.io/Slack
-    a8r.io/bugs: https://github.com/datawire/ambassador/issues
-    a8r.io/support: https://www.getambassador.io/about-us/support/
-    a8r.io/dependencies: {{ include "ambassador.fullname" . }}-redis.{{ include "ambassador.namespace" . }}
 {{- if .Values.service.annotations }}
+  annotations:
   {{- range $key, $value := .Values.service.annotations }}
     {{ $key }}: {{ $value | quote }}
   {{- end }}

--- a/charts/emissary-ingress/templates/service.yaml
+++ b/charts/emissary-ingress/templates/service.yaml
@@ -12,16 +12,8 @@ metadata:
     {{- include "ambassador.labels" . | nindent 4 }}
     app.kubernetes.io/component: ambassador-service
     product: aes
-  annotations:
-    a8r.io/owner: "Ambassador Labs"
-    a8r.io/repository: github.com/datawire/ambassador
-    a8r.io/description: "The Ambassador Edge Stack goes beyond traditional API Gateways and Ingress Controllers with the advanced edge features needed to support developer self-service and full-cycle development."
-    a8r.io/documentation: https://www.getambassador.io/docs/edge-stack/latest/
-    a8r.io/chat: http://a8r.io/Slack
-    a8r.io/bugs: https://github.com/datawire/ambassador/issues
-    a8r.io/support: https://www.getambassador.io/about-us/support/
-    a8r.io/dependencies: {{ include "ambassador.fullname" . }}-redis.{{ include "ambassador.namespace" . }}
 {{- if .Values.service.annotations }}
+  annotations:
   {{- range $key, $value := .Values.service.annotations }}
     {{ $key }}: {{ $value | quote }}
   {{- end }}

--- a/docs/yaml/ambassador/ambassador-service.yaml
+++ b/docs/yaml/ambassador/ambassador-service.yaml
@@ -5,15 +5,6 @@ metadata:
   name: ambassador
   labels:
     app.kubernetes.io/component: ambassador-service
-  annotations:
-    a8r.io/owner: "Ambassador Labs"
-    a8r.io/repository: github.com/datawire/ambassador
-    a8r.io/description: "The Ambassador Edge Stack goes beyond traditional API Gateways and Ingress Controllers with the advanced edge features needed to support developer self-service and full-cycle development."
-    a8r.io/documentation: https://www.getambassador.io/docs/edge-stack/latest/
-    a8r.io/chat: http://a8r.io/Slack
-    a8r.io/bugs: https://github.com/datawire/ambassador/issues
-    a8r.io/support: https://www.getambassador.io/about-us/support/
-    a8r.io/dependencies: "ambassador-redis"
 spec:
   type: LoadBalancer
   externalTrafficPolicy: Local

--- a/docs/yaml/consul/ambassador-consul-connector-old.yaml
+++ b/docs/yaml/consul/ambassador-consul-connector-old.yaml
@@ -21,15 +21,6 @@ kind: Service
 metadata:
   name: ambassador-consul-connector
   namespace: default
-  annotations:
-    a8r.io/owner: "Ambassador Labs"
-    a8r.io/repository: github.com/datawire/ambassador
-    a8r.io/description: "The Ambassador Edge Stack Consul Connect integration."
-    a8r.io/documentation: https://www.getambassador.io/docs/edge-stack/latest/
-    a8r.io/chat: http://a8r.io/Slack
-    a8r.io/bugs: https://github.com/datawire/ambassador/issues
-    a8r.io/support: https://www.getambassador.io/about-us/support/
-    a8r.io/dependencies: "Consul"
 spec:
   ports:
   - name: ambassador-consul-connector

--- a/docs/yaml/consul/ambassador-consul-connector.yaml
+++ b/docs/yaml/consul/ambassador-consul-connector.yaml
@@ -42,15 +42,6 @@ kind: Service
 metadata:
   name: ambassador-consul-connector
   namespace: ambassador
-  annotations:
-    a8r.io/owner: "Ambassador Labs"
-    a8r.io/repository: github.com/datawire/ambassador
-    a8r.io/description: "The Ambassador Edge Stack Consul Connect integration."
-    a8r.io/documentation: https://www.getambassador.io/docs/edge-stack/latest/
-    a8r.io/chat: http://a8r.io/Slack
-    a8r.io/bugs: https://github.com/datawire/ambassador/issues
-    a8r.io/support: https://www.getambassador.io/about-us/support/
-    a8r.io/dependencies: "consul-server.default"
 spec:
   ports:
   - name: ambassador-consul-connector

--- a/docs/yaml/quickstart/qotm.yaml
+++ b/docs/yaml/quickstart/qotm.yaml
@@ -26,17 +26,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: quote
-  annotations:
-        a8r.io/description: "Quote of the moment service"
-        a8r.io/owner: "No owner"
-        a8r.io/chat: "#ambassador"
-        a8r.io/bugs: "https://github.com/datawire/quote/issues"
-        a8r.io/documentation: "https://github.com/datawire/quote/blob/master/README.md"
-        a8r.io/repository: "https://github.com/datawire/quote"
-        a8r.io/support: "http://a8r.io/Slack"
-        a8r.io/runbook: "https://github.com/datawire/quote/blob/master/README.md"
-        a8r.io/incidents: "https://github.com/datawire/quote/issues"
-        a8r.io/dependencies: "None"
 spec:
   ports:
   - name: http

--- a/manifests/emissary/emissary-defaultns.yaml.in
+++ b/manifests/emissary/emissary-defaultns.yaml.in
@@ -3,16 +3,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    a8r.io/bugs: https://github.com/datawire/ambassador/issues
-    a8r.io/chat: http://a8r.io/Slack
-    a8r.io/dependencies: None
-    a8r.io/description: The Ambassador Edge Stack admin service for internal use and
-      health checks.
-    a8r.io/documentation: https://www.getambassador.io/docs/edge-stack/latest/
-    a8r.io/owner: Ambassador Labs
-    a8r.io/repository: github.com/datawire/ambassador
-    a8r.io/support: https://www.getambassador.io/about-us/support/
   labels:
     app.kubernetes.io/instance: emissary-ingress
     app.kubernetes.io/managed-by: getambassador.io
@@ -40,17 +30,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    a8r.io/bugs: https://github.com/datawire/ambassador/issues
-    a8r.io/chat: http://a8r.io/Slack
-    a8r.io/dependencies: emissary-ingress-redis.default
-    a8r.io/description: The Ambassador Edge Stack goes beyond traditional API Gateways
-      and Ingress Controllers with the advanced edge features needed to support developer
-      self-service and full-cycle development.
-    a8r.io/documentation: https://www.getambassador.io/docs/edge-stack/latest/
-    a8r.io/owner: Ambassador Labs
-    a8r.io/repository: github.com/datawire/ambassador
-    a8r.io/support: https://www.getambassador.io/about-us/support/
   labels:
     app.kubernetes.io/component: ambassador-service
     app.kubernetes.io/instance: emissary-ingress

--- a/manifests/emissary/emissary-emissaryns.yaml.in
+++ b/manifests/emissary/emissary-emissaryns.yaml.in
@@ -3,16 +3,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    a8r.io/bugs: https://github.com/datawire/ambassador/issues
-    a8r.io/chat: http://a8r.io/Slack
-    a8r.io/dependencies: None
-    a8r.io/description: The Ambassador Edge Stack admin service for internal use and
-      health checks.
-    a8r.io/documentation: https://www.getambassador.io/docs/edge-stack/latest/
-    a8r.io/owner: Ambassador Labs
-    a8r.io/repository: github.com/datawire/ambassador
-    a8r.io/support: https://www.getambassador.io/about-us/support/
   labels:
     app.kubernetes.io/instance: emissary-ingress
     app.kubernetes.io/managed-by: getambassador.io
@@ -40,17 +30,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    a8r.io/bugs: https://github.com/datawire/ambassador/issues
-    a8r.io/chat: http://a8r.io/Slack
-    a8r.io/dependencies: emissary-ingress-redis.emissary
-    a8r.io/description: The Ambassador Edge Stack goes beyond traditional API Gateways
-      and Ingress Controllers with the advanced edge features needed to support developer
-      self-service and full-cycle development.
-    a8r.io/documentation: https://www.getambassador.io/docs/edge-stack/latest/
-    a8r.io/owner: Ambassador Labs
-    a8r.io/repository: github.com/datawire/ambassador
-    a8r.io/support: https://www.getambassador.io/about-us/support/
   labels:
     app.kubernetes.io/component: ambassador-service
     app.kubernetes.io/instance: emissary-ingress

--- a/python/tests/integration/manifests/ambassador.yaml
+++ b/python/tests/integration/manifests/ambassador.yaml
@@ -45,17 +45,6 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    a8r.io/bugs: https://github.com/datawire/ambassador/issues
-    a8r.io/chat: http://a8r.io/Slack
-    a8r.io/dependencies: {self.path.k8s}-redis.{self.namespace}
-    a8r.io/description: The Ambassador Edge Stack goes beyond traditional API Gateways
-      and Ingress Controllers with the advanced edge features needed to support developer
-      self-service and full-cycle development.
-    a8r.io/documentation: https://www.getambassador.io/docs/edge-stack/latest/
-    a8r.io/owner: Ambassador Labs
-    a8r.io/repository: github.com/datawire/ambassador
-    a8r.io/support: https://www.getambassador.io/about-us/support/
   labels:
     app.kubernetes.io/component: ambassador-service
     app.kubernetes.io/instance: kat-ambassador
@@ -82,16 +71,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    a8r.io/bugs: https://github.com/datawire/ambassador/issues
-    a8r.io/chat: http://a8r.io/Slack
-    a8r.io/dependencies: None
-    a8r.io/description: The Ambassador Edge Stack admin service for internal use and
-      health checks.
-    a8r.io/documentation: https://www.getambassador.io/docs/edge-stack/latest/
-    a8r.io/owner: Ambassador Labs
-    a8r.io/repository: github.com/datawire/ambassador
-    a8r.io/support: https://www.getambassador.io/about-us/support/
   labels:
     app.kubernetes.io/instance: kat-ambassador
     app.kubernetes.io/managed-by: kat


### PR DESCRIPTION
https://github.com/emissary-ingress/emissary/pull/5691 needs to land before this.

Four significant changes here:

1. Make the chart version match the image version.

This will appear to be a conflict with existing Emissary charts, but the 4.x charts and the older charts don't live in the same Helm repository, so it doesn't matter.

**NOTE WELL**: this _may_ be something we need to change later, since right now a Helm-chart-only change will require making new binaries. The goal here is that releases get to be sufficiently lightweight that we don't care.

2. Also, change the default naming so that we don't end with insane things like a Service named "emissary-ingress-emissary-chart-admin".

3. _Also_, change the `app.kubernetes.io/name` annotation _not_ to default to `.Chart.Name` -- https://helm.sh/docs/chart_best_practices/labels/ differentiates this from the `helm.sh/chart` annotation, so use Emissary's name for the `app.kubernetes.io/name` annotation.

4. Ditch the `a8r.io/*` annotations that were left over from older Ambassador Cloud stuff.

Also, I cleaned up the chart README some. Holy _crap_ that was out of date.
