### PR TITLE
CI for 5715

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,12 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
 - Change: Upgraded Emissary-ingress to the latest release of Golang as part of our general
   dependency upgrade process.
 
+- Bugfix: Emissary-ingress was incorrectly caching Mappings with regex headers using the header name
+  instead of the Mapping name, which could reduce the cache's effectiveness. This has been fixed so
+  that the correct key is used. ([Incorrect Cache Key for Mapping])
+
+[Incorrect Cache Key for Mapping]: https://github.com/emissary-ingress/emissary/issues/5714
+
 ## [3.9.0] November 13, 2023
 [3.9.0]: https://github.com/emissary-ingress/emissary/compare/v3.8.0...v3.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,7 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
 ### Emissary-ingress and Ambassador Edge Stack
 
 - Feature: This upgrades Emissary-ingress to be built on Envoy v1.28.0 which provides security,
-  performance  and feature enhancements. You can read more about them here:  <a
+  performance and feature enhancements. You can read more about them here: <a
   href="https://www.envoyproxy.io/docs/envoy/v1.28.0/version_history/version_history">Envoy Proxy
   1.28.0 Release Notes</a>
 
@@ -115,37 +115,30 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
 ### Emissary-ingress and Ambassador Edge Stack
 
 - Feature: This upgrades Emissary-ingress to be built on Envoy v1.27.2 which provides security,
-  performance  and feature enhancements. You can read more about them here:  <a
+  performance and feature enhancements. You can read more about them here: <a
   href="https://www.envoyproxy.io/docs/envoy/v1.27.2/version_history/version_history">Envoy Proxy
   1.27.2 Release Notes</a>
 
-- Feature: By default, Emissary-ingress will return an `UNAVAILABLE` code when a request using gRPC 
+- Feature: By default, Emissary-ingress will return an `UNAVAILABLE` code when a request using gRPC
   is rate limited. The `RateLimitService` resource now exposes a new
-  `grpc.use_resource_exhausted_code`  field that when set to `true`, Emissary-ingress will return a
-  `RESOURCE_EXHAUSTED` gRPC code instead.  Thanks to <a href="https://github.com/jeromefroe">Jerome
+  `grpc.use_resource_exhausted_code` field that when set to `true`, Emissary-ingress will return a
+  `RESOURCE_EXHAUSTED` gRPC code instead. Thanks to <a href="https://github.com/jeromefroe">Jerome
   Froelich</a> for contributing this feature!
 
 - Feature: Envoy runtime fields that were provided to mitigate the recent HTTP/2 rapid reset
-  vulnerability  can now be configured via the Module resource so the configuration will persist
-  between restarts.  This configuration is added to the Envoy bootstrap config, so restarting
-  Emissary is necessary after  changing these fields for the configuration to take effect.
+  vulnerability can now be configured via the Module resource so the configuration will persist
+  between restarts. This configuration is added to the Envoy bootstrap config, so restarting
+  Emissary is necessary after changing these fields for the configuration to take effect.
 
 - Change: APIExt would previously allow for TLS 1.0 connections. We have updated it to now only use
-  a minimum  TLS version of 1.3 to resolve security concerns.
+  a minimum TLS version of 1.3 to resolve security concerns.
 
 - Change: - Update default image to Emissary-ingress v3.9.0. <br/>
 
 - Bugfix: The APIExt server provides CRD conversion between the stored version v2 and the version
-  watched for  by Emissary-ingress v3alpha1. Since this component is required to operate
-  Emissary-ingress, we have  introduced an init container that will ensure it is available before
-  starting. This will help address  some of the intermittent issues seen during install and
-  upgrades.
-
-- Bugfix: _cache_key is getting generated incorrectly for mappings in ir.json, when using header
-  with regex in mapping. Always, It should be in the format of {kind}-{version}-{name}-{namespace}. 
-  But header name is getting updated in the place of mapping name, if we created mapping with regex 
-  header.
-
+  watched for by Emissary-ingress v3alpha1. Since this component is required to operate
+  Emissary-ingress, we have introduced an init container that will ensure it is available before
+  starting. This will help address some of the intermittent issues seen during install and upgrades.
 
 ## [3.8.0] August 29, 2023
 [3.8.0]: https://github.com/emissary-ingress/emissary/compare/v3.7.2...v3.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,12 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
   starting. This will help address  some of the intermittent issues seen during install and
   upgrades.
 
+- Bugfix: _cache_key is getting generated incorrectly for mappings in ir.json, when using header
+  with regex in mapping. Always, It should be in the format of {kind}-{version}-{name}-{namespace}. 
+  But header name is getting updated in the place of mapping name, if we created mapping with regex 
+  header.
+
+
 ## [3.8.0] August 29, 2023
 [3.8.0]: https://github.com/emissary-ingress/emissary/compare/v3.7.2...v3.8.0
 

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -35,15 +35,15 @@ items:
   - version: 3.10.0-dev
     prevVersion: 3.9.0
     date: 'TBD'
-    notes: 
+    notes:
       - title: Upgrade to Envoy 1.30.2
         type: feature
         body: >-
-          This upgrades $productName$ to be built on Envoy v1.28.0 which provides security, performance 
-          and feature enhancements. You can read more about them here: 
+          This upgrades $productName$ to be built on Envoy v1.28.0 which provides security, performance
+          and feature enhancements. You can read more about them here:
           <a href="https://www.envoyproxy.io/docs/envoy/v1.28.0/version_history/version_history">Envoy Proxy 1.28.0 Release Notes</a>
         docs: https://www.envoyproxy.io/docs/envoy/v1.28.0/version_history/version_history
-        
+
       - title: Remove Ambassador Agent from published YAML Manifest
         type: change
         body: >-
@@ -51,12 +51,11 @@ items:
           This is an optional component that provides additional features on top of $productName$ and we recommend
           installing it using the instructions found in the <a href="https://github.com/datawire/ambassador-agenty">Ambassador Agent Repo</a>.
         docs: https://github.com/datawire/ambassador-agent
-      
+
       - title: Update to golang 1.22.4
         type: change
         body: >-
           Upgraded $productName$ to the latest release of Golang as part of our general dependency upgrade process.
-      
 
       - title: Fix internal keying for regex Mappings
         type: bugfix
@@ -76,34 +75,34 @@ items:
       - title: Upgrade to Envoy 1.27.2
         type: feature
         body: >-
-          This upgrades $productName$ to be built on Envoy v1.27.2 which provides security, performance 
-          and feature enhancements. You can read more about them here: 
+          This upgrades $productName$ to be built on Envoy v1.27.2 which provides security, performance
+          and feature enhancements. You can read more about them here:
           <a href="https://www.envoyproxy.io/docs/envoy/v1.27.2/version_history/version_history">Envoy Proxy 1.27.2 Release Notes</a>
         docs: https://www.envoyproxy.io/docs/envoy/v1.27.2/version_history/version_history
 
       - title: Added support for RESOURCE_EXHAUSTED responses to grpc clients when rate limited
         type: feature
         body: >-
-          By default, $productName$ will return an <code>UNAVAILABLE</code> code when a request using gRPC 
-          is rate limited. The <code>RateLimitService</code> resource now exposes a new <code>grpc.use_resource_exhausted_code</code> 
-          field that when set to <code>true</code>, $productName$ will return a <code>RESOURCE_EXHAUSTED</code> gRPC code instead. 
+          By default, $productName$ will return an <code>UNAVAILABLE</code> code when a request using gRPC
+          is rate limited. The <code>RateLimitService</code> resource now exposes a new <code>grpc.use_resource_exhausted_code</code>
+          field that when set to <code>true</code>, $productName$ will return a <code>RESOURCE_EXHAUSTED</code> gRPC code instead.
           Thanks to <a href="https://github.com/jeromefroe">Jerome Froelich</a> for contributing this feature!
 
       - title: Added support for setting specific Envoy runtime flags in the Module
         type: feature
         body: >-
-          Envoy runtime fields that were provided to mitigate the recent HTTP/2 rapid reset vulnerability 
-          can now be configured via the Module resource so the configuration will persist between restarts. 
-          This configuration is added to the Envoy bootstrap config, so restarting Emissary is necessary after 
+          Envoy runtime fields that were provided to mitigate the recent HTTP/2 rapid reset vulnerability
+          can now be configured via the Module resource so the configuration will persist between restarts.
+          This configuration is added to the Envoy bootstrap config, so restarting Emissary is necessary after
           changing these fields for the configuration to take effect.
 
       - title: Update APIExt minimum TLS version
         type: change
         body: >-
-          APIExt would previously allow for TLS 1.0 connections. We have updated it to now only use a minimum 
+          APIExt would previously allow for TLS 1.0 connections. We have updated it to now only use a minimum
           TLS version of 1.3 to resolve security concerns.
         docs: https://www.tenable.com/plugins/nessus/104743
-      
+
       - title: Shipped Helm chart v8.9.0
         type: change
         body: >-
@@ -113,9 +112,9 @@ items:
       - title: Ensure APIExt server is available before starting Emissary-ingress
         type: bugfix
         body: >-
-          The APIExt server provides CRD conversion between the stored version v2 and the version watched for 
-          by $productName$ v3alpha1. Since this component is required to operate $productName$, we have 
-          introduced an init container that will ensure it is available before starting. This will help address 
+          The APIExt server provides CRD conversion between the stored version v2 and the version watched for
+          by $productName$ v3alpha1. Since this component is required to operate $productName$, we have
+          introduced an init container that will ensure it is available before starting. This will help address
           some of the intermittent issues seen during install and upgrades.
         docs: https://artifacthub.io/packages/helm/datawire/edge-stack/$emissaryChartVersion$
 

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -58,6 +58,16 @@ items:
           Upgraded $productName$ to the latest release of Golang as part of our general dependency upgrade process.
       
 
+      - title: Fix internal keying for regex Mappings
+        type: bugfix
+        body: >-
+          $productName$ was incorrectly caching Mappings with regex headers
+          using the header name instead of the Mapping name, which could
+          reduce the cache's effectiveness. This has been fixed so that the
+          correct key is used.
+        github:
+          - title: "Incorrect Cache Key for Mapping"
+            link: https://github.com/emissary-ingress/emissary/issues/5714
 
   - version: 3.9.0
     prevVersion: 3.8.0

--- a/python/ambassador/ir/irhttpmapping.py
+++ b/python/ambassador/ir/irhttpmapping.py
@@ -241,8 +241,8 @@ class IRHTTPMapping(IRBaseMapping):
         if "regex_headers" in kwargs:
             # DON'T do anything special with a regex :authority match: we can't
             # do host-based filtering within the IR for it anyway.
-            for name, value in kwargs.get("regex_headers", {}).items():
-                hdrs.append(KeyValueDecorator(name, value, regex=True))
+            for hdr_name, hdr_value in kwargs.get("regex_headers", {}).items():
+                hdrs.append(KeyValueDecorator(hdr_name, hdr_value, regex=True))
 
         if "host" in kwargs:
             # It's deliberate that we'll allow kwargs['host'] to silently override an exact :authority


### PR DESCRIPTION
CI for #5715 (the fix for #5714) from @sekar-saravanan

Reviewers, this is best done commit by commit:

- e8ca6504 is @sekar-saravanan's actual fix
- d04280e3 is my edit to `releaseNotes.yml` and its corresponding generate CHANGELOG change (and yes, I reworded it to, hopefully, explain the effect of the bug rather than just the internals 🙂)
- 642c7842 is a bunch of whitespace changes from my editor saving `releaseNotes.yml` that had corresponding changes in the generated CHANGELOG.

Thanks @sekar-saravanan!