### PR TITLE
Add Phil Peble as a maintainer (and fix table formatting)

### DIFF
--- a/Community/MAINTAINERS.md
+++ b/Community/MAINTAINERS.md
@@ -10,9 +10,10 @@ Maintainers are listed in alphabetical order.
 | Maintainer       | GitHub ID                                     | Affiliation                                         |
 | ---------------- | --------------------------------------------- | --------------------------------------------------- |
 | Alice Wasko      | [aliceproxy](https://github.com/aliceproxy)   | [Ambassador Labs](https://www.github.com/datawire/) |
-| David Dymko      | [ddymko](https://github.com/ddymko)           | [CoreWeave](https://www.coreweave.com) |
+| David Dymko      | [ddymko](https://github.com/ddymko)           | [CoreWeave](https://www.coreweave.com)              |
 | Flynn            | [kflynn](https://github.com/kflynn)           | [Buoyant](https://www.buoyant.io)                   |
 | Hamzah Qudsi     | [haq204](https://github.com/haq204)           | [Ambassador Labs](https://www.github.com/datawire/) |
+| Phil Peble       | [ppeble](https://github.com/ppeble)           | [ActiveCampaign](https://www.activecampaign.com/)   |
 | Rafael Schloming | [rhs](https://github.com/rhs)                 | [Ambassador Labs](https://www.github.com/datawire/) |
 
 


### PR DESCRIPTION
Phil Peble is a _long_time Emissary user who's taken on the job of wrangling docs into shape for emissary-ingress.dev, as well as being comfortable enough with Python, Go, and Emissary to help review and fix things. I'm nominating him as our newest maintainer. :slightly_smiling_face: (I'm also fixing the table formatting a touch too.)

Maintainers, please vote yay with a :+1: comment below (or, I guess, nay with a :-1:?). We'll do this by lazy consensus, closing either when we have enough votes or a week out. Thanks!

Signed-off-by: Flynn <emissary@flynn.kodachi.com>
