### PR TITLE
ambex: Remove usage of md5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,8 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
   instead of the Mapping name, which could reduce the cache's effectiveness. This has been fixed so
   that the correct key is used. ([Incorrect Cache Key for Mapping])
 
+- Change: Changed Ambex suffix hashing algorithm to use xxhash64 instead of md5.
+
 [Incorrect Cache Key for Mapping]: https://github.com/emissary-ingress/emissary/issues/5714
 
 ## [3.9.0] November 13, 2023

--- a/go.mod
+++ b/go.mod
@@ -83,6 +83,7 @@ require (
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/census-instrumentation/opencensus-proto v0.4.1
+	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/cncf/xds/go v0.0.0-20230607035331-e9ce68804cb4
 	github.com/datawire/dlib v1.3.1
 	github.com/datawire/dtest v0.0.0-20210928162311-722b199c4c2f
@@ -146,7 +147,6 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
-	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/chai2010/gettext-go v1.0.2 // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.4 // indirect

--- a/pkg/ambex/transforms.go
+++ b/pkg/ambex/transforms.go
@@ -3,12 +3,12 @@ package ambex
 import (
 	// standard library
 	"context"
-	"crypto/md5"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"strconv"
 
 	// third-party libraries
+	"github.com/cespare/xxhash/v2"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 
@@ -146,9 +146,10 @@ func V3ListenerToRdsListener(lnr *v3listener.Listener) (*v3listener.Listener, []
 						// associated with a given listener.
 						filterChainMatch, _ := json.Marshal(fc.GetFilterChainMatch())
 
-						// Use MD5 because it's decently fast and cryptographic security isn't needed.
-						matchHash := md5.Sum(filterChainMatch)
-						matchKey := hex.EncodeToString(matchHash[:])
+						// Use xxhash64 because it's decently fast and cryptographic security isn't needed.
+						h := xxhash.New()
+						h.Write(filterChainMatch)
+						matchKey := strconv.FormatUint(h.Sum64(), 16)
 
 						rc.Name = fmt.Sprintf("%s-routeconfig-%s-%d", l.Name, matchKey, matchKeyIndex[matchKey])
 

--- a/pkg/ambex/transforms_test.go
+++ b/pkg/ambex/transforms_test.go
@@ -78,7 +78,7 @@ func TestV3ListenerToRdsListener(t *testing.T) {
 
 	for i, rc := range routes {
 		// Confirm that the route name was transformed to the hashed version
-		assert.Equal(t, fmt.Sprintf("emissary-ingress-listener-8080-routeconfig-8c82e45fa3f94ab4e879543e0a1a30ac-%d", i), rc.GetName())
+		assert.Equal(t, fmt.Sprintf("emissary-ingress-listener-8080-routeconfig-29865f40cbcf32dc-%d", i), rc.GetName())
 
 		// Make sure the virtual hosts are unmodified
 		virtualHosts := rc.GetVirtualHosts()


### PR DESCRIPTION
## Description

When trying to run emissary in crypto-restricted environments (e.g. FIPS), usage of md5 can be problematic:

```
time="2024-10-17 19:20:29.7063" level=error msg="shut down with error error: PANIC: openssl: MD5 failed" func=github.com/emissary-ingress/emissary/v3/pkg/busy.Main file="github.com/emissary-ingress/emissary/v3/pkg/busy/busy.go:87" CMD=entrypoint PID=1
```

This replaces the usage with [xxhash](https://github.com/cespare/xxhash), which avoids the usage of md5 but keeps the same deterministic hash behavior. This was chosen over other stdlib hash functions that would be conformant (e.g. sha256) to minimize hash size since long hash length may be problematic for [k8s name length restrictions (253 characters)](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names).

## Related Issues

n/a

## Testing

Updated unit tests.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->
- [ ] **Does my change need to be backported to a previous release?**
  - What backport versions were discussed with the Maintainers in the Issue?

  Shouldn't need backport.

- [x] **I made sure to update `CHANGELOG.md`.**

   Remember, the CHANGELOG needs to mention:
  - Any new features
  - Any changes to our included version of Envoy
  - Any non-backward-compatible changes
  - Any deprecations

- [x] **This is unlikely to impact how Ambassador performs at scale.**

   Remember, things that might have an impact at scale include:
  - Any significant changes in memory use that might require adjusting the memory limits
  - Any significant changes in CPU use that might require adjusting the CPU limits
  - Anything that might change how many replicas users should use
  - Changes that impact data-plane latency/scalability

- [x] **My change is adequately tested.**

   Remember when considering testing:
  - Your change needs to be specifically covered by tests.
    - Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
  - You also need to make sure that the _entire area being changed_ has adequate test coverage.
    - If existing tests don't actually cover the entire area being changed, add tests.
    - This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
  - We should lean on the bulk of code being covered by unit tests, but...
  - ... an end-to-end test should cover the integration points

- [ ] **I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.**

- [x] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
