### PR TITLE
Cleaner UV setup

### DIFF
--- a/.github/actions/setup-deps/action.yml
+++ b/.github/actions/setup-deps/action.yml
@@ -82,5 +82,5 @@ runs:
       env:
         DEBIAN_FRONTEND: noninteractive
       run: |
-        uv venv
-        uv --no-config pip install -U awscli
+        uv sync --dev
+        # uv --no-config pip install -U awscli

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -203,5 +203,4 @@ libraries:
     python-json-logger  2.0.7     2-clause BSD license
     requests            2.32.4    Apache License 2.0
     semantic-version    2.10.0    2-clause BSD license
-    typing_extensions   4.14.1    Python Software Foundation license
     urllib3             2.5.0     MIT license

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -178,71 +178,30 @@ following Free and Open Source software:
 The Emissary-ingress Python code makes use of the following Free and Open Source
 libraries:
 
-    Name                  Version          License(s)
-    ----                  -------          ----------
-    Flask                 3.1.1            3-clause BSD license
-    GitPython             3.1.45           3-clause BSD license
-    Jinja2                3.1.6            3-clause BSD license
-    MarkupSafe            3.0.2            2-clause BSD license
-    PyYAML                6.0.2            MIT license
-    Pygments              2.19.2           2-clause BSD license
-    Werkzeug              3.1.3            3-clause BSD license
-    awscli                1.42.6           Apache License 2.0
-    blinker               1.9.0            MIT license
-    botocore              1.40.6           Apache License 2.0
-    certifi               2025.8.3         Mozilla Public License 2.0
-    cffi                  1.17.1           MIT license
-    charset-normalizer    3.4.2            MIT license
-    click                 8.2.1            3-clause BSD license
-    colorama              0.4.6            3-clause BSD license
-    coverage              7.10.2           Apache License 2.0
-    cryptography          45.0.6           3-clause BSD license, Apache License 2.0
-    decorator             5.2.1            2-clause BSD license
-    docutils              0.19             2-clause BSD license, Python Software Foundation license
-    durationpy            0.10             MIT license
-    expiringdict          1.2.2            Apache License 2.0
-    gitdb                 4.0.12           3-clause BSD license
-    gunicorn              22.0.0           MIT license
-    httpretty             1.1.4            MIT license
-    idna                  3.10             3-clause BSD license
-    iniconfig             2.1.0            MIT license
-    itsdangerous          2.2.0            3-clause BSD license
-    jmespath              1.0.1            MIT license
-    jsonpatch             1.33             3-clause BSD license
-    jsonpointer           3.0.0            3-clause BSD license
-    mypy                  1.17.1           MIT license
-    mypy_extensions       1.1.0            MIT license
-    orjson                3.11.1           Apache License 2.0, MIT license
-    packaging             24.2             2-clause BSD license, Apache License 2.0
-    pathspec              0.12.1           Mozilla Public License 2.0
-    pexpect               4.9.0            ISC license
-    pip                   25.2             MIT license
-    pluggy                1.6.0            MIT license
-    prometheus_client     0.22.1           2-clause BSD license, Apache License 2.0
-    ptyprocess            0.7.0            ISC license
-    pyOpenSSL             25.1.0           Apache License 2.0
-    pyasn1                0.6.1            2-clause BSD license
-    pycparser             2.22             3-clause BSD license
-    pytest                8.4.1            MIT license
-    pytest-cov            6.2.1            MIT license
-    pytest-rerunfailures  15.1             Mozilla Public License 2.0
-    python-dateutil       2.9.0.post0      3-clause BSD license, Apache License 2.0
-    python-json-logger    2.0.7            2-clause BSD license
-    requests              2.32.4           Apache License 2.0
-    retry2                0.9.5            Apache License 2.0
-    rsa                   4.7.2            Apache License 2.0
-    ruff                  0.12.8           MIT license
-    s3transfer            0.13.1           Apache License 2.0
-    semantic-version      2.10.0           2-clause BSD license
-    six                   1.17.0           MIT license
-    smmap                 5.0.2            3-clause BSD license
-    types-PyYAML          6.0.12.20250516  Apache License 2.0
-    types-cffi            1.17.0.20250805  Apache License 2.0
-    types-orjson          3.6.2            Apache License 2.0
-    types-protobuf        6.30.2.20250703  Apache License 2.0
-    types-pyOpenSSL       24.1.0.20240722  Apache License 2.0
-    types-requests        2.32.4.20250611  Apache License 2.0
-    types-retry           0.9.9.20250322   Apache License 2.0
-    types-setuptools      80.9.0.20250801  Apache License 2.0
-    typing_extensions     4.14.1           Python Software Foundation license
-    urllib3               2.5.0            MIT license
+    Name                Version   License(s)
+    ----                -------   ----------
+    Flask               3.1.1     3-clause BSD license
+    Jinja2              3.1.6     3-clause BSD license
+    MarkupSafe          3.0.2     2-clause BSD license
+    PyYAML              6.0.2     MIT license
+    Werkzeug            3.1.3     3-clause BSD license
+    blinker             1.9.0     MIT license
+    certifi             2025.8.3  Mozilla Public License 2.0
+    charset-normalizer  3.4.3     MIT license
+    click               8.2.1     3-clause BSD license
+    durationpy          0.10      MIT license
+    expiringdict        1.2.2     Apache License 2.0
+    gunicorn            22.0.0    MIT license
+    idna                3.10      3-clause BSD license
+    itsdangerous        2.2.0     3-clause BSD license
+    jsonpatch           1.33      3-clause BSD license
+    jsonpointer         3.0.0     3-clause BSD license
+    orjson              3.11.1    Apache License 2.0, MIT license
+    packaging           24.2      2-clause BSD license, Apache License 2.0
+    pip                 25.2      MIT license
+    prometheus_client   0.22.1    2-clause BSD license, Apache License 2.0
+    python-json-logger  2.0.7     2-clause BSD license
+    requests            2.32.4    Apache License 2.0
+    semantic-version    2.10.0    2-clause BSD license
+    typing_extensions   4.14.1    Python Software Foundation license
+    urllib3             2.5.0     MIT license

--- a/DEPENDENCY_LICENSES.md
+++ b/DEPENDENCY_LICENSES.md
@@ -6,4 +6,3 @@ Emissary-ingress incorporates Free and Open Source software under the following 
 * [ISC license](https://opensource.org/licenses/ISC)
 * [MIT license](https://opensource.org/licenses/MIT)
 * [Mozilla Public License 2.0](https://opensource.org/licenses/MPL-2.0)
-* [Python Software Foundation license](https://spdx.org/licenses/PSF-2.0.html)

--- a/build-aux/builder.mk
+++ b/build-aux/builder.mk
@@ -195,7 +195,7 @@ pytest-kat-envoy3-%: python-integration-test-environment pytest-kat-envoy3-tests
 
 $(OSS_HOME)/.venv: pyproject.toml
 	rm -rf $@
-	uv sync
+	uv sync --dev
 clobber: .venv.rm-r
 
 GOTEST_ARGS ?= -race -count=1 -timeout=30m -ldflags=-linkmode=internal

--- a/build-aux/deps.mk
+++ b/build-aux/deps.mk
@@ -20,12 +20,15 @@ clean: vendor.rm-r
 # `uv` should use and which pip3 to use, because we do _not_ want system
 # packages in here.
 #
-# Finally, even though pip-show.txt depends on having the virtualenv set
-# up, the rule must always run (hence the FORCE).
+# Finally, we use an ephemeral venv for this, which _only_ has the real
+# runtime dependencies plus pip. There's no real point in including dev
+# dependencies here.
 
-$(OSS_HOME)/build-aux/pip-show.txt: FORCE $(OSS_HOME)/.venv
+$(OSS_HOME)/build-aux/pip-show.txt: FORCE
 	echo "Generating $@ in $(OSS_HOME)/build-aux"
-	uv pip list --python $(OSS_HOME)/.venv/bin/python --format=freeze --exclude-editable | cut -d= -f1 | xargs $(OSS_HOME)/.venv/bin/pip3 show | egrep '^([A-Za-z-]+: |---)' > $@
+	UV_PROJECT_ENVIRONMENT=.pip-venv uv sync --group pip
+	uv pip list --python $(OSS_HOME)/.pip-venv/bin/python --format=freeze --exclude-editable | cut -d= -f1 | xargs $(OSS_HOME)/.pip-venv/bin/pip3 show | egrep '^([A-Za-z-]+: |---)' > $@
+	rm -rf $(OSS_HOME)/.pip-venv
 clean: build-aux/pip-show.txt.rm
 
 $(OSS_HOME)/build-aux/go-version.txt: $(_go-version/deps)

--- a/docker/emissary/Dockerfile
+++ b/docker/emissary/Dockerfile
@@ -25,7 +25,7 @@ ARG TARGETARCH
 ARG LIBARCH
 
 # Based on https://github.com/alexdmoss/distroless-python...
-RUN pip install --upgrade pip uv ruff
+RUN pip install --upgrade pip uv
 
 # Copy over ambassador.version
 WORKDIR /buildroot/ambassador/python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,35 @@ dependencies = [
     "ambassador-diag==4.*",
 ]
 
+[dependency-groups]
+runtime = []
+dev = [
+    # Project-Specific
+    "kat==4.*",
+    "tests==4.*",
+    # Dev Requirements
+    "pip>=25.2",
+    "mypy>=1",
+    "ruff>=0.6",
+    "retry2>=0.9",
+    "pytest==8.*",
+    "pexpect>=4.9",
+    "packaging>=24",
+    "httpretty>=1.1",
+    "gitpython>=3.1",
+    "pyopenssl>=24.2",
+    "pytest-cov>=5.0",
+    "pytest-rerunfailures>=14",
+    # Type Stubs
+    "types-orjson>=3",
+    "types-pyyaml>=6",
+    "types-retry>=0.9",
+    "types-protobuf>=5",
+    "types-requests>=2",
+    "types-pyopenssl>=24",
+    "types-setuptools>=71",
+]
+
 
 [project.urls]
 homepage = "https://www.getambassador.io"
@@ -55,39 +84,12 @@ build-backend = "hatchling.build"
 [tool.uv]
 cache-dir = ".uv_cache"
 link-mode = "symlink"
+default-groups = ["runtime"]
 managed = true
 native-tls = false
 python-downloads = "automatic"
 python-preference = "only-managed"
 upgrade-package = []  # ref: https://docs.astral.sh/uv/reference/settings/#upgrade-package
-dev-dependencies = [
-    # Project-Specific
-    "kat==4.*",
-    "tests==4.*",
-    # Dev Requirements
-    "pip>=25.2",
-    "mypy>=1",
-    "ruff>=0.6",
-    "retry2>=0.9",
-    "pytest==8.*",
-    "awscli>=1.33",
-    "pexpect>=4.9",
-    "packaging>=24",
-    "httpretty>=1.1",
-    "gitpython>=3.1",
-    "pyopenssl>=24.2",
-    "pytest-cov>=5.0",
-    "pytest-rerunfailures>=14",
-    # Type Stubs
-    "types-orjson>=3",
-    "types-pyyaml>=6",
-    "types-retry>=0.9",
-    "types-protobuf>=5",
-    "types-requests>=2",
-    "types-pyopenssl>=24",
-    "types-setuptools>=71",
-]
-
 
 [tool.uv.sources]
 kat = { workspace = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ runtime = [
     "orjson==3.11.1",
     "pyyaml==6.0.2",
     "durationpy==0.10",
-    "typing-extensions==4.14.1",
     "semantic-version==2.10.0",
     "prometheus-client==0.22.1",
     "python-json-logger==2.0.7",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,22 @@ dependencies = [
 ]
 
 [dependency-groups]
-runtime = []
+runtime = [
+    # Production runtime dependencies - centrally managed versions
+    "click==8.2.1",
+    "flask==3.1.1",
+    "requests==2.32.4",
+    "gunicorn==22.0.0",
+    "jsonpatch==1.33",
+    "expiringdict==1.2.2",
+    "orjson==3.11.1",
+    "pyyaml==6.0.2",
+    "durationpy==0.10",
+    "typing-extensions==4.14.1",
+    "semantic-version==2.10.0",
+    "prometheus-client==0.22.1",
+    "python-json-logger==2.0.7",
+]
 dev = [
     # Project-Specific
     "kat==4.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,29 +58,27 @@ dev = [
     # Project-Specific
     "kat==4.*",
     "tests==4.*",
-    # Dev Requirements
-    "pip>=25.2",
-    "mypy>=1",
-    "ruff>=0.6",
-    "retry2>=0.9",
-    "pytest==8.*",
+    # Dev Requirements (critical - locked to current versions)
+    "mypy==1.17.1",
+    "ruff==0.12.8",
+    "pytest==8.4.1",
+    "pytest-cov==6.2.1",
+    "cryptography==45.0.6",
+    # Dev Requirements (flexible)
     "pexpect>=4.9",
     "packaging>=24",
     "httpretty>=1.1",
-    "gitpython>=3.1",
-    "pyopenssl>=24.2",
-    "pytest-cov>=5.0",
     "pytest-rerunfailures>=14",
-    # Type Stubs
+    # Type Stubs (flexible for latest improvements)
     "types-orjson>=3",
     "types-pyyaml>=6",
-    "types-retry>=0.9",
     "types-protobuf>=5",
     "types-requests>=2",
-    "types-pyopenssl>=24",
     "types-setuptools>=71",
 ]
-
+pip = [
+    "pip>=25.2",
+]
 
 [project.urls]
 homepage = "https://www.getambassador.io"

--- a/python/ambassador-diag/pyproject.toml
+++ b/python/ambassador-diag/pyproject.toml
@@ -3,15 +3,14 @@ name = "ambassador_diag"
 version = "4.0.0-dev"
 readme = "../README.md"
 dependencies = [
-    "click==8.*",
-    "flask==3.*",
-    "requests==2.*",
-    "gunicorn==22.*",
-    "jsonpatch==1.*",
-    "expiringdict==1.*",
-    "typing-extensions>=4",
-    "prometheus-client<=1.0",
-    "python-json-logger>=2.0",
+    "click",
+    "flask",
+    "requests",
+    "gunicorn",
+    "jsonpatch",
+    "expiringdict",
+    "prometheus-client",
+    "python-json-logger",
 ]
 
 

--- a/python/ambassador-diag/src/ambassador_diag/diagd.py
+++ b/python/ambassador-diag/src/ambassador_diag/diagd.py
@@ -59,7 +59,7 @@ from prometheus_client import (
     generate_latest,
 )
 from pythonjsonlogger import jsonlogger
-from typing_extensions import NotRequired, TypedDict
+from typing import NotRequired, TypedDict
 
 from ambassador import IR, Cache, Config, Diagnostics, EnvoyConfig, Scout, Version
 from ambassador.ambscout import LocalScout

--- a/python/ambassador/pyproject.toml
+++ b/python/ambassador/pyproject.toml
@@ -7,7 +7,6 @@ dependencies = [
     "pyyaml",
     "requests",
     "durationpy",
-    "typing-extensions",
     "semantic-version",
     "prometheus-client",
 ]

--- a/python/ambassador/pyproject.toml
+++ b/python/ambassador/pyproject.toml
@@ -3,13 +3,13 @@ name = "ambassador"
 version = "4.0.0-dev"
 readme = "../README.md"
 dependencies = [
-    "orjson==3.*",
-    "pyyaml==6.*",
-    "requests==2.*",
-    "durationpy<=1.0",
-    "typing-extensions>=4",
-    "semantic-version==2.*",
-    "prometheus-client<=1.0",
+    "orjson",
+    "pyyaml",
+    "requests",
+    "durationpy",
+    "typing-extensions",
+    "semantic-version",
+    "prometheus-client",
 ]
 
 

--- a/python/ambassador/src/ambassador/compile.py
+++ b/python/ambassador/src/ambassador/compile.py
@@ -15,7 +15,7 @@
 import logging
 from typing import Any, Optional
 
-from typing_extensions import NotRequired, TypedDict
+from typing import NotRequired, TypedDict
 
 from .cache import Cache
 from .config import Config

--- a/python/tests/src/tests/utils.py
+++ b/python/tests/src/tests/utils.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import logging
 import os
@@ -6,7 +7,9 @@ import tempfile
 from base64 import b64encode
 from collections import namedtuple
 
-from OpenSSL import crypto
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import dsa, ec, rsa
 
 from ambassador import IR, Cache, Config, EnvoyConfig
 from ambassador.compile import Compile
@@ -341,21 +344,33 @@ def assert_valid_envoy_config(config_dict, extra_dirs=[]):
 
 
 def create_crl_pem_b64(issuerCert, issuerKey, revokedCerts):
-    when = b"20220516010101Z"
-    crl = crypto.CRL()
-    crl.set_lastUpdate(when)
+    cert = x509.load_pem_x509_certificate(issuerCert.encode("utf-8"))
+    key = serialization.load_pem_private_key(issuerKey.encode("utf-8"), password=None)
+
+    assert isinstance(key, (rsa.RSAPrivateKey, dsa.DSAPrivateKey, ec.EllipticCurvePrivateKey))
+
+    when = datetime.datetime(
+        year=2022, month=5, day=16, hour=1, minute=1, second=1, tzinfo=datetime.timezone.utc
+    )
+
+    thirty_days_out = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=30)
+
+    crl_builder = (
+        x509.CertificateRevocationListBuilder()
+        .issuer_name(cert.subject)
+        .last_update(when)
+        .next_update(thirty_days_out)
+    )
 
     for revokedCert in revokedCerts:
-        clientCert = crypto.load_certificate(crypto.FILETYPE_PEM, bytes(revokedCert, "utf-8"))
-        r = crypto.Revoked()
-        r.set_serial(bytes("{:x}".format(clientCert.get_serial_number()), "ascii"))
-        r.set_rev_date(when)
-        r.set_reason(None)
-        crl.add_revoked(r)
+        clientCert = x509.load_pem_x509_certificate(revokedCert.encode("utf-8"))
+        revoked_cert = (
+            x509.RevokedCertificateBuilder()
+            .serial_number(clientCert.serial_number)
+            .revocation_date(when)
+            .build()
+        )
+        crl_builder = crl_builder.add_revoked_certificate(revoked_cert)
 
-    cert = crypto.load_certificate(crypto.FILETYPE_PEM, bytes(issuerCert, "utf-8"))
-    key = crypto.load_privatekey(crypto.FILETYPE_PEM, bytes(issuerKey, "utf-8"))
-    crl.sign(cert, key, b"sha256")
-    return b64encode(
-        (crypto.dump_crl(crypto.FILETYPE_PEM, crl).decode("utf-8") + "\n").encode("utf-8")
-    ).decode("utf-8")
+    crl = crl_builder.sign(private_key=key, algorithm=hashes.SHA256())
+    return b64encode(crl.public_bytes(serialization.Encoding.PEM)).decode("utf-8")


### PR DESCRIPTION
Clean up the `uv` configuration in a few important ways:

- split runtime dependencies and dev dependencies
- don't duplicate runtime dependencies in the main `pyproject.toml` when they're already in the `pyproject.toml`s for `ambassador` and `ambassador-diag`
- ditch `awscli` entirely
- ditch `typing_extensions` because what we need is part of the Python 3.12 standard `typing` package
- ditch `pyOpenSSL` in favor of `cryptography` (cherry-picked from d9f94770a356a0272ed28c8e4d2e0c99ab76bce2)
- pin all the runtime dependencies and some of the critical dev dependencies
- don't show dev dependencies in `DEPENDENCIES`
- don't install `ruff` when building the Emissary Docker image

Note that the Make target for `$(OSS_HOME)/.venv` still runs `uv sync --dev`, because it's used to set up a development environment by definition. By contrast, Emissary's Dockerfile uses `uv build --wheel` and doesn't run `uv sync` at all, and the `ambassador` and `ambassador-diag` `pyproject.toml`s correctly don't include dev dependencies at all.