### PR TITLE
Add Mark Schlachter (@the-wondersmith) as a maintainer

### DIFF
--- a/Community/MAINTAINERS.md
+++ b/Community/MAINTAINERS.md
@@ -7,15 +7,15 @@ maintainer responsibilities.
 
 Maintainers are listed in alphabetical order.
 
-| Maintainer       | GitHub ID                                     | Affiliation                                         |
-| ---------------- | --------------------------------------------- | --------------------------------------------------- |
-| Alice Wasko      | [aliceproxy](https://github.com/aliceproxy)   | [Ambassador Labs](https://www.github.com/datawire/) |
-| David Dymko      | [ddymko](https://github.com/ddymko)           | [CoreWeave](https://www.coreweave.com)              |
-| Flynn            | [kflynn](https://github.com/kflynn)           | [Buoyant](https://www.buoyant.io)                   |
-| Hamzah Qudsi     | [haq204](https://github.com/haq204)           | [Ambassador Labs](https://www.github.com/datawire/) |
-| Phil Peble       | [ppeble](https://github.com/ppeble)           | [ActiveCampaign](https://www.activecampaign.com/)   |
-| Rafael Schloming | [rhs](https://github.com/rhs)                 | [Ambassador Labs](https://www.github.com/datawire/) |
-
+| Maintainer       | GitHub ID                                              | Affiliation                                         |
+| ---------------- | ------------------------------------------------------ | --------------------------------------------------- |
+| Alice Wasko      | [aliceproxy](https://github.com/aliceproxy)            | [Ambassador Labs](https://www.github.com/datawire/) |
+| David Dymko      | [ddymko](https://github.com/ddymko)                    | [CoreWeave](https://www.coreweave.com)              |
+| Flynn            | [kflynn](https://github.com/kflynn)                    | [Buoyant](https://www.buoyant.io)                   |
+| Hamzah Qudsi     | [haq204](https://github.com/haq204)                    | [Ambassador Labs](https://www.github.com/datawire/) |
+| Mark Schlachter  | [the-wondersmith](https://github.com/the-wondersmith)  | [Shuttle](https://www.shuttle.rs)                   |
+| Phil Peble       | [ppeble](https://github.com/ppeble)                    | [ActiveCampaign](https://www.activecampaign.com/)   |
+| Rafael Schloming | [rhs](https://github.com/rhs)                          | [Ambassador Labs](https://www.github.com/datawire/) |
 
 
 In addition to the maintainers, Emissary releases may be created by any


### PR DESCRIPTION
Mark Schlachter is another long-time OG Emissary user who's recently been tackling dev/v4's CI pipeline, Python dependency handling, and beginning the journey into the recesses of KAT where angels fear to tread. I'm nominating him as an Emissary maintainer (though fair warning, he might encourage rewrites in Rust... 🙂).

Maintainers, once again please vote with a 👍 or 👎 on this comment. We'll do a lazy one-week consensus (unless we have enough votes to short-circuit).

Signed-off-by: Flynn emissary@flynn.kodachi.com
