### PR TITLE
test(e2e): port the gRPC rate limit suite

### DIFF
--- a/test/e2e/fixtures/ratelimit-grpc/chainsaw-test.yaml
+++ b/test/e2e/fixtures/ratelimit-grpc/chainsaw-test.yaml
@@ -1,0 +1,39 @@
+---
+# Port of KAT's tests/kat/t_ratelimit.py::RateLimitV1Test.
+#
+# `exclusive` because a RateLimitService is instance-global.
+#
+# KAT's check() only looked at query [2]; the status assertions on [0] and [1]
+# came from each Query's `expected`. Both are assertions here.
+#
+# Response headers are canonical-cased (`.result.headers["Hello"]`), unlike the
+# request headers kat-server echoes back lowercased.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  labels:
+    slot: exclusive
+  name: ratelimit-grpc
+spec:
+  steps:
+    - name: apply
+      try:
+        - apply:
+            file: manifests.yaml
+
+    - name: rate limit allows and rejects per descriptor
+      try:
+        - script:
+            timeout: 2m
+            content: |
+              ../../probe.sh queries.json \
+                'no descriptor headers, so no rate limiting' '.[0].result.status == 200' \
+                'reached the target'                         '.[0].result.json.backend == "target"' \
+                'rls allowed the request'                    '.[1].result.status == 200' \
+                'allowed request reached the target'         '.[1].result.json.backend == "target"' \
+                'rls rejected the request'                   '.[2].result.status == 429' \
+                'the 429 body came from the rls'              '.[2].result.json.backend == "rls"' \
+                'rls appended Hello'                         '.[2].result.headers["Hello"] == ["Foo"]' \
+                'rls appended Hi'                            '.[2].result.headers["Hi"] == ["Baz"]' \
+                'rls overrode the content type'              '.[2].result.headers["Content-Type"] == ["application/json"]' \
+                'rls answered over v3'                       '.[2].result.headers["Kat-Resp-Rls-Protocol-Version"] == ["v3"]'

--- a/test/e2e/fixtures/ratelimit-grpc/manifests.yaml
+++ b/test/e2e/fixtures/ratelimit-grpc/manifests.yaml
@@ -1,0 +1,121 @@
+---
+# Port of KAT's tests/kat/t_ratelimit.py::RateLimitV1Test.
+#
+# One plain target plus a gRPC rate limit service: kat-server in `grpc_rls`
+# mode decides per request based on the `kat-req-rls-allow` header, and
+# appends whatever `kat-req-rls-headers-append` asks for to the 429 it
+# returns.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: target
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: target
+  template:
+    metadata:
+      labels:
+        app: target
+    spec:
+      containers:
+        - name: kat-server
+          image: (env('KAT_SERVER_IMAGE'))
+          imagePullPolicy: IfNotPresent
+          command: ["/work/kat-server"]
+          env:
+            - name: BACKEND
+              value: target
+          ports:
+            - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: target
+spec:
+  selector:
+    app: target
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rls
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rls
+  template:
+    metadata:
+      labels:
+        app: rls
+    spec:
+      containers:
+        - name: kat-server
+          image: (env('KAT_SERVER_IMAGE'))
+          imagePullPolicy: IfNotPresent
+          command: ["/work/kat-server"]
+          env:
+            - name: BACKEND
+              value: rls
+            - name: KAT_BACKEND_TYPE
+              value: grpc_rls
+            # Must match the RateLimitService's protocol_version; kat-server
+            # echoes it back in Kat-Resp-Rls-Protocol-Version.
+            - name: GRPC_RLS_PROTOCOL_VERSION
+              value: v3
+          ports:
+            - containerPort: 8080
+---
+# Port 80, not 8080: a RateLimitService's `service` with no port defaults to 80.
+apiVersion: v1
+kind: Service
+metadata:
+  name: rls
+spec:
+  selector:
+    app: rls
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+---
+apiVersion: getambassador.io/v3alpha1
+kind: RateLimitService
+metadata:
+  name: rls
+spec:
+  ambassador_id: [(env('SLOT'))]
+  service: (join('.', ['rls', $namespace]))
+  timeout_ms: 500
+  protocol_version: v3
+---
+# The `ambassador` key is the rate limit domain. Both headers are
+# omit_if_not_present, so a request carrying neither produces no descriptor at
+# all and never reaches the rate limit service.
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: target
+spec:
+  ambassador_id: [(env('SLOT'))]
+  hostname: "*"
+  prefix: /target/
+  service: target:8080
+  labels:
+    ambassador:
+      - request_label_group:
+          - request_headers:
+              key: kat-req-rls-allow
+              header_name: kat-req-rls-allow
+              omit_if_not_present: true
+          - request_headers:
+              key: kat-req-rls-headers-append
+              header_name: kat-req-rls-headers-append
+              omit_if_not_present: true

--- a/test/e2e/fixtures/ratelimit-grpc/queries.json
+++ b/test/e2e/fixtures/ratelimit-grpc/queries.json
@@ -1,0 +1,22 @@
+[
+  {
+    "url": "/target/",
+    "method": "GET"
+  },
+  {
+    "url": "/target/",
+    "method": "GET",
+    "headers": {
+      "kat-req-rls-allow": "true",
+      "kat-req-rls-headers-append": "no header"
+    }
+  },
+  {
+    "url": "/target/",
+    "method": "GET",
+    "headers": {
+      "kat-req-rls-allow": "over my dead body",
+      "kat-req-rls-headers-append": "Hello=Foo; Hi=Baz"
+    }
+  }
+]


### PR DESCRIPTION
## Description

Ports `t_ratelimit.py::RateLimitV1Test` as the `ratelimit-grpc` fixture. This is the first fixture with a gRPC aux service and the first to assert a 429, but it needed no framework changes: the labelled-assertion form of `probe.sh` from #5980 covers it as-is.

`kat-server` in `grpc_rls` mode decides per request from the `kat-req-rls-allow` descriptor, and on rejection appends whatever `kat-req-rls-headers-append` asks for to its own 429 response. So the three queries are one per path through that logic:

- **No descriptor headers.** Both label entries are `omit_if_not_present`, so no descriptor is generated and the rate limit service is never consulted. Reaches the target.
- **Allowed descriptor.** The service is consulted and returns `OK`. Reaches the target.
- **Rejected descriptor.** 429, and the response carries the `Hello`/`Hi` headers the descriptor asked the service to append, the `application/json` content type it overrides, and the `Kat-Resp-Rls-Protocol-Version: v3` it echoes from `GRPC_RLS_PROTOCOL_VERSION`.

Ten labelled assertions cover those. KAT's `check()` only inspected the third query; the status assertions on the first two were implicit in each `Query`'s `expected=`. Both are explicit here.

`exclusive` slot, because a `RateLimitService` is instance-global for the Emissary that owns it.

One assertion is stronger than KAT's. The 429 body is generated by the rate limit service and reports `backend: "rls"`, so the fixture asserts that positively rather than merely asserting the request did not reach the target. That distinguishes an RLS-generated 429 from one Envoy synthesized on its own.

## Related Issues

Continues the KAT-to-Chainsaw port from #5940 (framework) and #5980 (extauth).

## Testing

Green locally on arm64, and green on both `Test amd64 Images` and `Test arm64 Images` in CI.

10/10 assertions. Across local runs the fixture needed either 1 or 2 probe attempts, which is the Envoy config-propagation lag the retry loop in `probe.sh` exists to absorb; the first attempt returns 0/10 when config has not landed yet, rather than partially passing.

## Follow-ups (not in this PR)

- The other three classes in `t_ratelimit.py` are now cheap: `RateLimitV0Test`, `RateLimitVerTest` (`protocol_version` handling) and `RateLimitV1WithTLSTest` all reuse this fixture's shape.
- `RLSGRPC` was one of the KAT `ServiceType`s with no e2e equivalent; `ALSGRPC` (`t_logservice.py`) is the remaining gRPC one.
- The `manifests.yaml` duplication called out in #5980 grows with this fixture: the target Deployment/Service pair here is byte-identical to extauth's. A shared `backends/` library would collapse it.
