### PR TITLE
Add Helm Chart Support for Opt-In Support for Exposing Port 8878 in the AdminService

### DIFF
--- a/charts/emissary-ingress/templates/admin-service.yaml
+++ b/charts/emissary-ingress/templates/admin-service.yaml
@@ -32,6 +32,12 @@ spec:
       {{- if (and (eq .Values.adminService.type "NodePort") (not (empty .Values.adminService.nodePort))) }}
       nodePort: {{ int .Values.adminService.nodePort }}
       {{- end }}
+      {{- if .Values.adminService.goPluginMetricsPort}}
+    - port: {{ .Values.adminService.goPluginMetricsPort }}
+      targetPort: 8878
+      protocol: TCP
+      name: go-plugin-filter-metrics
+      {{- end }}
     - port: {{ .Values.adminService.snapshotPort }}
       targetPort: 8005
       protocol: TCP

--- a/charts/emissary-ingress/templates/deployment.yaml
+++ b/charts/emissary-ingress/templates/deployment.yaml
@@ -215,7 +215,15 @@ spec:
             {{- end}}
             - name: admin
               containerPort: {{ .Values.adminService.port }}
+            {{- if .Values.adminService.goPluginMetricsPort}}
+            - name: go-plugin-metrics-port
+              containerPort: {{ .Values.adminService.goPluginMetricsPort}}
+            {{- end}}
           env:
+            {{- if .Values.adminService.goPluginMetricsPort}}
+            - name: ENABLE_PLUGIN_FILTER_METRICS
+              value: "true"
+            {{- end }}
             {{- if .Values.prometheusExporter.enabled }}
             - name: STATSD_ENABLED
               value: "true"

--- a/charts/emissary-ingress/values.yaml.in
+++ b/charts/emissary-ingress/values.yaml.in
@@ -208,6 +208,7 @@ adminService:
   type: ClusterIP
   port: 8877
   snapshotPort: 8005
+  goPluginMetricsPort: 
   # If explicit NodePort for admin service is required
   nodePort:
   # Annotations to apply to Ambassador admin service


### PR DESCRIPTION
…in for access to the Go Plugin Filter Metrics

## Description

Adding support in the Helm chart to allow an Opt-In feature for users to configure a new port to open in the adminService. This new port will allow users to set `Values.adminService.goPluginMetricsPort=8878` to expose port `8878` for users to get access to the Go Filter Plugin Metrics, which we added in Edge Stack release `3.11.0`. This allows users to expose an additional port so that they may use metric scraping tools to scrape the new Go Plugin metrics using Helm.

## Related Issues

List related issues.

## Testing

Running `helm install --dry-run --debug <LOCAL-CHART>` has the expected default output, where `goPluginMetricsPort` inside the adminService file is empty, the adminService remains unchanged, and emissary-ingress installs with no changes. 

Running `helm install --dry-run --debug <LOCAL-CHART> --set adminService.goPluginMetricsPort=8878` has the expected output where the `goPluginMetricsPort` field inside the adminService has the value `8878`, the environment variable `ENABLE_PLUGIN_FILTER_METRICS` is set to `"true"`, port `8878` is opened on the emissary-ingress deployment, and the adminService has the port `8878` exposed on it. 

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->
- [ ] **Does my change need to be backported to a previous release?**
  - What backport versions were discussed with the Maintainers in the Issue?

- [ ] **I made sure to update `CHANGELOG.md`.**

   Remember, the CHANGELOG needs to mention:
  - Any new features
  - Any changes to our included version of Envoy
  - Any non-backward-compatible changes
  - Any deprecations

- [ ] **This is unlikely to impact how Ambassador performs at scale.**

   Remember, things that might have an impact at scale include:
  - Any significant changes in memory use that might require adjusting the memory limits
  - Any significant changes in CPU use that might require adjusting the CPU limits
  - Anything that might change how many replicas users should use
  - Changes that impact data-plane latency/scalability

- [ ] **My change is adequately tested.**

   Remember when considering testing:
  - Your change needs to be specifically covered by tests.
    - Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
  - You also need to make sure that the _entire area being changed_ has adequate test coverage.
    - If existing tests don't actually cover the entire area being changed, add tests.
    - This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
  - We should lean on the bulk of code being covered by unit tests, but...
  - ... an end-to-end test should cover the integration points

- [ ] **I updated `DEVELOPING.md` with any any special dev tricks I had to use to work on this code efficiently.**

- [ ] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
