### PR TITLE
issue-5702 - Multiple duplicate mappings generated for single mapping resource fixed

### DIFF
--- a/python/ambassador/ir/ir.py
+++ b/python/ambassador/ir/ir.py
@@ -817,7 +817,13 @@ class IR:
             else:
                 self.logger.debug(f"IR: already have group for {mapping.name}")
                 group = self.groups[mapping.group_id]
-                group.add_mapping(aconf, mapping)
+                
+                # Add mapping into the group only if the _cache_key doesn't exist in a group.
+                existing_mapping_cache_keys = [ group_mapping["_cache_key"] for group_mapping in group["mappings"] if "_cache_key" in group_mapping ]
+                if mapping["_cache_key"] in existing_mapping_cache_keys:
+                    self.logger.debug(f"IR: _cache_key for {mapping.name} is {mapping['_cache_key']} already exists in a group.")
+                else:
+                    group.add_mapping(aconf, mapping)
 
             self.cache_add(mapping)
             self.cache_add(group)

--- a/python/ambassador_diag/diagd.py
+++ b/python/ambassador_diag/diagd.py
@@ -551,7 +551,7 @@ class DiagApp(Flask):
             result = False
             self.logger.error("CACHE: ENVOY CONFIG MISMATCH")
             errors += "econf diffs:\n"
-            errors += self.json_diff("econf", i1, i2)
+            errors += self.json_diff("econf", e1, e2)
 
         if not result:
             err_path = os.path.join(self.snapshot_path, "diff-tmp.txt")


### PR DESCRIPTION
## Description

Emissary creating multiple duplicate mappings for single mapping resource in ir.json and econf.json while adding weight for canary release

## Related Issues

https://github.com/emissary-ingress/emissary/issues/5702

## Testing

manual tests

## Checklist

- [ ] **Does my change need to be backported to a previous release?**

- [ ] **I made sure to update `CHANGELOG.md`.**

- [ ] **This is unlikely to impact how Ambassador performs at scale.**

- [ ] **My change is adequately tested.**

- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**

- [ ] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
