### PR TITLE
Re-adding HostIP to helm charts and deployments

### DIFF
--- a/charts/emissary-ingress/templates/deployment.yaml
+++ b/charts/emissary-ingress/templates/deployment.yaml
@@ -216,6 +216,10 @@ spec:
             - name: admin
               containerPort: {{ .Values.adminService.port }}
           env:
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
             {{- if .Values.prometheusExporter.enabled }}
             - name: STATSD_ENABLED
               value: "true"

--- a/manifests/emissary/emissary-defaultns.yaml.in
+++ b/manifests/emissary/emissary-defaultns.yaml.in
@@ -272,6 +272,10 @@ spec:
             weight: 100
       containers:
       - env:
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         - name: AMBASSADOR_NAMESPACE
           valueFrom:
             fieldRef:

--- a/manifests/emissary/emissary-emissaryns.yaml.in
+++ b/manifests/emissary/emissary-emissaryns.yaml.in
@@ -272,6 +272,10 @@ spec:
             weight: 100
       containers:
       - env:
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         - name: AMBASSADOR_NAMESPACE
           valueFrom:
             fieldRef:

--- a/python/tests/integration/manifests/ambassador.yaml
+++ b/python/tests/integration/manifests/ambassador.yaml
@@ -133,6 +133,10 @@ metadata:
 spec:
   containers:
   - env:
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.hostIP
     - name: AMBASSADOR_NAMESPACE
       valueFrom:
         fieldRef:


### PR DESCRIPTION
## Description

There was some friction in the upgrade process when users noticed that hostIP was missing. This reduces that friction. 

