### PR TITLE
fix: prevent panic on nil atomic.Value in snapshot servers

### DIFF
--- a/cmd/entrypoint/snapshot_server.go
+++ b/cmd/entrypoint/snapshot_server.go
@@ -18,7 +18,12 @@ const ExternalSnapshotPort = 8005
 func externalSnapshotServer(ctx context.Context, snapshot *atomic.Value) error {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/snapshot-external", func(w http.ResponseWriter, r *http.Request) {
-		sanitizedSnap, err := sanitizeExternalSnapshot(ctx, snapshot.Load().([]byte))
+		data, ok := snapshot.Load().([]byte)
+		if !ok || data == nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		sanitizedSnap, err := sanitizeExternalSnapshot(ctx, data)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
@@ -37,7 +42,12 @@ func externalSnapshotServer(ctx context.Context, snapshot *atomic.Value) error {
 func snapshotServer(ctx context.Context, snapshot *atomic.Value) error {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/snapshot", func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write(snapshot.Load().([]byte))
+		data, ok := snapshot.Load().([]byte)
+		if !ok || data == nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		_, _ = w.Write(data)
 	})
 
 	s := &dhttp.ServerConfig{


### PR DESCRIPTION
Both snapshot HTTP handlers perform unchecked type assertions on snapshot.Load().([]byte). If the atomic.Value has never been stored to (before first snapshot is ready), Load() returns nil and the type assertion panics, crashing the HTTP handler.

Use comma-ok type assertion and return 503 Service Unavailable when no snapshot is available yet.

## Description

A few sentences describing the overall goals of the pull request's commits.

## Related Issues

List related issues.

## Testing

A few sentences describing what testing you've done, e.g., manual tests, automated tests, deployed in production, etc.

## Checklist

<!--
  Please review the requirements for each checkbox, and check them
  off (change "[ ]" to "[x]") as you verify that they are complete.
-->
- [ ] **Does my change need to be backported to a previous release?**
  - What backport versions were discussed with the Maintainers in the Issue?

- [ ] **I made sure to update `CHANGELOG.md`.**

   Remember, the CHANGELOG needs to mention:
  - Any new features
  - Any changes to our included version of Envoy
  - Any non-backward-compatible changes
  - Any deprecations

- [ ] **This is unlikely to impact how Emissary Ingress performs at scale.**

   Remember, things that might have an impact at scale include:
  - Any significant changes in memory use that might require adjusting the memory limits
  - Any significant changes in CPU use that might require adjusting the CPU limits
  - Anything that might change how many replicas users should use
  - Changes that impact data-plane latency/scalability

- [ ] **My change is adequately tested.**

   Remember when considering testing:
  - Your change needs to be specifically covered by tests.
    - Tests need to cover all the states where your change is relevant: for example, if you add a behavior that can be enabled or disabled, you'll need tests that cover the enabled case and tests that cover the disabled case. It's not sufficient just to test with the behavior enabled.
  - You also need to make sure that the _entire area being changed_ has adequate test coverage.
    - If existing tests don't actually cover the entire area being changed, add tests.
    - This applies even for aspects of the area that you're not changing – check the test coverage, and improve it if needed!
  - We should lean on the bulk of code being covered by unit tests, but...
  - ... an end-to-end test should cover the integration points

- [ ] **I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.**

- [ ] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
