### PR TITLE
test: Cover TCPMapping with the Kubernetes endpoint resolver (#3330)

### DIFF
--- a/cmd/entrypoint/endpoint_routing_test.go
+++ b/cmd/entrypoint/endpoint_routing_test.go
@@ -275,3 +275,140 @@ func makeSubset(args ...interface{}) (kates.EndpointSubset, error) {
 
 	return kates.EndpointSubset{Addresses: addrs, Ports: ports}, nil
 }
+
+// TestEndpointRoutingTCPMapping checks that a TCPMapping using the endpoint
+// resolver causes the watcher to track the Service's Endpoints, and that the
+// resulting Envoy cluster is an EDS cluster rather than a STRICT_DNS cluster
+// pointed at the Service's ClusterIP.
+//
+// Regression test for https://github.com/emissary-ingress/emissary/issues/3330
+func TestEndpointRoutingTCPMapping(t *testing.T) {
+	f := entrypoint.RunFake(t, entrypoint.FakeConfig{EnvoyConfig: true}, nil)
+	assert.NoError(t, f.UpsertYAML(`
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Listener
+metadata:
+  name: tcp-listener
+  namespace: default
+spec:
+  port: 9999
+  protocol: TCP
+  securityModel: INSECURE
+  hostBinding:
+    namespace:
+      from: ALL
+---
+apiVersion: getambassador.io/v3alpha1
+kind: TCPMapping
+metadata:
+  name: foo
+  namespace: default
+spec:
+  port: 9999
+  service: foo:80
+  resolver: endpoint
+`))
+	assert.NoError(t, f.Upsert(makeService("default", "foo")))
+	subset, err := makeSubset(8080, "1.2.3.4")
+	require.NoError(t, err)
+	assert.NoError(t, f.Upsert(makeEndpoints("default", "foo", subset)))
+	f.Flush()
+
+	snap, err := f.GetSnapshot(HasTCPMapping("default", "foo"))
+	require.NoError(t, err)
+	assert.NotNil(t, snap)
+
+	// The watcher must have picked up the Endpoints for the TCPMapping's Service.
+	endpoints, err := f.GetEndpoints(HasEndpoints("k8s/default/foo/80"))
+	require.NoError(t, err)
+	assert.Equal(t, "1.2.3.4", endpoints.Entries["k8s/default/foo/80"][0].Ip)
+	assert.Equal(t, uint32(8080), endpoints.Entries["k8s/default/foo/80"][0].Port)
+
+	// The Envoy cluster for the TCPMapping must use EDS, keyed on the endpoint path above.
+	config, err := f.GetEnvoyConfig(func(config *v3bootstrap.Bootstrap) bool {
+		return FindCluster(config, ClusterNameContains("foo_80")) != nil
+	})
+	require.NoError(t, err)
+	cluster := FindCluster(config, ClusterNameContains("foo_80"))
+	require.NotNil(t, cluster)
+	assert.Equal(t, v3cluster.Cluster_EDS, cluster.GetType())
+	require.NotNil(t, cluster.EdsClusterConfig)
+	assert.Equal(t, "k8s/default/foo/80", cluster.EdsClusterConfig.ServiceName)
+	assert.Nil(t, cluster.LoadAssignment)
+}
+
+// TestEndpointRoutingTCPMappingModuleDefault checks that a TCPMapping with no
+// explicit resolver inherits the endpoint resolver configured as the default in
+// the Ambassador Module.
+func TestEndpointRoutingTCPMappingModuleDefault(t *testing.T) {
+	f := entrypoint.RunFake(t, entrypoint.FakeConfig{}, nil)
+	assert.NoError(t, f.UpsertYAML(`
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Module
+metadata:
+  name: ambassador
+  namespace: default
+spec:
+  config:
+    resolver: endpoint
+---
+apiVersion: getambassador.io/v3alpha1
+kind: TCPMapping
+metadata:
+  name: foo
+  namespace: default
+spec:
+  port: 9999
+  service: foo:80
+`))
+	assert.NoError(t, f.Upsert(makeService("default", "foo")))
+	subset, err := makeSubset(8080, "1.2.3.4")
+	require.NoError(t, err)
+	assert.NoError(t, f.Upsert(makeEndpoints("default", "foo", subset)))
+	f.Flush()
+
+	endpoints, err := f.GetEndpoints(HasEndpoints("k8s/default/foo/80"))
+	require.NoError(t, err)
+	assert.Equal(t, "1.2.3.4", endpoints.Entries["k8s/default/foo/80"][0].Ip)
+	assert.Equal(t, uint32(8080), endpoints.Entries["k8s/default/foo/80"][0].Port)
+}
+
+// TestEndpointRoutingTCPMappingServiceResolver checks that a TCPMapping using
+// the default kubernetes-service resolver does NOT cause Endpoints to be watched.
+func TestEndpointRoutingTCPMappingServiceResolver(t *testing.T) {
+	f := entrypoint.RunFake(t, entrypoint.FakeConfig{}, nil)
+	assert.NoError(t, f.UpsertYAML(`
+---
+apiVersion: getambassador.io/v3alpha1
+kind: TCPMapping
+metadata:
+  name: foo
+  namespace: default
+spec:
+  port: 9999
+  service: foo:80
+`))
+	assert.NoError(t, f.Upsert(makeService("default", "foo")))
+	subset, err := makeSubset(8080, "1.2.3.4")
+	require.NoError(t, err)
+	assert.NoError(t, f.Upsert(makeEndpoints("default", "foo", subset)))
+	f.Flush()
+
+	snap, err := f.GetSnapshot(HasTCPMapping("default", "foo"))
+	require.NoError(t, err)
+	assert.NotNil(t, snap)
+	f.AssertEndpointsEmpty(timeout)
+}
+
+func HasTCPMapping(namespace, name string) func(snapshot *snapshot.Snapshot) bool {
+	return func(snapshot *snapshot.Snapshot) bool {
+		for _, m := range snapshot.Kubernetes.TCPMappings {
+			if m.Namespace == namespace && m.Name == name {
+				return true
+			}
+		}
+		return false
+	}
+}

--- a/python/tests/src/tests/kat/t_tcpmapping.py
+++ b/python/tests/src/tests/kat/t_tcpmapping.py
@@ -361,6 +361,53 @@ spec:
         assert self.results[0].json["request"]["tls"]["enabled"] is False
 
 
+class TCPMappingEndpointResolverTest(AmbassadorTest):
+    """A TCPMapping using a KubernetesEndpointResolver must route to the
+    Service's endpoint IPs (EDS) rather than to the Service's ClusterIP.
+
+    Regression test for https://github.com/emissary-ingress/emissary/issues/3330
+    """
+
+    extra_ports = [6789]
+    target: ServiceType
+
+    def init(self) -> None:
+        self.target = HTTP()
+
+    def manifests(self) -> str:
+        return (
+            format(
+                """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: KubernetesEndpointResolver
+metadata:
+  name: {self.path.k8s}-endpoint
+spec:
+  ambassador_id: [ {self.ambassador_id} ]
+---
+apiVersion: getambassador.io/v3alpha1
+kind: TCPMapping
+metadata:
+  name: {self.path.k8s}
+spec:
+  ambassador_id: [ {self.ambassador_id} ]
+  port: 6789
+  service: {self.target.path.fqdn}:80
+  resolver: {self.path.k8s}-endpoint
+"""
+            )
+            + super().manifests()
+        )
+
+    def queries(self):
+        yield Query(self.url("", port=6789))
+
+    def check(self):
+        assert self.results[0].json["backend"] == self.target.path.k8s
+        assert self.results[0].json["request"]["tls"]["enabled"] is False
+
+
 class TCPMappingCrossNamespaceTest(AmbassadorTest):
     extra_ports = [6789]
     target: ServiceType
@@ -1301,7 +1348,6 @@ spec:
 #  - enable_ipv6: false
 #  - circuit_breakers
 #  - idle_timeout_ms
-#  - resolver
 #
 # TODO: Add tests for the config knobs for stats:
 #  - cluster_tag

--- a/python/tests/src/tests/unit/test_tcpmapping_resolver.py
+++ b/python/tests/src/tests/unit/test_tcpmapping_resolver.py
@@ -1,0 +1,121 @@
+"""Regression tests for https://github.com/emissary-ingress/emissary/issues/3330
+
+A TCPMapping that uses a KubernetesEndpointResolver (explicitly, or via the
+Ambassador Module's default resolver) must produce an EDS cluster that routes to
+the Service's endpoint IPs, not a STRICT_DNS cluster pointed at the ClusterIP.
+"""
+
+import pytest
+
+from tests.utils import compile_with_cachecheck, default_tcp_listener_manifest
+
+
+ENDPOINT_RESOLVER = """
+---
+apiVersion: getambassador.io/v3alpha1
+kind: KubernetesEndpointResolver
+metadata:
+  name: my-endpoint
+  namespace: default
+spec: {}
+"""
+
+
+def _tcpmapping(service: str, resolver: str = "") -> str:
+    resolver_line = f"  resolver: {resolver}\n" if resolver else ""
+    return f"""
+---
+apiVersion: getambassador.io/v3alpha1
+kind: TCPMapping
+metadata:
+  name: mysql
+  namespace: default
+spec:
+  port: 8443
+  service: {service}
+{resolver_line}"""
+
+
+def _module(resolver: str) -> str:
+    return f"""
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Module
+metadata:
+  name: ambassador
+  namespace: default
+spec:
+  config:
+    resolver: {resolver}
+"""
+
+
+def _find_cluster(yaml: str, name: str) -> dict:
+    compiled = compile_with_cachecheck(yaml)
+    clusters = compiled["xds"].as_dict()["static_resources"]["clusters"]
+    matches = [c for c in clusters if c["name"] == name]
+    assert len(matches) == 1, f"expected exactly one cluster named {name}, got {clusters}"
+    return matches[0]
+
+
+@pytest.mark.compilertest
+def test_tcpmapping_explicit_endpoint_resolver():
+    yaml = (
+        default_tcp_listener_manifest()
+        + ENDPOINT_RESOLVER
+        + _tcpmapping("mysql:3306", resolver="my-endpoint")
+    )
+    cluster = _find_cluster(yaml, "cluster_mysql_3306_default")
+
+    assert cluster["type"] == "EDS"
+    assert cluster["eds_cluster_config"]["service_name"] == "k8s/default/mysql/3306"
+    assert "load_assignment" not in cluster
+
+
+@pytest.mark.compilertest
+def test_tcpmapping_builtin_endpoint_resolver():
+    # "endpoint" is an implicitly-defined KubernetesEndpointResolver.
+    yaml = default_tcp_listener_manifest() + _tcpmapping("mysql:3306", resolver="endpoint")
+    cluster = _find_cluster(yaml, "cluster_mysql_3306_default")
+
+    assert cluster["type"] == "EDS"
+    assert cluster["eds_cluster_config"]["service_name"] == "k8s/default/mysql/3306"
+
+
+@pytest.mark.compilertest
+def test_tcpmapping_module_default_endpoint_resolver():
+    yaml = (
+        default_tcp_listener_manifest()
+        + ENDPOINT_RESOLVER
+        + _module("my-endpoint")
+        + _tcpmapping("mysql:3306")
+    )
+    cluster = _find_cluster(yaml, "cluster_mysql_3306_default")
+
+    assert cluster["type"] == "EDS"
+    assert cluster["eds_cluster_config"]["service_name"] == "k8s/default/mysql/3306"
+
+
+@pytest.mark.compilertest
+def test_tcpmapping_endpoint_resolver_cross_namespace():
+    yaml = (
+        default_tcp_listener_manifest()
+        + ENDPOINT_RESOLVER
+        + _tcpmapping("mysql.other:3306", resolver="my-endpoint")
+    )
+    cluster = _find_cluster(yaml, "cluster_mysql_other_3306_default")
+
+    assert cluster["type"] == "EDS"
+    assert cluster["eds_cluster_config"]["service_name"] == "k8s/other/mysql/3306"
+
+
+@pytest.mark.compilertest
+def test_tcpmapping_default_service_resolver():
+    yaml = default_tcp_listener_manifest() + _tcpmapping("mysql:3306")
+    cluster = _find_cluster(yaml, "cluster_mysql_3306_default")
+
+    assert cluster["type"] == "STRICT_DNS"
+    assert "eds_cluster_config" not in cluster
+    addr = cluster["load_assignment"]["endpoints"][0]["lb_endpoints"][0]["endpoint"]["address"]
+    assert addr["socket_address"]["address"] == "mysql"
+    assert addr["socket_address"]["port_value"] == 3306


### PR DESCRIPTION
test: Cover TCPMapping with the Kubernetes endpoint resolver (#3330)

## Description

Issue #3330 reported that a TCPMapping using a KubernetesEndpointResolver still
sent traffic to the Service's ClusterIP instead of to the endpoint IPs. The
underlying bug (IRTCPMapping dropping the resolver before it reached
IRBaseMapping) was fixed in d5550fb2a, but the issue was never closed and
nothing guarded against a regression. On `main` today a TCPMapping with an
endpoint resolver correctly produces an `EDS` cluster keyed on
`k8s/<namespace>/<service>/<port>`, and the Go watcher already tracks
`Endpoints` for TCPMappings.

This PR adds regression coverage at each layer involved, with no production
code changes:

- **cmd/entrypoint** (`endpoint_routing_test.go`): the watcher must start
  watching Endpoints for a TCPMapping that names an endpoint resolver
  (explicitly, or via the Ambassador Module default), must not do so for the
  default kubernetes-service resolver, and the generated Envoy cluster must be
  EDS keyed on `k8s/<ns>/<svc>/<port>`. Adds a `HasTCPMapping` snapshot
  predicate alongside `HasMapping`.
- **python unit / compiler** (`tests/unit/test_tcpmapping_resolver.py`): the
  TCPMapping cluster is EDS with the right `eds_cluster_config.service_name`
  for explicit, built-in (`endpoint`), Module-default, and cross-namespace
  resolvers, and STRICT_DNS with a static `load_assignment` when no resolver
  is set.
- **KAT** (`tests/kat/t_tcpmapping.py`): `TCPMappingEndpointResolverTest`
  sends real TCP traffic through a TCPMapping bound to a
  KubernetesEndpointResolver and checks it lands on the backend. Also removes
  `resolver` from the file's "TODO: add tests for" list.

## Related Issues

Fixes #3330

## Testing

Run locally on this branch:

```
$ uv run go test -count=1 -v ./cmd/entrypoint -run TestEndpointRouting
--- PASS: TestEndpointRouting
--- PASS: TestEndpointRoutingMappingAnnotations
--- PASS: TestEndpointRoutingMultiplePorts
--- PASS: TestEndpointRoutingIP
--- PASS: TestEndpointRoutingMappingCreation
--- PASS: TestEndpointRoutingTCPMapping
--- PASS: TestEndpointRoutingTCPMappingModuleDefault
--- PASS: TestEndpointRoutingTCPMappingServiceResolver
ok      github.com/emissary-ingress/emissary/v3/cmd/entrypoint

$ uv run pytest --no-cov python/tests/src/tests/unit/test_tcpmapping_resolver.py
5 passed
```

`gofmt`, `ruff check --config=pyproject.toml`, and
`ruff format --config=pyproject.toml` are clean.

The KAT test was not run locally (it needs a cluster). It follows the existing
`TCPMappingBasicTest` / `TCPMappingCrossNamespaceTest` pattern and the
`KubernetesEndpointResolver` pattern from `t_grpc.py`, and will run in CI.

## Checklist

- [ ] **Does my change need to be backported to a previous release?**
  - No. Test-only change; the fix itself (d5550fb2a) has shipped since 2021.

- [x] **I made sure to update `CHANGELOG.md`.**
  - Not needed: no new features, Envoy changes, non-backward-compatible
    changes, or deprecations. Tests only.

- [x] **This is unlikely to impact how Emissary Ingress performs at scale.**
  - No production code changes.

- [x] **My change is adequately tested.**
  - Both the enabled case (endpoint resolver, explicit and Module-default)
    and the disabled case (default kubernetes-service resolver) are covered
    at the watcher, compiler, and end-to-end (KAT) layers.

- [x] **I am submitting a bug fix.**
  - [x] I have included a reproducible test case that demonstrates the bug.
  - [x] I have included a test case that demonstrates the fix.
  - [x] I have included a test that guards against regressions (i.e., a test
        that will fail if the bug is re-introduced in the future).

- [ ] **I updated `CONTRIBUTING.md` with any special dev tricks I had to use to work on this code efficiently.**
  - Nothing special was needed.

- [x] **The changes in this PR have been reviewed for security concerns and adherence to security best practices.**
  - Test-only change.
