### PR TITLE
issue-5702 - Multiple duplicate mappings generated for single mapping resource fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,13 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
 - Change: Upgraded Emissary-ingress to the latest release of Golang as part of our general
   dependency upgrade process.
 
+- Bugfix: Emissary creating duplicate mapping in ir.json and econf.json while adding weight for canary 
+  release. This leads to getting IR MISMATCH & ENVOY CONFIG MISMATCH error frequently in the logs and 
+  also consumes more cpu. We have introduced a condition that, it will add the mapping only if the mapping
+  is not already present in the group.
+
+[#5702]: https://github.com/emissary-ingress/emissary/issues/5702
+
 ## [3.9.0] November 13, 2023
 [3.9.0]: https://github.com/emissary-ingress/emissary/compare/v3.8.0...v3.9.0
 

--- a/python/ambassador/ir/ir.py
+++ b/python/ambassador/ir/ir.py
@@ -1008,7 +1008,16 @@ class IR:
             else:
                 self.logger.debug(f"IR: already have group for {mapping.name}")
                 group = self.groups[mapping.group_id]
-                group.add_mapping(aconf, mapping)
+                is_mapping_present = False
+                try:
+                    existing_mapping_keys = [ group_mapping["rkey"] for group_mapping in group["mappings"] ]
+                    is_mapping_present = True if mapping["rkey"] in existing_mapping_keys else False
+                except Exception as e:
+                    self.logger.error(f"IR: Exception occurred {e} when checking {mapping.name} already presents in {mapping.group_id}")
+
+                if not is_mapping_present:
+                    self.logger.debug(f"IR: mapping {mapping.name} is not exists. adding it into the group.")
+                    group.add_mapping(aconf, mapping)
 
             self.cache_add(mapping)
             self.cache_add(group)

--- a/python/ambassador_diag/diagd.py
+++ b/python/ambassador_diag/diagd.py
@@ -550,7 +550,7 @@ class DiagApp(Flask):
             result = False
             self.logger.error("CACHE: ENVOY CONFIG MISMATCH")
             errors += "econf diffs:\n"
-            errors += self.json_diff("econf", i1, i2)
+            errors += self.json_diff("econf", e1, e2)
 
         if not result:
             err_path = os.path.join(self.snapshot_path, "diff-tmp.txt")


### PR DESCRIPTION
## Description

Emissary creating multiple duplicate mappings for single mapping resource in ir.json and econf.json while adding weight for canary release

## Related Issues

[#5702](https://github.com/emissary-ingress/emissary/issues/5702
)
## Testing

manual tests

## Checklist

- [ ] **Does my change need to be backported to a previous release?**

- [x] **I made sure to update `CHANGELOG.md`.**

- [ ] **This is unlikely to impact how Ambassador performs at scale.**

- [ ] **My change is adequately tested.**

- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**

- [ ] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
