### PR TITLE
[CI Run] ambex: Remove usage of md5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,7 +116,11 @@ it will be removed; but as it won't be user-visible this isn't considered a brea
   href="https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/attribute_context.proto">
   Envoy extauth documentation</a>.
 
+- Change: The `ambex` component of Emissary-ingress now uses `xxhash64` instead of `md5`, since
+  `md5` can cause problems in crypto-restricted environments (e.g. FIPS) ([Remove usage of md5])
+
 [Incorrect Cache Key for Mapping]: https://github.com/emissary-ingress/emissary/issues/5714
+[Remove usage of md5]: https://github.com/emissary-ingress/emissary/pull/5794
 
 ## [3.9.0] November 13, 2023
 [3.9.0]: https://github.com/emissary-ingress/emissary/compare/v3.8.0...v3.9.0

--- a/docs/releaseNotes.yml
+++ b/docs/releaseNotes.yml
@@ -85,6 +85,16 @@ items:
           href="https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/attribute_context.proto">
           Envoy extauth documentation</a>.
 
+      - title: Update `ambex` to use `xxhash64` instead of `md5`
+        type: change
+        body: >-
+          The `ambex` component of $productName$ now uses `xxhash64` instead
+          of `md5`, since `md5` can cause problems in crypto-restricted
+          environments (e.g. FIPS)
+        github:
+          - title: "Remove usage of md5"
+            link: https://github.com/emissary-ingress/emissary/pull/5794
+
   - version: 3.9.0
     prevVersion: 3.8.0
     date: "2023-11-13"

--- a/go.mod
+++ b/go.mod
@@ -106,6 +106,7 @@ require (
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/census-instrumentation/opencensus-proto v0.4.1
+	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/cncf/xds/go v0.0.0-20250121191232-2f005788dc42
 	github.com/datawire/dlib v1.3.1
 	github.com/datawire/dtest v0.0.0-20210928162311-722b199c4c2f
@@ -170,7 +171,6 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
-	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/chai2010/gettext-go v1.0.3 // indirect
 	github.com/cloudflare/circl v1.6.0 // indirect
 	github.com/cyphar/filepath-securejoin v0.4.1 // indirect

--- a/pkg/ambex/transforms.go
+++ b/pkg/ambex/transforms.go
@@ -3,12 +3,12 @@ package ambex
 import (
 	// standard library
 	"context"
-	"crypto/md5"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"strconv"
 
 	// third-party libraries
+	"github.com/cespare/xxhash/v2"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 
@@ -146,9 +146,10 @@ func V3ListenerToRdsListener(lnr *v3listener.Listener) (*v3listener.Listener, []
 						// associated with a given listener.
 						filterChainMatch, _ := json.Marshal(fc.GetFilterChainMatch())
 
-						// Use MD5 because it's decently fast and cryptographic security isn't needed.
-						matchHash := md5.Sum(filterChainMatch)
-						matchKey := hex.EncodeToString(matchHash[:])
+						// Use xxhash64 because it's decently fast and cryptographic security isn't needed.
+						h := xxhash.New()
+						h.Write(filterChainMatch)
+						matchKey := strconv.FormatUint(h.Sum64(), 16)
 
 						rc.Name = fmt.Sprintf("%s-routeconfig-%s-%d", l.Name, matchKey, matchKeyIndex[matchKey])
 

--- a/pkg/ambex/transforms.go
+++ b/pkg/ambex/transforms.go
@@ -148,7 +148,9 @@ func V3ListenerToRdsListener(lnr *v3listener.Listener) (*v3listener.Listener, []
 
 						// Use xxhash64 because it's decently fast and cryptographic security isn't needed.
 						h := xxhash.New()
-						h.Write(filterChainMatch)
+						if _, err := h.Write(filterChainMatch); err != nil {
+							return nil, nil, fmt.Errorf("xxhash write error: %w", err)
+						}
 						matchKey := strconv.FormatUint(h.Sum64(), 16)
 
 						rc.Name = fmt.Sprintf("%s-routeconfig-%s-%d", l.Name, matchKey, matchKeyIndex[matchKey])

--- a/pkg/ambex/transforms_test.go
+++ b/pkg/ambex/transforms_test.go
@@ -78,7 +78,7 @@ func TestV3ListenerToRdsListener(t *testing.T) {
 
 	for i, rc := range routes {
 		// Confirm that the route name was transformed to the hashed version
-		assert.Equal(t, fmt.Sprintf("emissary-ingress-listener-8080-routeconfig-8c82e45fa3f94ab4e879543e0a1a30ac-%d", i), rc.GetName())
+		assert.Equal(t, fmt.Sprintf("emissary-ingress-listener-8080-routeconfig-29865f40cbcf32dc-%d", i), rc.GetName())
 
 		// Make sure the virtual hosts are unmodified
 		virtualHosts := rc.GetVirtualHosts()


### PR DESCRIPTION
When trying to run emissary in crypto-restricted environments (e.g. FIPS), usage of md5 can be problematic:

```
time="2024-10-17 19:20:29.7063" level=error msg="shut down with error error: PANIC: openssl: MD5 failed" func=github.com/emissary-ingress/emissary/v3/pkg/busy.Main file="github.com/emissary-ingress/emissary/v3/pkg/busy/busy.go:87" CMD=entrypoint PID=1
```

This replaces the usage with xxhash, which should avoid usage of unsupport crypto libraries, but keep the deterministic behavior.

Signed-off-by: Billy Lynch <billy@chainguard.dev>
(cherry picked from commit f1b539c92c901a50e662bb0c2392cfaab214b810)

## Description

A few sentences describing the overall goals of the pull request's commits.

## Related Issues

List related issues.

## Testing

A few sentences describing what testing you've done, e.g., manual tests, automated tests, deployed in production, etc.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->
- [ ] **Does my change need to be backported to a previous release?**
  - What backport versions were discussed with the Maintainers in the Issue?

- [ ] **I made sure to update `CHANGELOG.md`.**

   Remember, the CHANGELOG needs to mention:
  - Any new features
  - Any changes to our included version of Envoy
  - Any non-backward-compatible changes
  - Any deprecations

- [ ] **This is unlikely to impact how Ambassador performs at scale.**

   Remember, things that might have an impact at scale include:
  - Any significant changes in memory use that might require adjusting the memory limits
  - Any significant changes in CPU use that might require adjusting the CPU limits
  - Anything that might change how many replicas users should use
  - Changes that impact data-plane latency/scalability

- [ ] **My change is adequately tested.**

   Remember when considering testing:
  - Your change needs to be specifically covered by tests.
    - Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
  - You also need to make sure that the _entire area being changed_ has adequate test coverage.
    - If existing tests don't actually cover the entire area being changed, add tests.
    - This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
  - We should lean on the bulk of code being covered by unit tests, but...
  - ... an end-to-end test should cover the integration points

- [ ] **I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.**

- [ ] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
