### PR TITLE
test(e2e): probe over HTTPS, and port t_hosts.py::HostCRDSingle

### DIFF
--- a/build-aux/e2e.mk
+++ b/build-aux/e2e.mk
@@ -13,6 +13,7 @@ E2E_CLUSTER       ?= emissary-e2e
 E2E_NAMESPACE     ?= emissary
 E2E_CRD_NAMESPACE ?= emissary-system
 E2E_GATEWAY_URL   ?= http://localhost
+E2E_GATEWAY_HTTPS_URL ?= https://localhost
 E2E_COMPONENTS    ?= apiext emissary kat-client kat-server test-auth test-shadow test-stats
 
 # Slots (isolated Emissary installs for tests that set global config) are
@@ -118,6 +119,7 @@ e2e/run: $(tools/kat-client) $(tools/chainsaw)
 	KAT_SERVER_IMAGE="ghcr.io/emissary-ingress/kat-server:$$tag" \
 	E2E_NAMESPACE=$(E2E_NAMESPACE) \
 	E2E_GATEWAY_URL=$(E2E_GATEWAY_URL) \
+	E2E_GATEWAY_HTTPS_URL=$(E2E_GATEWAY_HTTPS_URL) \
 	    $(E2E_SLOTS_SH) run \
 	        $(tools/chainsaw) \
 	        $(OSS_HOME)/test/e2e/.chainsaw.yaml \
@@ -139,13 +141,13 @@ e2e/run/%: $(tools/kat-client) $(tools/chainsaw)
 	fi
 	@tag="$$(head -n1 $(E2E_VERSION_FILE))-$(ARCH)"; \
 	kind="$$(sed -n 's/^ *slot: *//p' $(OSS_HOME)/test/e2e/fixtures/$*/chainsaw-test.yaml | head -n1)"; \
-	url="$(E2E_GATEWAY_URL)"; tcp_url="$(E2E_GATEWAY_URL):6789"; slot=default; \
+	url="$(E2E_GATEWAY_URL)"; https_url="$(E2E_GATEWAY_HTTPS_URL)"; tcp_url="$(E2E_GATEWAY_URL):6789"; slot=default; \
 	if test "$$kind" = "exclusive"; then \
 	    want="$${E2E_SLOT:-}"; \
 	    while read -r name base; do \
 	        if test -z "$$want" -o "$$name" = "$$want"; then \
 	            slot="$$name"; \
-	            url="$(E2E_GATEWAY_URL):$$base"; tcp_url="$(E2E_GATEWAY_URL):$$((base+2))"; \
+	            url="$(E2E_GATEWAY_URL):$$base"; https_url="$(E2E_GATEWAY_HTTPS_URL):$$((base+1))"; tcp_url="$(E2E_GATEWAY_URL):$$((base+2))"; \
 	            break; \
 	        fi; \
 	    done <<<"$$($(E2E_SLOTS_SH) list)"; \
@@ -155,6 +157,7 @@ e2e/run/%: $(tools/kat-client) $(tools/chainsaw)
 	KAT_CLIENT=$(tools/kat-client) \
 	KAT_SERVER_IMAGE="ghcr.io/emissary-ingress/kat-server:$$tag" \
 	GATEWAY_URL="$$url" \
+	GATEWAY_HTTPS_URL="$$https_url" \
 	GATEWAY_TCP_URL="$$tcp_url" \
 	    $(tools/chainsaw) test \
 	        --config $(OSS_HOME)/test/e2e/.chainsaw.yaml \

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -145,7 +145,11 @@ environment, and manifests call `(env('KAT_SERVER_IMAGE'))` and
 - `queries.json` is a plain [kat-client][] input file. URLs starting with `/`
   are prefixed with `$PROBE_BASE` (defaults to `$GATEWAY_URL`); absolute URLs
   are left alone, so TLS and alternate-port fixtures spell out their own
-  scheme and host.
+  scheme and host. A fixture that wants to probe the downstream HTTPS
+  listener sets `PROBE_BASE="$GATEWAY_HTTPS_URL"` in its `script` step;
+  `slots.sh` and `e2e.mk` export `GATEWAY_HTTPS_URL` alongside `GATEWAY_URL`
+  and `GATEWAY_TCP_URL`, pointing at the slot's `+1` port (see the port table
+  above).
 - The `jq` expression is evaluated against kat-client's output array. It maps
   directly onto the old KAT Python assertions: `Query(..., expected=404)`
   becomes `.[0].result.status == 404`, and `r.backend.name == "x"` becomes
@@ -249,6 +253,7 @@ All have sensible defaults; override on the command line as needed:
 | `E2E_NAMESPACE`      | `emissary`             | namespace for the Emissary install       |
 | `E2E_CRD_NAMESPACE`  | `emissary-system`      | namespace for the CRDs chart             |
 | `E2E_GATEWAY_URL`    | `http://localhost`     | host the probes target (slot ports are appended) |
+| `E2E_GATEWAY_HTTPS_URL` | `https://localhost` | https counterpart of `E2E_GATEWAY_URL`, for fixtures that probe the downstream TLS listener |
 | `E2E_LOCAL_VERSION`  | `v4.0.0-local`         | short chart VERSION (dirty trees produce strings longer than k8s' 63-char label limit) |
 | `E2E_SLOTS`          | `slot1:8100 ... slot8:8128` | `<name>:<port-base>` list of isolated Emissary installs |
 | `E2E_DEFAULT_PARALLEL` | `8`                  | how many `shared` fixtures run at once |

--- a/test/e2e/fixtures/host-tls/chainsaw-test.yaml
+++ b/test/e2e/fixtures/host-tls/chainsaw-test.yaml
@@ -1,0 +1,63 @@
+---
+# Port of KAT's tests/kat/t_hosts.py::HostCRDSingle.
+#
+# `exclusive` because a Host reconfigures the listener's TLS, which is
+# instance-global.
+#
+# The Secret is a leaf serving cert for the downstream listener, generated
+# per run rather than committed: a default `openssl req -x509` cert is a CA
+# and BoringSSL rejects it at handshake time (see docker/kat-server/Dockerfile
+# for the same fix on the upstream side). It carries a SAN for "localhost",
+# which is what the client actually connects to; the Host's own `hostname` is
+# "*" for reasons explained in manifests.yaml.
+#
+# The KAT test issues two queries, one over https and one over http, so it
+# needs two query files and two probe steps: PROBE_BASE picks the scheme,
+# and queries.json can't hardcode either since the slot's port varies at run
+# time.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  labels:
+    slot: exclusive
+  name: host-tls
+spec:
+  steps:
+    - name: generate the downstream cert
+      try:
+        - script:
+            content: |
+              set -eu
+              dir=$(mktemp -d)
+              trap 'rm -rf "$dir"' EXIT
+              openssl req -x509 -newkey rsa:2048 -nodes -days 3650 \
+                -subj /CN=localhost \
+                -addext basicConstraints=critical,CA:FALSE \
+                -addext keyUsage=critical,digitalSignature,keyEncipherment \
+                -addext extendedKeyUsage=serverAuth \
+                -addext subjectAltName=DNS:localhost \
+                -keyout "$dir/tls.key" -out "$dir/tls.crt" 2>/dev/null
+              kubectl create secret tls host-tls-secret \
+                -n "$NAMESPACE" --cert="$dir/tls.crt" --key="$dir/tls.key"
+
+    - name: apply
+      try:
+        - apply:
+            file: manifests.yaml
+
+    - name: https reaches the target
+      try:
+        - script:
+            timeout: 2m
+            content: |
+              PROBE_BASE="$GATEWAY_HTTPS_URL" ../../probe.sh queries-https.json \
+                'client got 200 over https'       '.[0].result.status == 200' \
+                'reached the target'               '.[0].result.json.backend == "target"'
+
+    - name: http redirects to https
+      try:
+        - script:
+            timeout: 2m
+            content: |
+              PROBE_BASE="$GATEWAY_URL" ../../probe.sh queries-http.json \
+                'client got redirected to tls'    '.[0].result.status == 301'

--- a/test/e2e/fixtures/host-tls/manifests.yaml
+++ b/test/e2e/fixtures/host-tls/manifests.yaml
@@ -1,0 +1,69 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: target
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: target
+  template:
+    metadata:
+      labels:
+        app: target
+    spec:
+      containers:
+        - name: kat-server
+          image: (env('KAT_SERVER_IMAGE'))
+          imagePullPolicy: IfNotPresent
+          command: ["/work/kat-server"]
+          env:
+            - name: BACKEND
+              value: target
+          ports:
+            - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: target
+spec:
+  selector:
+    app: target
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+---
+# hostname is "*" rather than "localhost": the client reaches the gateway as
+# localhost on a slot-specific port, and Envoy's virtual host domain match is
+# against the ":authority" header including that port, which varies at run
+# time and can't be hardcoded here. "*" matches any authority, and also
+# leaves the TLS filter chain's SNI match wide open, which is fine since the
+# query below never sets "sni".
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: host-tls
+spec:
+  ambassador_id: [(env('SLOT'))]
+  hostname: "*"
+  acmeProvider:
+    authority: none
+  tlsSecret:
+    name: host-tls-secret
+  mappingSelector:
+    matchLabels:
+      host: host-tls
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
+metadata:
+  name: target
+  labels:
+    host: host-tls
+spec:
+  ambassador_id: [(env('SLOT'))]
+  prefix: /target/
+  service: target:8080

--- a/test/e2e/fixtures/host-tls/queries-http.json
+++ b/test/e2e/fixtures/host-tls/queries-http.json
@@ -1,0 +1,6 @@
+[
+  {
+    "url": "/target/",
+    "method": "GET"
+  }
+]

--- a/test/e2e/fixtures/host-tls/queries-https.json
+++ b/test/e2e/fixtures/host-tls/queries-https.json
@@ -1,0 +1,7 @@
+[
+  {
+    "url": "/target/",
+    "method": "GET",
+    "insecure": true
+  }
+]

--- a/test/e2e/slots.sh
+++ b/test/e2e/slots.sh
@@ -19,6 +19,7 @@ SLOTS="${E2E_SLOTS:-slot1:8100 slot2:8104 slot3:8108 slot4:8112 slot5:8116 slot6
 
 NAMESPACE="${E2E_NAMESPACE:-emissary}"
 GATEWAY_URL="${E2E_GATEWAY_URL:-http://localhost}"
+GATEWAY_HTTPS_URL="${E2E_GATEWAY_HTTPS_URL:-https://localhost}"
 DEFAULT_PARALLEL="${E2E_DEFAULT_PARALLEL:-8}"
 
 cmd_list() {
@@ -179,10 +180,10 @@ cmd_run() {
     logdir="$(mktemp -d)"
 
     run_shard() {
-        local shard="$1" slot="$2" url="$3" tcp_url="$4" parallel="$5"
-        shift 5
+        local shard="$1" slot="$2" url="$3" https_url="$4" tcp_url="$5" parallel="$6"
+        shift 6
         set +e
-        SLOT="$slot" GATEWAY_URL="$url" GATEWAY_TCP_URL="$tcp_url" \
+        SLOT="$slot" GATEWAY_URL="$url" GATEWAY_HTTPS_URL="$https_url" GATEWAY_TCP_URL="$tcp_url" \
             "$chainsaw" test \
                 --config "$config" \
                 --parallel "$parallel" \
@@ -192,7 +193,7 @@ cmd_run() {
         set -e
     }
 
-    run_shard shared default "$GATEWAY_URL" "${GATEWAY_URL}:6789" "$DEFAULT_PARALLEL" \
+    run_shard shared default "$GATEWAY_URL" "$GATEWAY_HTTPS_URL" "${GATEWAY_URL}:6789" "$DEFAULT_PARALLEL" \
         --selector "slot=shared" &
     pids+=("$!"); shards+=(shared)
 
@@ -201,7 +202,7 @@ cmd_run() {
         # empty regex would select every test rather than none.
         [[ -n "${assigned[i]}" ]] || continue
         local name="${slot_names[i]}" base="${slot_bases[i]}"
-        run_shard "$name" "$name" "${GATEWAY_URL}:${base}" "${GATEWAY_URL}:$((base + 2))" 1 \
+        run_shard "$name" "$name" "${GATEWAY_URL}:${base}" "${GATEWAY_HTTPS_URL}:$((base + 1))" "${GATEWAY_URL}:$((base + 2))" 1 \
             --include-test-regex "chainsaw/(${assigned[i]#|})\$" &
         pids+=("$!"); shards+=("$name")
     done


### PR DESCRIPTION
## Description

Every existing `test/e2e` fixture probes Emissary over plain HTTP. This adds the missing piece for downstream TLS and the first fixture that uses it.

**`test(e2e): export GATEWAY_HTTPS_URL`** is the framework half. Each slot already reserved and published an HTTPS port (`slots.sh` documents `<base>+0` http, `+1` https, `+2` tcp, and `cmd_install` points `service.ports[1]` at 8443), but nothing exported it, so a fixture had no way to address it. `run_shard` now takes and exports `GATEWAY_HTTPS_URL` alongside `GATEWAY_URL` and `GATEWAY_TCP_URL`, derived the same way: the base value for the `shared` shard, `<base>+1` for a slot. `build-aux/e2e.mk` does the equivalent for `make e2e/run/<fixture>`, and adds `E2E_GATEWAY_HTTPS_URL` next to `E2E_GATEWAY_URL` so the scheme is configured rather than string-substituted.

`probe.sh` needed no change. It already prefixes relative URLs with `$PROBE_BASE`, so a fixture opts into HTTPS by setting `PROBE_BASE="$GATEWAY_HTTPS_URL"` in its script step.

**`test(e2e): port t_hosts.py::HostCRDSingle as host-tls`** is the fixture. A `Host` with a `tlsSecret` and a `mappingSelector`, plus the `Mapping` its selector matches. Two probes, which is what makes this a useful first case: one over HTTPS expecting 200 from the target, and one over cleartext expecting the 301 redirect to TLS. So the fixture exercises both the new variable and the existing one.

The certificate is generated per run by an `openssl` script step into the test's own namespace, following the pattern established in #5988. Nothing certificate-shaped is committed.

### On `hostname: "*"`

The KAT original uses a specific hostname. This fixture uses `"*"`, which is a real constraint rather than a shortcut. Slots are distinguished by port, so a probe arrives with `:authority: localhost:8101`, while `v3listener.py` emits `"domains": [host.hostname]` as a single literal and `strip_matching_host_port` defaults to false. A literal `hostname: localhost` therefore matches nothing. Confirmed by trying it: the fixture fails both assertions.

Follow-on ports from `t_hosts.py` that genuinely test hostname and SNI matching will set a `Host` header on the query instead, which `cmd/kat-client/client.go` already honours (and uses for `ServerName` when `sni` is set), giving a port-free authority that a literal hostname will match.

## Related Issues

None.

## Testing

Test-only change, verified against a local k3d cluster.

- `make e2e/run/host-tls` passes in isolation. The HTTPS probe returns 200 with `backend: target`, the cleartext probe returns 301.
- `make e2e/run` (full suite, sharded) passes: **13 of 13 fixtures, 0 failed, 0 skipped**, including the 12 pre-existing ones to confirm the `run_shard` signature change broke nothing.
- Falsification of the `hostname` note above: with `hostname: localhost` instead of `"*"`, `host-tls` fails 0 of 2 assertions.

## Checklist

- [x] **Does my change need to be backported to a previous release?**
  - No. This adds test infrastructure and a test; there is no runtime behaviour change to backport.

- [x] **I made sure to update `CHANGELOG.md`.**
  - Not applicable. No new features, no Envoy version change, no non-backward-compatible changes, no deprecations. This is test-only.

- [x] **This is unlikely to impact how Emissary Ingress performs at scale.**
  - Nothing here ships in the image or touches the data plane.

- [x] **My change is adequately tested.**
  - The change *is* a test, and it is exercised in CI by the `Test Images` jobs, which run the whole `fixtures` directory. Both branches of the fixture's subject are covered: TLS on the HTTPS port, and the cleartext redirect. The full suite was run to confirm the framework change is safe for the existing fixtures.

- [x] **I am submitting a bug fix.**
  - No, this is test coverage.

- [x] **I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.**
  - No new tricks. `test/e2e/README.md` is updated to document `GATEWAY_HTTPS_URL` where the other exported variables are described.

- [x] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
  - The certificate is generated at run time rather than committed, so no key material enters the repository. It is scoped to the test's ephemeral namespace and discarded with it. The generated certificate is deliberately a leaf (`CA:FALSE`, `digitalSignature`, `serverAuth`) rather than the CA a default `openssl req -x509` would produce.