### PR TITLE
fix(apiext): eagerly generate webhook TLS certificate during startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,15 @@ from the Helm charts.
   you'll now see an error posted if you try to use it. (This shouldn't affect anyone
   running Emissary.)
 
+- Fix: `apiext` now eagerly generates its webhook server certificate for its
+  well-known Service hostname as part of its readiness check, rather than
+  generating it lazily on the first incoming TLS handshake. Previously, the
+  first CRD-conversion request from the Kubernetes apiserver after `apiext`
+  reported itself ready could be the one paying for certificate generation,
+  occasionally causing that request to time out ([#4275]).
+
+[#4275]: https://github.com/emissary-ingress/emissary/issues/4275
+
 ## [4.1.0] 1 May 2026
 [4.1.0]: https://github.com/emissary-ingress/emissary/compare/v4.0.1...v4.1.0
 

--- a/pkg/apiext/server.go
+++ b/pkg/apiext/server.go
@@ -53,6 +53,7 @@ type WebhookServer struct {
 	namespace            string
 	serviceSettings      types.NamespacedName
 	caSecretSettings     types.NamespacedName
+	webhookHostname      string
 	httpPort             int
 	httpsPort            int
 
@@ -86,6 +87,12 @@ func NewWebhookServer(logger *zap.Logger, serviceName string, options ...Webhook
 		Namespace: server.namespace,
 		Name:      serviceName,
 	}
+
+	// This is the hostname that the Kubernetes apiserver will use as the SNI ServerName
+	// when it dials us through our Service to deliver a CRD conversion request; it is
+	// derived entirely from well-known values (our Service's name/namespace), so we don't
+	// need to wait for an incoming request to know what server certificate to generate.
+	server.webhookHostname = fmt.Sprintf("%s.%s.svc", server.serviceSettings.Name, server.serviceSettings.Namespace)
 
 	return server
 }
@@ -167,12 +174,16 @@ func (s *WebhookServer) Run(ctx context.Context, scheme *runtime.Scheme) error {
 		return mgr.Start(gctx)
 	})
 
-	// we will wait until we have successfully obtained a CA root certificate
-	// before we start the web servers, to ensure we don't become ready too early
+	// We will wait until we have successfully obtained a CA root certificate, and used it
+	// to eagerly generate our webhook server certificate, before we start the web servers.
+	// This ensures we don't become ready too early: if we waited to lazily generate the
+	// server certificate on the first incoming TLS handshake, that handshake would be
+	// competing with certificate generation for time against the apiserver's webhook call
+	// timeout, and could time out under load.
 	runImmediately := true
 	pollInterval := 1 * time.Second
 	if err := wait.PollUntilContextCancel(gctx, pollInterval, runImmediately, s.ready); err != nil {
-		return fmt.Errorf("apiext server unable to obtain a root ca during startup")
+		return fmt.Errorf("apiext server unable to prepare a root ca and server certificate during startup")
 	}
 
 	grp.Go(func() error {
@@ -186,8 +197,22 @@ func (s *WebhookServer) Run(ctx context.Context, scheme *runtime.Scheme) error {
 	return grp.Wait()
 }
 
+// ready reports whether the webhook server is prepared to start serving traffic: we need a
+// CA root certificate, and we need to have eagerly generated (and cached) the server
+// certificate for our well-known webhook hostname, so that the apiserver's first TLS
+// handshake with us doesn't pay the cost of certificate generation.
 func (s *WebhookServer) ready(_ context.Context) (done bool, err error) {
-	return s.certificateAuthority.Ready(), nil
+	if !s.certificateAuthority.Ready() {
+		return false, nil
+	}
+
+	if _, err := s.certificateAuthority.GetCertificate(&tls.ClientHelloInfo{ServerName: s.webhookHostname}); err != nil {
+		s.logger.Error("unable to eagerly generate webhook server certificate",
+			zap.String("serverName", s.webhookHostname), zap.Error(err))
+		return false, nil
+	}
+
+	return true, nil
 }
 
 // serveHTTPS starts listening for incoming https request and handles ConversionWebhookRequuests.

--- a/pkg/apiext/server_test.go
+++ b/pkg/apiext/server_test.go
@@ -1,0 +1,86 @@
+package apiext
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"testing"
+
+	"github.com/emissary-ingress/emissary/v3/pkg/apiext/internal/ca"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+)
+
+// fakeCertificateAuthority is a test double for ca.CertificateAuthority that lets us assert on
+// how the WebhookServer's readiness check drives certificate generation, without needing a real
+// CA or paying the cost of RSA key generation.
+type fakeCertificateAuthority struct {
+	caReady             bool
+	getCertificateErr   error
+	getCertificateCalls []string
+}
+
+func (f *fakeCertificateAuthority) SetCACert(*ca.CACert) {}
+
+func (f *fakeCertificateAuthority) GetCACert() *ca.CACert { return nil }
+
+func (f *fakeCertificateAuthority) Ready() bool { return f.caReady }
+
+func (f *fakeCertificateAuthority) GetCertificate(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	f.getCertificateCalls = append(f.getCertificateCalls, hello.ServerName)
+	if f.getCertificateErr != nil {
+		return nil, f.getCertificateErr
+	}
+	return &tls.Certificate{}, nil
+}
+
+var _ ca.CertificateAuthority = (*fakeCertificateAuthority)(nil)
+
+func TestWebhookServerWebhookHostname(t *testing.T) {
+	server := NewWebhookServer(zaptest.NewLogger(t), "emissary-apiext", WithNamespace("emissary-system"))
+	assert.Equal(t, "emissary-apiext.emissary-system.svc", server.webhookHostname)
+}
+
+func TestWebhookServerReadyWaitsForCACert(t *testing.T) {
+	fake := &fakeCertificateAuthority{caReady: false}
+	server := &WebhookServer{
+		logger:               zaptest.NewLogger(t),
+		certificateAuthority: fake,
+		webhookHostname:      "emissary-apiext.emissary-system.svc",
+	}
+
+	done, err := server.ready(context.Background())
+	require.NoError(t, err)
+	assert.False(t, done)
+	assert.Empty(t, fake.getCertificateCalls, "should not attempt to generate a server cert before the CA is ready")
+}
+
+func TestWebhookServerReadyEagerlyGeneratesServerCertificate(t *testing.T) {
+	fake := &fakeCertificateAuthority{caReady: true}
+	server := &WebhookServer{
+		logger:               zaptest.NewLogger(t),
+		certificateAuthority: fake,
+		webhookHostname:      "emissary-apiext.emissary-system.svc",
+	}
+
+	done, err := server.ready(context.Background())
+	require.NoError(t, err)
+	assert.True(t, done, "server should be ready once the CA cert and server cert are both prepared")
+	require.Len(t, fake.getCertificateCalls, 1)
+	assert.Equal(t, "emissary-apiext.emissary-system.svc", fake.getCertificateCalls[0],
+		"should eagerly generate a server cert for our well-known webhook hostname")
+}
+
+func TestWebhookServerReadyNotReadyIfServerCertGenerationFails(t *testing.T) {
+	fake := &fakeCertificateAuthority{caReady: true, getCertificateErr: errors.New("boom")}
+	server := &WebhookServer{
+		logger:               zaptest.NewLogger(t),
+		certificateAuthority: fake,
+		webhookHostname:      "emissary-apiext.emissary-system.svc",
+	}
+
+	done, err := server.ready(context.Background())
+	require.NoError(t, err)
+	assert.False(t, done, "should not report ready if we failed to eagerly generate the server certificate")
+}


### PR DESCRIPTION
## Description

`apiext`'s conversion webhook server was generating its TLS server certificate lazily, on the first incoming TLS handshake, rather than up front. This PR makes it generate that certificate eagerly during startup, as part of its readiness check.

## Problem

`apiext`'s `CertificateAuthority.GetCertificate` (used as the `tls.Config.GetCertificate` callback) only generates a server certificate for a given hostname the first time it's asked for one — i.e., on the first real TLS handshake. Meanwhile, `apiext`'s readiness probe only checked that the CA root certificate existed (`certificateAuthority.Ready()`), not that a server certificate had actually been generated yet.

As a result, a pod could report itself `Ready` (and therefore get registered as an available endpoint / cause the Deployment to become `Available`) before it had ever generated its own server certificate. The *first* CRD conversion request the kube-apiserver sent to it afterward would then have to pay the cost of certificate generation (RSA-4096 key generation + certificate signing) during the TLS handshake itself, racing against the apiserver's webhook call timeout. Under load, or on slower nodes, this occasionally caused the handshake — and the conversion request — to time out:

```
Error from server: error when creating "STDIN": conversion webhook for getambassador.io/v3alpha1, Kind=Host failed: Post https://emissary-apiext.emissary-system.svc:443/webhooks/crd-convert?timeout=30s: net/http: TLS handshake timeout
```

## Root cause

- `pkg/apiext/server.go`'s `ready()` function (used to gate startup of the HTTPS/healthz servers) only checked `certificateAuthority.Ready()`, i.e. that the CA root cert existed — it never checked/forced generation of the actual server leaf certificate.
- `pkg/apiext/internal/ca/authority.go`'s `GetCertificate` only generates (and caches) a server cert lazily, in response to a `tls.ClientHelloInfo`, which normally only happens on a real incoming connection.

`apiext` is always deployed to a well-known Service (name + namespace), so the hostname the apiserver will use for its TLS ServerName (`<service>.<namespace>.svc`) is known ahead of time — there's no need to wait for a real handshake to find out what certificate to generate.

## Fix

- Added a `webhookHostname` field to `WebhookServer`, computed once at construction time from the already-known Service name/namespace (`<service>.<namespace>.svc` — the same hostname the apiserver uses to reach the webhook via its `ServiceReference`).
- Updated `WebhookServer.ready()` to, once the CA is ready, eagerly call `certificateAuthority.GetCertificate` for that hostname (which generates and caches the server cert), and only report ready once that succeeds. This reuses the existing pre-serve readiness gate in `Run()`, so the HTTPS/healthz servers — and therefore the pod's readiness probe — don't start until both the CA root and the server leaf certificate are prepared.

This is scoped to startup; it doesn't change behavior on CA rotation (which already invalidates cached server certs and would need separate consideration).

## Testing

Added `pkg/apiext/server_test.go` covering the new `ready()` behavior against a fake `CertificateAuthority`:
- not ready while the CA cert is unavailable (and no certificate-generation attempted)
- reports ready once the CA cert is available *and* eagerly generates the server certificate for the known webhook hostname
- stays not-ready (without erroring) if certificate generation fails
- `webhookHostname` is derived correctly from the Service name/namespace

```
$ go test ./pkg/apiext/...
ok  	github.com/emissary-ingress/emissary/v3/pkg/apiext	0.827s
ok  	github.com/emissary-ingress/emissary/v3/pkg/apiext/internal/ca	8.680s
```

Also ran:
```
$ go build ./pkg/apiext/... ./cmd/apiext/...
$ go vet ./pkg/apiext/... ./cmd/apiext/...
$ make lint/go   # golangci-lint run ./...  -> clean
```

I don't have a way to spin up a real cluster with the apiserver hitting the webhook under contention in this environment, so I wasn't able to reproduce the original timeout end-to-end, but the unit tests directly exercise the changed readiness/certificate-generation logic described in the issue.

## Related Issues

Fixes #4275

## Checklist

- [x] **Does my change need to be backported to a previous release?**
  - Not discussed with maintainers yet; this is a startup-readiness bug fix with no API/behavior surface change, so happy to backport if maintainers want it on a supported release branch.
- [x] **I made sure to update `CHANGELOG.md`.**
- [x] **This is unlikely to impact how Emissary Ingress performs at scale.**
  - The only added cost is generating one RSA-4096 certificate once during `apiext` startup (previously generated lazily on first handshake anyway) — no ongoing CPU/memory/latency impact.
- [x] **My change is adequately tested.**
- [x] **I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.**
  - No special tricks were needed beyond the standard Go toolchain.
- [x] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
  - No new external inputs; the certificate is generated from the existing in-memory CA using the same code path as before, just triggered eagerly instead of lazily.