### PR TITLE
Upgrade Envoy to 1.30.2

### DIFF
--- a/_cxx/envoy.mk
+++ b/_cxx/envoy.mk
@@ -11,8 +11,8 @@ export ENVOY_TEST_LABEL
 
 # IF YOU MESS WITH ANY OF THESE VALUES, YOU MUST RUN `make update-base`.
 ENVOY_REPO ?= https://github.com/datawire/envoy.git
-# https://github.com/datawire/envoy/tree/rebase/release/v1.30.1
-ENVOY_COMMIT ?= c5eb07f628b37313fa4d3cdb14d5b3e9ed5379e9
+# https://github.com/datawire/envoy/tree/rebase/release/v1.30.2
+ENVOY_COMMIT ?= d63d736572a67e69cd81713f79888b85901166f0
 ENVOY_COMPILATION_MODE ?= opt
 # Increment BASE_ENVOY_RELVER on changes to `docker/base-envoy/Dockerfile`, or Envoy recipes.
 # You may reset BASE_ENVOY_RELVER when adjusting ENVOY_COMMIT.


### PR DESCRIPTION

![Screen Shot 2024-06-10 at 4 27 14 PM](https://github.com/emissary-ingress/emissary/assets/92330484/774f9378-e83c-4001-a9d1-5985757ff4ed)

## Description

Upgrading Envoy to 1.30.2

