### PR TITLE
Max concurrent streams

### DIFF
--- a/python/ambassador/envoy/v3/v3listener.py
+++ b/python/ambassador/envoy/v3/v3listener.py
@@ -533,6 +533,12 @@ class V3Listener:
                     "headers_with_underscores_action": self.config.ir.ambassador_module.headers_with_underscores_action
                 }
 
+        max_concurrent_streams = self.config.ir.ambassador_module.get(
+            "max_concurrent_streams", None
+        )
+        if max_concurrent_streams:
+            base_http_config["max_concurrent_streams"] = max_concurrent_streams
+
         max_request_headers_kb = self.config.ir.ambassador_module.get(
             "max_request_headers_kb", None
         )

--- a/python/ambassador/envoy/v3/v3ready.py
+++ b/python/ambassador/envoy/v3/v3ready.py
@@ -60,6 +60,11 @@ class V3Ready(dict):
         if ambassador_ready_log:
             typed_config["access_log"] = cls.access_log(config)
 
+        # required for test_max_concurrent_streams.py
+        max_concurrent_streams = config.ir.ambassador_module.get("max_concurrent_streams", None)
+        if max_concurrent_streams:
+            typed_config["max_concurrent_streams"] = max_concurrent_streams
+
         # required for test_max_request_header.py
         max_request_headers_kb = config.ir.ambassador_module.get("max_request_headers_kb", None)
         if max_request_headers_kb:

--- a/python/ambassador/ir/ir.py
+++ b/python/ambassador/ir/ir.py
@@ -1163,6 +1163,9 @@ class IR:
         od["headers_with_underscores_action"] = self.ambassador_module.get(
             "headers_with_underscores_action", None
         )
+
+        od["max_concurrent_streams"] = self.ambassador_module.get("max_concurrent_streams", None)
+
         od["max_request_headers_kb"] = self.ambassador_module.get("max_request_headers_kb", None)
 
         od["server_name"] = bool(self.ambassador_module.server_name != "envoy")

--- a/python/ambassador/ir/irambassador.py
+++ b/python/ambassador/ir/irambassador.py
@@ -51,6 +51,7 @@ class IRAmbassador(IRResource):
         "listener_idle_timeout_ms",
         "liveness_probe",
         "load_balancer",
+        "max_concurrent_streams",
         "max_request_headers_kb",
         "merge_slashes",
         "reject_requests_with_escaped_slashes",
@@ -150,6 +151,7 @@ class IRAmbassador(IRResource):
             server_name="envoy",
             debug_mode=False,
             preserve_external_request_id=False,
+            max_concurrent_streams=None,
             max_request_headers_kb=None,
             **kwargs,
         )

--- a/python/ambassador/ir/irerrorresponse.py
+++ b/python/ambassador/ir/irerrorresponse.py
@@ -77,7 +77,7 @@ ALLOWED_ENVOY_FMT_TOKENS = [
     "FILTER_CHAIN_NAME",
 ]
 ENVOY_FMT_TOKEN_REGEX = (
-    "\%([A-Za-z0-9_]+?)(\([A-Za-z0-9_.]+?((:|\?)[A-Za-z0-9_.]+?)+\))?(:[A-Za-z0-9_]+?)?\%"
+    r'''\%([A-Za-z0-9_]+?)(\([A-Za-z0-9_.]+?((:|\?)[A-Za-z0-9_.]+?)+\))?(:[A-Za-z0-9_]+?)?\%'''
 )
 
 

--- a/python/ambassador/ir/irerrorresponse.py
+++ b/python/ambassador/ir/irerrorresponse.py
@@ -77,7 +77,7 @@ ALLOWED_ENVOY_FMT_TOKENS = [
     "FILTER_CHAIN_NAME",
 ]
 ENVOY_FMT_TOKEN_REGEX = (
-    r'''\%([A-Za-z0-9_]+?)(\([A-Za-z0-9_.]+?((:|\?)[A-Za-z0-9_.]+?)+\))?(:[A-Za-z0-9_]+?)?\%'''
+    "\%([A-Za-z0-9_]+?)(\([A-Za-z0-9_.]+?((:|\?)[A-Za-z0-9_.]+?)+\))?(:[A-Za-z0-9_]+?)?\%"
 )
 
 

--- a/python/tests/kat/t_max_concurrent_streams.py
+++ b/python/tests/kat/t_max_concurrent_streams.py
@@ -1,0 +1,85 @@
+import json
+from typing import Generator, Tuple, Union
+
+from abstract_tests import HTTP, AmbassadorTest, Node, ServiceType
+from kat.harness import Query
+
+
+class MaxConcurrentStreamsTest(AmbassadorTest):
+    target: ServiceType
+
+    def init(self):
+        self.target = HTTP()
+
+    def config(self) -> Generator[Union[str, Tuple[Node, str]], None, None]:
+        yield self, self.format(
+            """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Module
+name: ambassador
+ambassador_id: [{self.ambassador_id}]
+config:
+  max_concurrent_streams: 30
+"""
+        )
+        yield self, self.format(
+            """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+name:  {self.name}
+hostname: "*"
+prefix: /target/
+service: http://{self.target.path.fqdn}
+"""
+        )
+
+    def queries(self):
+        h1 = "i" * (31 * 1024)
+        yield Query(self.url("target/"), expected=431, headers={"big": h1})
+        h2 = "i" * (29 * 1024)
+        yield Query(self.url("target/"), expected=200, headers={"small": h2})
+
+    def check(self):
+        expected_val = "3600s"
+        actual_val = ""
+        assert self.results[0].body
+        body = json.loads(self.results[0].body)
+        for config_obj in body.get("configs"):
+            if config_obj.get("@type") == "type.googleapis.com/envoy.admin.v3.ListenersConfigDump":
+                listeners = config_obj.get("dynamic_listeners")
+                found_max_conn_duration = False
+                for listener_obj in listeners:
+                    listener = listener_obj.get("active_state").get("listener")
+                    filter_chains = listener.get("filter_chains")
+                    for filters in filter_chains:
+                        for filter in filters.get("filters"):
+                            if (
+                                filter.get("name")
+                                == "envoy.filters.network.http_connection_manager"
+                            ):
+                                filter_config = filter.get("typed_config")
+                                common_http_protocol_options = filter_config.get(
+                                    "common_http_protocol_options"
+                                )
+                                if common_http_protocol_options:
+                                    actual_val = common_http_protocol_options.get(
+                                        "max_connection_duration", ""
+                                    )
+                                    if actual_val != "":
+                                        if actual_val == expected_val:
+                                            found_max_conn_duration = True
+                                    else:
+                                        assert (
+                                            False
+                                        ), "Expected to find common_http_protocol_options.max_connection_duration property on listener"
+                                else:
+                                    assert (
+                                        False
+                                    ), "Expected to find common_http_protocol_options property on listener"
+                assert (
+                    found_max_conn_duration
+                ), "Expected common_http_protocol_options.max_connection_duration = {}, Got common_http_protocol_options.max_connection_duration = {}".format(
+                    expected_val, actual_val
+                )

--- a/python/tests/unit/test_common_http_protocol_options.py
+++ b/python/tests/unit/test_common_http_protocol_options.py
@@ -110,3 +110,13 @@ def test_both_one_module_one_mapping():
     _test_common_http_protocol_options(
         yaml, expectations={"max_connection_duration": "2.005s", "idle_timeout": "4.005s"}
     )
+
+
+@pytest.mark.compilertest
+def test_max_concurrent_streams():
+    yaml = module_and_mapping_manifests(
+        None, ["max_concurrent_streams: 100"]
+    )
+    _test_common_http_protocol_options(
+        yaml, expectations={"max_concurrent_streams": "100"}
+    )

--- a/python/tests/unit/test_max_concurrent_streams.py
+++ b/python/tests/unit/test_max_concurrent_streams.py
@@ -1,0 +1,77 @@
+import logging
+
+import pytest
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s test %(levelname)s: %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+
+logger = logging.getLogger("ambassador")
+
+from ambassador import IR, Config, EnvoyConfig
+from ambassador.fetch import ResourceFetcher
+from ambassador.utils import NullSecretHandler
+from tests.utils import default_listener_manifests
+
+
+def _get_envoy_config(yaml):
+    aconf = Config()
+    fetcher = ResourceFetcher(logger, aconf)
+    fetcher.parse_yaml(default_listener_manifests() + yaml, k8s=True)
+
+    aconf.load_all(fetcher.sorted())
+
+    secret_handler = NullSecretHandler(logger, None, None, "0")
+
+    ir = IR(aconf, file_checker=lambda path: True, secret_handler=secret_handler)
+
+    assert ir
+
+    return EnvoyConfig.generate(ir)
+
+@pytest.mark.compilertest
+def test_max_concurrent_requests_v3():
+    yaml = """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Module
+metadata:
+  name: ambassador
+  namespace: default
+spec:
+  config:
+    max_concurrent_requests: 96
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: ambassador
+  namespace: default
+spec:
+  hostname: "*"
+  prefix: /test/
+  service: test:9999
+"""
+    print("hey ----------- i am here")
+    econf = _get_envoy_config(yaml)
+    expected = 96
+    key_found = False
+
+    conf = econf.as_dict()
+
+    for listener in conf["static_resources"]["listeners"]:
+        for filter_chain in listener["filter_chains"]:
+            for f in filter_chain["filters"]:
+                max_concurrent_requests = f["typed_config"].get("max_concurrent_requests", None)
+                assert (
+                    max_concurrent_requests is not None
+                ), f"max_concurrent_requests not found on typed_config: {f['typed_config']}"
+
+                print(f"Found max_concurrent_requests = {max_concurrent_requests}")
+                key_found = True
+                assert expected == int(
+                    max_concurrent_requests
+                ), "max_concurrent_requests must equal the value set on the ambassador Module"
+    assert key_found, "max_concurrent_requests must be found in the envoy config"


### PR DESCRIPTION
## Description

Added support for configuring max_concurrent_streams

## Testing

Added unit tests and integration tests

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->
- [ ] **Does my change need to be backported to a previous release?**
  - What backport versions were discussed with the Maintainers in the Issue?

- [x] **I made sure to update `CHANGELOG.md`.**

   Remember, the CHANGELOG needs to mention:
  - Any new features
  - Any changes to our included version of Envoy
  - Any non-backward-compatible changes
  - Any deprecations

- [x] **This is unlikely to impact how Ambassador performs at scale.**

   Remember, things that might have an impact at scale include:
  - Any significant changes in memory use that might require adjusting the memory limits
  - Any significant changes in CPU use that might require adjusting the CPU limits
  - Anything that might change how many replicas users should use
  - Changes that impact data-plane latency/scalability

- [x] **My change is adequately tested.**

   Remember when considering testing:
  - Your change needs to be specifically covered by tests.
    - Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
  - You also need to make sure that the _entire area being changed_ has adequate test coverage.
    - If existing tests don't actually cover the entire area being changed, add tests.
    - This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
  - We should lean on the bulk of code being covered by unit tests, but...
  - ... an end-to-end test should cover the integration points

- [ ] **I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.**

- [ ] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
