### PR TITLE
feat(service): provide options to pass `loadBalancerClass`

### DIFF
--- a/charts/emissary-ingress/templates/service.yaml
+++ b/charts/emissary-ingress/templates/service.yaml
@@ -23,6 +23,9 @@ spec:
   {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: "{{ .Values.service.loadBalancerIP }}"
   {{- end }}
+  {{- if .Values.service.loadBalancerClass }}
+  loadBalancerClass: "{{ .Values.service.loadBalancerClass }}"
+  {{- end }}
   {{- if .Values.service.externalTrafficPolicy }}
   externalTrafficPolicy: "{{ .Values.service.externalTrafficPolicy }}"
   {{- end }}

--- a/charts/emissary-ingress/values.yaml.in
+++ b/charts/emissary-ingress/values.yaml.in
@@ -164,6 +164,9 @@ hostNetwork: false
 
 service:
   type: LoadBalancer
+  
+  # Name of the load balancer class specified to be reconciled by this controller
+  # loadBalancerClass: service.k8s.aws/nlb 
 
   # Note that target http ports need to match your ambassador configurations service_port
   # https://www.getambassador.io/reference/modules/#the-ambassador-module


### PR DESCRIPTION
## Description

This is a new PR with commits targeting `dev/v4` from https://github.com/emissary-ingress/emissary/pull/5835.

Original description:

In order to use dedicated load balancer controller (in my case, its   [AWS Load Balancer Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.12/deploy/configurations/)  which has feature to create network LB and Application LB both. We need to provide `loadBalancerClass` to allow events to be listened by the controller deployed by the operator. Without this flag, default cloud operator picks up the changes and process it to provision cloud resources. 

Submitting this feature request to enable it as part of the emissary charts. 

ref: https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class
