### PR TITLE
fix: prevent double snapshotProcessor call in Notify

### DIFF
--- a/cmd/entrypoint/watcher.go
+++ b/cmd/entrypoint/watcher.go
@@ -650,9 +650,7 @@ func (sh *SnapshotHolder) Notify(
 		notifyWebhooksTimer.Time(func() {
 			err = snapshotProcessor(ctx, SnapshotReady, snapshotJSON)
 		})
-		if err != nil {
-			return err
-		}
+		return err
 	}
 	return snapshotProcessor(ctx, SnapshotIncomplete, snapshotJSON)
 }


### PR DESCRIPTION
  When `bootstrapped` is true, `Notify()` calls `snapshotProcessor` with `SnapshotReady` and then falls through to call it again with `SnapshotIncomplete`. Return directly after the `SnapshotReady` call to
  prevent contradictory duplicate notifications.

  ## Description

  Every bootstrapped snapshot was being sent to `snapshotProcessor` twice — once as `SnapshotReady` and once as `SnapshotIncomplete`. This is contradictory and causes unnecessary processing downstream. The fix
  returns directly after the `SnapshotReady` path.

  ## Related Issues

  None found (new discovery via code analysis).

  ## Testing

  The change is a simple control flow fix. The existing `SnapshotReady` path already returns on error — this makes it also return on success instead of falling through.

  ## Checklist

  - [x] This is unlikely to impact how Emissary Ingress performs at scale.
  - [x] My change is adequately tested.
  - [x] The changes in this PR have been reviewed for security concerns and adherence to security best practices.
