### PR TITLE
issue-5714 - incorrect _cache_key generation fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,12 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
   starting. This will help address  some of the intermittent issues seen during install and
   upgrades.
 
+- Bugfix: _cache_key is getting generated incorrectly for mappings in ir.json, when using header
+  with regex in mapping. Always, It should be in the format of {kind}-{version}-{name}-{namespace}. 
+  But header name is getting updated in the place of mapping name, if we created mapping with regex 
+  header.
+
+
 ## [3.8.0] August 29, 2023
 [3.8.0]: https://github.com/emissary-ingress/emissary/compare/v3.7.2...v3.8.0
 

--- a/python/ambassador/ir/irhttpmapping.py
+++ b/python/ambassador/ir/irhttpmapping.py
@@ -241,8 +241,8 @@ class IRHTTPMapping(IRBaseMapping):
         if "regex_headers" in kwargs:
             # DON'T do anything special with a regex :authority match: we can't
             # do host-based filtering within the IR for it anyway.
-            for name, value in kwargs.get("regex_headers", {}).items():
-                hdrs.append(KeyValueDecorator(name, value, regex=True))
+            for hdr_name, hdr_value in kwargs.get("regex_headers", {}).items():
+                hdrs.append(KeyValueDecorator(hdr_name, hdr_value, regex=True))
 
         if "host" in kwargs:
             # It's deliberate that we'll allow kwargs['host'] to silently override an exact :authority


### PR DESCRIPTION
## Description

_cache_key is getting generated incorrectly for mappings in ir.json, when using header with regex. Always _cache_key should be in the format of [{kind}-{version}-{name}-{namespace}](https://github.com/emissary-ingress/emissary/blob/master/python/ambassador/ir/irbasemapping.py#L166-L181). But header name is getting updated in the place of mapping name

## Related Issues

https://github.com/emissary-ingress/emissary/issues/5714

## Testing

manual tests

## Checklist

- [ ] **Does my change need to be backported to a previous release?**

- [ ] **I made sure to update `CHANGELOG.md`.**

- [ ] **This is unlikely to impact how Ambassador performs at scale.**

- [ ] **My change is adequately tested.**

- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**

- [ ] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
