### PR TITLE
fix/dispatcher-add-mutex-thread-safety

### DIFF
--- a/pkg/gateway/dispatcher.go
+++ b/pkg/gateway/dispatcher.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
 
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -58,6 +59,7 @@ type Dispatcher struct {
 	transforms map[string]func(kates.Object) (*CompiledConfig, error)
 	configs    map[string]*CompiledConfig
 
+	mutex           sync.Mutex
 	version         string
 	changeCount     int
 	snapshot        *ecp_v3_cache.Snapshot
@@ -110,6 +112,8 @@ func (d *Dispatcher) IsRegistered(kind string) bool {
 
 // Upsert processes the given kubernetes resource whether it is new or just updated.
 func (d *Dispatcher) Upsert(resource kates.Object) error {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
 	gvk := resource.GetObjectKind().GroupVersionKind()
 	xform, ok := d.transforms[gvk.Kind]
 	if !ok {
@@ -131,6 +135,8 @@ func (d *Dispatcher) Upsert(resource kates.Object) error {
 
 // Delete processes the deletion of the given kubernetes resource.
 func (d *Dispatcher) Delete(resource kates.Object) {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
 	key := resourceKey(resource)
 	delete(d.configs, key)
 
@@ -139,6 +145,8 @@ func (d *Dispatcher) Delete(resource kates.Object) {
 }
 
 func (d *Dispatcher) DeleteKey(kind, namespace, name string) {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
 	key := resourceKeyFromParts(kind, namespace, name)
 	delete(d.configs, key)
 	d.snapshot = nil
@@ -161,6 +169,8 @@ func (d *Dispatcher) UpsertYaml(manifests string) error {
 
 // GetErrors returns all compiled items with errors.
 func (d *Dispatcher) GetErrors() []*CompiledItem {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
 	var result []*CompiledItem
 	for _, config := range d.configs {
 		if config.Error != "" {
@@ -198,6 +208,8 @@ func (d *Dispatcher) GetErrors() []*CompiledItem {
 // GetSnapshot returns a version and a snapshot if the snapshot is consistent
 // Important: a nil snapshot can be returned so you must check to to make sure it exists
 func (d *Dispatcher) GetSnapshot(ctx context.Context) (string, *ecp_v3_cache.Snapshot) {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
 	if d.snapshot == nil {
 		d.buildSnapshot(ctx)
 	}
@@ -243,6 +255,8 @@ func (d *Dispatcher) GetRouteConfiguration(ctx context.Context, name string) *v3
 // IsWatched is a temporary hack for dealing with the way endpoint data currenttly flows from
 // watcher -> ambex.n
 func (d *Dispatcher) IsWatched(namespace, name string) bool {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
 	key := fmt.Sprintf("%s:%s", namespace, name)
 	_, ok := d.endpointWatches[key]
 	return ok


### PR DESCRIPTION
The Dispatcher struct has no synchronization. Its methods (Upsert, Delete, GetSnapshot, IsWatched, GetErrors) read/write shared maps concurrently, which causes data races and potential concurrent map panic in Go.

Add sync.Mutex and acquire it in all public methods.

## Description

A few sentences describing the overall goals of the pull request's commits.

## Related Issues

List related issues.

## Testing

A few sentences describing what testing you've done, e.g., manual tests, automated tests, deployed in production, etc.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->
- [ ] **Does my change need to be backported to a previous release?**
  - What backport versions were discussed with the Maintainers in the Issue?

- [ ] **I made sure to update `CHANGELOG.md`.**

   Remember, the CHANGELOG needs to mention:
  - Any new features
  - Any changes to our included version of Envoy
  - Any non-backward-compatible changes
  - Any deprecations

- [ ] **This is unlikely to impact how Emissary Ingress performs at scale.**

   Remember, things that might have an impact at scale include:
  - Any significant changes in memory use that might require adjusting the memory limits
  - Any significant changes in CPU use that might require adjusting the CPU limits
  - Anything that might change how many replicas users should use
  - Changes that impact data-plane latency/scalability

- [ ] **My change is adequately tested.**

   Remember when considering testing:
  - Your change needs to be specifically covered by tests.
    - Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
  - You also need to make sure that the _entire area being changed_ has adequate test coverage.
    - If existing tests don't actually cover the entire area being changed, add tests.
    - This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
  - We should lean on the bulk of code being covered by unit tests, but...
  - ... an end-to-end test should cover the integration points

- [ ] **I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.**

- [ ] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
