### PR TITLE
fix: race condition on firstReconcileHasHappened in consulWatcher

### DIFF
--- a/cmd/entrypoint/consul.go
+++ b/cmd/entrypoint/consul.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"reflect"
 	"sync"
+	"sync/atomic"
 
 	consulapi "github.com/hashicorp/consul/api"
 
@@ -63,7 +64,7 @@ func ReconcileConsul(ctx context.Context, consulWatcher *consulWatcher, s *snaps
 type consulWatcher struct {
 	watchFunc                 watchConsulFunc
 	resolvers                 map[string]*resolver
-	firstReconcileHasHappened bool
+	firstReconcileHasHappened atomic.Bool
 
 	// The changed method returns this channel. We write down this channel to signal that a new
 	// snapshot is available since the last time the update method was invoke.
@@ -134,7 +135,7 @@ func (c *consulWatcher) update(snap *snapshotTypes.ConsulSnapshot) {
 }
 
 func (c *consulWatcher) isBootstrapped() bool {
-	if !c.firstReconcileHasHappened {
+	if !c.firstReconcileHasHappened.Load() {
 		return false
 	}
 	c.mutex.Lock()
@@ -242,8 +243,8 @@ func (c *consulWatcher) reconcile(ctx context.Context, resolvers []*amb.ConsulRe
 
 	// If this is the first time we are reconciling, we need to compute conditions for being
 	// bootstrapped.
-	if !c.firstReconcileHasHappened {
-		c.firstReconcileHasHappened = true
+	if !c.firstReconcileHasHappened.Load() {
+		c.firstReconcileHasHappened.Store(true)
 		var keysForBootstrap []string
 		for _, mappings := range mappingsByResolver {
 			for _, m := range mappings {


### PR DESCRIPTION
firstReconcileHasHappened is read in isBootstrapped() and written in reconcile() without synchronization. Since isBootstrapped() is called from a different goroutine (health check path), this is a data race.

Replace bool with atomic.Bool for safe concurrent access.

## Description

A few sentences describing the overall goals of the pull request's commits.

## Related Issues

List related issues.

## Testing

A few sentences describing what testing you've done, e.g., manual tests, automated tests, deployed in production, etc.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->
- [ ] **Does my change need to be backported to a previous release?**
  - What backport versions were discussed with the Maintainers in the Issue?

- [ ] **I made sure to update `CHANGELOG.md`.**

   Remember, the CHANGELOG needs to mention:
  - Any new features
  - Any changes to our included version of Envoy
  - Any non-backward-compatible changes
  - Any deprecations

- [ ] **This is unlikely to impact how Emissary Ingress performs at scale.**

   Remember, things that might have an impact at scale include:
  - Any significant changes in memory use that might require adjusting the memory limits
  - Any significant changes in CPU use that might require adjusting the CPU limits
  - Anything that might change how many replicas users should use
  - Changes that impact data-plane latency/scalability

- [ ] **My change is adequately tested.**

   Remember when considering testing:
  - Your change needs to be specifically covered by tests.
    - Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
  - You also need to make sure that the _entire area being changed_ has adequate test coverage.
    - If existing tests don't actually cover the entire area being changed, add tests.
    - This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
  - We should lean on the bulk of code being covered by unit tests, but...
  - ... an end-to-end test should cover the integration points

- [ ] **I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.**

- [ ] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
